### PR TITLE
feat(ui): v2 weather location picker in Integrations [S]

### DIFF
--- a/src/v2/components/SettingsModal.css
+++ b/src/v2/components/SettingsModal.css
@@ -923,3 +923,50 @@
   font: 500 12px/1.4 var(--v2-font-body);
   color: var(--v2-energy-errand);
 }
+
+/* Weather location picker (Integrations row) */
+.v2-weather-current {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: rgba(var(--v2-text-rgb), 0.04);
+}
+.v2-weather-current-label {
+  font: 500 13px/1.3 var(--v2-font-body);
+  color: var(--v2-text);
+}
+.v2-weather-search {
+  display: flex;
+  gap: 8px;
+}
+.v2-weather-search .v2-form-input {
+  flex: 1;
+}
+.v2-weather-results {
+  list-style: none;
+  margin: 4px 0 0;
+  padding: 4px;
+  border: 1px solid var(--v2-hairline);
+  border-radius: 10px;
+  max-height: 220px;
+  overflow-y: auto;
+}
+.v2-weather-result {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: 8px 12px;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--v2-text);
+  font: 400 13px/1.3 var(--v2-font-body);
+  cursor: pointer;
+  transition: background var(--v2-dur-quick) var(--v2-ease-standard);
+}
+.v2-weather-result:hover {
+  background: rgba(var(--v2-text-rgb), 0.05);
+}

