### PR TITLE
fix(ui): v2 wordmark wave completes before restarting [S]

### DIFF
--- a/src/v2/components/Header.jsx
+++ b/src/v2/components/Header.jsx
@@ -6,15 +6,17 @@ import './Header.css'
 
 const WORDMARK_LETTERS = 'BOOMERANG'.split('')
 
-// Sync-state derivation. Maps useServerSync's syncStatus + transient
-// "just-synced" pulse + queue length into the visual states the wordmark
-// reflects. Permanent states (offline / degraded) fade ambient stress into
-// the brand instead of using a separate icon. "Just-synced" is a brief flash
-// that decays back to idle.
-function deriveSyncVisualState(syncStatus, queueLength, justSynced) {
+// Sync-state derivation. Maps useServerSync's syncStatus + the local
+// `animState` (saving / just-synced / idle, with minimum hold enforcement)
+// + queue length into the visual states the wordmark reflects. Permanent
+// states (offline / degraded) fade ambient stress into the brand instead
+// of using a separate icon. animState wins over instantaneous syncStatus
+// for the saving / just-synced phases so a fast sync still gets a full
+// wave + flash.
+function deriveSyncVisualState(syncStatus, queueLength, animState) {
   if (syncStatus === 'offline') return 'offline'
-  if (syncStatus === 'saving') return 'saving'
-  if (justSynced) return 'just-synced'
+  if (animState === 'saving') return 'saving'
+  if (animState === 'just-synced') return 'just-synced'
   if (queueLength > 0) return 'degraded'
   return 'idle'
 }
@@ -35,16 +37,46 @@ export default function Header({
   // Just-synced pulse — flashes green for ~700ms after a save completes,
   // then decays. Ambient by design: if everything's working you see the
   // flash once and forget about it.
-  const [justSynced, setJustSynced] = useState(false)
-  const prevSyncStatus = useRef(syncStatus)
+  //
+  // We also enforce a minimum saving-hold (1300ms) so a fast sync doesn't
+  // strand the bounce on the B before the wave reaches the G. The wave
+  // takes ~1140ms to traverse all nine letters at 60ms stagger; rounding
+  // up to 1300 gives margin without feeling sluggish. If saving completes
+  // mid-wave, the green flash queues to fire after the hold expires.
+  const SAVING_MIN_HOLD = 1300
+  const FLASH_MS = 700
+  const [animState, setAnimState] = useState('idle')
+  const allowFlashRef = useRef(false)
+  const timerRef = useRef(null)
+
   useEffect(() => {
-    if (prevSyncStatus.current === 'saving' && syncStatus === 'synced') {
-      setJustSynced(true)
-      const t = setTimeout(() => setJustSynced(false), 700)
-      return () => clearTimeout(t)
+    return () => { if (timerRef.current) clearTimeout(timerRef.current) }
+  }, [])
+
+  useEffect(() => {
+    if (syncStatus === 'saving') {
+      // Start (or restart) the wave. Clear any pending flash.
+      allowFlashRef.current = false
+      setAnimState('saving')
+      if (timerRef.current) clearTimeout(timerRef.current)
+      timerRef.current = setTimeout(() => {
+        timerRef.current = null
+        if (allowFlashRef.current) {
+          setAnimState('just-synced')
+          timerRef.current = setTimeout(() => {
+            timerRef.current = null
+            setAnimState('idle')
+          }, FLASH_MS)
+        } else {
+          setAnimState('idle')
+        }
+      }, SAVING_MIN_HOLD)
+    } else if (syncStatus === 'synced' && animState === 'saving') {
+      // Saving completed mid-wave — queue the green flash for when the hold
+      // timer fires. Don't transition yet; wave finishes first.
+      allowFlashRef.current = true
     }
-    prevSyncStatus.current = syncStatus
-  }, [syncStatus])
+  }, [syncStatus, animState])
 
   // Click outside closes the brand popover.
   useEffect(() => {
@@ -62,7 +94,7 @@ export default function Header({
     }
   }, [popoverOpen])
 
-  const syncVisualState = deriveSyncVisualState(syncStatus, queueLength, justSynced)
+  const syncVisualState = deriveSyncVisualState(syncStatus, queueLength, animState)
   const syncLabel =
     syncVisualState === 'offline' ? `Offline${queueLength ? ` · ${queueLength} pending` : ''}` :
     syncVisualState === 'degraded' ? `Working through ${queueLength} pending change${queueLength === 1 ? '' : 's'}` :

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,12 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-09
 
+- fix(ui): v2 wordmark wave completes a full pass before restarting [S]
+  - Bug. Fast syncs (saving → synced under ~200ms) flipped `data-sync-state` back to idle before the bounce wave reached the G — only the B and the first O ever moved.
+  - Fix. Header now runs a small state machine: when saving starts, the visual state is held at "saving" for a minimum 1300ms (one full wave traversal + margin). If sync completes mid-wave, the green "just-synced" flash queues to fire after the hold, instead of clobbering the in-flight wave. Subsequent saves during the hold restart the timer cleanly.
+  - Replaces the old `justSynced` boolean with an `animState` (`idle | saving | just-synced`) that's the single source of truth for wave / flash timing. `deriveSyncVisualState` reads animState, so the visible behavior matches the timing intent regardless of how quickly the underlying sync resolves.
+  - Modified: `src/v2/components/Header.jsx`
+
 - style(ui): v2 labels back to flex-wrap (5-wide grid was wrong for dynamic content) [XS]
   - Reverted PR #56's 5-column grid: with variable label counts the last row's leftover chips stretched to 1fr each (looked busted), and ellipsis-truncating long custom names ("low-energy", "phone-call") was unfriendly. Back to flex-wrap with content-sized chips. Kept the energy-type chip typography (12px font, 32px height, lowercase) so labels still read as the same kind of control as the energy chips above; just no rigid column grid.
   - `title` attr on each chip from PR #56 stays (harmless, useful as accessible name).


### PR DESCRIPTION
## Bug

Fast syncs (saving → synced in <200ms) flipped `data-sync-state` back to idle before the bounce wave could traverse all nine letters. Net effect: only the B and the first O ever bounced; the user-perceived wave was stuck on the first letter.

## Fix

Header now runs a tiny state machine for animation timing:

- **`saving` start** → visual state pinned at `saving` for a minimum **1300ms** (one full wave traversal + margin: stagger=60ms × 8 letters + 1100ms cycle = ~1580ms; rounded down because last-letter-bounce-peak happens at ~810ms and the visible wave is "complete" by ~1140ms).
- **`synced` mid-wave** → queues a "just-synced" flash for after the hold expires; the in-flight wave finishes uninterrupted.
- **`saving` again during hold** → timer restarts cleanly, flash flag cleared.

Replaced the old `justSynced` boolean with an `animState` (`idle | saving | just-synced`) as the single source of truth for wave / flash timing. `deriveSyncVisualState` reads animState rather than instantaneous syncStatus for the saving / just-synced phases.

## Test plan
- [x] `npm run lint` clean
- [x] `npm test` smoke passes
- [ ] Manual: trigger a fast sync (toggle a setting). All nine letters bounce, then the green flash fires. Trigger several saves in quick succession — wave doesn't reset, completes once per minimum hold.

https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_