### PR TITLE
fix(ui): v2 TDZ — useKeyboardShortcuts called before handlers defined [S]

### DIFF
--- a/src/v2/AppV2.jsx
+++ b/src/v2/AppV2.jsx
@@ -274,18 +274,6 @@ export default function AppV2() {
     setTimeout(() => document.querySelector('.v2-toolbar-search-input')?.focus(), 60)
   }, [])
 
-  const { selectedTaskId, showHelp, setShowHelp } = useKeyboardShortcuts({
-    isDesktop,
-    visibleTasks,
-    onEdit: setEditTarget,
-    onComplete: handleComplete,
-    onSnooze: handleSnooze,
-    openAddModal: useCallback(() => setShowAdd(true), []),
-    focusSearch: focusSearchInput,
-    activeModals,
-    closeTopModal,
-  })
-
   const handleComplete = useCallback((id) => {
     const task = tasks.find(t => t.id === id)
     completeTask(id)
@@ -355,6 +343,22 @@ export default function AppV2() {
       setSnoozeTarget(task)
     }
   }, [])
+
+  // Keyboard shortcuts hook needs handleComplete + handleSnooze in scope —
+  // const declarations don't hoist, so this call lives below the handler
+  // definitions. Hook order is stable across renders, which is all React
+  // requires.
+  const { selectedTaskId, showHelp, setShowHelp } = useKeyboardShortcuts({
+    isDesktop,
+    visibleTasks,
+    onEdit: setEditTarget,
+    onComplete: handleComplete,
+    onSnooze: handleSnooze,
+    openAddModal: useCallback(() => setShowAdd(true), []),
+    focusSearch: focusSearchInput,
+    activeModals,
+    closeTopModal,
+  })
 
   const handleStatusChange = useCallback((id, newStatus) => {
     if (newStatus === 'done') { handleComplete(id); return }


### PR DESCRIPTION
## Bug

Black screen on every fresh load of v2 (confirmed in iOS Safari private tab — no localStorage cache could hide it).

**Root cause.** PR #39 (header chrome + keyboard shortcuts) placed the `useKeyboardShortcuts(...)` call *above* `handleComplete` and `handleSnooze` in `AppV2`. JavaScript `const` declarations don't hoist, so every render threw a TDZ ReferenceError accessing `handleComplete` in the props object — blowing up before AppV2's mount effect could set `data-ui="v2"`. Result: dark `:root` defaults from `index.css` paint, but no React tree mounts. Pure black, no console error visible to user.

**Why CI didn't catch.** `npm test` smoke only parses the JS bundle — never actually mounts React.

## Fix

Moved the `useKeyboardShortcuts(...)` call to *after* the handler definitions. React only cares about hook *call order being stable across renders*, not source-line position; the hook still runs in the same place each render, just later in the function body.

Order is now: `activeModals` → `closeTopModal` → `focusSearchInput` → `handleComplete` → `handleSnooze` → `useKeyboardShortcuts(...)`.

## Follow-up

Adding a real mount-coverage step to the smoke test (e.g. headless Vite preview + page open) is queued separately so this class of bug never ships again. This PR is the immediate unbreak.

## Test plan
- [x] `npm run build` clean
- [x] `npm run lint` clean
- [x] `npm test` smoke passes
- [ ] CI build green
- [ ] Manual: load on iOS Safari private tab → app renders.

https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_