### PR TITLE
feat(ui): v2 manual sync triggers (Trello / Notion / GCal / Gmail) in Integrations [M]

### DIFF
--- a/src/v2/AppV2.jsx
+++ b/src/v2/AppV2.jsx
@@ -34,6 +34,8 @@ import { useAdviser } from '../hooks/useAdviser'
 import { useIsDesktop } from '../hooks/useIsDesktop'
 import { useWeather } from '../hooks/useWeather'
 import { useTrelloSync } from '../hooks/useTrelloSync'
+import { useNotionSync } from '../hooks/useNotionSync'
+import { useGCalSync } from '../hooks/useGCalSync'
 import { inferSize, trelloUpdateCard } from '../api'
 import { loadLabels, loadSettings, saveSettings, saveLabels, sortTasks } from '../store'
 import './AppV2.css'
@@ -98,7 +100,12 @@ export default function AppV2() {
   usePackageNotifications(packages)
   // Trello status push lives at this level so handleComplete / status-change
   // / handleUncomplete can fire it for any task with a linked Trello card.
-  const { pushStatusToTrello } = useTrelloSync(tasks, setTasks, changeStatus)
+  const { pushStatusToTrello, syncTrello, syncing: trelloSyncing } = useTrelloSync(tasks, setTasks, changeStatus)
+  // Notion + GCal pull-syncs. Both also auto-fire on mount + visibility-change
+  // when configured — matching v1 behavior. v2 previously didn't run them at
+  // all, so the dev image was silently missing inbound Notion/GCal sync.
+  const { syncing: notionSyncing, syncNotion } = useNotionSync(tasks, setTasks)
+  const { syncing: gcalSyncing, syncGCal } = useGCalSync(tasks, setTasks)
 
   // Server hydration + cross-client sync. Mirror v1's hydrateFromServer so
   // settings + labels stay in localStorage when other clients update them.
@@ -512,6 +519,12 @@ export default function AppV2() {
         onClearCompleted={() => { clearCompleted(); setShowSettings(false); flushSync() }}
         onClearAll={() => { clearAll(); setShowSettings(false); flushSync() }}
         onShowActivityLog={() => setShowActivityLog(true)}
+        onTrelloSync={syncTrello}
+        trelloSyncing={trelloSyncing}
+        onNotionSync={syncNotion}
+        notionSyncing={notionSyncing}
+        onGCalSync={syncGCal}
+        gcalSyncing={gcalSyncing}
       />
       <ProjectsView
         open={showProjects}

--- a/src/v2/components/SettingsModal.css
+++ b/src/v2/components/SettingsModal.css
@@ -758,3 +758,17 @@
   font: 500 12px/1.4 var(--v2-font-body);
   color: var(--v2-energy-errand);
 }
+
+.v2-integrations-row-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.v2-integrations-sync-result {
+  margin-top: 6px;
+  font: 500 12px/1.4 var(--v2-font-body);
+  color: var(--v2-energy-errand);
+}

--- a/src/v2/components/SettingsModal.jsx
+++ b/src/v2/components/SettingsModal.jsx
@@ -293,12 +293,32 @@ function AnthropicKeyBlock({ settings, update }) {
   )
 }
 
