### PR TITLE
feat(ui): v2 channel test buttons + notification history [M]

### DIFF
--- a/src/v2/components/SettingsModal.css
+++ b/src/v2/components/SettingsModal.css
@@ -719,6 +719,107 @@
   }
 }
 
+/* Channel test buttons */
+.v2-notif-tests {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 12px;
+}
+.v2-notif-test-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+/* Notification history collapsible */
+.v2-notif-history-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 0;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: var(--v2-text);
+}
+.v2-notif-history-toggle .v2-form-label {
+  margin-bottom: 0;
+}
+.v2-notif-history-chev {
+  font: 600 16px/1 var(--v2-font-body);
+  color: var(--v2-text-meta);
+  width: 20px;
+  text-align: center;
+}
+.v2-notif-history {
+  margin-top: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.v2-notif-history-toolbar {
+  display: flex;
+  gap: 8px;
+}
+.v2-notif-history-empty {
+  padding: 18px 0;
+  text-align: center;
+  font: 400 12px/1.4 var(--v2-font-body);
+  color: var(--v2-text-meta);
+}
+.v2-notif-history-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  border: 1px solid var(--v2-hairline);
+  border-radius: 12px;
+  max-height: 360px;
+  overflow-y: auto;
+}
+.v2-notif-history-item {
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--v2-hairline);
+}
+.v2-notif-history-item:last-child {
+  border-bottom: none;
+}
+.v2-notif-history-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font: 600 10px/1 var(--v2-font-body);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--v2-text-meta);
+  margin-bottom: 4px;
+}
+.v2-notif-history-channel {
+  padding: 2px 6px;
+  border-radius: 4px;
+  background: rgba(var(--v2-text-rgb), 0.08);
+  color: var(--v2-text);
+}
+.v2-notif-history-type {
+  flex: 1;
+}
+.v2-notif-history-time {
+  color: var(--v2-text-faint);
+}
+.v2-notif-history-title {
+  font: 500 13px/1.3 var(--v2-font-body);
+  color: var(--v2-text);
+}
+.v2-notif-history-body {
+  font: 400 12px/1.4 var(--v2-font-body);
+  color: var(--v2-text-meta);
+  margin-top: 2px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
 /* === Integrations tab === */
 
 .v2-integrations-list {

--- a/src/v2/components/SettingsModal.jsx
+++ b/src/v2/components/SettingsModal.jsx
@@ -595,6 +595,56 @@ function NotificationsPanel({ settings, update }) {
     </label>
   )
 
+  // Channel test buttons — small per-button state machine: idle | sending | sent | error.
+  const [tests, setTests] = useState({})
+  const [emergencyConfirm, setEmergencyConfirm] = useState(false)
+
+  const runTest = async (key, fn) => {
+    setTests(prev => ({ ...prev, [key]: { status: 'sending' } }))
+    try {
+      const result = await fn()
+      if (result?.success === false) {
+        setTests(prev => ({ ...prev, [key]: { status: 'error', error: result.error || 'Send failed' } }))
+        return
+      }
+      const sentMsg = result?.fired ? `Sent via ${result.fired.join(', ')}` : null
+      setTests(prev => ({ ...prev, [key]: { status: 'sent', detail: sentMsg } }))
+      setTimeout(() => setTests(prev => ({ ...prev, [key]: { status: null } })), 4000)
+    } catch (e) {
+      setTests(prev => ({ ...prev, [key]: { status: 'error', error: e?.message || 'Send failed' } }))
+    }
+  }
+
+  // Notification history — last 50 entries from the server-side log.
+  const [history, setHistory] = useState(null)
+  const [historyOpen, setHistoryOpen] = useState(false)
+  const [historyLoading, setHistoryLoading] = useState(false)
+
+  const loadHistory = async () => {
+    setHistoryLoading(true)
+    try {
+      const api = await import('../../api')
+      const data = await api.getNotifLog(50)
+      setHistory(Array.isArray(data) ? data : (data?.entries || []))
+    } catch {
+      setHistory([])
+    } finally {
+      setHistoryLoading(false)
+    }
+  }
+
+  const clearHistory = async () => {
+    try {
+      const api = await import('../../api')
+      await api.clearServerNotifLog()
+      setHistory([])
+    } catch { /* no-op */ }
+  }
+
+  useEffect(() => {
+    if (historyOpen && history === null) loadHistory()
+  }, [historyOpen, history])
+
   return (
     <div className="v2-settings-form">
       {/* Channel masters */}
@@ -779,12 +829,133 @@ function NotificationsPanel({ settings, update }) {
         )}
       </div>
 
+      {/* Test channels — fire a one-off notification per channel to verify config */}
+      <div className="v2-settings-block">
+        <div className="v2-form-label">Test channels</div>
+        <div className="v2-settings-row-hint">Send a one-off test notification through each channel to verify it's working. Test buttons obey channel master toggles + Pushover credentials.</div>
+        <div className="v2-notif-tests">
+          {[
+            { key: 'push', label: 'Test push', enabled: settings.push_notifications_enabled === true,
+              fn: () => import('../../api').then(m => m.testPush()) },
+            { key: 'email', label: 'Test email', enabled: settings.email_notifications_enabled === true,
+              fn: () => import('../../api').then(m => m.testEmail()) },
+            { key: 'pushover', label: 'Test Pushover', enabled: settings.pushover_notifications_enabled === true && !!settings.pushover_user_key,
+              fn: () => import('../../api').then(m => m.testPushover({ userKey: settings.pushover_user_key, appToken: settings.pushover_app_token })) },
+            { key: 'digest', label: 'Test digest', enabled: settings.push_notifications_enabled || settings.email_notifications_enabled || settings.pushover_digest_enabled,
+              fn: () => import('../../api').then(m => m.testDigest()) },
+          ].map(t => {
+            const state = tests[t.key] || {}
+            return (
+              <div key={t.key} className="v2-notif-test-row">
+                <button
+                  className="v2-settings-btn"
+                  disabled={!t.enabled || state.status === 'sending'}
+                  onClick={() => runTest(t.key, t.fn)}
+                  title={!t.enabled ? 'Channel disabled or unconfigured' : `Send a test ${t.label.replace('Test ', '').toLowerCase()}`}
+                >
+                  {state.status === 'sending' ? 'Sending…' : state.status === 'sent' ? 'Sent ✓' : t.label}
+                </button>
+                {state.status === 'sent' && state.detail && (
+                  <span className="v2-integrations-status-ok">{state.detail}</span>
+                )}
+                {state.status === 'error' && (
+                  <span className="v2-integrations-error">{state.error}</span>
+                )}
+              </div>
+            )
+          })}
+          <div className="v2-notif-test-row">
+            <button
+              className="v2-settings-btn v2-settings-btn-danger"
+              disabled={settings.pushover_notifications_enabled !== true || !settings.pushover_user_key || (tests.emergency || {}).status === 'sending'}
+              onClick={() => setEmergencyConfirm(true)}
+              title="Trigger a real Pushover priority-2 alarm (auto-cancels after ~90s)"
+            >
+              {(tests.emergency || {}).status === 'sending' ? 'Triggering…' : (tests.emergency || {}).status === 'sent' ? 'Alarm sent ✓' : 'Test Pushover Emergency'}
+            </button>
+            {(tests.emergency || {}).status === 'error' && (
+              <span className="v2-integrations-error">{(tests.emergency || {}).error}</span>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Notification history — collapsible to keep the panel calm by default */}
+      <div className="v2-settings-block">
+        <button
+          className="v2-notif-history-toggle"
+          onClick={() => setHistoryOpen(o => !o)}
+          aria-expanded={historyOpen}
+        >
+          <span className="v2-form-label">Notification history</span>
+          <span className="v2-notif-history-chev">{historyOpen ? '−' : '+'}</span>
+        </button>
+        {historyOpen && (
+          <div className="v2-notif-history">
+            <div className="v2-notif-history-toolbar">
+              <button className="v2-settings-btn" onClick={loadHistory} disabled={historyLoading}>
+                <RefreshCw size={13} strokeWidth={1.75} className={historyLoading ? 'v2-spinner' : ''} />
+                {historyLoading ? 'Loading…' : 'Refresh'}
+              </button>
+              <button className="v2-settings-btn v2-settings-btn-danger" onClick={clearHistory} disabled={!history?.length}>
+                <Trash2 size={13} strokeWidth={1.75} /> Clear
+              </button>
+            </div>
+            {history === null || historyLoading ? (
+              <div className="v2-notif-history-empty">Loading…</div>
+            ) : history.length === 0 ? (
+              <div className="v2-notif-history-empty">No notifications logged yet.</div>
+            ) : (
+              <ul className="v2-notif-history-list">
+                {history.map((entry, i) => (
+                  <li key={i} className="v2-notif-history-item">
+                    <div className="v2-notif-history-meta">
+                      <span className="v2-notif-history-channel">{entry.channel || 'unknown'}</span>
+                      <span className="v2-notif-history-type">{entry.type}</span>
+                      <span className="v2-notif-history-time">{new Date(entry.timestamp).toLocaleString(undefined, { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' })}</span>
+                    </div>
+                    {entry.title && <div className="v2-notif-history-title">{entry.title}</div>}
+                    {entry.body && <div className="v2-notif-history-body">{entry.body}</div>}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        )}
+      </div>
+
+      {emergencyConfirm && (
+        <div className="v2-settings-confirm-overlay" onClick={() => setEmergencyConfirm(false)}>
+          <div className="v2-settings-confirm" onClick={e => e.stopPropagation()}>
+            <div className="v2-settings-confirm-title">Trigger Emergency alarm?</div>
+            <div className="v2-settings-confirm-message">
+              This fires a Pushover priority-2 alarm that repeats every 30 seconds and bypasses Do Not Disturb. Auto-cancels after about 90 seconds.
+            </div>
+            <div className="v2-settings-confirm-actions">
+              <button className="v2-settings-btn" onClick={() => setEmergencyConfirm(false)}>Cancel</button>
+              <button
+                className="v2-settings-btn v2-settings-btn-danger"
+                onClick={() => {
+                  setEmergencyConfirm(false)
+                  runTest('emergency', () => import('../../api').then(m => m.testPushoverEmergency({
+                    userKey: settings.pushover_user_key,
+                    appToken: settings.pushover_app_token,
+                  })))
+                }}
+              >
+                Trigger
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
       {/* Pointer to v1 for the rest */}
       <div className="v2-settings-block">
         <div className="v2-form-label">More notification options</div>
         <div className="v2-settings-row-hint">
-          Morning digest configuration, channel test buttons, notification history, adaptive throttling controls,
-          and Pushover priority routing live in v1 → Settings → Notifications.
+          Morning digest schedule + style, adaptive throttling 👍/👎 feedback chips, email From overrides + batch mode,
+          Pushover priority routing helper text, and weather-notification toggles still live in v1 → Settings → Notifications.
         </div>
       </div>
     </div>

--- a/wiki/V2-State.md
+++ b/wiki/V2-State.md
@@ -96,8 +96,8 @@ These are daily-use gaps that users would notice:
 
 ### Medium priority
 
-- [ ] **Channel test buttons** (Test push / Test email / Test Pushover priority-0 / Test Pushover Emergency / Test digest) in v2 Notifications.
-- [ ] **Notification history list** in v2 (currently v1-only — stored in `notification_log` table).
+- [x] ~~**Channel test buttons** (Test push / Test email / Test Pushover priority-0 / Test Pushover Emergency / Test digest) in v2 Notifications.~~ Landed 2026-05-09. Each button gates on its channel master + credential availability; per-button state machine (idle / sending / sent ✓ / error). Emergency goes through a v2 confirm dialog before firing. Digest button surfaces which channels actually fired (e.g. "Sent via push, email").
+- [x] ~~**Notification history list** in v2 (currently v1-only — stored in `notification_log` table).~~ Landed 2026-05-09 as a collapsible section at the bottom of the Notifications tab. Loads last 50 entries from `getNotifLog(50)` on first expand, with Refresh + Clear toolbar. Hairline list with channel chip + type + time + title + body per entry.
 - [ ] **Comments + AI Research + Attachments + Extract-Text** in v2 EditTaskModal. Common power-user features in v1 EditTaskModal still v1-only.
 - [ ] **Notion search/link/create + DB sync configuration** in v2.
 - [ ] **Trello board/list pickers + GCal calendar picker + Gmail scan controls** in v2 Integrations.

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,14 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-09
 
+- feat(ui): v2 channel test buttons + notification history in Notifications tab [M]
+  - **Why.** Two of the medium-priority items from V2-State knocked out together since they share the same panel. v2 Notifications had no way to fire a one-off test (Push / Email / Pushover priority-0 / Pushover Emergency / Digest) and no surface for the historical `notification_log` rows — both lived only in v1.
+  - **Test buttons.** New "Test channels" block with five buttons. Each button gates on its channel master being on (and Pushover additionally on credentials being saved). Per-button state machine: idle → sending → sent ✓ → idle (4s auto-reset) or error with inline message. Digest test surfaces which channels actually fired (e.g. "Sent via push, email"). Pushover Emergency gates behind a v2 confirm dialog since it triggers the priority-2 alarm.
+  - **Notification history.** Collapsible block at the bottom of the panel. First expand triggers `getNotifLog(50)` and renders a hairline list of recent entries: channel chip + type + time on the meta row, then title + body. Refresh button (with spinner) and Clear button (calls `clearServerNotifLog()`) in a small toolbar. Capped at 50 entries; max-height 360px with internal scroll.
+  - **Polish.** Trailing "More notification options" pointer narrowed — no longer mentions test buttons or history (those landed); now points at digest schedule + style, adaptive throttling 👍/👎 chips, email From overrides + batch mode, Pushover priority routing helper, and weather-notification toggles as the remaining v1-only surfaces.
+  - **Verification.** `npm run lint` clean (warnings only). `npm test` smoke test passes. Bundle: 715KB precache (up from 710KB).
+  - Modified: `src/v2/components/SettingsModal.jsx`, `src/v2/components/SettingsModal.css`, `wiki/V2-State.md`
+
 - fix(ui): v2 visual bugs from device screenshots — notif cards, quiet hours, settings rows, dark-mode init, danger zone [M]
   - Five fixes for visual bugs the user logged from the live `:dev` build earlier today.
   - **Bug 1 — notification matrix cut off on narrow screens.** Replaced the type×channel `<table>` with a card-per-type list. Each `.v2-notif-card` has type label + freq input on top, a 3-column grid of channel toggles (Push / Email / Pushover) below — labeled chips so the channel name doesn't need a header row. Works at any width without horizontal scroll. Same data shape, same toggles, same settings keys; just a different render.


### PR DESCRIPTION
## Summary

Two medium-priority items from V2-State, knocked out together since they share the v2 Notifications panel surface.

### Test channels block

Five buttons, each gated on its channel master + credentials. Per-button state machine: idle → sending → sent ✓ → idle (4s auto-reset) or error with inline message.

- **Test push** → `testPush()`
- **Test email** → `testEmail()`
- **Test Pushover** (priority 0) → `testPushover({ userKey, appToken })`
- **Test Pushover Emergency** (priority 2) → `testPushoverEmergency(...)` behind a v2 confirm dialog
- **Test digest** → `testDigest()`, surfaces which channels actually fired

### Notification history

Collapsible block at the bottom of the panel. First expand triggers `getNotifLog(50)` and renders a hairline list. Refresh button (with spinner) + Clear button (calls `clearServerNotifLog()`). Each entry shows channel chip + type + time on the meta row, title + body below. Capped at 50 entries with internal scroll.

### Trailing pointer narrowed

The "More notification options" footer no longer mentions test buttons or history (just landed). Now points at digest schedule + style, adaptive throttling 👍/👎 chips, email From overrides + batch mode, Pushover priority routing helper, and weather-notification toggles as the remaining v1-only surfaces.

## Test plan
- [x] `npm run lint` clean (warnings only)
- [x] `npm test` smoke test passes — bundle 715KB
- [ ] CI build green
- [ ] Manual: each Test button fires through its channel; disabled buttons show why; Emergency confirm dialog routes to a real priority-2 send. History expands → loads 50 entries → Clear empties it.

https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_