### PR TITLE
feat(ui): v2 EditTaskModal — forecast widget + weather-hidden + GCal duration [S]

### DIFF
--- a/src/v2/AppV2.jsx
+++ b/src/v2/AppV2.jsx
@@ -536,6 +536,7 @@ export default function AppV2() {
           onProject={handleProject}
           onStatusChange={handleStatusChange}
           onConvertToRoutine={handleConvertToRoutine}
+          weather={weather}
         />
       )}
 

--- a/src/v2/components/EditTaskModal.css
+++ b/src/v2/components/EditTaskModal.css
@@ -700,3 +700,41 @@
   color: var(--v2-text);
   background: rgba(var(--v2-text-rgb), 0.04);
 }
+
+/* 7-day forecast widget */
+.v2-edit-weather-hide {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 8px;
+  font: 400 12px/1.4 var(--v2-font-body);
+  color: var(--v2-text-meta);
+  cursor: pointer;
+}
+
+.v2-edit-weather-drawer {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border: 1px dashed var(--v2-hairline);
+  border-radius: var(--v2-radius-pill);
+  background: transparent;
+  color: var(--v2-text-meta);
+  font: 500 12px/1 var(--v2-font-body);
+  cursor: pointer;
+}
+.v2-edit-weather-drawer:hover {
+  background: rgba(var(--v2-text-rgb), 0.04);
+  color: var(--v2-text);
+}
+
+.v2-edit-weather-drawer-body {
+  margin-top: 8px;
+}
+
+/* GCal duration override input */
+.v2-edit-duration-input {
+  width: 120px;
+  font-variant-numeric: tabular-nums;
+}

--- a/src/v2/components/EditTaskModal.jsx
+++ b/src/v2/components/EditTaskModal.jsx
@@ -1,8 +1,9 @@
 import { useState, useEffect } from 'react'
-import { Sparkles, Trash2, FolderKanban, Archive, Plus, X as XIcon, Search, Paperclip, FileText } from 'lucide-react'
+import { Sparkles, Trash2, FolderKanban, Archive, Plus, X as XIcon, Search, Paperclip, FileText, Sun, ChevronDown, ChevronRight } from 'lucide-react'
 import { loadLabels, ENERGY_TYPES, STATUS_META, uuid } from '../../store'
 import { useTaskForm } from '../../hooks/useTaskForm'
 import { researchTask } from '../../api'
+import WeatherSection, { resolveWeatherVisibility } from '../../components/WeatherSection'
 import ModalShell from './ModalShell'
 import './AddTaskModal.css' // shared form-control styles
 import './EditTaskModal.css'
@@ -22,7 +23,7 @@ const STATUS_OPTIONS = ['not_started', 'doing', 'waiting']
 
 const CADENCE_OPTIONS = ['daily', 'weekly', 'monthly', 'quarterly', 'annually', 'custom']
 
