### PR TITLE
fix(ui): strip iOS date-input chrome + unify add-affordance pills [S]

### DIFF
--- a/src/v2/components/AddTaskModal.css
+++ b/src/v2/components/AddTaskModal.css
@@ -12,6 +12,12 @@
   font: 400 14px/1.4 var(--v2-font-body);
   outline: none;
   transition: border-color var(--v2-dur-quick) var(--v2-ease-standard);
+  /* Strip the native iOS Safari date-input chrome (which renders an internal
+   * UI that bleeds past the styled border and breaks grid column width).
+   * The picker still triggers on tap; only the rendered field becomes
+   * fully styleable. */
+  -webkit-appearance: none;
+  appearance: none;
 }
 
 .v2-form-input:focus,

--- a/src/v2/components/EditTaskModal.css
+++ b/src/v2/components/EditTaskModal.css
@@ -377,6 +377,10 @@
   border-style: solid;
 }
 
+/* Shared add-affordance pill — dashed border, transparent bg, hover fills.
+ * Used as the empty-state "tap to add" pill across Checklists / Attachments /
+ * Comments / Connections so all four read as the same kind of action. */
+.v2-edit-add-pill,
 .v2-edit-checklist-new {
   display: inline-flex;
   align-items: center;
@@ -394,10 +398,16 @@
               border-color var(--v2-dur-quick) var(--v2-ease-standard);
 }
 
+.v2-edit-add-pill:hover:not(:disabled),
 .v2-edit-checklist-new:hover {
   background: rgba(var(--v2-text-rgb), 0.04);
   color: var(--v2-text);
   border-color: var(--v2-text-meta);
+}
+
+.v2-edit-add-pill:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 
 /* Notes toolbar — Polish + Research as a horizontal row BELOW the textarea.

--- a/src/v2/components/EditTaskModal.jsx
+++ b/src/v2/components/EditTaskModal.jsx
@@ -594,7 +594,11 @@ export default function EditTaskModal({ task, onSave, onClose, onDelete, onBackl
           onChange={form.handleFileSelect}
         />
         <div className="v2-edit-attach-actions">
-          <button type="button" className="v2-form-ai-pill v2-form-ai-pill-inline" onClick={() => form.fileInputRef.current?.click()}>
+          <button
+            type="button"
+            className={form.attachments.length > 0 ? 'v2-form-ai-pill v2-form-ai-pill-inline' : 'v2-edit-add-pill'}
+            onClick={() => form.fileInputRef.current?.click()}
+          >
             <Paperclip size={12} strokeWidth={1.75} /> Attach files
           </button>
           {form.attachments.length > 0 && (
@@ -657,7 +661,7 @@ export default function EditTaskModal({ task, onSave, onClose, onDelete, onBackl
           ) : !form.notionState ? (
             <button
               type="button"
-              className="v2-form-ai-pill v2-form-ai-pill-static"
+              className="v2-edit-add-pill"
               onClick={form.handleNotionSearch}
               disabled={!form.title.trim()}
               title="Search Notion for matching pages, or create a new one"
@@ -790,7 +794,7 @@ export default function EditTaskModal({ task, onSave, onClose, onDelete, onBackl
           </div>
         )}
         {!showComments && (
-          <button type="button" className="v2-form-ai-pill v2-form-ai-pill-inline" onClick={() => setShowComments(true)}>
+          <button type="button" className="v2-edit-add-pill" onClick={() => setShowComments(true)}>
             <Plus size={12} strokeWidth={2} /> Add comment
           </button>
         )}

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,12 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-09
 
+- fix(ui): v2 EditTaskModal — strip native date-input chrome + unified add-pill style [S]
+  - **Due/Priority STILL overlapped** despite the `minmax(0, 1fr)` fix in PR #51. Root cause was iOS Safari rendering native chrome on `<input type="date">` that bleeds *outside* the styled border into the adjacent grid column. `-webkit-appearance: none; appearance: none;` on `.v2-form-input` strips the native UI and leaves only the styled box; the picker still triggers on tap.
+  - **Add-affordance pills were inconsistent.** "+ Add checklist" (dashed, transparent), "Attach files" (gray-fill), "Notion" (gray-fill), "+ Add comment" (gray-fill) — three different visual treatments for four structurally-identical "tap to add" empty-state pills. New shared `.v2-edit-add-pill` class with the dashed-border treatment; applied to all four. Existing `.v2-edit-checklist-new` aliased to the same selector to keep the original markup working.
+  - **Verification.** `npm run lint` clean. `npm test` smoke passes. Bundle: 752KB precache (unchanged).
+  - Modified: `src/v2/components/AddTaskModal.css`, `src/v2/components/EditTaskModal.css`, `src/v2/components/EditTaskModal.jsx`
+
 - fix(ui): v2 EditTaskModal — Due/Priority overlap + Checklists empty-collapse + Connections moves up [S]
   - **Due/Priority overlap (iOS Safari).** `.v2-form-row` was `grid-template-columns: 1fr 1fr`. `1fr` is shorthand for `minmax(auto, 1fr)`, where `auto` falls back to the cell's intrinsic content size. iOS Safari's `<input type="date">` has a wide intrinsic content size when filled (~150px+), which expanded the Due column past its half-share and overlapped the Priority column. Fix: `minmax(0, 1fr) minmax(0, 1fr)` lets columns shrink below intrinsic. Added `min-width: 0` to `.v2-form-input` / `.v2-form-textarea` defensively.
   - **Checklists section empty-collapse.** CHECKLISTS label only renders when at least one checklist exists. Empty state is just the "+ Add checklist" pill with the tighter `.v2-form-section-compact` margin. Same pattern Attachments / Comments / Connections already use.


### PR DESCRIPTION
## Two follow-ups from the latest screenshot

### 1. Due/Priority overlap — actually fixed this time

PR #51's `minmax(0, 1fr)` got the grid math right, but iOS Safari's `<input type="date">` renders **native chrome that bleeds outside the styled border** into the next column. Browser layout engine puts the grid track at the right size; Safari's date picker ignores it.

Fix: `-webkit-appearance: none; appearance: none;` on `.v2-form-input` strips the native UI entirely. The styled border becomes authoritative; the picker still fires on tap.

### 2. Add-pills unified

Four structurally-identical "tap to add" empty-state pills used three different visual treatments:

| Pill | Old style |
|---|---|
| "+ Add checklist" | dashed transparent |
| "Attach files" | gray-fill |
| "Notion" | gray-fill |
| "+ Add comment" | gray-fill |

New shared `.v2-edit-add-pill` class — dashed border, transparent bg, fills on hover. Applied to all four. The dashed convention reads as "tap to add" cleaner than the gray-fill (which reads as a status pill).

`.v2-edit-checklist-new` aliased to the same selector so the existing markup keeps working.

## Test plan
- [x] `npm run lint` clean
- [x] `npm test` smoke passes
- [ ] CI build green
- [ ] Manual on iOS: open task with no due date → Due input fills its half cleanly, no overlap with Priority. Open task with no checklists/attachments/comments/notion → all four "+ Add" pills render with the same dashed style.

https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_