### PR TITLE
docs(v2): log 5 known visual bugs from device screenshots [XS]

### DIFF
--- a/wiki/V2-State.md
+++ b/wiki/V2-State.md
@@ -115,11 +115,21 @@ These are daily-use gaps that users would notice:
 
 ### Deferred — wait for above to settle
 
-- [ ] **Dark-mode QA pass** across every v2 surface. Tokens defined; surfaces not visually audited at `data-theme="dark"`.
+- [ ] **Dark-mode QA pass** across every v2 surface. Tokens defined; surfaces not visually audited at `data-theme="dark"`. Bug 4 below is the canonical instance — toggling the dark-mode switch in v2 → General doesn't actually flip the theme on adjacent surfaces.
+
+### Known visual bugs (deferred — captured 2026-05-09 from device screenshots)
+
+These are real bugs the user logged from the live `:dev` build, intentionally parked until light-mode sizes/positions/colors stabilize. None of them block functionality; they're styling and layout polish. Pick from this list when revisiting v2 visual fit-and-finish.
+
+- [ ] **Bug 1 — Notification matrix cut off on narrow screens.** Settings → Notifications → "Notification types" type×channel table on mobile (dark mode). Header row is `TYPE / PUSH / EMAIL / PUSHOVER / EVERY` and the EVERY (frequency input) column gets clipped past the viewport's right edge. Whole table needs a rethink for ≤480px — likely options: stacked rows-per-type with channel chips inline, an accordion per type, or the freq input moved into an expansion drawer behind a tap-to-edit affordance. Reference: `NotificationsPanel` in `src/v2/components/SettingsModal.jsx`.
+- [ ] **Bug 2 — Quiet hours START/END time inputs overlapping; bypass-label input oversized.** Settings → Notifications → Quiet hours section. Native `<input type="time">` boxes appear to overlap on iOS Safari and the bypass-label text input spans the full content width when it only needs ~10 chars. Inputs in general feel too large in this section.
+- [ ] **Bug 3 — Quiet hours time selectors feel weird.** Same section as Bug 2. The native iOS time picker doesn't fit the v2 hairline aesthetic and the START/END pair feels disconnected. Consider a custom time picker (e.g. two number-spin inputs side by side) or at minimum tighter container styling.
+- [ ] **Bug 4 — Dark-mode toggle visual state desyncs from actual theme + General-tab number inputs are full-width.** Settings → General. Dark-mode toggle reads "ON" (orange filled track) but the modal body + underlying app render in light mode — toggling doesn't reach every surface (related to the broader Dark-mode QA item above). Separately: the number inputs (default due days, staleness, reframe, max open tasks) span the full content width when they only need to fit one or two digits. On small screens they'd read better small (~80px) and right-aligned in the row, with the label on the left.
+- [ ] **Bug 5 — Danger zone buttons look odd.** Settings → Data → Danger zone. The pink-bordered card holds two buttons of inconsistent visual weight: outline-style "Clear completed tasks" stacked above a solid red filled "Clear all data." Different button styles + left-justified pill stacking feel unbalanced. Either match button styles (both filled or both outline with the destructive variant differentiated by color only), or rethink the layout (full-width row, side-by-side, etc.).
 
 ### Final-mile cleanup
 
