### PR TITLE
feat(ui): v2 search bar + results view [S]

### DIFF
--- a/src/v2/AppV2.jsx
+++ b/src/v2/AppV2.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { ListChecks, Settings as SettingsIcon, FolderKanban, BarChart3, History, ChevronRight, CheckCircle2, RotateCw } from 'lucide-react'
 import Header from './components/Header'
 import ModalShell from './components/ModalShell'
@@ -59,6 +59,10 @@ export default function AppV2() {
   const [activeFilter, setActiveFilter] = useState('all')
   const [sortBy, setSortBy] = useState(() => loadSettings().sort_by || 'age')
   const [labels, setLabels] = useState(() => loadLabels())
+  const [searchOpen, setSearchOpen] = useState(false)
+  const [searchQuery, setSearchQuery] = useState('')
+  const [searchResults, setSearchResults] = useState(null)
+  const searchTimerRef = useRef(null)
   // Adviser conversation state lives at the App level so it survives modal
   // open/close — user can pop in, ask something, close, come back to the
   // same thread. Server session TTL still governs the staged-plan life.
@@ -155,6 +159,27 @@ export default function AppV2() {
     saveSettings({ ...loadSettings(), sort_by: value })
     flushSync()
   }, [flushSync])
+
+  // Debounced search against /api/tasks?q=. Mirrors v1's pattern. Empty
+  // query clears the result set; results=null means "search inactive."
+  const handleSearchChange = useCallback((query) => {
+    setSearchQuery(query)
+    if (searchTimerRef.current) clearTimeout(searchTimerRef.current)
+    if (!query.trim()) { setSearchResults(null); return }
+    searchTimerRef.current = setTimeout(() => {
+      fetch(`/api/tasks?q=${encodeURIComponent(query.trim())}`)
+        .then(res => res.ok ? res.json() : [])
+        .then(results => setSearchResults(results))
+        .catch(() => setSearchResults(null))
+    }, 300)
+  }, [])
+
+  const handleCloseSearch = useCallback(() => {
+    setSearchOpen(false)
+    setSearchQuery('')
+    setSearchResults(null)
+    if (searchTimerRef.current) clearTimeout(searchTimerRef.current)
+  }, [])
   const totalActive = sortedDoing.length + sortedStale.length + sortedUpNext.length + sortedWaiting.length
   const todayStr = new Date().toDateString()
   const todayCount = tasks.filter(t => t.status === 'done' && t.completed_at && new Date(t.completed_at).toDateString() === todayStr).length
