### PR TITLE
style(ui): v2 labels grid is 5 wide to match energy-type [XS]

### DIFF
--- a/src/v2/components/AddTaskModal.css
+++ b/src/v2/components/AddTaskModal.css
@@ -238,20 +238,28 @@
   border-width: 1.5px;
 }
 
+/* Labels — 5-wide grid that matches the energy-type row width-for-width.
+ * Long user labels ellipsis-truncate (the full name is in the title attr
+ * + accessible name; tap registers regardless). */
 .v2-form-label-grid {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 4px;
 }
 
 .v2-form-label-pill {
+  min-width: 0;
   height: 32px;
-  padding: 0 12px;
+  padding: 0 8px;
   border-radius: var(--v2-radius-pill);
   background: var(--v2-bg);
   color: var(--v2-text);
   border: 1px solid var(--v2-hairline);
-  font: 500 13px/1 var(--v2-font-body);
+  font: 500 12px/1 var(--v2-font-body);
+  text-align: center;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
   cursor: pointer;
   transition: background var(--v2-dur-quick) var(--v2-ease-standard),
               border-color var(--v2-dur-quick) var(--v2-ease-standard);

--- a/src/v2/components/AddTaskModal.jsx
+++ b/src/v2/components/AddTaskModal.jsx
@@ -181,6 +181,7 @@ export default function AddTaskModal({ open, onAdd, onClose }) {
                   className={`v2-form-label-pill${active ? ' v2-form-label-pill-active' : ''}`}
                   onClick={() => form.toggleTag(lbl.id)}
                   style={active ? { background: lbl.color, borderColor: lbl.color, color: '#fff' } : undefined}
+                  title={lbl.name}
                 >
                   {lbl.name}
                 </button>

--- a/src/v2/components/EditTaskModal.jsx
+++ b/src/v2/components/EditTaskModal.jsx
@@ -742,6 +742,7 @@ export default function EditTaskModal({ task, onSave, onClose, onDelete, onBackl
                   className={`v2-form-label-pill${active ? ' v2-form-label-pill-active' : ''}`}
                   onClick={() => form.toggleTag(lbl.id)}
                   style={active ? { background: lbl.color, borderColor: lbl.color, color: '#fff' } : undefined}
+                  title={lbl.name}
                 >
                   {lbl.name}
                 </button>

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,10 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-09
 
+- style(ui): v2 labels grid → 5 wide to match energy-type row [XS]
+  - `.v2-form-label-grid` switched from flex-wrap to `grid-template-columns: repeat(5, minmax(0, 1fr))` and chips picked up the energy-type sizing (12px font, 0 8px padding, 32px height, gap 4px). Same width math, same lowercase aesthetic. Long custom-label names ellipsis-truncate; full name available via `title` attribute.
+  - Modified: `src/v2/components/AddTaskModal.css`, `src/v2/components/AddTaskModal.jsx`, `src/v2/components/EditTaskModal.jsx`
+
 - style(ui): v2 energy-type row fits all five chips on a single line [XS]
   - Was wrapping to two rows on iPhone (`desk / people / errand` then `creative / physical`). New layout: `flex: 1 1 0` per chip with `min-width: 0` so they share equal slices of the row, smaller font (12px) + tighter padding (0 8px) + height 32px + gap 4px. Five-chip width fits ≤375px viewports without ellipsis. `flex-wrap: nowrap` enforces one line.
   - Modified: `src/v2/components/AddTaskModal.css`


### PR DESCRIPTION
## Summary

`.v2-form-label-grid` switched from flex-wrap to `grid-template-columns: repeat(5, minmax(0, 1fr))`. Chips picked up the energy-type sizing (12px font, 0 8px padding, 32px height, gap 4px) so the rows visually line up under each other.

Long custom-label names (e.g. `low-energy`, `phone-call`) ellipsis-truncate; full name is available via the `title` attribute for hover / long-press / accessibility.

## Test plan
- [x] `npm run lint` clean
- [x] `npm test` smoke passes
- [ ] Manual on iOS: labels render in a 5-column grid; "low-energy" / "phone-call" / etc. fit cleanly or ellipsis-truncate gracefully

https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_