### PR TITLE
fix(ui): v2 visual bugs from device screenshots [M]

### DIFF
--- a/src/v2/AppV2.jsx
+++ b/src/v2/AppV2.jsx
@@ -72,9 +72,19 @@ export default function AppV2() {
   const isDesktop = useIsDesktop()
   const weather = useWeather()
 
-  // Mark the document so v2-namespaced tokens activate.
+  // Mark the document so v2-namespaced tokens activate. Also apply the saved
+  // theme on mount so the rendered UI matches whatever the Settings dark-mode
+  // toggle reads — without this, settings.theme could be 'dark' (carried over
+  // from another device or previous session) but data-theme would be unset,
+  // making the modal say ON while the rest of the app renders light.
   useEffect(() => {
     document.documentElement.setAttribute('data-ui', 'v2')
+    const theme = loadSettings().theme
+    if (theme === 'dark' || theme === 'light') {
+      document.documentElement.setAttribute('data-theme', theme)
+      const meta = document.querySelector('meta[name="theme-color"]')
+      if (meta) meta.content = theme === 'dark' ? '#0B0B0F' : '#FFFFFF'
+    }
     return () => { document.documentElement.removeAttribute('data-ui') }
   }, [])
 

--- a/src/v2/components/SettingsModal.css
+++ b/src/v2/components/SettingsModal.css
@@ -188,6 +188,39 @@
   margin-top: 8px;
 }
 
