### PR TITLE
feat(ui): v2 Pushover credential entry + test buttons in Integrations [S]

### DIFF
--- a/src/v2/components/SettingsModal.css
+++ b/src/v2/components/SettingsModal.css
@@ -730,6 +730,9 @@
 
 .v2-integrations-inline {
   margin-top: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 
 .v2-integrations-env {
@@ -738,4 +741,15 @@
   background: rgba(var(--v2-text-rgb), 0.04);
   font: 400 12px/1.4 var(--v2-font-body);
   color: var(--v2-text-meta);
+}
+
+.v2-integrations-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.v2-integrations-error {
+  font: 400 12px/1.4 var(--v2-font-body);
+  color: var(--v2-alert-overdue);
 }

--- a/src/v2/components/SettingsModal.jsx
+++ b/src/v2/components/SettingsModal.jsx
@@ -200,6 +200,9 @@ const NOTIF_PACKAGE_TYPES = [
 function IntegrationsPanel({ settings, update, switchToV1 }) {
   const [envKeys, setEnvKeys] = useState({ anthropic: false, notion: false, trello: false, tracking: false })
   const [statuses, setStatuses] = useState({})
+  const [pushoverTest, setPushoverTest] = useState({ status: null, error: null })
+  const [pushoverEmer, setPushoverEmer] = useState({ status: null, error: null })
+  const [emergencyConfirm, setEmergencyConfirm] = useState(false)
 
   // Load env-key flags + each integration's connection status on mount.
   // Failures are silent — a missing status just leaves the dot grey.
@@ -277,17 +280,40 @@ function IntegrationsPanel({ settings, update, switchToV1 }) {
       hint: 'iOS-friendly transport that bypasses Safari throttling. One-time $5 app required.',
       connected: !!statuses.pushover?.configured,
       v1Section: 'Integrations → Pushover',
+      inline: 'pushover',
+      appTokenFromEnv: !!statuses.pushover?.app_token_from_env,
     },
   ]
+
+  const runPushoverTest = async (emergency) => {
+    const setter = emergency ? setPushoverEmer : setPushoverTest
+    setter({ status: 'sending', error: null })
+    try {
+      const api = await import('../../api')
+      const fn = emergency ? api.testPushoverEmergency : api.testPushover
+      const result = await fn({
+        userKey: settings.pushover_user_key,
+        appToken: settings.pushover_app_token,
+      })
+      if (result?.success) {
+        setter({ status: 'sent', error: null })
+        setTimeout(() => setter({ status: null, error: null }), 4000)
+      } else {
+        setter({ status: 'error', error: result?.error || 'Send failed' })
+      }
+    } catch (e) {
+      setter({ status: 'error', error: e?.message || 'Send failed' })
+    }
+  }
 
   return (
     <div className="v2-settings-form">
       <div className="v2-settings-block">
         <div className="v2-form-label">Status</div>
         <div className="v2-settings-row-hint">
-          OAuth-heavy integrations (Notion, Trello, GCal, Gmail, Pushover) are configured in v1
+          OAuth-heavy integrations (Notion, Trello, GCal, Gmail) are configured in v1
           to avoid duplicating multi-step consent flows. Simple key-only integrations
-          (Anthropic, 17track) can be set inline below.
+          (Anthropic, 17track, Pushover) can be set inline below.
         </div>
         <ul className="v2-integrations-list">
           {integrations.map(int => (
@@ -314,23 +340,89 @@ function IntegrationsPanel({ settings, update, switchToV1 }) {
                     )}
                   </div>
                 )}
+                {int.inline === 'pushover' && (
+                  <div className="v2-integrations-inline">
+                    <input
+                      type="password"
+                      className="v2-form-input"
+                      placeholder="User Key (from pushover.net dashboard)"
+                      value={settings.pushover_user_key || ''}
+                      onChange={e => update('pushover_user_key', e.target.value)}
+                    />
+                    <input
+                      type="password"
+                      className="v2-form-input"
+                      placeholder={int.appTokenFromEnv ? 'App Token (from env var)' : 'App Token (create app named "Boomerang")'}
+                      value={settings.pushover_app_token || ''}
+                      onChange={e => update('pushover_app_token', e.target.value)}
+                      disabled={int.appTokenFromEnv && !settings.pushover_app_token}
+                    />
+                    <div className="v2-integrations-actions">
+                      <button
+                        className="v2-settings-btn"
+                        disabled={pushoverTest.status === 'sending'}
+                        onClick={() => runPushoverTest(false)}
+                      >
+                        {pushoverTest.status === 'sending' ? 'Sending…' : pushoverTest.status === 'sent' ? 'Sent ✓' : 'Test'}
+                      </button>
+                      <button
+                        className="v2-settings-btn v2-settings-btn-danger"
+                        disabled={pushoverEmer.status === 'sending'}
+                        onClick={() => setEmergencyConfirm(true)}
+                      >
+                        {pushoverEmer.status === 'sending' ? 'Triggering…' : pushoverEmer.status === 'sent' ? 'Alarm sent ✓' : 'Test emergency'}
+                      </button>
+                    </div>
+                    {pushoverTest.status === 'error' && pushoverTest.error && (
+                      <div className="v2-integrations-error">{pushoverTest.error}</div>
+                    )}
+                    {pushoverEmer.status === 'error' && pushoverEmer.error && (
+                      <div className="v2-integrations-error">{pushoverEmer.error}</div>
+                    )}
+                    <div className="v2-integrations-hint" style={{ marginTop: 6 }}>
+                      Configure which notification types fire over Pushover in the Notifications tab.
+                    </div>
+                  </div>
+                )}
               </div>
-              <button
-                className="v2-settings-btn"
-                onClick={switchToV1}
-                title={`Open ${int.v1Section} in v1`}
-              >
-                {int.connected ? 'Manage in v1' : 'Connect in v1'}
-              </button>
+              {int.inline !== 'pushover' && (
+                <button
+                  className="v2-settings-btn"
+                  onClick={switchToV1}
+                  title={`Open ${int.v1Section} in v1`}
+                >
+                  {int.connected ? 'Manage in v1' : 'Connect in v1'}
+                </button>
+              )}
             </li>
           ))}
         </ul>
       </div>
 
