### PR TITLE
fix(ui): v2 EditTaskModal — due/priority overlap, checklists empty-collapse, connections position [S]

### DIFF
--- a/src/v2/components/AddTaskModal.css
+++ b/src/v2/components/AddTaskModal.css
@@ -45,15 +45,26 @@
 /* Two-column row used for date+priority etc. CSS Grid (over flex) so each
  * column gets exactly half the available width regardless of intrinsic
  * content widths — Safari/iOS renders empty <input type="date"> at a
- * collapsed intrinsic width which broke the flex layout. */
+ * collapsed intrinsic width which broke the flex layout.
+ *
+ * minmax(0, 1fr) (not the shorthand `1fr` which is minmax(auto, 1fr)) so
+ * filled date inputs don't expand the column past its half-share —
+ * iOS Safari's date intrinsic-content-width is wide enough to overflow
+ * 1fr. Coupled with min-width: 0 on the field child + 100% width on the
+ * input, the cell clamps cleanly. */
 .v2-form-row {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
   gap: 12px;
   margin-top: 18px;
 }
 
 .v2-form-field {
+  min-width: 0;
+}
+
+.v2-form-input,
+.v2-form-textarea {
   min-width: 0;
 }
 

--- a/src/v2/components/EditTaskModal.jsx
+++ b/src/v2/components/EditTaskModal.jsx
@@ -470,18 +470,19 @@ export default function EditTaskModal({ task, onSave, onClose, onDelete, onBackl
         )}
       </div>
 