+/* Compact input that lives in the right half of a v2-settings-row.
+ * Used for the General tab numeric settings + the bypass-label text input. */
+.v2-settings-compact-input {
+  width: 80px;
+  flex-shrink: 0;
+  padding: 8px 10px;
+  font: 500 14px/1 var(--v2-font-body);
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+.v2-settings-compact-input-wide {
+  width: 140px;
+  text-align: left;
+}
+
+/* Quiet hours START/END time inputs sit side-by-side without spanning the row. */
+.v2-settings-quiet-times {
+  display: flex;
+  gap: 12px;
+  margin-top: 12px;
+  flex-wrap: wrap;
+}
+.v2-settings-quiet-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.v2-settings-time-input {
+  width: 110px;
+  padding: 8px 10px;
+  font-variant-numeric: tabular-nums;
+}
+
 .v2-settings-actions {
   display: flex;
   flex-wrap: wrap;
@@ -258,6 +291,18 @@
 
 .v2-settings-danger .v2-form-label {
   color: var(--v2-alert-overdue);
+}
+
+.v2-settings-danger-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: 14px;
+}
+
+.v2-settings-btn-block {
+  width: 100%;
+  justify-content: center;
 }
 
 /* Logs panel */
@@ -566,78 +611,90 @@
 
 /* === Notifications tab === */
 
-.v2-notif-matrix-wrap {
+/* Card-per-type layout. One card holds the type label + freq input + a
+ * row of channel toggles. Works at any width — no more horizontal-scroll
+ * table that clipped on mobile. */
+.v2-notif-cards {
   margin-top: 12px;
-  overflow-x: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.v2-notif-card {
   border: 1px solid var(--v2-hairline);
   border-radius: 12px;
-  padding: 4px;
+  padding: 12px 14px;
+  background: var(--v2-surface);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
 }
 
-.v2-notif-matrix {
-  width: 100%;
-  border-collapse: collapse;
+.v2-notif-card-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
 }
 
-.v2-notif-matrix th {
-  padding: 10px 8px;
-  font: 600 10px/1 var(--v2-font-body);
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--v2-text-meta);
-  text-align: center;
-  border-bottom: 1px solid var(--v2-hairline);
-}
-
-.v2-notif-matrix th.v2-notif-matrix-type {
-  text-align: left;
-  padding-left: 12px;
-}
-
-.v2-notif-matrix td {
-  padding: 10px 8px;
-  text-align: center;
-  vertical-align: middle;
-  border-bottom: 1px solid var(--v2-hairline);
-}
-
-.v2-notif-matrix tr:last-child td {
-  border-bottom: none;
-}
-
-.v2-notif-matrix td.v2-notif-matrix-type {
-  text-align: left;
-  padding-left: 12px;
-  font: 500 13px/1.3 var(--v2-font-body);
+.v2-notif-card-label {
+  font: 600 14px/1.2 var(--v2-font-body);
   color: var(--v2-text);
-  white-space: nowrap;
 }
 
-.v2-notif-matrix td .v2-settings-toggle {
+.v2-notif-card-freq {
   display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
 }
 
-.v2-notif-matrix-freq {
+.v2-notif-card-freq-input {
   width: 64px;
   padding: 6px 8px;
-  border: 1px solid var(--v2-hairline);
-  border-radius: 8px;
-  background: var(--v2-bg);
-  color: var(--v2-text);
   font: 500 12px/1 var(--v2-font-body);
-  text-align: center;
+  text-align: right;
   font-variant-numeric: tabular-nums;
 }
 
-.v2-notif-matrix-freq:focus {
-  border-color: var(--v2-accent);
-  outline: none;
+.v2-notif-card-freq-unit {
+  font: 500 12px/1 var(--v2-font-body);
+  color: var(--v2-text-meta);
 }
 
-.v2-notif-matrix-freq-na {
-  color: var(--v2-text-faint);
-  font-size: 18px;
-  line-height: 1;
+.v2-notif-card-channels {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+}
+
+.v2-notif-card-channel {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 4px;
+  border-radius: 8px;
+  background: rgba(var(--v2-text-rgb), 0.03);
+  cursor: pointer;
+  transition: background var(--v2-dur-quick) var(--v2-ease-standard);
+}
+
+.v2-notif-card-channel:hover {
+  background: rgba(var(--v2-text-rgb), 0.06);
+}
+
+.v2-notif-card-channel-label {
+  font: 600 10px/1 var(--v2-font-body);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--v2-text-meta);
+}
+
+.v2-notif-card-channel-disabled {
+  opacity: 0.4;
+  pointer-events: none;
 }
 
 .v2-notif-stages {
@@ -659,13 +716,6 @@
 @media (max-width: 600px) {
   .v2-notif-stages {
     grid-template-columns: 1fr;
-  }
-  .v2-notif-matrix th,
-  .v2-notif-matrix td {
-    padding: 8px 4px;
-  }
-  .v2-notif-matrix-type {
-    font-size: 12px !important;
   }
 }
 

--- a/src/v2/components/SettingsModal.jsx
+++ b/src/v2/components/SettingsModal.jsx
@@ -615,88 +615,70 @@ function NotificationsPanel({ settings, update }) {
         ))}
       </div>
 
-      {/* Per-type × per-channel matrix */}
+      {/* Per-type × per-channel — card-per-type layout works at any width */}
       <div className="v2-settings-block">
         <div className="v2-form-label">Notification types</div>
-        <div className="v2-settings-row-hint">Each row toggles per channel. Frequency is the cooldown between repeats.</div>
-        <div className="v2-notif-matrix-wrap">
-          <table className="v2-notif-matrix">
-            <thead>
-              <tr>
-                <th className="v2-notif-matrix-type">Type</th>
-                <th>Push</th>
-                <th>Email</th>
-                <th>Pushover</th>
-                <th>Every (h)</th>
-              </tr>
-            </thead>
-            <tbody>
-              {NOTIF_TYPES.map(t => (
-                <tr key={t.key}>
-                  <td className="v2-notif-matrix-type">{t.label}</td>
-                  <td>
+        <div className="v2-settings-row-hint">Each card toggles a notification type per channel. Frequency is the cooldown between repeats.</div>
+        <div className="v2-notif-cards">
+          {NOTIF_TYPES.map(t => (
+            <div key={t.key} className="v2-notif-card">
+              <div className="v2-notif-card-head">
+                <div className="v2-notif-card-label">{t.label}</div>
+                <div className="v2-notif-card-freq">
+                  <input
+                    className="v2-form-input v2-notif-card-freq-input"
+                    type="number"
+                    min="0.25"
+                    max="168"
+                    step="0.25"
+                    value={settings[t.freqKey] ?? t.freqDefault}
+                    onChange={e => update(t.freqKey, Math.max(0.25, parseFloat(e.target.value) || 0.25))}
+                    aria-label={`${t.label} frequency in hours`}
+                  />
+                  <span className="v2-notif-card-freq-unit">h</span>
+                </div>
+              </div>
+              <div className="v2-notif-card-channels">
+                {[
+                  { key: 'push', master: 'push_notifications_enabled', defaultOn: true },
+                  { key: 'email', master: 'email_notifications_enabled', defaultOn: true },
+                  { key: 'pushover', master: 'pushover_notifications_enabled', defaultOn: false },
+                ].map(c => (
+                  <label key={c.key} className={`v2-notif-card-channel${settings[c.master] !== true ? ' v2-notif-card-channel-disabled' : ''}`}>
                     <Toggle
-                      checked={settings[`push_notif_${t.key}`] !== false}
-                      onChange={e => update(`push_notif_${t.key}`, e.target.checked)}
-                      disabled={settings.push_notifications_enabled !== true}
+                      checked={c.defaultOn ? settings[`${c.key}_notif_${t.key}`] !== false : settings[`${c.key}_notif_${t.key}`] === true}
+                      onChange={e => update(`${c.key}_notif_${t.key}`, e.target.checked)}
+                      disabled={settings[c.master] !== true}
                     />
-                  </td>
-                  <td>
+                    <span className="v2-notif-card-channel-label">{c.key === 'push' ? 'Push' : c.key === 'email' ? 'Email' : 'Pushover'}</span>
+                  </label>
+                ))}
+              </div>
+            </div>
+          ))}
+          {NOTIF_PACKAGE_TYPES.map(t => (
+            <div key={t.key} className="v2-notif-card">
+              <div className="v2-notif-card-head">
+                <div className="v2-notif-card-label">{t.label}</div>
+              </div>
+              <div className="v2-notif-card-channels">
+                {[
+                  { key: 'push', master: 'push_notifications_enabled' },
+                  { key: 'email', master: 'email_notifications_enabled' },
+                  { key: 'pushover', master: 'pushover_notifications_enabled' },
+                ].map(c => (
+                  <label key={c.key} className={`v2-notif-card-channel${settings[c.master] !== true ? ' v2-notif-card-channel-disabled' : ''}`}>
                     <Toggle
-                      checked={settings[`email_notif_${t.key}`] !== false}
-                      onChange={e => update(`email_notif_${t.key}`, e.target.checked)}
-                      disabled={settings.email_notifications_enabled !== true}
+                      checked={settings[`${c.key}_notif_${t.key}`] !== false}
+                      onChange={e => update(`${c.key}_notif_${t.key}`, e.target.checked)}
+                      disabled={settings[c.master] !== true}
                     />
-                  </td>
-                  <td>
-                    <Toggle
-                      checked={settings[`pushover_notif_${t.key}`] === true}
-                      onChange={e => update(`pushover_notif_${t.key}`, e.target.checked)}
-                      disabled={settings.pushover_notifications_enabled !== true}
-                    />
-                  </td>
-                  <td>
-                    <input
-                      className="v2-notif-matrix-freq"
-                      type="number"
-                      min="0.25"
-                      max="168"
-                      step="0.25"
-                      value={settings[t.freqKey] ?? t.freqDefault}
-                      onChange={e => update(t.freqKey, Math.max(0.25, parseFloat(e.target.value) || 0.25))}
-                    />
-                  </td>
-                </tr>
-              ))}
-              {NOTIF_PACKAGE_TYPES.map(t => (
-                <tr key={t.key}>
-                  <td className="v2-notif-matrix-type">{t.label}</td>
-                  <td>
-                    <Toggle
-                      checked={settings[`push_notif_${t.key}`] !== false}
-                      onChange={e => update(`push_notif_${t.key}`, e.target.checked)}
-                      disabled={settings.push_notifications_enabled !== true}
-                    />
-                  </td>
-                  <td>
-                    <Toggle
-                      checked={settings[`email_notif_${t.key}`] !== false}
-                      onChange={e => update(`email_notif_${t.key}`, e.target.checked)}
-                      disabled={settings.email_notifications_enabled !== true}
-                    />
-                  </td>
-                  <td>
-                    <Toggle
-                      checked={settings[`pushover_notif_${t.key}`] !== false}
-                      onChange={e => update(`pushover_notif_${t.key}`, e.target.checked)}
-                      disabled={settings.pushover_notifications_enabled !== true}
-                    />
-                  </td>
-                  <td className="v2-notif-matrix-freq-na">—</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+                    <span className="v2-notif-card-channel-label">{c.key === 'push' ? 'Push' : c.key === 'email' ? 'Email' : 'Pushover'}</span>
+                  </label>
+                ))}
+              </div>
+            </div>
+          ))}
         </div>
       </div>
 
@@ -760,21 +742,21 @@ function NotificationsPanel({ settings, update }) {
           />
         </div>
         {settings.quiet_hours_enabled && (
-          <div className="v2-form-row" style={{ marginTop: 12 }}>
-            <div className="v2-form-field">
+          <div className="v2-settings-quiet-times">
+            <div className="v2-settings-quiet-field">
               <label className="v2-form-label">Start</label>
               <input
                 type="time"
-                className="v2-form-input"
+                className="v2-form-input v2-settings-time-input"
                 value={settings.quiet_hours_start || '22:00'}
                 onChange={e => update('quiet_hours_start', e.target.value)}
               />
             </div>
-            <div className="v2-form-field">
+            <div className="v2-settings-quiet-field">
               <label className="v2-form-label">End</label>
               <input
                 type="time"
-                className="v2-form-input"
+                className="v2-form-input v2-settings-time-input"
                 value={settings.quiet_hours_end || '08:00'}
                 onChange={e => update('quiet_hours_end', e.target.value)}
               />
@@ -782,11 +764,13 @@ function NotificationsPanel({ settings, update }) {
           </div>
         )}
         {settings.quiet_hours_enabled && (
-          <div className="v2-settings-block" style={{ marginTop: 12 }}>
-            <label className="v2-form-label">Bypass label</label>
-            <div className="v2-settings-row-hint">Tasks with this tag wake you even during quiet hours.</div>
+          <div className="v2-settings-row" style={{ marginTop: 12 }}>
+            <div className="v2-settings-row-text">
+              <label className="v2-settings-row-label">Bypass label</label>
+              <div className="v2-settings-row-hint">Tasks with this tag wake you even during quiet hours.</div>
+            </div>
             <input
-              className="v2-form-input v2-settings-narrow-input"
+              className="v2-form-input v2-settings-compact-input v2-settings-compact-input-wide"
               type="text"
               value={settings.quiet_hours_bypass_label || 'wake-me'}
               onChange={e => update('quiet_hours_bypass_label', e.target.value)}
@@ -1041,25 +1025,27 @@ export default function SettingsModal({
               <label className="v2-settings-toggle">
                 <input
                   type="checkbox"
-                  checked={(settings.theme || 'dark') === 'dark'}
+                  checked={settings.theme === 'dark'}
                   onChange={e => {
                     const theme = e.target.checked ? 'dark' : 'light'
                     update('theme', theme)
                     document.documentElement.setAttribute('data-theme', theme)
                     const meta = document.querySelector('meta[name="theme-color"]')
-                    if (meta) meta.content = theme === 'dark' ? '#0B0B0F' : '#F5F5F7'
+                    if (meta) meta.content = theme === 'dark' ? '#0B0B0F' : '#FFFFFF'
                   }}
                 />
                 <span className="v2-settings-toggle-track"><span className="v2-settings-toggle-thumb" /></span>
               </label>
             </div>
 
-            <div className="v2-settings-block">
-              <label className="v2-form-label" htmlFor="v2-default-due-days">Default due date (days from now)</label>
-              <div className="v2-settings-row-hint">0 means no default — tasks ship without a due date unless you pick one.</div>
+            <div className="v2-settings-row">
+              <div className="v2-settings-row-text">
+                <label className="v2-settings-row-label" htmlFor="v2-default-due-days">Default due date</label>
+                <div className="v2-settings-row-hint">Days from now. 0 = no default; tasks ship without a due date unless you pick one.</div>
+              </div>
               <input
                 id="v2-default-due-days"
-                className="v2-form-input v2-settings-narrow-input"
+                className="v2-form-input v2-settings-compact-input"
                 type="number"
                 min="0"
                 max="90"
@@ -1068,12 +1054,14 @@ export default function SettingsModal({
               />
             </div>
 
-            <div className="v2-settings-block">
-              <label className="v2-form-label" htmlFor="v2-staleness-days">Staleness threshold (days)</label>
-              <div className="v2-settings-row-hint">A task with no activity for this long shows up in the Stale section.</div>
+            <div className="v2-settings-row">
+              <div className="v2-settings-row-text">
+                <label className="v2-settings-row-label" htmlFor="v2-staleness-days">Staleness threshold</label>
+                <div className="v2-settings-row-hint">Days of inactivity before a task surfaces in the Stale section.</div>
+              </div>
               <input
                 id="v2-staleness-days"
-                className="v2-form-input v2-settings-narrow-input"
+                className="v2-form-input v2-settings-compact-input"
                 type="number"
                 min="1"
                 max="30"
@@ -1082,12 +1070,14 @@ export default function SettingsModal({
               />
             </div>
 
-            <div className="v2-settings-block">
-              <label className="v2-form-label" htmlFor="v2-reframe-threshold">Reframe trigger (snooze count)</label>
-              <div className="v2-settings-row-hint">After this many snoozes, tapping snooze opens the Reframe modal instead.</div>
+            <div className="v2-settings-row">
+              <div className="v2-settings-row-text">
+                <label className="v2-settings-row-label" htmlFor="v2-reframe-threshold">Reframe trigger</label>
+                <div className="v2-settings-row-hint">Snooze count after which tapping Snooze opens the Reframe modal instead.</div>
+              </div>
               <input
                 id="v2-reframe-threshold"
-                className="v2-form-input v2-settings-narrow-input"
+                className="v2-form-input v2-settings-compact-input"
                 type="number"
                 min="1"
                 max="20"
@@ -1096,12 +1086,14 @@ export default function SettingsModal({
               />
             </div>
 
-            <div className="v2-settings-block">
-              <label className="v2-form-label" htmlFor="v2-max-open">Max open tasks</label>
-              <div className="v2-settings-row-hint">Warns when you exceed this. 0 = no limit.</div>
+            <div className="v2-settings-row">
+              <div className="v2-settings-row-text">
+                <label className="v2-settings-row-label" htmlFor="v2-max-open">Max open tasks</label>
+                <div className="v2-settings-row-hint">Warns when you exceed this. 0 = no limit.</div>
+              </div>
               <input
                 id="v2-max-open"
-                className="v2-form-input v2-settings-narrow-input"
+                className="v2-form-input v2-settings-compact-input"
                 type="number"
                 min="0"
                 max="100"
@@ -1183,15 +1175,15 @@ export default function SettingsModal({
             <div className="v2-settings-danger">
               <div className="v2-form-label">Danger zone</div>
               <div className="v2-settings-row-hint">These wipe data. No undo other than restoring from a backup.</div>
-              <div className="v2-settings-actions">
+              <div className="v2-settings-danger-actions">
                 <button
-                  className="v2-settings-btn v2-settings-btn-danger"
+                  className="v2-settings-btn v2-settings-btn-danger v2-settings-btn-block"
                   onClick={onClearCompleted}
                 >
                   <Trash2 size={13} strokeWidth={1.75} /> Clear completed tasks
                 </button>
                 <button
-                  className="v2-settings-btn v2-settings-btn-danger v2-settings-btn-danger-strong"
+                  className="v2-settings-btn v2-settings-btn-danger v2-settings-btn-danger-strong v2-settings-btn-block"
                   onClick={() => setConfirmDialog({
                     title: 'Clear all data',
                     message: 'This will delete all tasks, settings, and history. Are you sure?',

--- a/wiki/V2-State.md
+++ b/wiki/V2-State.md
@@ -115,17 +115,18 @@ These are daily-use gaps that users would notice:
 
 ### Deferred — wait for above to settle
 
-- [ ] **Dark-mode QA pass** across every v2 surface. Tokens defined; surfaces not visually audited at `data-theme="dark"`. Bug 4 below is the canonical instance — toggling the dark-mode switch in v2 → General doesn't actually flip the theme on adjacent surfaces.
+- [ ] **Dark-mode QA pass** across every v2 surface. Tokens defined; surfaces not visually audited at `data-theme="dark"`. The dark-mode toggle desync was fixed (see Bug 4 in resolved list below) but a full surface-by-surface audit at `data-theme="dark"` is still pending.
 
-### Known visual bugs (deferred — captured 2026-05-09 from device screenshots)
+### Known visual bugs (resolved 2026-05-09)
 
-These are real bugs the user logged from the live `:dev` build, intentionally parked until light-mode sizes/positions/colors stabilize. None of them block functionality; they're styling and layout polish. Pick from this list when revisiting v2 visual fit-and-finish.
+All five bugs the user logged from device screenshots have been addressed:
 
-- [ ] **Bug 1 — Notification matrix cut off on narrow screens.** Settings → Notifications → "Notification types" type×channel table on mobile (dark mode). Header row is `TYPE / PUSH / EMAIL / PUSHOVER / EVERY` and the EVERY (frequency input) column gets clipped past the viewport's right edge. Whole table needs a rethink for ≤480px — likely options: stacked rows-per-type with channel chips inline, an accordion per type, or the freq input moved into an expansion drawer behind a tap-to-edit affordance. Reference: `NotificationsPanel` in `src/v2/components/SettingsModal.jsx`.
-- [ ] **Bug 2 — Quiet hours START/END time inputs overlapping; bypass-label input oversized.** Settings → Notifications → Quiet hours section. Native `<input type="time">` boxes appear to overlap on iOS Safari and the bypass-label text input spans the full content width when it only needs ~10 chars. Inputs in general feel too large in this section.
-- [ ] **Bug 3 — Quiet hours time selectors feel weird.** Same section as Bug 2. The native iOS time picker doesn't fit the v2 hairline aesthetic and the START/END pair feels disconnected. Consider a custom time picker (e.g. two number-spin inputs side by side) or at minimum tighter container styling.
-- [ ] **Bug 4 — Dark-mode toggle visual state desyncs from actual theme + General-tab number inputs are full-width.** Settings → General. Dark-mode toggle reads "ON" (orange filled track) but the modal body + underlying app render in light mode — toggling doesn't reach every surface (related to the broader Dark-mode QA item above). Separately: the number inputs (default due days, staleness, reframe, max open tasks) span the full content width when they only need to fit one or two digits. On small screens they'd read better small (~80px) and right-aligned in the row, with the label on the left.
-- [ ] **Bug 5 — Danger zone buttons look odd.** Settings → Data → Danger zone. The pink-bordered card holds two buttons of inconsistent visual weight: outline-style "Clear completed tasks" stacked above a solid red filled "Clear all data." Different button styles + left-justified pill stacking feel unbalanced. Either match button styles (both filled or both outline with the destructive variant differentiated by color only), or rethink the layout (full-width row, side-by-side, etc.).
+- [x] ~~**Bug 1 — Notification matrix cut off on narrow screens.**~~ Replaced the table with a card-per-type list. Each card shows the type label + freq input on top, a 3-column grid of channel toggles (Push / Email / Pushover) below. Works at any viewport width without horizontal scroll.
+- [x] ~~**Bug 2 — Quiet hours START/END inputs overlapping; bypass-label oversized.**~~ START/END now sit side-by-side as 110px-wide tight inputs (`.v2-settings-time-input`). Bypass-label is a 140px compact input on the right of a labeled row.
+- [x] ~~**Bug 3 — Quiet hours time selectors feel weird.**~~ Same fix as Bug 2 — tighter widths + smaller padding pull the START/END pair together visually. Native `<input type="time">` retained (a custom picker is over-engineering for a self-hosted personal app).
+- [x] ~~**Bug 4 part A — Dark-mode toggle desyncs from actual theme.**~~ AppV2 mount-effect now applies `data-theme` from `loadSettings().theme` so the toggle's reading and the rendered UI agree. Toggle's default also flipped from `(theme || 'dark')` to `theme === 'dark'` — v2 tokens default to light without `data-theme`, so the previous default-to-dark assumption was the desync source.
+- [x] ~~**Bug 4 part B — General-tab number inputs full-width.**~~ Restructured each numeric setting from a vertical stack (label / hint / full-width input) to a labeled row (label + hint on the left, 80px right-aligned input on the right). Same for the Bypass label text input (140px).
+- [x] ~~**Bug 5 — Danger zone buttons inconsistent.**~~ Both buttons now full-width-stacked (`.v2-settings-btn-block`) inside `.v2-settings-danger-actions` flex column. Outline-red "Clear completed tasks" sits above filled-red "Clear all data" — same width, same height, intentional fill-intensity step indicating destructiveness.
 
 ### Future-direction parking lot
 

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,17 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-09
 
+- fix(ui): v2 visual bugs from device screenshots — notif cards, quiet hours, settings rows, dark-mode init, danger zone [M]
+  - Five fixes for visual bugs the user logged from the live `:dev` build earlier today.
+  - **Bug 1 — notification matrix cut off on narrow screens.** Replaced the type×channel `<table>` with a card-per-type list. Each `.v2-notif-card` has type label + freq input on top, a 3-column grid of channel toggles (Push / Email / Pushover) below — labeled chips so the channel name doesn't need a header row. Works at any width without horizontal scroll. Same data shape, same toggles, same settings keys; just a different render.
+  - **Bug 2 + 3 — quiet hours inputs.** New `.v2-settings-quiet-times` flex row with `.v2-settings-time-input` (110px wide, 8px/10px padding) for the START/END time inputs. Bypass label moved into a labeled row using the new `.v2-settings-compact-input-wide` (140px). Native `<input type="time">` retained — a custom time picker is over-engineering for the use case.
+  - **Bug 4A — dark-mode toggle desyncs from actual theme.** Two-part fix. `AppV2.jsx` mount effect now reads `loadSettings().theme` and applies `data-theme` + `meta[name="theme-color"]` so the rendered UI matches whatever the toggle reads. Settings toggle default also flipped from `(theme || 'dark') === 'dark'` to `theme === 'dark'` — v2 tokens default to light when `data-theme` is unset, so the previous "default to dark in the toggle" assumption was the source of the desync.
+  - **Bug 4B — General-tab number inputs full-width.** Each numeric setting (default due days, staleness, reframe trigger, max open tasks) restructured from a vertical block (label / hint / full-width input) to a `.v2-settings-row` (label + hint on the left, 80px right-aligned `.v2-settings-compact-input` on the right). Reads cleaner on mobile.
+  - **Bug 5 — danger-zone buttons inconsistent.** Both buttons now stack full-width (`.v2-settings-btn-block`) inside `.v2-settings-danger-actions` flex column. Outline-red "Clear completed tasks" sits above filled-red "Clear all data" — same width, same height, intentional fill-intensity step indicating destructiveness.
+  - **Other.** Removed the orphan `@media (max-width: 600px)` rule that referenced the now-deleted `.v2-notif-matrix*` classes.
+  - **Verification.** `npm run lint` clean (warnings only). `npm test` smoke test passes. Bundle: 710KB precache (up from 709KB).
+  - Modified: `src/v2/AppV2.jsx`, `src/v2/components/SettingsModal.jsx`, `src/v2/components/SettingsModal.css`, `wiki/V2-State.md`
+
 - feat(ui): v2 manual sync triggers (Trello / Notion / GCal / Gmail) in Integrations [M]
   - **Why.** Last v2 ship-blocker. v2 had no manual "Sync now" UI for any of the four pull-sync integrations — users had to flip back to v1 to trigger a one-shot sync. Worse: AppV2 wasn't even mounting `useNotionSync` or `useGCalSync`, so the auto-on-mount + visibility-change syncs that v1 runs were silently disabled on dev. This commit fixes both.
   - **AppV2 hook wiring.** Added `useNotionSync(tasks, setTasks)` and `useGCalSync(tasks, setTasks)` imports and call sites alongside the existing `useTrelloSync`. Pulled `syncTrello` / `syncing: trelloSyncing` from the existing useTrelloSync call (was previously only consuming `pushStatusToTrello`). Threaded all three sync functions + their busy flags through to `<SettingsModal>` as new props.


### PR DESCRIPTION
## Summary

All 5 bugs you flagged via screenshots earlier today, fixed in one PR.

1. **Notification matrix cut off on narrow screens.** Replaced the type×channel `<table>` with a card-per-type list. Each card has type label + freq input on top, a 3-column grid of channel toggles below. Works at any width without horizontal scroll.
2. **Quiet hours START/END overlapping; bypass-label oversized.** New `.v2-settings-quiet-times` flex row with 110px-wide `.v2-settings-time-input` boxes side-by-side. Bypass label moved into a labeled row with a 140px compact input.
3. **Quiet hours selectors feel weird.** Same fix as #2 — tighter widths + smaller padding pull the START/END pair together. Native `<input type="time">` retained.
4. **Dark-mode toggle desyncs + General-tab inputs full-width.** AppV2 mount effect now applies `data-theme` from `settings.theme` so the rendered UI matches the toggle. Toggle default flipped from `(theme || 'dark')` to `theme === 'dark'` — v2 tokens default to light when `data-theme` is unset. Each numeric setting in General restructured from a vertical block to a labeled row with 80px right-aligned compact input.
5. **Danger zone buttons inconsistent.** Both buttons now full-width stacked inside `.v2-settings-danger-actions` flex column. Same width, same height, outline-red over filled-red.

## What's NOT in this PR

- Full dark-mode QA pass across every v2 surface (still deferred per V2-State).
- The skip-this-cycle / sort-filter / search / Pushover / Anthropic / manual-sync ship-blockers (already landed earlier today).

## Test plan
- [x] `npm run lint` clean (warnings only)
- [x] `npm test` smoke test passes — bundle 710KB
- [ ] CI build green
- [ ] Manual on iOS:
  - Settings → Notifications → matrix renders as cards, no overflow.
  - Quiet hours inputs sit tight side-by-side; bypass-label is compact.
  - Settings → General → dark-mode toggle reads matches the rendered theme. Number inputs are small + right-aligned.
  - Settings → Data → Danger zone has two same-width stacked buttons.

https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_