### PR TITLE
refactor: cherry-pick checklist-column drop + orphan-route cleanup from main [S]

### DIFF
--- a/db.js
+++ b/db.js
@@ -233,7 +233,6 @@ function taskToRow(task) {
     energy_level: task.energyLevel ?? task.energy_level ?? null,
     tags_json: JSON.stringify(task.tags || []),
     attachments_json: JSON.stringify(task.attachments || []),
-    checklist_json: JSON.stringify(task.checklist || []),
     checklists_json: JSON.stringify(task.checklists || []),
     comments_json: JSON.stringify(task.comments || []),
     toast_messages_json: task.toast_messages ? JSON.stringify(task.toast_messages) : null,
@@ -274,7 +273,6 @@ function rowToTask(row) {
     energyLevel: row.energy_level ?? null,
     tags: safeJsonParse(row.tags_json, []),
     attachments: safeJsonParse(row.attachments_json, []),
-    checklist: safeJsonParse(row.checklist_json, []),
     checklists: safeJsonParse(row.checklists_json, []),
     comments: safeJsonParse(row.comments_json, []),
     toast_messages: safeJsonParse(row.toast_messages_json, null),
@@ -298,15 +296,18 @@ function safeJsonParse(str, fallback) {
 // Task CRUD operations
 // ============================================================
 
+// checklist_json column is kept in the schema (migration 018 emptied it; SQLite
+// column drops are painful) but is no longer written or read. It will retain its
+// existing '[]' value via the schema default for any rows touched here.
 const UPSERT_TASK_SQL = `
   INSERT INTO tasks (id, title, status, notes, due_date, snoozed_until, snooze_count,
     staleness_days, last_touched, created_at, completed_at, reframe_notes,
     notion_page_id, notion_url, trello_card_id, trello_card_url, routine_id,
     high_priority, low_priority, size, energy, energy_level, tags_json, attachments_json,
-    checklist_json, checklists_json, comments_json, toast_messages_json, trello_sync_enabled,
+    checklists_json, comments_json, toast_messages_json, trello_sync_enabled,
     gcal_event_id, gcal_duration, gmail_message_id, gmail_pending, weather_hidden, size_inferred,
     pushover_receipt)
-  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   ON CONFLICT(id) DO UPDATE SET
     title=excluded.title, status=excluded.status, notes=excluded.notes,
     due_date=excluded.due_date, snoozed_until=excluded.snoozed_until,
@@ -319,7 +320,7 @@ const UPSERT_TASK_SQL = `
     low_priority=excluded.low_priority,
     size=excluded.size, energy=excluded.energy, energy_level=excluded.energy_level,
     tags_json=excluded.tags_json, attachments_json=excluded.attachments_json,
-    checklist_json=excluded.checklist_json, checklists_json=excluded.checklists_json,
+    checklists_json=excluded.checklists_json,
     comments_json=excluded.comments_json, toast_messages_json=excluded.toast_messages_json,
     trello_sync_enabled=excluded.trello_sync_enabled,
     gcal_event_id=excluded.gcal_event_id, gcal_duration=excluded.gcal_duration,
@@ -334,7 +335,7 @@ function runUpsertTask(task) {
     r.staleness_days, r.last_touched, r.created_at, r.completed_at, r.reframe_notes,
     r.notion_page_id, r.notion_url, r.trello_card_id, r.trello_card_url, r.routine_id,
     r.high_priority, r.low_priority, r.size, r.energy, r.energy_level, r.tags_json, r.attachments_json,
-    r.checklist_json, r.checklists_json, r.comments_json, r.toast_messages_json,
+    r.checklists_json, r.comments_json, r.toast_messages_json,
     r.trello_sync_enabled, r.gcal_event_id, r.gcal_duration,
     r.gmail_message_id, r.gmail_pending, r.weather_hidden, r.size_inferred,
     r.pushover_receipt,

--- a/gmailSync.js
+++ b/gmailSync.js
@@ -274,7 +274,6 @@ function createTaskFromGmail(item, messageId) {
     energy_level: null,
     tags_json: '[]',
     attachments_json: '[]',
-    checklist_json: '[]',
     checklists_json: '[]',
     comments_json: '[]',
     toast_messages_json: null,

--- a/server.js
+++ b/server.js
@@ -3,7 +3,7 @@ import cors from 'cors'
 import { readFileSync, existsSync } from 'fs'
 import { fileURLToPath } from 'url'
 import path from 'path'
-import { initDb, getAllData, setAllData, setData, clearAllData, getVersion, bumpVersion, flushNow,
+import { initDb, getAllData, setAllData, setData, getVersion, bumpVersion, flushNow,
   upsertTask, getTask, deleteTask, queryTasks, updateTaskPartial,
   upsertRoutine, getRoutine, getAllRoutines, deleteRoutine, updateRoutinePartial,
   getAnalytics, getAnalyticsHistory, getData,
@@ -370,20 +370,6 @@ app.post('/api/data/restore', (req, res) => {
   broadcast(newVersion, body._clientId || null)
   console.log(`[Restore] Replaced DB from backup: ${tasks.length} tasks, ${routines.length} routines, settings=${!!settings}, labels=${!!labels}`)
   res.json({ ok: true, version: newVersion, restored: { tasks: tasks.length, routines: routines.length, settings: !!settings, labels: !!labels } })
-})
-
-app.patch('/api/data/:collection', (req, res) => {
-  setData(req.params.collection, req.body)
-  const newVersion = bumpVersion()
-  broadcast(newVersion, null)
-  res.json({ ok: true, version: newVersion })
-})
-
-app.delete('/api/data', (req, res) => {
-  clearAllData()
-  const newVersion = bumpVersion()
-  broadcast(newVersion, null)
-  res.json({ ok: true, version: newVersion })
 })
 
 // --- Analytics ---
@@ -1187,21 +1173,6 @@ app.post('/api/trello/cards/:id/attachments', async (req, res) => {
     const result = await response.json()
     if (!response.ok) return res.status(response.status).json(result)
     res.json(result)
-  } catch (err) {
-    res.status(500).json({ error: err.message })
-  }
-})
-
-app.post('/api/trello/sync', async (req, res) => {
-  const { key, token } = getTrelloAuth(req)
-  if (!key || !token) return res.status(400).json({ error: 'Trello not configured' })
-  try {
-    const { idList } = req.body
-    if (!idList) return res.status(400).json({ error: 'idList is required' })
-    const response = await fetch(`${TRELLO_BASE}/lists/${idList}/cards?fields=name,desc,closed,idList,pos,due,labels,url&key=${key}&token=${token}`)
-    const data = await response.json()
-    if (!response.ok) return res.status(response.status).json(data)
-    res.json(data)
   } catch (err) {
     res.status(500).json({ error: err.message })
   }
@@ -2470,11 +2441,6 @@ app.post('/api/weather/geocode', async (req, res) => {
   } catch (err) {
     res.status(500).json({ error: err.message })
   }
-})
-
-app.post('/api/weather/clear-cache', (req, res) => {
-  clearWeatherCache()
-  res.json({ ok: true })
 })
 
 // --- Push notification endpoints ---

--- a/src/api.js
+++ b/src/api.js
@@ -688,16 +688,6 @@ export async function trelloUploadAttachment(cardId, name, mimeType, data) {
   return res.json()
 }
 
-export async function trelloSyncCards(idList) {
-  const res = await fetch('/api/trello/sync', {
-    method: 'POST',
-    headers: getApiHeaders(),
-    body: JSON.stringify({ idList }),
-  })
-  if (!res.ok) throw new Error('Failed to sync cards')
-  return res.json()
-}
-
 export async function trelloSyncAllLists(listIds) {
   const res = await fetch('/api/trello/sync-all-lists', {
     method: 'POST',
@@ -926,13 +916,6 @@ export async function serverDeleteTask(id) {
   return res.json()
 }
 
-export async function serverFetchTasks(filters = {}) {
-  const params = new URLSearchParams(filters)
-  const res = await fetch(`/api/tasks?${params}`)
-  if (!res.ok) throw new Error(`fetch tasks failed: ${res.status}`)
-  return res.json()
-}
-
 export async function serverCreateRoutine(routine, clientId) {
   const res = await fetch('/api/routines', {
     method: 'POST',
@@ -965,12 +948,6 @@ export async function fetchPackages(status) {
   const params = status ? `?status=${status}` : ''
   const res = await fetch(`/api/packages${params}`)
   if (!res.ok) throw new Error(`fetch packages failed: ${res.status}`)
-  return res.json()
-}
-
-export async function fetchPackage(id) {
-  const res = await fetch(`/api/packages/${id}`)
-  if (!res.ok) throw new Error(`fetch package failed: ${res.status}`)
   return res.json()
 }
 

--- a/src/components/EditTaskModal.jsx
+++ b/src/components/EditTaskModal.jsx
@@ -62,18 +62,13 @@ export default function EditTaskModal({ task, onSave, onConvertToRoutine, onClos
   const [attachments, setAttachments] = useState(task.attachments || [])
   const [attachError, setAttachError] = useState(null)
   const [extracting, setExtracting] = useState(false)
-  // Migrate old flat checklist → named checklists
-  const [checklists, setChecklists] = useState(() => {
-    if (task.checklists?.length) return task.checklists
-    if (task.checklist?.length) return [{ id: uuid(), name: 'Checklist', items: task.checklist, hideCompleted: false }]
-    return []
-  })
+  const [checklists, setChecklists] = useState(() => task.checklists || [])
   const [newCheckItems, setNewCheckItems] = useState({}) // { checklistId: string }
   const [confirmDeleteChecklist, setConfirmDeleteChecklist] = useState(null)
   // Collapsible sections — expand if content exists
   const [expandedSections, setExpandedSections] = useState(() => {
     const s = new Set()
-    if (task.checklists?.length || task.checklist?.length) s.add('checklists')
+    if (task.checklists?.length) s.add('checklists')
     if (task.comments?.length) s.add('comments')
     if (task.attachments?.length) s.add('attachments')
     return s

--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -223,7 +223,7 @@ export default memo(function TaskCard({ task, expanded = false, onToggleExpand }
           <div className="desktop-notes-preview">{task.notes.length > 120 ? task.notes.slice(0, 120) + '...' : task.notes}</div>
         )}
         {(() => {
-          const lists = task.checklists?.length ? task.checklists : task.checklist?.length ? [{ items: task.checklist }] : []
+          const lists = task.checklists?.length ? task.checklists : []
           const total = lists.reduce((s, c) => s + c.items.length, 0)
           const done = lists.reduce((s, c) => s + c.items.filter(i => i.completed).length, 0)
           if (total === 0) return null
@@ -397,8 +397,6 @@ export default memo(function TaskCard({ task, expanded = false, onToggleExpand }
             {task.notes && (
               <div className="task-notes">{task.notes}</div>
             )}
-            {/* Named checklists (post-migration 018, legacy flat `checklist`
-                field is always empty). */}
             {task.checklists?.length > 0 && (() => {
               const lists = task.checklists
               return lists.map(cl => (

--- a/src/store.js
+++ b/src/store.js
@@ -260,7 +260,6 @@ export function createTask(title, tags = [], dueDate = null, notes = '') {
     energy: null,        // energy type: desk|people|errand|confrontation|creative|physical
     energyLevel: null,   // drain intensity: 1 (low), 2 (medium), 3 (high)
     attachments: [],
-    checklist: [],       // deprecated — migrated to checklists[]
     checklists: [],      // [{ id, name, items: [{ id, text, completed }], hideCompleted }]
     comments: [],
   }

--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -221,8 +221,6 @@ Stage 3 will migrate `useNotionSync` + `useExternalSync` + the REST proxy to MCP
 | `PUT` | `/api/data` | Write app_data blobs (settings, labels). Rejects `tasks`/`routines`/`packages` keys with HTTP 400. Requires `_clientId`. |
 | `POST` | `/api/data` | Same as PUT — for `navigator.sendBeacon` (requires `_clientId`) |
 | `POST` | `/api/data/restore` | Restore tasks + routines + settings + labels from a backup file. Requires `{"confirm": "wipe-and-replace"}` in body. |
-| `PATCH` | `/api/data/:collection` | Update a single collection |
-| `DELETE` | `/api/data` | Clear all data |
 | `POST` | `/api/log` | Client log relay (diagnostics to server terminal) |
 | `POST` | `/api/messages` | Proxy to Anthropic Claude API |
 | `POST` | `/api/adviser/chat` | SSE stream — runs the Claude tool-use loop for the AI Adviser |
@@ -271,7 +269,6 @@ Stage 3 will migrate `useNotionSync` + `useExternalSync` + the REST proxy to MCP
 | `PUT` | `/api/trello/cards/:cardId/checkItem/:itemId` | Update a check item |
 | `DELETE` | `/api/trello/checklists/:id` | Delete a checklist |
 | `POST` | `/api/trello/cards/:id/attachments` | Upload attachment to card |
-| `POST` | `/api/trello/sync` | Pull cards from a Trello list |
 | `POST` | `/api/trello/sync-all-lists` | Pull cards from multiple Trello lists at once |
 | `GET` | `/api/gcal/auth-url` | Generate Google OAuth authorization URL |
 | `GET` | `/api/gcal/callback` | OAuth callback — exchanges code for tokens |
@@ -293,7 +290,6 @@ Stage 3 will migrate `useNotionSync` + `useExternalSync` + the REST proxy to MCP
 | `GET` | `/api/weather` | Get cached forecast + status |
 | `POST` | `/api/weather/refresh` | Force-refresh forecast (respects 30-min freshness unless `{ force: true }`) |
 | `POST` | `/api/weather/geocode` | Geocode a location query via Open-Meteo |
-| `POST` | `/api/weather/clear-cache` | Clear the cached forecast |
 
 ## AI Adviser
 

--- a/wiki/V2-State.md
+++ b/wiki/V2-State.md
@@ -135,7 +135,7 @@ All five bugs the user logged from device screenshots have been addressed:
 
 ### Final-mile cleanup
 
-- [ ] **Cherry-pick remaining main-only commits onto dev**: `c8ef380` (drop legacy `task.checklist` column), `3cdd943` (delete orphan API routes). Each is a separate small PR via the MCP loop. The npm-audit cherry-pick (`c00d520`) already landed on dev as `9b48196` (PR #22, 2026-05-09). The skip-this-cycle hook change from `422c2ff` was ported manually as part of PR #24 (v2 RoutinesModal Skip button); v1 wiring intentionally skipped since v1 is frozen and gets deleted in the end-state cleanup below.
+- [x] ~~**Cherry-pick remaining main-only commits onto dev.**~~ Completed 2026-05-09. `c00d520` (npm-audit clears) landed via PR #22 as `9b48196`. `c8ef380` (drop legacy `task.checklist` column) landed via PR #45. `3cdd943` (delete orphan API routes) landed via PR #45. The skip-this-cycle hook change from `422c2ff` was ported manually as part of PR #24 (v2 RoutinesModal Skip button); v1 wiring intentionally skipped since v1 is frozen and gets deleted in the end-state cleanup below. Dev and main are functionally aligned for the v2 cutover; remaining commits on main are doc-only and auto-merge cleanly.
 - [ ] **End-state cleanup** (per `/root/.claude/plans/ui-redesign-ideas-i-iridescent-wren.md`): once v2 is validated, delete `src/AppV1.jsx` + `src/components/` and rename `src/v2/components/` → `src/components/`. Leave `?ui=v1` working for one release for safety.
 - [ ] **Stranded `test-push-probe` branch** on origin can't be deleted via the proxy or MCP — needs the GitHub UI. Pointed at `a87103e` from the original 2026-05-03 diagnostic.
 

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,14 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-09
 
+- chore(server): delete orphan API routes + dead client wrappers [S]
+  - Post-wipe-incident orphan sweep: 4 routes had no callers, 3 client wrappers had no callers. Deleting now to shrink the surface area before someone wires them to something fragile.
+  - **Routes deleted (server.js):** `PATCH /api/data/:collection`, `DELETE /api/data`, `POST /api/weather/clear-cache`, `POST /api/trello/sync`. The first two were bulk-blob escape hatches from before the per-record API took over; `weather/clear-cache` was an early debugging endpoint; `trello/sync` is single-list while the working code uses `trello/sync-all-lists`.
+  - **Client wrappers deleted (src/api.js):** `trelloSyncCards`, `serverFetchTasks`, `fetchPackage`. None had callers anywhere in `src/` or `public/`.
+  - **Kept:** `clearAllData()` in `db.js` is still used by `seed.js`; `clearWeatherCache()` is still used internally on weather-location changes.
+  - Cherry-picked from main onto dev (final-mile cleanup, 2026-05-09).
+  - Modified: `server.js`, `src/api.js`, `wiki/Architecture.md`
+
 - refactor(db): drop legacy `task.checklist` serialization [S]
   - Migration 018 emptied the legacy flat `checklist_json` column months ago and replaced it with the named `checklists_json` (multi-list) format. The serialization paths still wrote `task.checklist || []` on every upsert and the read path still parsed it into a `checklist` field on every row → JS object trip. Pure cleanup.
   - Removed: `task.checklist` reads/writes in `db.js` `taskToRow`/`rowToTask`/`UPSERT_TASK_SQL`, the `checklist: []` default in `src/store.js` `createTask`, the legacy fallback wrapper in `src/components/TaskCard.jsx`, the legacy migrate-on-read in `src/components/EditTaskModal.jsx`, the inert `checklist_json: '[]'` in `gmailSync.js`'s task constructor.

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,13 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-09
 
+- refactor(db): drop legacy `task.checklist` serialization [S]
+  - Migration 018 emptied the legacy flat `checklist_json` column months ago and replaced it with the named `checklists_json` (multi-list) format. The serialization paths still wrote `task.checklist || []` on every upsert and the read path still parsed it into a `checklist` field on every row → JS object trip. Pure cleanup.
+  - Removed: `task.checklist` reads/writes in `db.js` `taskToRow`/`rowToTask`/`UPSERT_TASK_SQL`, the `checklist: []` default in `src/store.js` `createTask`, the legacy fallback wrapper in `src/components/TaskCard.jsx`, the legacy migrate-on-read in `src/components/EditTaskModal.jsx`, the inert `checklist_json: '[]'` in `gmailSync.js`'s task constructor.
+  - **Column kept.** `checklist_json` stays in the schema (SQLite column drops are painful). It's inert — never read, never written. Existing rows retain their `'[]'` value via the schema default.
+  - Cherry-picked from main onto dev (final-mile cleanup, 2026-05-09).
+  - Modified: `db.js`, `gmailSync.js`, `src/store.js`, `src/components/TaskCard.jsx`, `src/components/EditTaskModal.jsx`
+
 - feat(ui): v2 MarkdownImportModal + skip ExtendModal/FindRelatedModal as superseded [S]
   - **Why.** Final polish item from V2-State. v1 has three "rare flow" modals — Extend (date preset shortcut), FindRelated (Notion search to link a task), MarkdownImport (bulk task creation from markdown). Audit found Extend + FindRelated are redundant in v2: EditTaskModal's date input already covers Extend's use case, and the inline Notion search in EditTaskModal Connections (PR #36) already covers FindRelated. MarkdownImport is the only one with an actual gap.
   - **`MarkdownImportModal.jsx` + `.css`.** Direct port of v1's component into v2 idiom — wide ModalShell, paste-or-upload first step, preview-and-toggle-tasks second step, "Import N task(s)" CTA. Uses the existing `parseMarkdown` util. Bullets (`- item`), checkboxes (`- [ ] item`), and section headings (`## Section`) all supported; headings become group labels on each parsed task.


### PR DESCRIPTION
## Summary

Final-mile cherry-picks from main onto dev. Closes the last remaining V2-State final-mile bullet.

- **`c8ef380` — drop legacy `task.checklist` serialization.** Migration 018 emptied the legacy flat `checklist_json` column months ago; serialization paths still wrote `task.checklist || []` on every upsert. Cleanup removes the dead reads/writes from `db.js`, `gmailSync.js`, `src/store.js`, `src/components/TaskCard.jsx`, `src/components/EditTaskModal.jsx`. Column itself stays in schema (SQLite drops are painful) — inert from now on.
- **`3cdd943` — delete orphan API routes + dead client wrappers.** Removes `PATCH /api/data/:collection`, `DELETE /api/data`, `POST /api/weather/clear-cache`, `POST /api/trello/sync` from `server.js`; removes `trelloSyncCards`, `serverFetchTasks`, `fetchPackage` from `src/api.js`. None had callers.
- **Doc cleanup.** V2-State updated to strike both off the final-mile list.

## Conflicts

Both cherry-picks conflicted only in `wiki/Version-History.md` (both branches add 2026-05-09 entries to the top). Resolved by inserting main's entries above dev's recent entries.

## Test plan
- [x] `npm run lint` clean
- [x] `npm test` smoke test passes — bundle 746KB
- [ ] CI build green
- [ ] Manual: smoke test still hits /api/health; the deleted routes have no callers (`grep` clean before push). v2 + v1 task lists still render checklists fine.

https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_