### PR TITLE
style(ui): v2 Anthropic key UI consolidates to Integrations [XS]

### DIFF
--- a/src/v2/components/SettingsModal.css
+++ b/src/v2/components/SettingsModal.css
@@ -980,3 +980,18 @@
   font: 400 13px/1.4 var(--v2-font-body);
   color: var(--v2-text);
 }
+
+/* Inline tab-link styled like an anchor inside a hint paragraph. Used for
+ * "configure under Settings → Integrations" pointer in the AI tab. */
+.v2-settings-inline-link {
+  display: inline;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--v2-accent);
+  font: inherit;
+  cursor: pointer;
+}
+.v2-settings-inline-link:hover {
+  text-decoration: underline;
+}

--- a/src/v2/components/SettingsModal.jsx
+++ b/src/v2/components/SettingsModal.jsx
@@ -200,7 +200,9 @@ const NOTIF_PACKAGE_TYPES = [
 // Anthropic key entry + status check. Lives in the AI tab; the
 // IntegrationsPanel still surfaces a status dot but the actual key
 // management happens here.
-function AnthropicKeyBlock({ settings, update }) {
+// Anthropic key entry + test. Embedded under the Anthropic row in
+// IntegrationsPanel; the AI tab just shows a one-liner pointer.
+function AnthropicKeyBlock({ settings, update, embedded = false }) {
   const [envKey, setEnvKey] = useState(false)
   const [status, setStatus] = useState(null) // null | 'checking' | 'connected' | 'error'
   const [error, setError] = useState(null)
@@ -239,19 +241,23 @@ function AnthropicKeyBlock({ settings, update }) {
     : status === 'error' ? 'v2-integrations-error'
     : 'v2-integrations-hint'
 
-  return (
-    <div className="v2-settings-block">
-      <div className="v2-form-label">Anthropic API key</div>
-      <div className="v2-settings-row-hint">
-        Powers AI inference, Quokka, polish, what-now suggestions, and notification rewrites.
-        Keys at <a href="https://console.anthropic.com/settings/keys" target="_blank" rel="noreferrer">console.anthropic.com</a>.
-      </div>
+  const inner = (
+    <>
+      {!embedded && (
+        <>
+          <div className="v2-form-label">Anthropic API key</div>
+          <div className="v2-settings-row-hint">
+            Powers AI inference, Quokka, polish, what-now suggestions, and notification rewrites.
+            Keys at <a href="https://console.anthropic.com/settings/keys" target="_blank" rel="noreferrer">console.anthropic.com</a>.
+          </div>
+        </>
+      )}
       {envKey ? (
         <div className="v2-integrations-env">
           Provided via env var. Configure server-side; this field is read-only.
         </div>
       ) : (
-        <div className="v2-integrations-inline">
+        <>
           <input
             type={showKey ? 'text' : 'password'}
             className="v2-form-input"
@@ -279,18 +285,20 @@ function AnthropicKeyBlock({ settings, update }) {
               </button>
             )}
           </div>
-        </div>
+        </>
       )}
       {envKey && (
-        <div className="v2-integrations-actions" style={{ marginTop: 8 }}>
+        <div className="v2-integrations-actions">
           <button className="v2-settings-btn" onClick={runTest} disabled={status === 'checking'}>
             {status === 'checking' ? 'Testing…' : 'Test'}
           </button>
         </div>
       )}
-      <div className={summaryClass} style={{ marginTop: 8 }}>{summary}</div>
-    </div>
+      <div className={summaryClass}>{summary}</div>
+    </>
   )
+
+  return embedded ? inner : <div className="v2-settings-block">{inner}</div>
 }
 
 function IntegrationsPanel({
@@ -476,10 +484,9 @@ function IntegrationsPanel({
     {
       key: 'anthropic',
       label: 'Anthropic (Claude)',
-      hint: 'Powers AI inference, Quokka, polish, what-now suggestions, notification rewrites. Configure in the AI tab.',
+      hint: 'Powers AI inference, Quokka, polish, what-now suggestions, notification rewrites.',
       connected: envKeys.anthropic || !!settings.anthropic_api_key,
-      v1Section: 'AI',
-      manageInTab: 'AI',
+      inline: 'anthropic',
     },
     {
       key: 'notion',
@@ -603,6 +610,11 @@ function IntegrationsPanel({
                         onChange={e => update(int.keyName, e.target.value)}
                       />
                     )}
+                  </div>
+                )}
+                {int.inline === 'anthropic' && (
+                  <div className="v2-integrations-inline">
+                    <AnthropicKeyBlock settings={settings} update={update} embedded />
                   </div>
                 )}
                 {int.inline === 'notion-config' && (
@@ -865,7 +877,7 @@ function IntegrationsPanel({
                     {int.sync.busy ? 'Syncing…' : 'Sync now'}
                   </button>
                 )}
-                {!['pushover', 'weather', 'trello-config', 'gcal-config', 'gmail-config', 'notion-config'].includes(int.inline) && (
+                {!['pushover', 'weather', 'trello-config', 'gcal-config', 'gmail-config', 'notion-config', 'anthropic'].includes(int.inline) && (
                   int.manageInTab ? (
                     <button
                       className="v2-settings-btn"
@@ -1736,7 +1748,12 @@ export default function SettingsModal({
                 )}
               </div>
             </div>
-            <AnthropicKeyBlock settings={settings} update={update} />
+            <div className="v2-settings-block">
+              <div className="v2-form-label">Anthropic API key</div>
+              <div className="v2-settings-row-hint">
+                Get a key at <a href="https://console.anthropic.com/settings/keys" target="_blank" rel="noreferrer">console.anthropic.com</a>, then configure it under <button type="button" className="v2-settings-inline-link" onClick={() => setActiveTab('Integrations')}>Settings → Integrations</button>.
+              </div>
+            </div>
           </div>
         )}
 

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,12 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-09
 
+- style(ui): v2 AI tab — Anthropic key UI moves to Integrations, AI shows pointer note [XS]
+  - Anthropic key UI was duplicated across the AI tab (full editable block) and the Integrations row (which routed back to AI). Consolidated: Integrations row now embeds the editable block directly via a new `inline: 'anthropic'` mode; AI tab drops the full block and shows a one-line pointer ("Get a key at console.anthropic.com, then configure under Settings → Integrations") with a clickable inline link that flips active tab to Integrations. Fixes the visual cramming where the ANTHROPIC API KEY header was butted against the Custom-instructions Clear button.
+  - `AnthropicKeyBlock` gains an `embedded` prop that strips the outer block wrapper + the redundant header/hint when rendered inside the Integrations row.
+  - New `.v2-settings-inline-link` utility for tab-link-as-anchor styling.
+  - Modified: `src/v2/components/SettingsModal.jsx`, `src/v2/components/SettingsModal.css`
+
 - fix(ui): v2 wordmark wave completes a full pass before restarting [S]
   - Bug. Fast syncs (saving → synced under ~200ms) flipped `data-sync-state` back to idle before the bounce wave reached the G — only the B and the first O ever moved.
   - Fix. Header now runs a small state machine: when saving starts, the visual state is held at "saving" for a minimum 1300ms (one full wave traversal + margin). If sync completes mid-wave, the green "just-synced" flash queues to fire after the hold, instead of clobbering the in-flight wave. Subsequent saves during the hold restart the timer cleanly.


### PR DESCRIPTION
## Why

The Anthropic key UI was duplicated:
- **AI tab** had the full editable block (input + Show/Test/Disconnect + status line)
- **Integrations row** had a "Configure in AI" button that just routed back to the AI tab

So users saw two surfaces for one config, and the AI-tab block's header was visually cramming the Custom-instructions Clear button row right above it.

## Fix

- **Integrations row** is now the canonical home. New `inline: 'anthropic'` mode embeds the `AnthropicKeyBlock` directly under the Anthropic integration's hint copy.
- **AI tab** drops the full block and shows a one-line pointer: "Get a key at console.anthropic.com, then configure under Settings → Integrations." The inline link flips `activeTab` to Integrations on tap.
- `AnthropicKeyBlock` gains an `embedded` prop that strips its outer block wrapper + the redundant header/hint when rendered inside the Integrations row (since Integrations row already provides them).
- New `.v2-settings-inline-link` utility for tab-link-as-anchor styling.

## Test plan
- [x] `npm run lint` clean
- [x] `npm test` smoke passes — bundle 753KB
- [ ] Manual: Settings → AI shows the short pointer; tapping "Settings → Integrations" link flips the tab. Settings → Integrations → Anthropic row shows the full editable block under the integration hint.

https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_