+      {emergencyConfirm && (
+        <div className="v2-settings-confirm-overlay" onClick={() => setEmergencyConfirm(false)}>
+          <div className="v2-settings-confirm" onClick={e => e.stopPropagation()}>
+            <div className="v2-settings-confirm-title">Trigger Emergency alarm?</div>
+            <div className="v2-settings-confirm-message">
+              This will fire a priority-2 Pushover alarm on your iOS device that repeats every 30 seconds and bypasses Do Not Disturb. The alarm auto-cancels after about 90 seconds.
+            </div>
+            <div className="v2-settings-confirm-actions">
+              <button className="v2-settings-btn" onClick={() => setEmergencyConfirm(false)}>Cancel</button>
+              <button
+                className="v2-settings-btn v2-settings-btn-danger"
+                onClick={() => { setEmergencyConfirm(false); runPushoverTest(true) }}
+              >
+                Trigger
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
       <div className="v2-settings-block">
         <div className="v2-form-label">Why v1 for OAuth?</div>
         <div className="v2-settings-row-hint">
-          OAuth flows for Notion / Trello / Google Calendar / Gmail / Pushover each have 4–8 UI
+          OAuth flows for Notion / Trello / Google Calendar / Gmail each have 4–8 UI
           states (consent prompt, callback handling, calendar picker, scope error, env-var
           override, disconnect with confirmation). v2 will absorb them in a future release;
           for now, v1 → Settings → Integrations does the work, and the resulting tokens are

--- a/wiki/V2-State.md
+++ b/wiki/V2-State.md
@@ -90,7 +90,7 @@ These are daily-use gaps that users would notice:
 - [x] ~~**Sort dropdown** above v2 task list.~~ Landed 2026-05-09 in `TaskListToolbar`. Persists via `settings.sort_by`. Options: age / due-date / size / name.
 - [x] ~~**Tag filter pills** above v2 task list.~~ Landed 2026-05-09 in `TaskListToolbar`. Horizontal pill row: All + each user label (active pill takes the label's color) + Routines (opens RoutinesModal). Empty-state messaging updated for filtered-to-zero.
 - [x] ~~**Search bar + results view** in v2.~~ Landed 2026-05-09 in `TaskListToolbar`. Search icon next to sort flips the toolbar into search mode (input + close, Esc closes). Debounced 300ms fetch to `/api/tasks?q=`; results render as a single section with count chip in place of the regular task list. Searches every task (active, done, backlog, project) per the v1 endpoint behavior.
-- [ ] **Pushover credential entry + test buttons** in v2 Integrations. Currently can't set up Pushover in v2 at all.
+- [x] ~~**Pushover credential entry + test buttons** in v2 Integrations.~~ Landed 2026-05-09. Inline user-key + app-token password fields, "Test" (priority-0) and "Test emergency" (priority-2 with v2 confirm dialog) buttons, status feedback, env-override notice. Pushover moved out of the OAuth-deferred bucket since it's actually credential-only.
 - [ ] **Anthropic API key entry + model picker + status check** in v2 AI tab.
 - [ ] **Manual sync triggers** (Trello / Notion / GCal / Gmail Sync-Now buttons) in v2 Integrations. Background syncs run; manual one-shots don't have UI.
 

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,15 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-09
 
+- feat(ui): v2 Pushover credential entry + test buttons in Integrations [S]
+  - **Why.** Pushover can't be set up from v2 at all today — clicking the row just punted to v1. But Pushover is credential-only (user_key + app_token, no OAuth flow), so the v1 punt was overkill. Ship-blocker on the v2 polish list.
+  - **Inline form.** Reclassified Pushover from OAuth-deferred to `inline: 'pushover'` in `IntegrationsPanel`. Two password inputs (user_key + app_token), with the app_token field placeholder + disabled state respecting `pushoverStatus.app_token_from_env`. Hint copy points users at the Notifications tab for type-by-type Pushover toggles.
+  - **Test buttons.** "Test" (priority-0, fires immediately) and "Test emergency" (priority-2, opens a v2 confirm dialog first since it triggers the bypass-DND alarm). Both show transient sending → sent ✓ → idle states; errors render inline in v2-alert-overdue red. Wired through dynamic-imported `testPushover` / `testPushoverEmergency` from api.js so the panel doesn't pull the test functions into the main bundle.
+  - **OAuth-deferral copy updated.** "OAuth-heavy integrations" line at the top + "OAuth flows for Notion / Trello / Google Calendar / Gmail / Pushover" line at the bottom both drop Pushover from the punt list. Anthropic + 17track + Pushover are now the three inline-credential integrations.
+  - **CSS.** `.v2-integrations-inline` now flex-column with gap so multiple inputs stack cleanly. New `.v2-integrations-actions` (flex row, wraps) and `.v2-integrations-error` (small alert-red copy).
+  - **Verification.** `npm run lint` clean (warnings only). `npm test` smoke test passes. Bundle: 705KB precache (up from 703KB).
+  - Modified: `src/v2/components/SettingsModal.jsx`, `src/v2/components/SettingsModal.css`, `wiki/V2-State.md`
+
 - feat(ui): v2 search bar + results view [S]
   - **Why.** Daily-use ship-blocker. v1 had a magnifier in the header; v2 had nothing — users had to flip back to v1 to find an old task by keyword.
   - **Search lives in TaskListToolbar.** Added a Search icon button next to the sort button. Click flips the toolbar into search mode: pills + sort + search-icon hidden, replaced by a Search-icon-prefixed input + X close button in the same row real estate (no layout shift). Esc closes too.


### PR DESCRIPTION
## Summary

Ship-blocker. Pushover is credential-only (user_key + app_token, no OAuth flow) but was being routed to v1 like the OAuth-heavy integrations — meaning users couldn't set up Pushover from v2 at all.

- `IntegrationsPanel` reclassifies Pushover as `inline: 'pushover'`. Two password inputs stacked, with the app_token field respecting `pushoverStatus.app_token_from_env`.
- "Test" button (priority-0) and "Test emergency" button (priority-2). Emergency opens a v2 confirm dialog first since it triggers a bypass-DND alarm.
- Sending → sent ✓ → idle transient states; errors render inline in alert red.
- `testPushover` / `testPushoverEmergency` are dynamic-imported so the test functions stay out of the main bundle.
- OAuth-deferral copy at the top + bottom of the Integrations panel both drop Pushover from the punt list. Anthropic + 17track + Pushover are now the three inline-credential integrations.

## Test plan
- [x] `npm run lint` clean (warnings only)
- [x] `npm test` smoke test passes — bundle 705KB
- [ ] CI build green
- [ ] Manual: open Settings → Integrations → Pushover. Paste user-key + app-token, click "Test" → "Sent ✓" feedback. Click "Test emergency" → confirm dialog → "Trigger" → emergency alarm fires.

https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_