### PR TITLE
chore(deps): clear 2 high-severity npm-audit vulnerabilities [XS]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -849,9 +849,10 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.0.tgz",
-      "integrity": "sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==",
+      "version": "7.29.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.4.tgz",
+      "integrity": "sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==",
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-module-transforms": "^7.28.6",
         "@babel/helper-plugin-utils": "^7.28.6",
@@ -4315,9 +4316,9 @@
       "dev": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -4327,7 +4328,8 @@
           "type": "opencollective",
           "url": "https://opencollective.com/fastify"
         }
-      ]
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fdir": {
       "version": "6.5.0",

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -15,6 +15,13 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
   - **Verification.** `npm run build` clean (852KB precache), `npm run lint` clean, `npm test` smoke test passes.
   - Modified: `src/v2/components/EditTaskModal.jsx`, `src/v2/components/EditTaskModal.css`, `src/v2/components/TaskCard.jsx`
 
+- chore(deps): clear 2 high-severity npm-audit vulnerabilities [XS]
+  - `fast-uri` 3.1.0 → 3.1.2 (path-traversal + host-confusion via percent-encoded sequences; transitive via ajv → MCP SDK).
+  - `@babel/plugin-transform-modules-systemjs` 7.29.0 → 7.29.4 (arbitrary code generation on malicious input; transitive via vite-plugin-pwa workbox; build-time only).
+  - `npm audit` clean afterward. Smoke test passes.
+  - Cherry-picked from main onto dev as the proxy-push diagnostic payload (2026-05-09 session).
+  - Modified: `package-lock.json`
+
 ---
 
 ## 2026-05-08


### PR DESCRIPTION
Cherry-pick of `c00d520` from `main` onto `dev`. Used as the proxy-push diagnostic payload for the 2026-05-09 session — direct `git push origin dev` still 403s, so this lands via PR + auto-merge instead.

## Summary
- `fast-uri` 3.1.0 → 3.1.2 (path-traversal + host-confusion via percent-encoded sequences; transitive via ajv → MCP SDK)
- `@babel/plugin-transform-modules-systemjs` 7.29.0 → 7.29.4 (arbitrary code generation; transitive via vite-plugin-pwa workbox; build-time only)
- `npm audit` clean afterward; lockfile-only change

## Test plan
- [x] `npm run lint` clean (warnings only)
- [x] `npm test` smoke test passes
- [ ] CI build green

https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_