### PR TITLE
docs(v2): note terminal-flavored loading animations on parking-lot bullet [XS]

### DIFF
--- a/wiki/V2-State.md
+++ b/wiki/V2-State.md
@@ -132,6 +132,7 @@ All five bugs the user logged from device screenshots have been addressed:
 ### Future-direction parking lot
 
 - [ ] **Terminal-aesthetic theme toggle.** Inspiration: [init.habits](https://inithabits.com) — monospace + ASCII-style checkboxes `[ ] / [✓]`, command-prompt header (`user@init.habits $ daily`), tabbed nav (habits / stats / profile), fire-emoji streak indicator, calendar-row date picker, soft glow on a deep-blue terminal palette. Could ship as a third tier beyond light/dark — likely a new `data-ui` mode (e.g. `data-ui="terminal"`) that swaps `tokens.css` for a terminal-specific palette + monospace font stack, leaving the layout/component contracts untouched. Not a v2 ship item; revisit after the dev → main merge.
+  - **Terminal-flavored loading/sync animations.** The current `BOOMERANG` wordmark wave (PR #58) — letter-by-letter bounce on saving, green flash on done, yellow/red for degraded/offline — translates beautifully to the terminal aesthetic. Ideas to carry forward into the terminal theme: ASCII spinner glyphs (`| / - \`) cycling per letter instead of bounce; cursor blink on the trailing `_` while saving; `[OK]` / `[ERR]` / `[BUSY]` bracketed status flashes that match terminal status conventions; `loading…` ellipsis dot-cycling; output-line scroll for status messages instead of a popover. Same state machine (`idle / saving / just-synced / degraded / offline`) drives a different visual vocabulary.
 
 ### Final-mile cleanup
 

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,10 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-09
 
+- docs(v2): note terminal-flavored loading animations on the parking-lot terminal-theme bullet [XS]
+  - The wordmark-wave from PR #58 is exactly the kind of ambient state-feedback that the terminal theme should preserve. Added an idea-bank sub-bullet to V2-State's terminal-aesthetic entry: ASCII spinner glyphs per letter, cursor blink on the trailing `_`, `[OK]/[ERR]/[BUSY]` bracketed flashes, `loading…` ellipsis cycling, output-line scroll. Same `animState` state machine drives a different visual vocabulary.
+  - Modified: `wiki/V2-State.md`
+
 - style(ui): v2 AI tab — Anthropic key UI moves to Integrations, AI shows pointer note [XS]
   - Anthropic key UI was duplicated across the AI tab (full editable block) and the Integrations row (which routed back to AI). Consolidated: Integrations row now embeds the editable block directly via a new `inline: 'anthropic'` mode; AI tab drops the full block and shows a one-line pointer ("Get a key at console.anthropic.com, then configure under Settings → Integrations") with a clickable inline link that flips active tab to Integrations. Fixes the visual cramming where the ANTHROPIC API KEY header was butted against the Custom-instructions Clear button.
   - `AnthropicKeyBlock` gains an `embedded` prop that strips the outer block wrapper + the redundant header/hint when rendered inside the Integrations row.


### PR DESCRIPTION
## Summary

Captures an idea-bank for the future terminal-aesthetic theme: the wordmark-wave from PR #58 should translate into terminal-flavored loading/sync animations.

Sub-bullet on the existing parking-lot entry mentions:
- ASCII spinner glyphs (`| / - \`) cycling per letter
- Cursor blink on the trailing `_` while saving
- `[OK]` / `[ERR]` / `[BUSY]` bracketed status flashes
- `loading…` ellipsis dot-cycling
- Output-line scroll for status messages instead of a popover

Same `animState` state machine drives a different visual vocabulary. Doc-only.

https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_