-function IntegrationsPanel({ settings, update, switchToV1, setActiveTab }) {
+function IntegrationsPanel({
+  settings, update, switchToV1, setActiveTab,
+  onTrelloSync, trelloSyncing, onNotionSync, notionSyncing, onGCalSync, gcalSyncing,
+}) {
   const [envKeys, setEnvKeys] = useState({ anthropic: false, notion: false, trello: false, tracking: false })
   const [statuses, setStatuses] = useState({})
   const [pushoverTest, setPushoverTest] = useState({ status: null, error: null })
   const [pushoverEmer, setPushoverEmer] = useState({ status: null, error: null })
   const [emergencyConfirm, setEmergencyConfirm] = useState(false)
+  const [gmailSyncing, setGmailSyncing] = useState(false)
+  const [gmailSyncResult, setGmailSyncResult] = useState(null)
+
+  const runGmailSync = async () => {
+    setGmailSyncing(true)
+    setGmailSyncResult(null)
+    try {
+      const api = await import('../../api')
+      const result = await api.gmailSync(settings.gmail_scan_days || 7)
+      setGmailSyncResult(`${result.tasksCreated || 0} task(s), ${result.packagesCreated || 0} package(s)`)
+      setTimeout(() => setGmailSyncResult(null), 6000)
+    } catch (e) {
+      setGmailSyncResult(`Error: ${e?.message || 'Sync failed'}`)
+    } finally {
+      setGmailSyncing(false)
+    }
+  }
 
   // Load env-key flags + each integration's connection status on mount.
   // Failures are silent — a missing status just leaves the dot grey.
@@ -334,6 +354,7 @@ function IntegrationsPanel({ settings, update, switchToV1, setActiveTab }) {
       hint: 'Pull pages as tasks, sync edits both ways. MCP-based connection (recommended).',
       connected: !!statuses.notion?.connected,
       v1Section: 'Integrations → Notion',
+      sync: onNotionSync && settings.notion_sync_parent_id ? { fn: onNotionSync, busy: notionSyncing } : null,
     },
     {
       key: 'trello',
@@ -341,6 +362,7 @@ function IntegrationsPanel({ settings, update, switchToV1, setActiveTab }) {
       hint: 'Push tasks to Trello with checklists + attachments. Bidirectional status sync.',
       connected: !!statuses.trello?.connected,
       v1Section: 'Integrations → Trello',
+      sync: onTrelloSync && settings.trello_sync_enabled ? { fn: onTrelloSync, busy: trelloSyncing } : null,
     },
     {
       key: 'gcal',
@@ -349,6 +371,7 @@ function IntegrationsPanel({ settings, update, switchToV1, setActiveTab }) {
       connected: !!statuses.gcal?.connected,
       sub: statuses.gcal?.email,
       v1Section: 'Integrations → Google Calendar',
+      sync: onGCalSync && settings.gcal_pull_enabled ? { fn: onGCalSync, busy: gcalSyncing } : null,
     },
     {
       key: 'gmail',
@@ -357,6 +380,8 @@ function IntegrationsPanel({ settings, update, switchToV1, setActiveTab }) {
       connected: !!statuses.gmail?.connected,
       sub: statuses.gmail?.email,
       v1Section: 'Integrations → Gmail',
+      sync: statuses.gmail?.connected ? { fn: runGmailSync, busy: gmailSyncing } : null,
+      syncResult: gmailSyncResult,
     },
     {
       key: 'tracking',
@@ -479,26 +504,42 @@ function IntegrationsPanel({ settings, update, switchToV1, setActiveTab }) {
                     </div>
                   </div>
                 )}
+                {int.syncResult && (
+                  <div className="v2-integrations-sync-result">{int.syncResult}</div>
+                )}
               </div>
-              {int.inline !== 'pushover' && (
-                int.manageInTab ? (
+              <div className="v2-integrations-row-actions">
+                {int.sync && (
                   <button
                     className="v2-settings-btn"
-                    onClick={() => setActiveTab(int.manageInTab)}
-                    title={`Open ${int.manageInTab} tab`}
+                    onClick={() => int.sync.fn()}
+                    disabled={int.sync.busy}
+                    title="Pull/refresh from this integration"
                   >
-                    Configure in {int.manageInTab}
+                    <RefreshCw size={13} strokeWidth={1.75} className={int.sync.busy ? 'v2-spinner' : ''} />
+                    {int.sync.busy ? 'Syncing…' : 'Sync now'}
                   </button>
-                ) : (
-                  <button
-                    className="v2-settings-btn"
-                    onClick={switchToV1}
-                    title={`Open ${int.v1Section} in v1`}
-                  >
-                    {int.connected ? 'Manage in v1' : 'Connect in v1'}
-                  </button>
-                )
-              )}
+                )}
+                {int.inline !== 'pushover' && (
+                  int.manageInTab ? (
+                    <button
+                      className="v2-settings-btn"
+                      onClick={() => setActiveTab(int.manageInTab)}
+                      title={`Open ${int.manageInTab} tab`}
+                    >
+                      Configure in {int.manageInTab}
+                    </button>
+                  ) : (
+                    <button
+                      className="v2-settings-btn"
+                      onClick={switchToV1}
+                      title={`Open ${int.v1Section} in v1`}
+                    >
+                      {int.connected ? 'Manage in v1' : 'Connect in v1'}
+                    </button>
+                  )
+                )}
+              </div>
             </li>
           ))}
         </ul>
@@ -853,6 +894,7 @@ function ServerLogsPanel() {
 
 export default function SettingsModal({
   open, onClose, onFlush, onClearCompleted, onClearAll, onShowActivityLog,
+  onTrelloSync, trelloSyncing, onNotionSync, notionSyncing, onGCalSync, gcalSyncing,
 }) {
   const [activeTab, setActiveTab] = useState('Beta')
   const [settings, setSettings] = useState(() => loadSettings())
@@ -1170,7 +1212,18 @@ export default function SettingsModal({
         )}
 
         {activeTab === 'Integrations' && (
-          <IntegrationsPanel settings={settings} update={update} switchToV1={switchToV1} setActiveTab={setActiveTab} />
+          <IntegrationsPanel
+            settings={settings}
+            update={update}
+            switchToV1={switchToV1}
+            setActiveTab={setActiveTab}
+            onTrelloSync={onTrelloSync}
+            trelloSyncing={trelloSyncing}
+            onNotionSync={onNotionSync}
+            notionSyncing={notionSyncing}
+            onGCalSync={onGCalSync}
+            gcalSyncing={gcalSyncing}
+          />
         )}
 
         {activeTab === 'Logs' && <ServerLogsPanel />}

--- a/wiki/V2-State.md
+++ b/wiki/V2-State.md
@@ -9,7 +9,7 @@ up the work in a future session.
 ## TL;DR
 
 - **v2 is the default UI** since `b1f2e76` (PR6 cutover, 2026-05-03). `?ui=v1` reverts.
-- **Every v1 surface has a v2 implementation.** All 8 Settings tabs, all task-flow modals, KanbanBoard on desktop, swipe gestures on mobile, weather badges, Trello status push, routine cadence advancing on complete, multi-list checklists.
+- **Every v1 surface has a v2 implementation.** All 8 Settings tabs, all task-flow modals, KanbanBoard on desktop, swipe gestures on mobile, weather badges, Trello status push, routine cadence advancing on complete, multi-list checklists. As of 2026-05-09, all six v2-polish ship-blockers have landed (skip-this-cycle, sort+filter pills, search, Pushover credentials, Anthropic key, manual sync triggers). Visual bugs deferred per the "Known visual bugs" section below.
 - **Dev-merge workflow is locked in.** Direct push to `refs/heads/dev` still 403s on the local proxy (status as of 2026-05-09). The MCP-PR-and-rebase-merge loop documented in CLAUDE.md is the canonical way work lands on `dev` — fully automated end-to-end with no GitHub-UI clicks.
 - **Dark-mode QA was deferred** at the user's request until light-mode sizes/positions/colors are dialed.
 
@@ -92,7 +92,7 @@ These are daily-use gaps that users would notice:
 - [x] ~~**Search bar + results view** in v2.~~ Landed 2026-05-09 in `TaskListToolbar`. Search icon next to sort flips the toolbar into search mode (input + close, Esc closes). Debounced 300ms fetch to `/api/tasks?q=`; results render as a single section with count chip in place of the regular task list. Searches every task (active, done, backlog, project) per the v1 endpoint behavior.
 - [x] ~~**Pushover credential entry + test buttons** in v2 Integrations.~~ Landed 2026-05-09. Inline user-key + app-token password fields, "Test" (priority-0) and "Test emergency" (priority-2 with v2 confirm dialog) buttons, status feedback, env-override notice. Pushover moved out of the OAuth-deferred bucket since it's actually credential-only.
 - [x] ~~**Anthropic API key entry + status check** in v2 AI tab.~~ Landed 2026-05-09. New `AnthropicKeyBlock` in the AI tab: env-var notice OR password input with show/hide toggle, "Test" button (calls `callClaude("ok")` ping), Disconnect, status feedback (Checking… / Connected ✓ / error message). Integrations panel's Anthropic row now points users at the AI tab via "Configure in AI" rather than punting to v1. **Model picker** dropped from scope — neither v1 nor server-side has a user-facing model selector today (both `ADVISER_MODEL` and other call sites are hardcoded). When that work happens, the picker can land in the same block.
-- [ ] **Manual sync triggers** (Trello / Notion / GCal / Gmail Sync-Now buttons) in v2 Integrations. Background syncs run; manual one-shots don't have UI.
+- [x] ~~**Manual sync triggers** (Trello / Notion / GCal / Gmail Sync-Now buttons) in v2 Integrations.~~ Landed 2026-05-09. AppV2 now mounts `useNotionSync` + `useGCalSync` (previously missing — the dev image was silently not running inbound Notion/GCal pull-sync), and exposes `syncTrello` / `syncNotion` / `syncGCal` to SettingsModal. IntegrationsPanel renders a "Sync now" button (RefreshCw icon, spinner while syncing) on each integration row when its inbound sync is configured: Trello (gated on `trello_sync_enabled`), Notion (gated on `notion_sync_parent_id`), GCal (gated on `gcal_pull_enabled`), Gmail (gated on connection status, calls `gmailSync(scan_days)` directly with task/package counts shown after).
 
 ### Medium priority
 

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,16 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-09
 
+- feat(ui): v2 manual sync triggers (Trello / Notion / GCal / Gmail) in Integrations [M]
+  - **Why.** Last v2 ship-blocker. v2 had no manual "Sync now" UI for any of the four pull-sync integrations — users had to flip back to v1 to trigger a one-shot sync. Worse: AppV2 wasn't even mounting `useNotionSync` or `useGCalSync`, so the auto-on-mount + visibility-change syncs that v1 runs were silently disabled on dev. This commit fixes both.
+  - **AppV2 hook wiring.** Added `useNotionSync(tasks, setTasks)` and `useGCalSync(tasks, setTasks)` imports and call sites alongside the existing `useTrelloSync`. Pulled `syncTrello` / `syncing: trelloSyncing` from the existing useTrelloSync call (was previously only consuming `pushStatusToTrello`). Threaded all three sync functions + their busy flags through to `<SettingsModal>` as new props.
+  - **IntegrationsPanel "Sync now" buttons.** New `sync` field on each integration descriptor — `{ fn, busy }`. Trello gated on `trello_sync_enabled`, Notion on `notion_sync_parent_id`, GCal on `gcal_pull_enabled`. Button uses `RefreshCw` icon with `v2-spinner` class while busy and "Syncing…" / "Sync now" labels.
+  - **Gmail.** Doesn't have a hook — handled inline via `runGmailSync()` in IntegrationsPanel. Dynamic-imports `gmailSync(gmail_scan_days)`, then surfaces a `syncResult` line under the row ("N task(s), M package(s)" or "Error: …") that auto-fades after 6 seconds.
+  - **Row layout.** `.v2-integrations-row-actions` is a vertical flex column on the right side of each row holding the Sync now button stacked above the existing Configure / Manage button. `.v2-integrations-sync-result` lives at the bottom of the meta column for the Gmail post-sync summary.
+  - **Behavior fix.** AppV2 now runs Notion + GCal pull-sync on mount + on visibility-change, matching v1 — fixes a silent regression where the dev image wasn't pulling inbound from those integrations at all.
+  - **Verification.** `npm run lint` clean (warnings only). `npm test` smoke test passes. Bundle: 709KB precache (up from 707KB).
+  - Modified: `src/v2/AppV2.jsx`, `src/v2/components/SettingsModal.jsx`, `src/v2/components/SettingsModal.css`, `wiki/V2-State.md`
+
 - docs(v2): park "terminal-aesthetic theme" idea (init.habits inspiration) [XS]
   - User shared a screenshot of [init.habits](https://inithabits.com) — monospace + ASCII checkboxes + terminal palette + command-prompt header. Logged as a future-direction parking-lot bullet in V2-State.md: a possible third theme tier beyond light/dark via a new `data-ui` mode that swaps `tokens.css`. Explicitly not a v2 ship item; post-dev→main experiment.
   - Modified: `wiki/V2-State.md`


### PR DESCRIPTION
## Summary

Last v2 ship-blocker. Two fixes in one commit:

1. **Behavior fix** — AppV2 was missing `useNotionSync` + `useGCalSync` entirely, so the auto-on-mount + visibility-change pull syncs that v1 runs were silently disabled on dev. Wired both up; inbound Notion/GCal sync now works like v1.
2. **UI** — `IntegrationsPanel` renders a "Sync now" button per integration when its inbound sync is configured. Trello gated on `trello_sync_enabled`, Notion on `notion_sync_parent_id`, GCal on `gcal_pull_enabled`. Gmail doesn't have a hook so it's handled inline via `gmailSync(gmail_scan_days)` with task/package counts shown after.

Row layout adds a vertical `.v2-integrations-row-actions` column on the right side, stacking Sync now above the existing Configure / Manage button. Gmail's post-sync result line lives at the bottom of the meta column.

## Test plan
- [x] `npm run lint` clean (warnings only)
- [x] `npm test` smoke test passes — bundle 709KB
- [ ] CI build green
- [ ] Manual: Settings → Integrations → connected integration → "Sync now" → spinner → success. Gmail shows "N task(s), M package(s)" line after.

## All ship-blockers down

With this PR, all six v2 polish ship-blockers from V2-State have landed (skip-this-cycle, sort+filter, search, Pushover credentials, Anthropic key, manual sync triggers). Visual bugs from yesterday's screenshots are still queued.

https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_