@@ -299,7 +324,7 @@ export default function AppV2() {
         onOpenMenu={() => setShowMenu(true)}
       />
       <main className={`v2-main${isDesktop ? ' v2-main-kanban' : ''}`}>
-        {tasks.length > 0 && (
+        {(tasks.length > 0 || searchOpen) && (
           <TaskListToolbar
             labels={labels}
             routinesCount={routines.length}
@@ -308,9 +333,48 @@ export default function AppV2() {
             onOpenRoutines={() => setShowRoutines(true)}
             sortBy={sortBy}
             onSortChange={handleSortChange}
+            searchMode={searchOpen}
+            searchQuery={searchQuery}
+            onSearchChange={handleSearchChange}
+            onOpenSearch={() => setSearchOpen(true)}
+            onCloseSearch={handleCloseSearch}
           />
         )}
-        {totalActive === 0 && sortedSnoozed.length === 0 && backlogTasks.length === 0 && projectTasks.length === 0 ? (
+        {searchOpen ? (
+          <div className="v2-list">
+            {searchResults === null ? (
+              <EmptyState
+                icon={ListChecks}
+                title="Type to search"
+                body="Searches every task — active, done, backlog, or project."
+              />
+            ) : searchResults.length === 0 ? (
+              <EmptyState
+                icon={ListChecks}
+                title="No matches"
+                body={`Nothing matches "${searchQuery}". Try a different keyword.`}
+              />
+            ) : (
+              <>
+                <SectionLabel count={searchResults.length}>
+                  {searchResults.length} result{searchResults.length === 1 ? '' : 's'}
+                </SectionLabel>
+                {searchResults.map(t => (
+                  <TaskCard
+                    key={t.id}
+                    task={t}
+                    expanded={expandedTaskId === t.id}
+                    onToggleExpand={setExpandedTaskId}
+                    onComplete={handleComplete}
+                    onEdit={handleEdit}
+                    onSnooze={handleSnooze}
+                    weatherByDate={weather.enabled ? weather.byDate : null}
+                  />
+                ))}
+              </>
+            )}
+          </div>
+        ) : totalActive === 0 && sortedSnoozed.length === 0 && backlogTasks.length === 0 && projectTasks.length === 0 ? (
           <EmptyState
             icon={ListChecks}
             title={activeFilter !== 'all' ? 'No tasks match this filter' : 'Nothing on your plate'}

--- a/src/v2/components/TaskListToolbar.css
+++ b/src/v2/components/TaskListToolbar.css
@@ -66,7 +66,7 @@
   position: relative;
   flex-shrink: 0;
 }
-.v2-toolbar-sort-btn {
+.v2-toolbar-icon-btn {
   width: 30px;
   height: 30px;
   border-radius: var(--v2-radius-pill);
@@ -77,12 +77,35 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  flex-shrink: 0;
   transition: background var(--v2-dur-quick) var(--v2-ease-standard),
               color var(--v2-dur-quick) var(--v2-ease-standard);
 }
-.v2-toolbar-sort-btn:hover {
+.v2-toolbar-icon-btn:hover {
   background: rgba(var(--v2-text-rgb), 0.04);
   color: var(--v2-text);
+}
+
+/* Search mode — replaces the pills + icons with an inline input row. */
+.v2-toolbar-search {
+  align-items: center;
+}
+.v2-toolbar-search-icon {
+  color: var(--v2-text-meta);
+  flex-shrink: 0;
+}
+.v2-toolbar-search-input {
+  flex: 1;
+  border: none;
+  outline: none;
+  background: transparent;
+  color: var(--v2-text);
+  font-family: var(--v2-font-body);
+  font-size: 14px;
+  padding: 6px 0;
+}
+.v2-toolbar-search-input::placeholder {
+  color: var(--v2-text-faint);
 }
 
 .v2-toolbar-sort-menu {

--- a/src/v2/components/TaskListToolbar.jsx
+++ b/src/v2/components/TaskListToolbar.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { ArrowUpDown } from 'lucide-react'
+import { ArrowUpDown, Search, X } from 'lucide-react'
 import './TaskListToolbar.css'
 
 const SORT_OPTIONS = [
@@ -17,9 +17,15 @@ export default function TaskListToolbar({
   onOpenRoutines,
   sortBy,
   onSortChange,
+  searchMode,
+  searchQuery,
+  onSearchChange,
+  onOpenSearch,
+  onCloseSearch,
 }) {
   const [sortOpen, setSortOpen] = useState(false)
   const sortRef = useRef(null)
+  const searchInputRef = useRef(null)
 
   useEffect(() => {
     if (!sortOpen) return
@@ -30,9 +36,43 @@ export default function TaskListToolbar({
     return () => document.removeEventListener('mousedown', handleClick)
   }, [sortOpen])
 
+  // Auto-focus the search input when search mode opens, and listen for Esc.
+  useEffect(() => {
+    if (!searchMode) return
+    searchInputRef.current?.focus()
+    const handleKey = (e) => { if (e.key === 'Escape') onCloseSearch() }
+    document.addEventListener('keydown', handleKey)
+    return () => document.removeEventListener('keydown', handleKey)
+  }, [searchMode, onCloseSearch])
+
   const handleSortPick = (value) => {
     onSortChange(value)
     setSortOpen(false)
+  }
+
+  if (searchMode) {
+    return (
+      <div className="v2-toolbar v2-toolbar-search">
+        <Search size={14} strokeWidth={1.75} className="v2-toolbar-search-icon" aria-hidden="true" />
+        <input
+          ref={searchInputRef}
+          type="text"
+          className="v2-toolbar-search-input"
+          placeholder="Search tasks…"
+          value={searchQuery}
+          onChange={e => onSearchChange(e.target.value)}
+          aria-label="Search tasks"
+        />
+        <button
+          className="v2-toolbar-icon-btn"
+          onClick={onCloseSearch}
+          title="Close search"
+          aria-label="Close search"
+        >
+          <X size={14} strokeWidth={1.75} />
+        </button>
+      </div>
+    )
   }
 
   return (
@@ -71,7 +111,7 @@ export default function TaskListToolbar({
       </div>
       <div className="v2-toolbar-sort" ref={sortRef}>
         <button
-          className="v2-toolbar-sort-btn"
+          className="v2-toolbar-icon-btn"
           onClick={() => setSortOpen(o => !o)}
           title={`Sort: ${SORT_OPTIONS.find(o => o.value === sortBy)?.label || 'Age'}`}
           aria-haspopup="menu"
@@ -95,6 +135,16 @@ export default function TaskListToolbar({
           </div>
         )}
       </div>
+      {onOpenSearch && (
+        <button
+          className="v2-toolbar-icon-btn"
+          onClick={onOpenSearch}
+          title="Search tasks"
+          aria-label="Search tasks"
+        >
+          <Search size={14} strokeWidth={1.75} />
+        </button>
+      )}
     </div>
   )
 }

--- a/wiki/V2-State.md
+++ b/wiki/V2-State.md
@@ -89,7 +89,7 @@ These are daily-use gaps that users would notice:
 - [x] ~~**Skip-this-cycle button in v2 RoutinesModal.**~~ Landed 2026-05-09. `skipCycle` ported from main into `useRoutines.js`; v2 wiring through `AppV2.jsx` + `RoutinesModal.jsx` (FastForward icon, "Skip cycle" button next to Spawn now, hidden for paused routines).
 - [x] ~~**Sort dropdown** above v2 task list.~~ Landed 2026-05-09 in `TaskListToolbar`. Persists via `settings.sort_by`. Options: age / due-date / size / name.
 - [x] ~~**Tag filter pills** above v2 task list.~~ Landed 2026-05-09 in `TaskListToolbar`. Horizontal pill row: All + each user label (active pill takes the label's color) + Routines (opens RoutinesModal). Empty-state messaging updated for filtered-to-zero.
-- [ ] **Search bar + results view** in v2. Uses `/api/tasks?q=` endpoint. v1 surfaces it via a magnifier icon in the header.
+- [x] ~~**Search bar + results view** in v2.~~ Landed 2026-05-09 in `TaskListToolbar`. Search icon next to sort flips the toolbar into search mode (input + close, Esc closes). Debounced 300ms fetch to `/api/tasks?q=`; results render as a single section with count chip in place of the regular task list. Searches every task (active, done, backlog, project) per the v1 endpoint behavior.
 - [ ] **Pushover credential entry + test buttons** in v2 Integrations. Currently can't set up Pushover in v2 at all.
 - [ ] **Anthropic API key entry + model picker + status check** in v2 AI tab.
 - [ ] **Manual sync triggers** (Trello / Notion / GCal / Gmail Sync-Now buttons) in v2 Integrations. Background syncs run; manual one-shots don't have UI.

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,16 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-09
 
+- feat(ui): v2 search bar + results view [S]
+  - **Why.** Daily-use ship-blocker. v1 had a magnifier in the header; v2 had nothing — users had to flip back to v1 to find an old task by keyword.
+  - **Search lives in TaskListToolbar.** Added a Search icon button next to the sort button. Click flips the toolbar into search mode: pills + sort + search-icon hidden, replaced by a Search-icon-prefixed input + X close button in the same row real estate (no layout shift). Esc closes too.
+  - **Debounced fetch.** AppV2 owns `searchOpen` / `searchQuery` / `searchResults`. `handleSearchChange` debounces 300ms then hits `GET /api/tasks?q=<query>` (same endpoint v1 uses; covers every task — active, done, backlog, project). `searchResults === null` means "search mode active, but no query / not yet fetched"; an empty array means "no matches"; a populated array renders.
+  - **Results render.** When `searchOpen`, the regular section list is replaced by a single SectionLabel ("N result(s)") + TaskCard list. Wired through the same TaskActionsContext-style handlers as the regular list — Complete / Edit / Snooze all work from results.
+  - **Empty states.** "Type to search" while idle, "No matches" when the query returns nothing.
+  - **`onCloseSearch`.** Resets query + results + clears the debounce timer. Toolbar still renders even when there are zero tasks if search is open (so the close button is reachable).
+  - **Verification.** `npm run lint` clean (warnings only). `npm test` smoke test passes. Bundle: 703KB precache (up from 701KB).
+  - Modified: `src/v2/AppV2.jsx`, `src/v2/components/TaskListToolbar.jsx`, `src/v2/components/TaskListToolbar.css`, `wiki/V2-State.md`
+
 - feat(ui): v2 TaskListToolbar — sort dropdown + tag filter pills [M]
   - **Why.** v2's task list was hardcoded to `'age'` sort with no filter UI — every-page gap that pushed users back to v1 just to focus on a tag or change the sort key. Last two ship-blockers from the v2 polish list landed together since they share the toolbar surface.
   - **New `TaskListToolbar` component.** `src/v2/components/TaskListToolbar.{jsx,css}`. Renders above the task list (and above KanbanBoard on desktop). Horizontal pill row: All + each user label + Routines (visual divider, opens RoutinesModal). Active label pill takes the label's color. Sort dropdown on the right: ArrowUpDown icon → menu with age / due-date / size / name. Click-outside closes. Pills row scrolls horizontally without a visible scrollbar when overflowing.


### PR DESCRIPTION
## Summary

Daily-use ship-blocker. v2 had no search affordance — users had to flip back to v1 to find old tasks by keyword.

- `TaskListToolbar` gains a Search icon next to the sort button. Click flips the toolbar into search mode: pills + sort hidden, replaced by a Search-icon-prefixed input + X close button in the same row real estate (no layout shift). Esc also closes.
- `AppV2` debounces 300ms then hits `GET /api/tasks?q=`, which covers every task — active, done, backlog, project. Same endpoint v1 uses.
- Results render as a single `SectionLabel` + `TaskCard` list, replacing the regular sections while search is active. All task actions (complete / edit / snooze) work from results.
- Empty states: "Type to search" while idle, "No matches" when the query returns nothing.
- `onCloseSearch` resets query + results + clears the debounce timer. Toolbar stays rendered when search is open even with zero tasks so the close button is reachable.

## Test plan
- [x] `npm run lint` clean (warnings only)
- [x] `npm test` smoke test passes — bundle 703KB
- [ ] CI build green
- [ ] Manual: tap search icon → toolbar swaps to input. Type → results render after 300ms. Esc or X closes. Tap a result → opens the task. Reopens in search mode if flipped back without closing first.

https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_