### PR TITLE
fix(ui): v2 version-refresh modal [S]

### DIFF
--- a/src/v2/AppV2.css
+++ b/src/v2/AppV2.css
@@ -250,3 +250,65 @@
     margin: 8px 24px 0;
   }
 }
+
+/* Update-available modal — appears when useServerSync detects a server
+ * version mismatch. The reload fires automatically after 1s; the button is
+ * for users who want to skip the delay. */
+.v2-update-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  background: rgba(0, 0, 0, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  animation: v2-update-fade-in var(--v2-dur-emphasis) var(--v2-ease-emphasis);
+}
+
+@keyframes v2-update-fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.v2-update-modal {
+  max-width: 360px;
+  width: 100%;
+  background: var(--v2-surface);
+  border-radius: var(--v2-radius-modal);
+  padding: 28px 24px 22px;
+  text-align: center;
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.25);
+}
+
+.v2-update-title {
+  font: 700 20px/1.2 var(--v2-font-display);
+  color: var(--v2-text);
+  margin-bottom: 4px;
+}
+
+.v2-update-version {
+  font: 600 14px/1 var(--v2-font-body);
+  color: var(--v2-accent);
+  font-variant-numeric: tabular-nums;
+  margin-bottom: 12px;
+}
+
+.v2-update-sub {
+  font: 400 13px/1.4 var(--v2-font-body);
+  color: var(--v2-text-meta);
+  margin-bottom: 18px;
+}
+
+.v2-update-reload {
+  width: 100%;
+  height: 42px;
+  border: none;
+  border-radius: var(--v2-radius-pill);
+  background: var(--v2-accent);
+  color: #fff;
+  font: 600 14px/1 var(--v2-font-body);
+  cursor: pointer;
+  transition: filter var(--v2-dur-quick) var(--v2-ease-standard);
+}
+.v2-update-reload:hover { filter: brightness(1.08); }

--- a/src/v2/AppV2.jsx
+++ b/src/v2/AppV2.jsx
@@ -55,6 +55,7 @@ export default function AppV2() {
   const [showDone, setShowDone] = useState(false)
   const [showActivityLog, setShowActivityLog] = useState(false)
   const [showMarkdownImport, setShowMarkdownImport] = useState(false)
+  const [updateVersion, setUpdateVersion] = useState(null)
   const [showRoutines, setShowRoutines] = useState(false)
   const [editRoutineId, setEditRoutineId] = useState(null)
   const [showPackages, setShowPackages] = useState(false)
@@ -135,7 +136,8 @@ export default function AppV2() {
     }
   }, [hydrateTasks, hydrateRoutines])
 