--- a/src/v2/components/SettingsModal.jsx
+++ b/src/v2/components/SettingsModal.jsx
@@ -304,6 +304,49 @@ function IntegrationsPanel({
   const [emergencyConfirm, setEmergencyConfirm] = useState(false)
   const [gmailSyncing, setGmailSyncing] = useState(false)
   const [gmailSyncResult, setGmailSyncResult] = useState(null)
+  const [weatherQuery, setWeatherQuery] = useState('')
+  const [weatherResults, setWeatherResults] = useState([])
+  const [weatherSearching, setWeatherSearching] = useState(false)
+  const [weatherError, setWeatherError] = useState(null)
+
+  const runWeatherSearch = async () => {
+    const q = weatherQuery.trim()
+    if (!q) return
+    setWeatherSearching(true)
+    setWeatherError(null)
+    setWeatherResults([])
+    try {
+      const api = await import('../../api')
+      const results = await api.geocodeWeather(q)
+      if (!results || results.length === 0) setWeatherError('No matches found')
+      else setWeatherResults(results)
+    } catch (e) {
+      setWeatherError(e?.message || 'Search failed')
+    } finally {
+      setWeatherSearching(false)
+    }
+  }
+
+  const pickWeatherLocation = async (r) => {
+    update('weather_latitude', r.latitude)
+    update('weather_longitude', r.longitude)
+    update('weather_location_name', r.label)
+    if (r.timezone) update('weather_timezone', r.timezone)
+    if (!settings.weather_enabled) update('weather_enabled', true)
+    setWeatherResults([])
+    setWeatherQuery('')
+    try {
+      const api = await import('../../api')
+      await api.refreshWeather({ force: true })
+    } catch { /* status will catch up on next mount */ }
+  }
+
+  const clearWeatherLocation = () => {
+    update('weather_latitude', null)
+    update('weather_longitude', null)
+    update('weather_location_name', '')
+    update('weather_enabled', false)
+  }
 
   const runGmailSync = async () => {
     setGmailSyncing(true)
@@ -394,6 +437,14 @@ function IntegrationsPanel({
       envFlag: envKeys.tracking,
     },
     {
+      key: 'weather',
+      label: 'Weather (Open-Meteo)',
+      hint: 'Free 7-day forecast — no key, no auth. Powers task badges, "best days" picks, weather notifications.',
+      connected: !!settings.weather_enabled && !!settings.weather_latitude,
+      sub: settings.weather_location_name,
+      inline: 'weather',
+    },
+    {
       key: 'pushover',
       label: 'Pushover',
       hint: 'iOS-friendly transport that bypasses Safari throttling. One-time $5 app required.',
@@ -460,6 +511,48 @@ function IntegrationsPanel({
                     )}
                   </div>
                 )}
+                {int.inline === 'weather' && (
+                  <div className="v2-integrations-inline">
+                    {settings.weather_latitude && settings.weather_location_name ? (
+                      <div className="v2-weather-current">
+                        <div className="v2-weather-current-label">📍 {settings.weather_location_name}</div>
+                        <button className="v2-settings-btn" onClick={clearWeatherLocation}>Change location</button>
+                      </div>
+                    ) : (
+                      <>
+                        <div className="v2-weather-search">
+                          <input
+                            type="text"
+                            className="v2-form-input"
+                            placeholder="City or zip code…"
+                            value={weatherQuery}
+                            onChange={e => setWeatherQuery(e.target.value)}
+                            onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); runWeatherSearch() } }}
+                          />
+                          <button
+                            className="v2-settings-btn"
+                            onClick={runWeatherSearch}
+                            disabled={weatherSearching || !weatherQuery.trim()}
+                          >
+                            {weatherSearching ? 'Searching…' : 'Search'}
+                          </button>
+                        </div>
+                        {weatherError && <div className="v2-integrations-error">{weatherError}</div>}
+                        {weatherResults.length > 0 && (
+                          <ul className="v2-weather-results">
+                            {weatherResults.map((r, i) => (
+                              <li key={i}>
+                                <button className="v2-weather-result" onClick={() => pickWeatherLocation(r)}>
+                                  {r.label}
+                                </button>
+                              </li>
+                            ))}
+                          </ul>
+                        )}
+                      </>
+                    )}
+                  </div>
+                )}
                 {int.inline === 'pushover' && (
                   <div className="v2-integrations-inline">
                     <input
@@ -520,7 +613,7 @@ function IntegrationsPanel({
                     {int.sync.busy ? 'Syncing…' : 'Sync now'}
                   </button>
                 )}
-                {int.inline !== 'pushover' && (
+                {int.inline !== 'pushover' && int.inline !== 'weather' && (
                   int.manageInTab ? (
                     <button
                       className="v2-settings-btn"

--- a/wiki/V2-State.md
+++ b/wiki/V2-State.md
@@ -101,7 +101,7 @@ These are daily-use gaps that users would notice:
 - [ ] **Comments + AI Research + Attachments + Extract-Text** in v2 EditTaskModal. Common power-user features in v1 EditTaskModal still v1-only.
 - [ ] **Notion search/link/create + DB sync configuration** in v2.
 - [ ] **Trello board/list pickers + GCal calendar picker + Gmail scan controls** in v2 Integrations.
-- [ ] **Weather geocode/location picker** in v2 Settings.
+- [x] ~~**Weather geocode/location picker** in v2 Settings.~~ Landed 2026-05-09 as an inline `inline: 'weather'` row in IntegrationsPanel. Search box → `geocodeWeather(query)` → results list → pick a result writes `weather_latitude`/`longitude`/`location_name`/`timezone` and triggers a forced server cache refresh. Configured state shows "📍 Location" with a "Change location" button to clear and re-pick.
 
 ### Polish + lower priority
 

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,14 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-09
 
+- feat(ui): v2 weather location picker in Integrations [S]
+  - **Why.** Medium-priority item from V2-State. v2 had no surface for setting the weather location at all — users had to flip back to v1 just to point Boomerang at a city/zip. Open-Meteo is keyless so this is purely a geocode + setting-write flow.
+  - **New `inline: 'weather'` row in IntegrationsPanel.** When unconfigured, shows a search input + Search button; Enter submits. Results render as a hairline-bordered scroll list with the geocoded `label` (city, region, country) per item. Picking a result writes `weather_latitude`, `weather_longitude`, `weather_location_name`, `weather_timezone` and flips `weather_enabled` on if it wasn't, then forces a server cache refresh so the badges/forecast update without a full reload.
+  - **Configured state.** "📍 Location name" line + a "Change location" button that clears the lat/lon/name and disables `weather_enabled`, returning the row to the search state.
+  - **Connection dot.** Weather row's status dot lights green when both `weather_enabled` is true and `weather_latitude` is set.
+  - **Verification.** `npm run lint` clean (warnings only). `npm test` smoke test passes. Bundle: 717KB precache (up from 715KB).
+  - Modified: `src/v2/components/SettingsModal.jsx`, `src/v2/components/SettingsModal.css`, `wiki/V2-State.md`
+
 - feat(ui): v2 channel test buttons + notification history in Notifications tab [M]
   - **Why.** Two of the medium-priority items from V2-State knocked out together since they share the same panel. v2 Notifications had no way to fire a one-off test (Push / Email / Pushover priority-0 / Pushover Emergency / Digest) and no surface for the historical `notification_log` rows — both lived only in v1.
   - **Test buttons.** New "Test channels" block with five buttons. Each button gates on its channel master being on (and Pushover additionally on credentials being saved). Per-button state machine: idle → sending → sent ✓ → idle (4s auto-reset) or error with inline message. Digest test surfaces which channels actually fired (e.g. "Sent via push, email"). Pushover Emergency gates behind a v2 confirm dialog since it triggers the priority-2 alarm.


### PR DESCRIPTION
## Summary

Medium-priority item. v2 had no surface for setting the weather location at all — users had to flip back to v1 just to point Boomerang at a city/zip.

- New `inline: 'weather'` row in `IntegrationsPanel`. When unconfigured: text input + Search button; Enter submits. Calls `geocodeWeather(query)` and renders results as a hairline scroll list with the geocoded label per item.
- Picking a result writes `weather_latitude`, `weather_longitude`, `weather_location_name`, `weather_timezone`, flips `weather_enabled` on, and forces a server cache refresh so badges + forecast widget update without a reload.
- Configured state: "📍 Location name" + "Change location" button that clears state and returns the row to the search UI.
- Status dot lights green when both `weather_enabled` is true and `weather_latitude` is set.

## Test plan
- [x] `npm run lint` clean (warnings only)
- [x] `npm test` smoke test passes — bundle 717KB
- [ ] CI build green
- [ ] Manual: search for a city → results appear → tap one → "📍 City, Region, Country" line appears + weather badges start showing on tasks within 7 days. "Change location" returns to the search UI.

https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_