### PR TITLE
style(ui): v2 chip controls — energy type matches drain shape, lowercase text [XS]

### DIFF
--- a/src/v2/components/AddTaskModal.css
+++ b/src/v2/components/AddTaskModal.css
@@ -173,12 +173,13 @@
   flex: 0 0 auto;
   min-width: 44px;
   height: 36px;
-  padding: 0 12px;
+  padding: 0 14px;
   border-radius: var(--v2-radius-pill);
   background: var(--v2-bg);
   color: var(--v2-text-meta);
   border: 1px solid var(--v2-hairline);
   font: 500 13px/1 var(--v2-font-body);
+  text-transform: lowercase;
   cursor: pointer;
   transition: background var(--v2-dur-quick) var(--v2-ease-standard),
               color var(--v2-dur-quick) var(--v2-ease-standard),
@@ -196,20 +197,25 @@
   border-color: var(--v2-text);
 }
 
+/* Energy type — matches Energy drain (.v2-form-seg) in shape: full pill,
+ * 36px height, lowercase. Differentiation comes from per-type color
+ * (border + text in the active state), set inline via the energy palette. */
 .v2-form-energy-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(96px, 1fr));
+  display: flex;
+  flex-wrap: wrap;
   gap: 6px;
 }
 
 .v2-form-energy-pill {
-  height: 40px;
-  padding: 0 12px;
-  border-radius: 10px;
+  flex: 0 0 auto;
+  height: 36px;
+  padding: 0 14px;
+  border-radius: var(--v2-radius-pill);
   background: var(--v2-bg);
   color: var(--v2-text);
   border: 1px solid var(--v2-hairline);
   font: 500 13px/1 var(--v2-font-body);
+  text-transform: lowercase;
   cursor: pointer;
   transition: background var(--v2-dur-quick) var(--v2-ease-standard),
               border-color var(--v2-dur-quick) var(--v2-ease-standard);

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,11 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-09
 
+- style(ui): v2 chip controls — energy type matches energy drain shape, lowercase chip text [XS]
+  - Energy type pills now share the `.v2-form-seg` shape: full pill (`var(--v2-radius-pill)`), 36px height, flex-wrap layout (was 96px-min grid columns with rounded-rect 10px corners). The per-type color treatment in the active state still distinguishes Desk / People / Errand / Creative / Physical via inline border + text colors.
+  - Added `text-transform: lowercase` to both `.v2-form-seg` and `.v2-form-energy-pill` so all chip controls read like the user's lowercase labels (Status / Size / Energy type / Energy drain).
+  - Modified: `src/v2/components/AddTaskModal.css`
+
 - fix(ui): v2 date input collapses with `appearance: none` — force block + min-height [S]
   - PR #52 stripped iOS Safari's native `<input type="date">` chrome to fix the overflow into Priority. Side effect: with native chrome gone, iOS gives an empty date input zero intrinsic dimensions, so the rendered border collapsed to padding-only and no longer matched the Priority button's width.
   - Fix: `display: block` forces it out of inline layout (where iOS computes width against content); explicit `min-height: 44px` matches `.v2-form-pri-toggle` so the row aligns vertically too. Cleaned up a duplicate `min-width: 0` block while editing.


### PR DESCRIPTION
## Two small things from your screenshot

- **Energy type now matches Energy drain shape.** Pills go from 96px-min grid columns + 10px rounded-rect to a flex-wrap row of full-pill chips (36px height, `var(--v2-radius-pill)`) — same as `.v2-form-seg`. Per-type color still distinguishes Desk / People / Errand / Creative / Physical via inline border + text in the active state.
- **All chip text lowercased.** `text-transform: lowercase` on both `.v2-form-seg` and `.v2-form-energy-pill`. Status, Size, Energy type, Energy drain all read in lowercase now — consistent with the user-defined Labels' lowercase aesthetic.

## Test plan
- [x] `npm run lint` clean
- [x] `npm test` smoke passes — bundle 752KB
- [ ] Manual: Energy type chips look identical in shape/size to Energy drain. All chip text reads lowercase.

https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_