-  const { flush: flushSync, syncStatus, queueLength } = useServerSync(tasks, routines, hydrateFromServer, () => {
+  const { flush: flushSync, checkVersion, syncStatus, queueLength } = useServerSync(tasks, routines, hydrateFromServer, (newVersion) => {
+    setUpdateVersion(newVersion)
     if ('serviceWorker' in navigator) {
       navigator.serviceWorker.getRegistrations().then(regs => {
         for (const r of regs) r.unregister()
@@ -143,6 +145,14 @@ export default function AppV2() {
     }
     setTimeout(() => window.location.reload(), 1000)
   })
+
+  // Check app version whenever a view/modal opens — same cadence v1 uses.
+  // Catches stale clients without waiting for the next SSE/sync round-trip.
+  useEffect(() => {
+    if (showSettings || showDone || showAnalytics || showRoutines || showActivityLog || showPackages || showProjects || showAdviser || editTarget || showAdd || showWhatNow || showMarkdownImport) {
+      checkVersion()
+    }
+  }, [showSettings, showDone, showAnalytics, showRoutines, showActivityLog, showPackages, showProjects, showAdviser, editTarget, showAdd, showWhatNow, showMarkdownImport, checkVersion])
 
   // Spawn due routine tasks on load + when routines change.
   useEffect(() => {
@@ -762,6 +772,25 @@ export default function AppV2() {
             setToast(null)
           }}
         />
+      )}
+
+      {updateVersion && (
+        <div className="v2-update-overlay">
+          <div className="v2-update-modal">
+            <div className="v2-update-title">Update available</div>
+            <div className="v2-update-version">v{updateVersion}</div>
+            <div className="v2-update-sub">Refreshing automatically…</div>
+            <button
+              className="v2-update-reload"
+              onClick={() => {
+                if ('serviceWorker' in navigator) navigator.serviceWorker.getRegistrations().then(regs => { for (const r of regs) r.unregister() })
+                window.location.reload()
+              }}
+            >
+              Reload now
+            </button>
+          </div>
+        </div>
       )}
     </div>
   )

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,13 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-09
 
+- fix(ui): v2 version-refresh modal [S]
+  - **Why.** v2's `onVersionMismatch` handler unregistered the service worker and triggered `window.location.reload()` after 1s, but rendered no UI between detection and reload. Users on slow connections saw the page seemingly hang then snap-reload — the v1 `update-modal` ("Update available: v0.99 · Refreshing automatically… [Reload now]") wasn't ported.
+  - **`v2-update-overlay` + `.v2-update-modal`.** New full-viewport overlay (z-index 9999, fade-in) holding a centered modal with the version label, "Refreshing automatically…" subtitle, and an explicit "Reload now" button for users who don't want to wait the 1s. Service-worker unregister still fires either way.
+  - **`checkVersion` polling.** Wired the version-check trigger v1 has — opening any of Settings / Done / Analytics / Routines / Activity Log / Packages / Projects / Adviser / Add / WhatNow / EditTask / MarkdownImport polls `checkVersion()`, which surfaces a stale-client modal without waiting for the next SSE round-trip.
+  - **Verification.** `npm run lint` clean. `npm test` smoke test passes. Bundle: 746KB precache (unchanged).
+  - Modified: `src/v2/AppV2.jsx`, `src/v2/AppV2.css`
+
 - chore(server): delete orphan API routes + dead client wrappers [S]
   - Post-wipe-incident orphan sweep: 4 routes had no callers, 3 client wrappers had no callers. Deleting now to shrink the surface area before someone wires them to something fragile.
   - **Routes deleted (server.js):** `PATCH /api/data/:collection`, `DELETE /api/data`, `POST /api/weather/clear-cache`, `POST /api/trello/sync`. The first two were bulk-blob escape hatches from before the per-record API took over; `weather/clear-cache` was an early debugging endpoint; `trello/sync` is single-list while the working code uses `trello/sync-all-lists`.


### PR DESCRIPTION
## Summary

Caught one missing port from the v2 base layer. v2's `onVersionMismatch` handler was unregistering the service worker and reloading after 1s — but it wasn't rendering the modal v1 shows in the meantime. Users on slow connections saw the page seemingly hang, then snap-reload.

- **`v2-update-overlay` + `.v2-update-modal`.** New full-viewport overlay (z-index 9999, fade-in) with a centered modal: version label, "Refreshing automatically…" subtitle, and an explicit "Reload now" button for skipping the 1s wait. Service-worker unregister still fires either way.
- **`checkVersion` polling.** Wired the same trigger v1 uses — opening any of Settings / Done / Analytics / Routines / Activity Log / Packages / Projects / Adviser / Add / WhatNow / EditTask / MarkdownImport calls `checkVersion()`, surfacing the modal without waiting for the next SSE round-trip.

## Test plan
- [x] `npm run lint` clean
- [x] `npm test` smoke test passes — bundle 746KB
- [ ] CI build green
- [ ] Manual: trigger an `appVersion` change server-side (or via `/api/health`) → modal appears with version → "Reload now" reloads immediately, otherwise auto-reload at 1s.

https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_