-- [ ] **Cherry-pick remaining main-only commits onto dev**: `c8ef380` (drop legacy `task.checklist` column), `3cdd943` (delete orphan API routes), `422c2ff` (skip-this-cycle in v1 — bring the `useRoutines.js` hook change so v2 can wire it up). Each is a separate small PR via the MCP loop. The npm-audit cherry-pick (`c00d520`) already landed on dev as `9b48196` (PR #22, 2026-05-09).
+- [ ] **Cherry-pick remaining main-only commits onto dev**: `c8ef380` (drop legacy `task.checklist` column), `3cdd943` (delete orphan API routes). Each is a separate small PR via the MCP loop. The npm-audit cherry-pick (`c00d520`) already landed on dev as `9b48196` (PR #22, 2026-05-09). The skip-this-cycle hook change from `422c2ff` was ported manually as part of PR #24 (v2 RoutinesModal Skip button); v1 wiring intentionally skipped since v1 is frozen and gets deleted in the end-state cleanup below.
 - [ ] **End-state cleanup** (per `/root/.claude/plans/ui-redesign-ideas-i-iridescent-wren.md`): once v2 is validated, delete `src/AppV1.jsx` + `src/components/` and rename `src/v2/components/` → `src/components/`. Leave `?ui=v1` working for one release for safety.
 - [ ] **Stranded `test-push-probe` branch** on origin can't be deleted via the proxy or MCP — needs the GitHub UI. Pointed at `a87103e` from the original 2026-05-03 diagnostic.
 

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,10 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-09
 
+- docs(v2): log 5 known visual bugs from device screenshots [XS]
+  - User reported 5 visual bugs from the live `:dev` build via screenshots: Notifications matrix cut off on narrow screens (Bug 1), Quiet hours time inputs overlap + bypass-label input oversized (Bug 2), time selectors feel disconnected (Bug 3), Dark-mode toggle desyncs from actual theme + General-tab number inputs full-width (Bug 4), Danger zone buttons inconsistent (Bug 5). Captured in V2-State.md "Known visual bugs (deferred)" with reproduction context and fix-direction hints. None block functionality — parked until light-mode polish settles. Also updated the dark-mode QA bullet to reference Bug 4 as the canonical instance, and the final-mile cherry-pick bullet to drop `422c2ff` from the skip-cycle entry (the hook port already landed via PR #24).
+  - Modified: `wiki/V2-State.md`
+
 - feat(ui): v2 Anthropic key entry + status check in AI tab [S]
   - **Why.** Ship-blocker. AI tab had a "Open v1 → AI" punt button for the entire API-key flow; users couldn't configure Claude from v2 at all. Notion/Trello-class punts make sense (heavy OAuth flows); Anthropic doesn't (pure key entry).
   - **`AnthropicKeyBlock`.** New sub-component in the AI tab. Loads `getKeyStatus()` on mount to detect `ANTHROPIC_API_KEY` env var. If env-set: read-only notice + a Test button. If user-set: password input (with show/hide toggle for verifying paste), Test button, Disconnect button (clears the key + resets status). Test calls `api.callClaude('Respond with just "ok".', 'ping')`. Status states: null / 'checking' / 'connected' / 'error', surfaced as a live status line below the controls.


### PR DESCRIPTION
## Summary

User reported 5 visual bugs via device screenshots of the live `:dev` build. Captured in `V2-State.md` under a new "Known visual bugs (deferred)" section with reproduction context and fix-direction hints. None block functionality — parked until light-mode polish settles.

1. **Notifications matrix cut off on narrow screens.** `EVERY` (frequency) column clipped past viewport's right edge on mobile.
2. **Quiet hours time inputs overlapping; bypass-label input oversized.** Native `<input type="time">` boxes overlap on iOS Safari; bypass-label text input spans full width when ~10 chars suffices.
3. **Quiet hours time selectors feel weird.** Native iOS time picker doesn't fit the v2 hairline aesthetic; START/END pair feels disconnected.
4. **Dark-mode toggle desyncs from actual theme + General number inputs full-width.** Toggle reads ON but adjacent surfaces stay light. Number inputs span full content width; better small + right-aligned on small screens.
5. **Danger zone buttons inconsistent visual weight.** Outline + filled mix feels unbalanced.

Also: Bug 4 referenced from the existing "Dark-mode QA pass" deferred bullet as the canonical instance. Final-mile cherry-pick bullet updated to drop `422c2ff` (the skip-cycle hook port already landed via PR #24).

## Test plan
- [x] Doc-only — no code change, no lint/test impact

https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_