-      {/* Checklists — multi-list. Each checklist has a name + items. Items
-          can be checked, renamed, deleted. Hide-completed toggles visibility
-          of completed items. v2 omits drag-drop reorder (v1 has it). */}
-      <div className="v2-form-section">
-        <div className="v2-edit-checklist-head">
-          <label className="v2-form-label">Checklists</label>
-          {checklists.reduce((n, c) => n + c.items.length, 0) > 0 && (
-            <span className="v2-edit-checklist-summary">
-              {checklists.reduce((n, c) => n + c.items.filter(i => i.completed).length, 0)}/{checklists.reduce((n, c) => n + c.items.length, 0)} done
-            </span>
-          )}
-        </div>
+      {/* Checklists — multi-list. Empty state shows just the "+ Add checklist"
+          pill below; CHECKLISTS label only renders when at least one exists. */}
+      <div className={`v2-form-section${checklists.length === 0 ? ' v2-form-section-compact' : ''}`}>
+        {checklists.length > 0 && (
+          <div className="v2-edit-checklist-head">
+            <label className="v2-form-label">Checklists</label>
+            {checklists.reduce((n, c) => n + c.items.length, 0) > 0 && (
+              <span className="v2-edit-checklist-summary">
+                {checklists.reduce((n, c) => n + c.items.filter(i => i.completed).length, 0)}/{checklists.reduce((n, c) => n + c.items.length, 0)} done
+              </span>
+            )}
+          </div>
+        )}
         {checklists.map(cl => {
           const completed = cl.items.filter(i => i.completed).length
           const total = cl.items.length
@@ -630,6 +631,101 @@ export default function EditTaskModal({ task, onSave, onClose, onDelete, onBackl
         )}
       </div>
 
+      {/* Connections — Notion link/create. Lives next to Checklists +
+          Attachments because it's the third "linking content" affordance.
+          CONNECTIONS label only when something is linked or in-flight; empty
+          state is just the "Notion" pill. */}
+      <div className={`v2-form-section${!form.notionResult && !form.notionState ? ' v2-form-section-compact' : ''}`}>
+        {(form.notionResult || form.notionState) && (
+          <div className="v2-edit-attach-head">
+            <label className="v2-form-label">Connections</label>
+          </div>
+        )}
+        <div className="v2-edit-connections">
+          {form.notionResult ? (
+            <div className="v2-edit-connection-pill v2-edit-connection-linked">
+              <a href={form.notionResult.url} target="_blank" rel="noopener noreferrer">Notion ↗</a>
+              <button
+                type="button"
+                className="v2-edit-connection-unlink"
+                onClick={() => form.setNotionResult(null)}
+                aria-label="Unlink Notion page"
+              >
+                <XIcon size={11} strokeWidth={2} />
+              </button>
+            </div>
+          ) : !form.notionState ? (
+            <button
+              type="button"
+              className="v2-form-ai-pill v2-form-ai-pill-static"
+              onClick={form.handleNotionSearch}
+              disabled={!form.title.trim()}
+              title="Search Notion for matching pages, or create a new one"
+            >
+              <Search size={12} strokeWidth={1.75} /> Notion
+            </button>
+          ) : null}
+        </div>
+        {form.notionState === 'searching' && (
+          <div className="v2-edit-notion-status">
+            <span className="v2-spinner" /> Searching Notion…
+          </div>
+        )}
+        {form.notionState?.action === 'error' && (
+          <div className="v2-form-error">
+            {form.notionState.reason}
+            <button
+              type="button"
+              className="v2-form-ai-pill v2-form-ai-pill-static"
+              onClick={form.handleNotionSearch}
+              style={{ marginLeft: 8 }}
+            >
+              Retry
+            </button>
+          </div>
+        )}
+        {form.notionState && form.notionState !== 'searching' && form.notionState.action !== 'error' && (
+          <div className="v2-edit-notion-suggestions">
+            {form.notionState.pages?.length > 0 && (
+              <>
+                <div className="v2-edit-notion-reason">{form.notionState.reason}</div>
+                <ul className="v2-edit-notion-list">
+                  {form.notionState.pages.map(page => (
+                    <li key={page.id}>
+                      <button
+                        type="button"
+                        className="v2-edit-notion-page"
+                        onClick={() => form.handleNotionLink(page)}
+                      >
+                        {page.title}
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              </>
+            )}
+            <div className="v2-edit-notion-actions">
+              <button
+                type="button"
+                className="v2-form-ai-pill v2-form-ai-pill-static"
+                onClick={form.handleNotionCreate}
+                disabled={form.notionCreating}
+              >
+                {form.notionCreating ? <span className="v2-spinner" /> : <Plus size={12} strokeWidth={2} />}
+                {form.notionCreating ? 'Creating…' : 'Create new Notion page'}
+              </button>
+              <button
+                type="button"
+                className="v2-edit-notion-cancel"
+                onClick={() => form.setNotionState(null)}
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+
       {labels.length > 0 && (
         <div className="v2-form-section">
           <label className="v2-form-label">Labels</label>
@@ -741,100 +837,6 @@ export default function EditTaskModal({ task, onSave, onClose, onDelete, onBackl
               </button>
             </div>
           </>
-        )}
-      </div>
-
-      {/* Connections — Notion link/create. CONNECTIONS label only when
-          something is linked or in-flight; empty state is just the
-          "Notion" pill. */}
-      <div className={`v2-form-section${!form.notionResult && !form.notionState ? ' v2-form-section-compact' : ''}`}>
-        {(form.notionResult || form.notionState) && (
-          <div className="v2-edit-attach-head">
-            <label className="v2-form-label">Connections</label>
-          </div>
-        )}
-        <div className="v2-edit-connections">
-          {form.notionResult ? (
-            <div className="v2-edit-connection-pill v2-edit-connection-linked">
-              <a href={form.notionResult.url} target="_blank" rel="noopener noreferrer">Notion ↗</a>
-              <button
-                type="button"
-                className="v2-edit-connection-unlink"
-                onClick={() => form.setNotionResult(null)}
-                aria-label="Unlink Notion page"
-              >
-                <XIcon size={11} strokeWidth={2} />
-              </button>
-            </div>
-          ) : !form.notionState ? (
-            <button
-              type="button"
-              className="v2-form-ai-pill v2-form-ai-pill-static"
-              onClick={form.handleNotionSearch}
-              disabled={!form.title.trim()}
-              title="Search Notion for matching pages, or create a new one"
-            >
-              <Search size={12} strokeWidth={1.75} /> Notion
-            </button>
-          ) : null}
-        </div>
-        {form.notionState === 'searching' && (
-          <div className="v2-edit-notion-status">
-            <span className="v2-spinner" /> Searching Notion…
-          </div>
-        )}
-        {form.notionState?.action === 'error' && (
-          <div className="v2-form-error">
-            {form.notionState.reason}
-            <button
-              type="button"
-              className="v2-form-ai-pill v2-form-ai-pill-static"
-              onClick={form.handleNotionSearch}
-              style={{ marginLeft: 8 }}
-            >
-              Retry
-            </button>
-          </div>
-        )}
-        {form.notionState && form.notionState !== 'searching' && form.notionState.action !== 'error' && (
-          <div className="v2-edit-notion-suggestions">
-            {form.notionState.pages?.length > 0 && (
-              <>
-                <div className="v2-edit-notion-reason">{form.notionState.reason}</div>
-                <ul className="v2-edit-notion-list">
-                  {form.notionState.pages.map(page => (
-                    <li key={page.id}>
-                      <button
-                        type="button"
-                        className="v2-edit-notion-page"
-                        onClick={() => form.handleNotionLink(page)}
-                      >
-                        {page.title}
-                      </button>
-                    </li>
-                  ))}
-                </ul>
-              </>
-            )}
-            <div className="v2-edit-notion-actions">
-              <button
-                type="button"
-                className="v2-form-ai-pill v2-form-ai-pill-static"
-                onClick={form.handleNotionCreate}
-                disabled={form.notionCreating}
-              >
-                {form.notionCreating ? <span className="v2-spinner" /> : <Plus size={12} strokeWidth={2} />}
-                {form.notionCreating ? 'Creating…' : 'Create new Notion page'}
-              </button>
-              <button
-                type="button"
-                className="v2-edit-notion-cancel"
-                onClick={() => form.setNotionState(null)}
-              >
-                Cancel
-              </button>
-            </div>
-          </div>
         )}
       </div>
 

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,13 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-09
 
+- fix(ui): v2 EditTaskModal — Due/Priority overlap + Checklists empty-collapse + Connections moves up [S]
+  - **Due/Priority overlap (iOS Safari).** `.v2-form-row` was `grid-template-columns: 1fr 1fr`. `1fr` is shorthand for `minmax(auto, 1fr)`, where `auto` falls back to the cell's intrinsic content size. iOS Safari's `<input type="date">` has a wide intrinsic content size when filled (~150px+), which expanded the Due column past its half-share and overlapped the Priority column. Fix: `minmax(0, 1fr) minmax(0, 1fr)` lets columns shrink below intrinsic. Added `min-width: 0` to `.v2-form-input` / `.v2-form-textarea` defensively.
+  - **Checklists section empty-collapse.** CHECKLISTS label only renders when at least one checklist exists. Empty state is just the "+ Add checklist" pill with the tighter `.v2-form-section-compact` margin. Same pattern Attachments / Comments / Connections already use.
+  - **Connections moved up.** Block now sits between Attachments and Labels (instead of below Comments). Groups the three "linking content" affordances together: Checklists / Attachments / Connections. Comments stays where it is — it's a task-internal thread, not external linking.
+  - **Verification.** `npm run lint` clean. `npm test` smoke passes. Bundle: 752KB precache (unchanged).
+  - Modified: `src/v2/components/EditTaskModal.jsx`, `src/v2/components/AddTaskModal.css`
+
 - fix(ui): v2 header trim + EditTaskModal density pass [M]
   - **Why.** Two surfaces became dense as v2 polish piled on. Header had 7 right-side affordances pushing the More button off-screen on iPhone (Settings unreachable). EditTaskModal had Notes pills overlapping DUE labels, Attachments pills bleeding into Energy buttons, an oversized "Convert to routine" full-width button, and unbalanced bottom action row with Delete styled as a loud destructive primary.
   - **Header — animated wordmark replaces sync icon.** Each letter of "BOOMERANG" wraps a span with a per-letter animation delay (60ms stagger). `data-sync-state` on the wordmark drives: `idle` (default), `saving` (staggered Y-bounce, 1100ms loop), `just-synced` (700ms green flash on saving→synced transition), `degraded` (yellow letters when queue is building / SSE reconnecting), `offline` (red letters steady). Removed the cloud / cloud-off icon entirely.


### PR DESCRIPTION
## Summary

Three EditTaskModal fixes you flagged.

### Due / Priority overlap (iOS Safari)

`.v2-form-row` was `grid-template-columns: 1fr 1fr`. `1fr` is shorthand for `minmax(auto, 1fr)`, where the `auto` minimum falls back to the cell's intrinsic content size. iOS Safari's `<input type="date">` has a **wide intrinsic content width when filled** (~150px+ for "Apr 2, 2026"), which expanded the Due column past its half-share and overlapped Priority.

Fix: `grid-template-columns: minmax(0, 1fr) minmax(0, 1fr)` lets columns shrink below intrinsic content size. Added `min-width: 0` to `.v2-form-input` / `.v2-form-textarea` defensively too.

### Checklists empty-collapse

CHECKLISTS label only renders when ≥1 checklist exists. Empty state is just the "+ Add checklist" pill with the tighter `.v2-form-section-compact` margin. Same pattern Attachments / Comments / Connections already use.

### Connections moves up

Block now sits between Attachments and Labels (was below Comments). Groups the three "linking content" affordances together — Checklists / Attachments / Connections. Comments stays where it is since it's a task-internal thread, not external linking.

## Test plan
- [x] `npm run lint` clean
- [x] `npm test` smoke passes — bundle 752KB
- [ ] CI build green
- [ ] Manual: open task with a due date set on iOS Safari → Due input fits cleanly in its half, Priority sits in the right half with proper gap. Empty task → no CHECKLISTS label, just a compact "+ Add checklist" pill. Notion pill sits in a Connections row right after Attachments.

https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_