-export default function EditTaskModal({ task, onSave, onClose, onDelete, onBacklog, onProject, onStatusChange, onConvertToRoutine }) {
+export default function EditTaskModal({ task, onSave, onClose, onDelete, onBacklog, onProject, onStatusChange, onConvertToRoutine, weather }) {
   const form = useTaskForm({
     title: task.title,
     notes: task.notes || '',
@@ -66,6 +67,11 @@ export default function EditTaskModal({ task, onSave, onClose, onDelete, onBackl
   const [comments, setComments] = useState(task.comments || [])
   const [newComment, setNewComment] = useState('')
   const [showComments, setShowComments] = useState(comments.length > 0)
+
+  // Per-task weather + GCal-duration overrides.
+  const [weatherHidden, setWeatherHidden] = useState(!!task.weather_hidden)
+  const [forecastDrawerOpen, setForecastDrawerOpen] = useState(false)
+  const [gcalDuration, setGcalDuration] = useState(task.gcal_duration || '')
 
   const addComment = () => {
     const text = newComment.trim()
@@ -117,6 +123,8 @@ export default function EditTaskModal({ task, onSave, onClose, onDelete, onBackl
       comments,
       notion_page_id: form.notionResult?.id || null,
       notion_url: form.notionResult?.url || null,
+      weather_hidden: weatherHidden,
+      gcal_duration: gcalDuration ? parseInt(gcalDuration, 10) : null,
       last_touched: new Date().toISOString(),
     })
     onClose()
@@ -278,6 +286,55 @@ export default function EditTaskModal({ task, onSave, onClose, onDelete, onBackl
         )}
       </div>
 
+      {(() => {
+        const forecast = weather?.status?.cache?.forecast
+        const weatherReady = !!(weather?.enabled && forecast?.days?.length)
+        if (!weatherReady) return null
+        const liveTask = { ...task, title: form.title, energy: form.energy, tags: form.selectedTags, weather_hidden: weatherHidden }
+        const visibility = resolveWeatherVisibility({ task: liveTask, labels, weatherEnabled: true })
+        if (visibility === 'hidden') return null
+        const hideToggle = (
+          <label className="v2-edit-weather-hide">
+            <input
+              type="checkbox"
+              checked={weatherHidden}
+              onChange={e => setWeatherHidden(e.target.checked)}
+            />
+            <span>Hide weather on this card</span>
+          </label>
+        )
+        if (visibility === 'visible') {
+          return (
+            <div className="v2-form-section v2-edit-weather">
+              <label className="v2-form-label">7-day forecast</label>
+              <WeatherSection forecast={forecast} dueDate={form.dueDate || null} />
+              {hideToggle}
+            </div>
+          )
+        }
+        // 'drawer' — collapsed by default, expand to reveal
+        return (
+          <div className="v2-form-section v2-edit-weather">
+            <button
+              type="button"
+              className="v2-edit-weather-drawer"
+              onClick={() => setForecastDrawerOpen(o => !o)}
+              aria-expanded={forecastDrawerOpen}
+            >
+              {forecastDrawerOpen ? <ChevronDown size={14} strokeWidth={1.75} /> : <ChevronRight size={14} strokeWidth={1.75} />}
+              <Sun size={14} strokeWidth={1.75} />
+              <span>7-day forecast</span>
+            </button>
+            {forecastDrawerOpen && (
+              <div className="v2-edit-weather-drawer-body">
+                <WeatherSection forecast={forecast} dueDate={form.dueDate || null} />
+                {hideToggle}
+              </div>
+            )}
+          </div>
+        )
+      })()}
+
       <div className="v2-form-row">
         <div className="v2-form-field">
           <label className="v2-form-label">Due</label>
@@ -299,6 +356,26 @@ export default function EditTaskModal({ task, onSave, onClose, onDelete, onBackl
           </button>
         </div>
       </div>
+
+      {form.dueDate && (
+        <div className="v2-form-section">
+          <label className="v2-form-label" htmlFor="v2-gcal-duration">GCal duration override (min)</label>
+          <div className="v2-settings-row-hint" style={{ marginTop: -4, marginBottom: 4 }}>
+            Default uses size mapping (XS=15, S=30, M=60, L=120, XL=240). Leave blank for default.
+          </div>
+          <input
+            id="v2-gcal-duration"
+            className="v2-form-input v2-edit-duration-input"
+            type="number"
+            min="5"
+            max="480"
+            step="5"
+            placeholder={form.size ? { XS: '15', S: '30', M: '60', L: '120', XL: '240' }[form.size] || 'auto' : 'auto'}
+            value={gcalDuration}
+            onChange={e => setGcalDuration(e.target.value ? parseInt(e.target.value, 10) : '')}
+          />
+        </div>
+      )}
 
       <div className="v2-form-section">
         <label className="v2-form-label">Size</label>

--- a/wiki/V2-State.md
+++ b/wiki/V2-State.md
@@ -112,7 +112,7 @@ These are daily-use gaps that users would notice:
 - [ ] **ExtendModal + FindRelatedModal + MarkdownImportModal** in v2 (rare flows).
 - [ ] **Adaptive-throttle 👍/👎 chips** on v2 Analytics (currently v1-only).
 - [ ] **Email From overrides + batch mode + weather notification toggles** in v2 Notifications.
-- [ ] **7-day forecast widget + weather-hidden toggle + GCal duration override** in v2 EditTaskModal.
+- [x] ~~**7-day forecast widget + weather-hidden toggle + GCal duration override** in v2 EditTaskModal.~~ Landed 2026-05-09. Forecast widget appears between Notes and Due when the task qualifies (outdoor energy or matching keyword/tags) — uses the shared `WeatherSection` + `resolveWeatherVisibility` from v1. Drawer mode shows a collapsed "🌤 7-day forecast" toggle that expands inline. Per-card "Hide weather on this card" checkbox writes `weather_hidden`. GCal duration override input appears when a due date is set; placeholder shows the size-derived default (XS=15 / S=30 / M=60 / L=120 / XL=240).
 
 ### Deferred — wait for above to settle
 

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,15 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-09
 
+- feat(ui): v2 EditTaskModal — 7-day forecast widget + weather-hidden + GCal duration override [S]
+  - **Why.** Three power-user EditTaskModal items grouped under one V2-State bullet. v2 had no forecast widget on outdoor tasks, no per-task weather hide control, and no GCal-duration override (the size-mapping default was the only value users could get).
+  - **Forecast widget.** Reuses the shared `WeatherSection` + `resolveWeatherVisibility` from v1 (no v2 fork needed — they're presentation-pure). Shows when `weather.enabled` and `forecast.days.length > 0` and the task qualifies (outdoor energy / matching keyword / tagged outside). Drawer mode renders a collapsed "🌤 7-day forecast" toggle button that expands inline.
+  - **Per-task hide.** Checkbox below the forecast (or inside the drawer) writes `task.weather_hidden`. Same flag used to suppress weather chips on TaskCard.
+  - **GCal duration override.** Number input (5-480 minutes, step 5) appears in its own form section when a due date is set. Placeholder shows the size-derived default (XS=15 / S=30 / M=60 / L=120 / XL=240). Empty value falls back to size mapping at sync time.
+  - **Wiring.** AppV2 passes the existing `weather` hook value as a prop to EditTaskModal. `weather_hidden` and `gcal_duration` are persisted in `handleSave` so the changes round-trip through `updateTask`.
+  - **Verification.** `npm run lint` clean. `npm test` smoke test passes. Bundle: 737KB precache (up from 735KB).
+  - Modified: `src/v2/AppV2.jsx`, `src/v2/components/EditTaskModal.jsx`, `src/v2/components/EditTaskModal.css`, `wiki/V2-State.md`
+
 - feat(ui): v2 header chrome — MiniRings + done-today + sync indicator + keyboard shortcuts [M]
   - **Why.** Two polish items from V2-State, both daily-visibility. v2 had no MiniRings (opens Analytics in v1), no done-today counter (opens DoneList in v1), no sync status indicator (saving/offline/synced cloud icon), and no keyboard shortcut wiring. Bundled together since the keyboard shortcuts also touch the header (helper modal + Esc closing).
   - **Header stats cluster.** New `.v2-header-stats` slot between brand and primary actions. Renders MiniRings (24px SVG with the same daily-task / daily-points / streak-divided-by-7 progress arcs v1 uses), a "today" pill (count + label, falls back to a "Done" link when no completions today but some history), and a sync icon (`Cloud` for saving/synced, `CloudOff` for offline; pulsing accent-colored animation while saving; alert-red while offline; subtle green while synced). Mobile collapses the "today" label to the bare count; wordmark hides ≤380px to make room.


### PR DESCRIPTION
## Summary

Three power-user EditTaskModal items grouped under one V2-State bullet.

- **Forecast widget.** Between Notes and Due. Reuses shared `WeatherSection` + `resolveWeatherVisibility` from v1 (presentation-pure, no fork needed). Visible mode renders the 7-day grid; drawer mode renders a collapsible "🌤 7-day forecast" toggle.
- **Hide weather on this card.** Checkbox below the forecast writes `task.weather_hidden` — same flag that suppresses weather chips on TaskCard.
- **GCal duration override.** Number input (5-480 min, step 5) appears when a due date is set. Placeholder shows the size-derived default (XS=15 / S=30 / M=60 / L=120 / XL=240). Empty falls back to size mapping at sync time.

`weather_hidden` + `gcal_duration` round-trip through `handleSave` → `updateTask`. AppV2 passes the existing `weather` hook value to EditTaskModal.

## Test plan
- [x] `npm run lint` clean
- [x] `npm test` smoke test passes — bundle 737KB
- [ ] CI build green
- [ ] Manual: open an outdoor task → forecast renders. Hide checkbox → reopen → forecast collapses to drawer. Set due date → duration input appears. Override 90 → reopen → 90 persists.

https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_