### PR TITLE
style(ui): v2 labels back to flex-wrap (5-wide grid was wrong for dynamic content) [XS]

### DIFF
--- a/src/v2/components/AddTaskModal.css
+++ b/src/v2/components/AddTaskModal.css
@@ -238,28 +238,26 @@
   border-width: 1.5px;
 }
 
-/* Labels — 5-wide grid that matches the energy-type row width-for-width.
- * Long user labels ellipsis-truncate (the full name is in the title attr
- * + accessible name; tap registers regardless). */
+/* Labels — flex-wrap with content-sized chips so dynamic label sets (any
+ * count, any length) don't run into the rigid 5-column grid problems
+ * (stretched leftovers in the last row, ellipsis on long custom names).
+ * Typography matches the energy-type chips so they read as the same kind
+ * of control. */
 .v2-form-label-grid {
-  display: grid;
-  grid-template-columns: repeat(5, minmax(0, 1fr));
+  display: flex;
+  flex-wrap: wrap;
   gap: 4px;
 }
 
 .v2-form-label-pill {
-  min-width: 0;
   height: 32px;
-  padding: 0 8px;
+  padding: 0 12px;
   border-radius: var(--v2-radius-pill);
   background: var(--v2-bg);
   color: var(--v2-text);
   border: 1px solid var(--v2-hairline);
   font: 500 12px/1 var(--v2-font-body);
-  text-align: center;
   white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
   cursor: pointer;
   transition: background var(--v2-dur-quick) var(--v2-ease-standard),
               border-color var(--v2-dur-quick) var(--v2-ease-standard);

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,11 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-09
 
+- style(ui): v2 labels back to flex-wrap (5-wide grid was wrong for dynamic content) [XS]
+  - Reverted PR #56's 5-column grid: with variable label counts the last row's leftover chips stretched to 1fr each (looked busted), and ellipsis-truncating long custom names ("low-energy", "phone-call") was unfriendly. Back to flex-wrap with content-sized chips. Kept the energy-type chip typography (12px font, 32px height, lowercase) so labels still read as the same kind of control as the energy chips above; just no rigid column grid.
+  - `title` attr on each chip from PR #56 stays (harmless, useful as accessible name).
+  - Modified: `src/v2/components/AddTaskModal.css`
+
 - style(ui): v2 labels grid → 5 wide to match energy-type row [XS]
   - `.v2-form-label-grid` switched from flex-wrap to `grid-template-columns: repeat(5, minmax(0, 1fr))` and chips picked up the energy-type sizing (12px font, 0 8px padding, 32px height, gap 4px). Same width math, same lowercase aesthetic. Long custom-label names ellipsis-truncate; full name available via `title` attribute.
   - Modified: `src/v2/components/AddTaskModal.css`, `src/v2/components/AddTaskModal.jsx`, `src/v2/components/EditTaskModal.jsx`


### PR DESCRIPTION
## Why

PR #56's 5-column grid looked tidy with the static set, but dynamic labels expose two failure modes:

1. **Last row stretches awkwardly.** With 12 labels, the last 2 chips in row 3 each claim 1fr → they balloon to ~3x the width of the chips in rows 1 and 2. Looks broken.
2. **Long custom names ellipsis-truncate.** "low-energy" / "phone-call" sat right at the edge of the 60px column. User-defined labels could be longer and visibly truncate.

## Fix

Back to flex-wrap with content-sized chips. Kept the energy-type chip typography (12px font, 32px height, lowercase) so labels still read as the same kind of control as the chips immediately above them — just without the rigid column grid forcing weird stretches.

`title={lbl.name}` from PR #56 stays (harmless, useful as accessible name).

## Test plan
- [x] `npm run lint` clean
- [x] `npm test` smoke passes
- [ ] Manual: long labels render at full width, no truncation; the leftover chips on the last row sit at their natural widths instead of stretching

https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_