### PR TITLE
chore(lint): catch TDZ-class bugs in v2 with no-use-before-define [S]

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -44,4 +44,22 @@ export default [
       ],
     },
   },
+  // v2-only: stricter check for the TDZ class of bug that took down v2 on
+  // 2026-05-09. `useKeyboardShortcuts({ onComplete: handleComplete })`
+  // referenced a `const handleComplete = useCallback(...)` defined later in
+  // the component. const doesn't hoist, so every fresh mount threw a
+  // ReferenceError before AppV2's useEffect could set data-ui="v2". Smoke
+  // test parses the bundle but doesn't mount React, so it shipped.
+  // `functions: false` keeps regular `function foo()` forward references OK
+  // (those genuinely hoist); `variables: true` is the new gate.
+  // Scoped to src/v2/** because v1 has 40 legitimate-at-runtime forward
+  // references inside `.then()` / `setTimeout` callbacks (they only execute
+  // after all consts are defined) and v1 is being deleted in the end-state
+  // cleanup anyway.
+  {
+    files: ['src/v2/**/*.{js,jsx}'],
+    rules: {
+      'no-use-before-define': ['error', { functions: false, classes: false, variables: true }],
+    },
+  },
 ]

--- a/src/v2/components/MarkdownImportModal.jsx
+++ b/src/v2/components/MarkdownImportModal.jsx
@@ -44,18 +44,18 @@ export default function MarkdownImportModal({ open, onImport, onClose }) {
   const selectAll = () => setSelected(new Set(parsed.map((_, i) => i)))
   const selectNone = () => setSelected(new Set())
 
-  const handleImport = () => {
-    if (!parsed) return
-    const tasksToImport = parsed.filter((_, i) => selected.has(i))
-    onImport(tasksToImport)
-    handleClose()
-  }
-
   const handleClose = () => {
     setText('')
     setParsed(null)
     setSelected(new Set())
     onClose()
+  }
+
+  const handleImport = () => {
+    if (!parsed) return
+    const tasksToImport = parsed.filter((_, i) => selected.has(i))
+    onImport(tasksToImport)
+    handleClose()
   }
 
   return (


### PR DESCRIPTION
## Summary

Preventative for the TDZ-class bug that took v2 black on 2026-05-09. Adds ESLint `no-use-before-define` (with `{ functions: false, classes: false, variables: true }`) scoped to `src/v2/**` — catches the exact pattern statically without needing a React mount.

The buggy commit had:

```js
const { selectedTaskId } = useKeyboardShortcuts({
  onComplete: handleComplete,  // ← referenced here, line 281
  ...
})

const handleComplete = useCallback((id) => { ... })  // ← declared here, line 289
```

`const` doesn't hoist → TDZ at every fresh mount. ESLint's static check flags this immediately.

## Why scope to v2

v1 has ~40 forward references inside `.then()` / `setTimeout` callbacks where the body only executes after all consts are defined — legitimate at runtime, just not pretty. v1 is being deleted in end-state cleanup, so per-file disables would be churn for code that's leaving anyway. v2 is what we care about.

## Bonus catch

`MarkdownImportModal.handleImport` (which I wrote in PR #44) called `handleClose` defined below it — same pattern, dormant only because nothing invoked `handleImport` at evaluation time. Reordered defensively.

## Test plan
- [x] `npm run lint` clean
- [x] `npm test` smoke passes

## Layered approach

This is **Layer 1** — cheapest catch. **Layer 2** would be a real React-mount step in the smoke test (JSDOM or headless) — that catches a wider class of runtime errors (undefined imports, missing props, etc.) but is heavier. Worth doing if another bug like this slips through despite the lint rule.

https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_