### PR TITLE
feat(ui): v2 TaskListToolbar — sort dropdown + tag filter pills [M]

### DIFF
--- a/src/v2/AppV2.jsx
+++ b/src/v2/AppV2.jsx
@@ -19,6 +19,7 @@ import PackagesModal from './components/PackagesModal'
 import AdviserModal from './components/AdviserModal'
 import AnalyticsModal from './components/AnalyticsModal'
 import KanbanBoard from './components/KanbanBoard'
+import TaskListToolbar from './components/TaskListToolbar'
 import Toast from './components/Toast'
 import { useTasks } from '../hooks/useTasks'
 import { useRoutines, enhanceSpawnedTasks } from '../hooks/useRoutines'
@@ -34,7 +35,7 @@ import { useIsDesktop } from '../hooks/useIsDesktop'
 import { useWeather } from '../hooks/useWeather'
 import { useTrelloSync } from '../hooks/useTrelloSync'
 import { inferSize, trelloUpdateCard } from '../api'
-import { loadSettings, saveSettings, saveLabels, sortTasks } from '../store'
+import { loadLabels, loadSettings, saveSettings, saveLabels, sortTasks } from '../store'
 import './AppV2.css'
 
 export default function AppV2() {
@@ -55,6 +56,9 @@ export default function AppV2() {
   const [showAdviser, setShowAdviser] = useState(false)
   const [showAnalytics, setShowAnalytics] = useState(false)
   const [expandedTaskId, setExpandedTaskId] = useState(null)
+  const [activeFilter, setActiveFilter] = useState('all')
+  const [sortBy, setSortBy] = useState(() => loadSettings().sort_by || 'age')
+  const [labels, setLabels] = useState(() => loadLabels())
   // Adviser conversation state lives at the App level so it survives modal
   // open/close — user can pop in, ask something, close, come back to the
   // same thread. Server session TTL still governs the staged-plan life.
@@ -97,8 +101,14 @@ export default function AppV2() {
   const hydrateFromServer = useCallback((data) => {
     if (data.tasks) hydrateTasks(data.tasks)
     if (data.routines) hydrateRoutines(data.routines)
-    if (data.settings) saveSettings(data.settings)
-    if (data.labels) saveLabels(data.labels)
+    if (data.settings) {
+      saveSettings(data.settings)
+      if (data.settings.sort_by) setSortBy(data.settings.sort_by)
+    }
+    if (data.labels) {
+      saveLabels(data.labels)
+      setLabels(data.labels)
+    }
   }, [hydrateTasks, hydrateRoutines])
 
   const { flush: flushSync } = useServerSync(tasks, routines, hydrateFromServer, () => {
@@ -124,14 +134,27 @@ export default function AppV2() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [routines])
 
-  // Sorted views — v2 currently uses a fixed 'age' sort. Sort UI ports later.
-  const sortedDoing = sortTasks(doingTasks, 'age')
-  const sortedStale = sortTasks(staleTasks, 'age')
-  const sortedUpNext = sortTasks(upNextTasks, 'age')
-  const sortedWaiting = sortTasks(waitingTasks, 'age')
-  const sortedSnoozed = sortTasks(snoozedTasks, 'age')
-  const backlogTasks = sortTasks(tasks.filter(t => t.status === 'backlog'), 'age')
-  const projectTasks = sortTasks(tasks.filter(t => t.status === 'project'), 'name')
+  // Filter + sort. activeFilter = 'all' | 'routines' | <label-id>; sortBy
+  // persists via settings.sort_by. Routines is a header pill that opens the
+  // RoutinesModal rather than filtering — list never sees that value.
+  const filterTasks = useCallback((list) => {
+    if (activeFilter === 'all') return list
+    return list.filter(t => Array.isArray(t.tags) && t.tags.includes(activeFilter))
+  }, [activeFilter])
+
+  const sortedDoing = sortTasks(filterTasks(doingTasks), sortBy)
+  const sortedStale = sortTasks(filterTasks(staleTasks), sortBy)
+  const sortedUpNext = sortTasks(filterTasks(upNextTasks), sortBy)
+  const sortedWaiting = sortTasks(filterTasks(waitingTasks), sortBy)
+  const sortedSnoozed = sortTasks(filterTasks(snoozedTasks), sortBy)
+  const backlogTasks = sortTasks(filterTasks(tasks.filter(t => t.status === 'backlog')), sortBy)
+  const projectTasks = sortTasks(filterTasks(tasks.filter(t => t.status === 'project')), sortBy === 'age' ? 'name' : sortBy)
+
+  const handleSortChange = useCallback((value) => {
+    setSortBy(value)
+    saveSettings({ ...loadSettings(), sort_by: value })
+    flushSync()
+  }, [flushSync])
   const totalActive = sortedDoing.length + sortedStale.length + sortedUpNext.length + sortedWaiting.length
   const todayStr = new Date().toDateString()
   const todayCount = tasks.filter(t => t.status === 'done' && t.completed_at && new Date(t.completed_at).toDateString() === todayStr).length
@@ -276,13 +299,24 @@ export default function AppV2() {
         onOpenMenu={() => setShowMenu(true)}
       />
       <main className={`v2-main${isDesktop ? ' v2-main-kanban' : ''}`}>
+        {tasks.length > 0 && (
+          <TaskListToolbar
+            labels={labels}
+            routinesCount={routines.length}
+            activeFilter={activeFilter}
+            onFilterChange={setActiveFilter}
+            onOpenRoutines={() => setShowRoutines(true)}
+            sortBy={sortBy}
+            onSortChange={handleSortChange}
+          />
+        )}
         {totalActive === 0 && sortedSnoozed.length === 0 && backlogTasks.length === 0 && projectTasks.length === 0 ? (
           <EmptyState
             icon={ListChecks}
-            title="Nothing on your plate"
-            body="No active tasks right now. Tap the + above to add one."
-            cta="Add task"
-            ctaOnClick={() => setShowAdd(true)}
+            title={activeFilter !== 'all' ? 'No tasks match this filter' : 'Nothing on your plate'}
+            body={activeFilter !== 'all' ? 'Tap All above to clear the filter.' : 'No active tasks right now. Tap the + above to add one.'}
+            cta={activeFilter !== 'all' ? 'Show all' : 'Add task'}
+            ctaOnClick={activeFilter !== 'all' ? () => setActiveFilter('all') : () => setShowAdd(true)}
           />
         ) : isDesktop ? (
           <KanbanBoard
@@ -409,7 +443,7 @@ export default function AppV2() {
 
       <SettingsModal
         open={showSettings}
-        onClose={() => { setShowSettings(false); flushSync() }}
+        onClose={() => { setShowSettings(false); setLabels(loadLabels()); flushSync() }}
         onFlush={flushSync}
         onClearCompleted={() => { clearCompleted(); setShowSettings(false); flushSync() }}
         onClearAll={() => { clearAll(); setShowSettings(false); flushSync() }}

--- a/src/v2/components/TaskListToolbar.css
+++ b/src/v2/components/TaskListToolbar.css
@@ -1,0 +1,133 @@
+.v2-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 24px 4px;
+  background: var(--v2-bg);
+}
+
+.v2-toolbar-pills {
+  display: flex;
+  gap: 6px;
+  flex: 1;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+  padding-bottom: 2px;
+}
+.v2-toolbar-pills::-webkit-scrollbar { display: none; }
+
+.v2-toolbar-pill {
+  flex-shrink: 0;
+  padding: 6px 12px;
+  border-radius: var(--v2-radius-pill);
+  border: 1px solid var(--v2-hairline);
+  background: transparent;
+  color: var(--v2-text-meta);
+  font-family: var(--v2-font-body);
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  transition: background var(--v2-dur-quick) var(--v2-ease-standard),
+              color var(--v2-dur-quick) var(--v2-ease-standard),
+              border-color var(--v2-dur-quick) var(--v2-ease-standard);
+}
+.v2-toolbar-pill:hover {
+  background: rgba(var(--v2-text-rgb), 0.04);
+  color: var(--v2-text);
+}
+.v2-toolbar-pill-active {
+  background: var(--v2-text);
+  border-color: var(--v2-text);
+  color: var(--v2-bg);
+}
+.v2-toolbar-pill-active:hover {
+  background: var(--v2-text);
+  color: var(--v2-bg);
+}
+
+.v2-toolbar-pill-routines {
+  margin-left: 4px;
+  position: relative;
+}
+.v2-toolbar-pill-routines::before {
+  content: '';
+  position: absolute;
+  left: -4px;
+  top: 20%;
+  bottom: 20%;
+  width: 1px;
+  background: var(--v2-hairline);
+}
+
+.v2-toolbar-sort {
+  position: relative;
+  flex-shrink: 0;
+}
+.v2-toolbar-sort-btn {
+  width: 30px;
+  height: 30px;
+  border-radius: var(--v2-radius-pill);
+  border: 1px solid var(--v2-hairline);
+  background: transparent;
+  color: var(--v2-text-meta);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: background var(--v2-dur-quick) var(--v2-ease-standard),
+              color var(--v2-dur-quick) var(--v2-ease-standard);
+}
+.v2-toolbar-sort-btn:hover {
+  background: rgba(var(--v2-text-rgb), 0.04);
+  color: var(--v2-text);
+}
+
+.v2-toolbar-sort-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  min-width: 140px;
+  background: var(--v2-surface);
+  border: 1px solid var(--v2-hairline);
+  border-radius: 12px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.08);
+  padding: 4px;
+  z-index: 50;
+  animation: v2-toolbar-fade-in var(--v2-dur-quick) var(--v2-ease-emphasis);
+}
+
+@keyframes v2-toolbar-fade-in {
+  from { opacity: 0; transform: translateY(-4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.v2-toolbar-sort-option {
+  display: block;
+  width: 100%;
+  padding: 8px 12px;
+  border: none;
+  background: transparent;
+  text-align: left;
+  font-family: var(--v2-font-body);
+  font-size: 13px;
+  color: var(--v2-text);
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background var(--v2-dur-quick) var(--v2-ease-standard);
+}
+.v2-toolbar-sort-option:hover {
+  background: rgba(var(--v2-text-rgb), 0.04);
+}
+.v2-toolbar-sort-option-active {
+  background: rgba(var(--v2-text-rgb), 0.06);
+  font-weight: 600;
+}
+
+@media (max-width: 480px) {
+  .v2-toolbar {
+    padding: 10px 16px 2px;
+  }
+}

--- a/src/v2/components/TaskListToolbar.jsx
+++ b/src/v2/components/TaskListToolbar.jsx
@@ -1,0 +1,100 @@
+import { useEffect, useRef, useState } from 'react'
+import { ArrowUpDown } from 'lucide-react'
+import './TaskListToolbar.css'
+
+const SORT_OPTIONS = [
+  { value: 'age', label: 'Age' },
+  { value: 'due_date', label: 'Due date' },
+  { value: 'size', label: 'Size' },
+  { value: 'name', label: 'Name' },
+]
+
+export default function TaskListToolbar({
+  labels,
+  routinesCount,
+  activeFilter,
+  onFilterChange,
+  onOpenRoutines,
+  sortBy,
+  onSortChange,
+}) {
+  const [sortOpen, setSortOpen] = useState(false)
+  const sortRef = useRef(null)
+
+  useEffect(() => {
+    if (!sortOpen) return
+    const handleClick = (e) => {
+      if (sortRef.current && !sortRef.current.contains(e.target)) setSortOpen(false)
+    }
+    document.addEventListener('mousedown', handleClick)
+    return () => document.removeEventListener('mousedown', handleClick)
+  }, [sortOpen])
+
+  const handleSortPick = (value) => {
+    onSortChange(value)
+    setSortOpen(false)
+  }
+
+  return (
+    <div className="v2-toolbar">
+      <div className="v2-toolbar-pills" role="tablist" aria-label="Filter tasks">
+        <button
+          className={`v2-toolbar-pill${activeFilter === 'all' ? ' v2-toolbar-pill-active' : ''}`}
+          onClick={() => onFilterChange('all')}
+          role="tab"
+          aria-selected={activeFilter === 'all'}
+        >
+          All
+        </button>
+        {labels.map(label => {
+          const active = activeFilter === label.id
+          return (
+            <button
+              key={label.id}
+              className={`v2-toolbar-pill${active ? ' v2-toolbar-pill-active' : ''}`}
+              onClick={() => onFilterChange(label.id)}
+              style={active ? { background: label.color, borderColor: label.color, color: '#fff' } : {}}
+              role="tab"
+              aria-selected={active}
+            >
+              {label.name.charAt(0).toUpperCase() + label.name.slice(1)}
+            </button>
+          )
+        })}
+        <button
+          className="v2-toolbar-pill v2-toolbar-pill-routines"
+          onClick={onOpenRoutines}
+          title="Open routines"
+        >
+          Routines{routinesCount > 0 ? ` · ${routinesCount}` : ''}
+        </button>
+      </div>
+      <div className="v2-toolbar-sort" ref={sortRef}>
+        <button
+          className="v2-toolbar-sort-btn"
+          onClick={() => setSortOpen(o => !o)}
+          title={`Sort: ${SORT_OPTIONS.find(o => o.value === sortBy)?.label || 'Age'}`}
+          aria-haspopup="menu"
+          aria-expanded={sortOpen}
+        >
+          <ArrowUpDown size={14} strokeWidth={1.75} />
+        </button>
+        {sortOpen && (
+          <div className="v2-toolbar-sort-menu" role="menu">
+            {SORT_OPTIONS.map(opt => (
+              <button
+                key={opt.value}
+                className={`v2-toolbar-sort-option${sortBy === opt.value ? ' v2-toolbar-sort-option-active' : ''}`}
+                onClick={() => handleSortPick(opt.value)}
+                role="menuitemradio"
+                aria-checked={sortBy === opt.value}
+              >
+                {opt.label}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/wiki/V2-State.md
+++ b/wiki/V2-State.md
@@ -87,8 +87,8 @@ Categorized by priority. The future session should pick from this list.
 These are daily-use gaps that users would notice:
 
 - [x] ~~**Skip-this-cycle button in v2 RoutinesModal.**~~ Landed 2026-05-09. `skipCycle` ported from main into `useRoutines.js`; v2 wiring through `AppV2.jsx` + `RoutinesModal.jsx` (FastForward icon, "Skip cycle" button next to Spawn now, hidden for paused routines).
-- [ ] **Sort dropdown** above v2 task list. Currently hardcoded to 'age'. v1 has age/due-date/size/name + persists in `settings.sort_by`.
-- [ ] **Tag filter pills** above v2 task list. v1 has horizontal pill row with All + each user label + Routines filter.
+- [x] ~~**Sort dropdown** above v2 task list.~~ Landed 2026-05-09 in `TaskListToolbar`. Persists via `settings.sort_by`. Options: age / due-date / size / name.
+- [x] ~~**Tag filter pills** above v2 task list.~~ Landed 2026-05-09 in `TaskListToolbar`. Horizontal pill row: All + each user label (active pill takes the label's color) + Routines (opens RoutinesModal). Empty-state messaging updated for filtered-to-zero.
 - [ ] **Search bar + results view** in v2. Uses `/api/tasks?q=` endpoint. v1 surfaces it via a magnifier icon in the header.
 - [ ] **Pushover credential entry + test buttons** in v2 Integrations. Currently can't set up Pushover in v2 at all.
 - [ ] **Anthropic API key entry + model picker + status check** in v2 AI tab.
@@ -180,6 +180,7 @@ src/
       ActivityLog, RoutinesModal, PackagesModal
       AdviserModal, AnalyticsModal, BalanceRadar
       KanbanBoard                                     ← desktop only
+      TaskListToolbar                                 ← sort + filter pills above the list
 ```
 
 All v2 components consume tokens from `tokens.css` (gated by `:root[data-ui="v2"]`). Nothing in v2 imports v1 component files; v2 reuses v1 hooks (`useTasks`, `useRoutines`, etc.), `store.js`, `api.js`, `db.js`, and `utils/` directly. v1 stays untouched.

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,16 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-09
 
+- feat(ui): v2 TaskListToolbar — sort dropdown + tag filter pills [M]
+  - **Why.** v2's task list was hardcoded to `'age'` sort with no filter UI — every-page gap that pushed users back to v1 just to focus on a tag or change the sort key. Last two ship-blockers from the v2 polish list landed together since they share the toolbar surface.
+  - **New `TaskListToolbar` component.** `src/v2/components/TaskListToolbar.{jsx,css}`. Renders above the task list (and above KanbanBoard on desktop). Horizontal pill row: All + each user label + Routines (visual divider, opens RoutinesModal). Active label pill takes the label's color. Sort dropdown on the right: ArrowUpDown icon → menu with age / due-date / size / name. Click-outside closes. Pills row scrolls horizontally without a visible scrollbar when overflowing.
+  - **AppV2 wiring.** Three new state pieces — `activeFilter` (default `'all'`), `sortBy` (initialized from `settings.sort_by` or `'age'`), `labels` (lifted up so the toolbar sees user-edited labels — settings close handler refreshes via `setLabels(loadLabels())`; cross-client hydrate also pushes new labels into state). `filterTasks(list)` filters on `tag` membership. All seven section arrays (doing/stale/up next/waiting/snoozed/backlog/projects) now go through `filterTasks` then `sortTasks(_, sortBy)`. Projects keeps its `name` sort when sortBy is `'age'` (visual consistency with v1 — projects lean alphabetical).
+  - **Persistence.** `handleSortChange` writes `settings.sort_by` and triggers a sync flush so the change rides the standard server path. Filter is in-memory (matches v1 — same intent, transient view state).
+  - **Empty-state nuance.** When filter is active and yields zero matches, the empty state copy switches to "No tasks match this filter" with a "Show all" CTA that resets the filter. When unfiltered list is genuinely empty, the original "Nothing on your plate" + "Add task" message stays.
+  - **Verification.** `npm run lint` clean (warnings only). `npm test` smoke test passes. Bundle: 701KB precache (up from 697KB — new component + CSS).
+  - New: `src/v2/components/TaskListToolbar.jsx`, `src/v2/components/TaskListToolbar.css`
+  - Modified: `src/v2/AppV2.jsx`, `wiki/V2-State.md`
+
 - feat(ui): v2 RoutinesModal — skip-this-cycle button [S]
   - **Why.** Top ship-blocker on the v2 polish list. Without it, vacation/illness/"the lawn doesn't need mowing this week" forces the user to spawn-now then immediately complete, which both pollutes the active task list and double-counts the cycle. Main has the feature (commit `422c2ff`, 2026-05-09 earlier in the day); dev didn't pick it up because the original landing path was a failed merge that was reverted before reaching dev.
   - **Hook port.** Ported `skipCycle(routineId)` callback from main's `useRoutines.js` verbatim. Stamps `completed_history` with `now()` so `getNextDueDate()` rolls forward by one cadence interval. No DB schema change, no server endpoint — pure local-state mutation flushed via the existing routine sync. Skips count toward the "Nx completed" total — close enough for a personal app, no separate skip log.


### PR DESCRIPTION
## Summary

Last two ship-blockers from the v2 polish list. New `TaskListToolbar` component renders above the task list (and above KanbanBoard on desktop):

- Horizontal pill row: All + each user label + Routines (visual divider, opens RoutinesModal). Active label pill takes the label's color.
- Sort dropdown on the right: ArrowUpDown icon → menu with age / due-date / size / name. Click-outside closes.
- Pills row scrolls horizontally without a visible scrollbar when overflowing.

## AppV2 wiring

- New state: `activeFilter` (default `'all'`), `sortBy` (initialized from `settings.sort_by` or `'age'`), `labels` (lifted up so toolbar sees user edits).
- `filterTasks(list)` filters on tag membership; `sortBy` replaces the hardcoded `'age'` everywhere.
- All seven section arrays (doing/stale/up next/waiting/snoozed/backlog/projects) flow through filter then sort.
- Projects keeps its `'name'` sort when `sortBy === 'age'` (matches v1's projects-lean-alphabetical default).
- Sort change persists via `saveSettings({ sort_by })` + triggers `flushSync()`.
- Settings close handler + cross-client hydrate both refresh `labels` so user-edited labels appear in the pill row without a remount.

## Empty-state nuance

When the filter yields zero matches, the empty state copy switches to "No tasks match this filter" with a "Show all" CTA that resets the filter. Genuine empty list stays "Nothing on your plate" + Add task.

## Test plan
- [x] `npm run lint` clean (warnings only)
- [x] `npm test` smoke test passes — bundle 701KB
- [ ] CI build green
- [ ] Manual: tap a label pill → list filters to that tag. Open sort menu → pick "Due date" → list re-sorts and persists across reload. Edit a label name in Settings → close Settings → toolbar shows the updated name.

https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_