### PR TITLE
feat(ui): v2 ErrorBoundary + early data-ui/data-theme application [S]

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,12 +13,18 @@
     <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600&family=Syne:wght@700;800&display=swap" rel="stylesheet" />
     <title>Boomerang</title>
     <script>
-      // Apply saved theme before first paint to prevent flash
+      // Apply saved UI version + theme before first paint so v2 tokens (and the
+      // chosen dark/light variant) are in scope before React mounts. Critical
+      // for the ErrorBoundary fallback: if AppV2 throws on first render, the
+      // boundary still renders with the right tokens applied.
       try {
+        var v = localStorage.getItem('ui_version')
+        if (v !== 'v1') document.documentElement.setAttribute('data-ui', 'v2')
         var s = JSON.parse(localStorage.getItem('boom_settings_v1'))
-        if (s && s.theme === 'light') {
-          document.documentElement.setAttribute('data-theme', 'light')
-          document.querySelector('meta[name="theme-color"]').content = '#F5F5F7'
+        if (s && (s.theme === 'light' || s.theme === 'dark')) {
+          document.documentElement.setAttribute('data-theme', s.theme)
+          var meta = document.querySelector('meta[name="theme-color"]')
+          if (meta) meta.content = s.theme === 'light' ? '#FFFFFF' : '#0B0B0F'
         }
       } catch(e) {}
     </script>

--- a/server.js
+++ b/server.js
@@ -188,6 +188,20 @@ app.post('/api/log', (req, res) => {
   res.json({ ok: true })
 })
 
+// --- Client render-error capture (v2 ErrorBoundary fallback fires this) ---
+app.post('/api/logs/client-error', (req, res) => {
+  const { message, stack, componentStack, url, userAgent, appVersion } = req.body || {}
+  console.error('[CLIENT-ERROR]', JSON.stringify({
+    message: message || 'unknown',
+    url: url || null,
+    userAgent: userAgent || null,
+    appVersion: appVersion || null,
+  }))
+  if (stack) console.error('[CLIENT-ERROR] stack:\n' + stack)
+  if (componentStack) console.error('[CLIENT-ERROR] component stack:\n' + componentStack)
+  res.json({ ok: true })
+})
+
 // --- Key status route (tells frontend what's configured via env) ---
 app.get('/api/keys/status', (req, res) => {
   res.json({

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import AppV1 from './AppV1.jsx'
 import AppV2 from './v2/AppV2.jsx'
+import ErrorBoundary from './v2/components/ErrorBoundary.jsx'
 
 const STORAGE_KEY = 'ui_version'
 
@@ -29,5 +30,16 @@ export default function App() {
     document.documentElement.setAttribute('data-ui-version', version)
   }, [version])
 
-  return version === 'v2' ? <AppV2 /> : <AppV1 />
+  // Error boundary wraps v2 so a render-time exception (TDZ, undefined
+  // hook return, broken third-party module) shows a recoverable fallback
+  // with the actual error instead of a black screen. v1 stays unwrapped to
+  // keep the legacy escape hatch identical to its historical behavior.
+  if (version === 'v2') {
+    return (
+      <ErrorBoundary>
+        <AppV2 />
+      </ErrorBoundary>
+    )
+  }
+  return <AppV1 />
 }

--- a/src/v2/components/ErrorBoundary.css
+++ b/src/v2/components/ErrorBoundary.css
@@ -1,0 +1,137 @@
+/* Error boundary fallback. Token-driven so it adapts to dark mode the same
+ * way the rest of v2 does. Force data-ui="v2" attribute parent context isn't
+ * relied on here — the boundary may render before AppV2 sets data-ui — so
+ * we duplicate the token defaults inline as a safety net. */
+.v2-error-boundary {
+  --eb-bg: var(--v2-bg, #FFFFFF);
+  --eb-surface: var(--v2-surface, #FFFFFF);
+  --eb-text: var(--v2-text, #1A1A1F);
+  --eb-text-rgb: var(--v2-text-rgb, 26, 26, 31);
+  --eb-text-meta: var(--v2-text-meta, rgba(26, 26, 31, 0.55));
+  --eb-hairline: var(--v2-hairline, rgba(0, 0, 0, 0.08));
+  --eb-accent: var(--v2-accent, #FF6240);
+
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: var(--eb-bg);
+  color: var(--eb-text);
+  font-family: var(--v2-font-body, 'DM Sans', system-ui, sans-serif);
+  z-index: 99999;
+  overflow-y: auto;
+}
+
+.v2-error-boundary-card {
+  max-width: 520px;
+  width: 100%;
+  background: var(--eb-surface);
+  border: 1px solid var(--eb-hairline);
+  border-radius: 20px;
+  padding: 28px 24px;
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.15);
+}
+
+.v2-error-boundary-emoji {
+  font-size: 36px;
+  margin-bottom: 12px;
+}
+
+.v2-error-boundary-title {
+  font: 700 22px/1.2 var(--v2-font-display, 'Syne', serif);
+  margin: 0 0 8px;
+  color: var(--eb-text);
+}
+
+.v2-error-boundary-body {
+  font: 400 14px/1.5 var(--v2-font-body, 'DM Sans', sans-serif);
+  color: var(--eb-text-meta);
+  margin: 0 0 18px;
+}
+
+.v2-error-boundary-details {
+  margin-bottom: 18px;
+  padding: 12px;
+  border: 1px solid var(--eb-hairline);
+  border-radius: 12px;
+  background: rgba(var(--eb-text-rgb), 0.03);
+}
+
+.v2-error-boundary-details summary {
+  font: 500 13px/1 var(--v2-font-body, sans-serif);
+  color: var(--eb-text-meta);
+  cursor: pointer;
+  padding: 4px 0;
+  user-select: none;
+}
+
+.v2-error-boundary-details summary:hover {
+  color: var(--eb-text);
+}
+
+.v2-error-boundary-detail-block {
+  margin-top: 12px;
+}
+
+.v2-error-boundary-detail-label {
+  font: 600 10px/1 var(--v2-font-body, sans-serif);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--eb-text-meta);
+  margin-bottom: 4px;
+}
+
+.v2-error-boundary-detail-block pre {
+  font: 400 11px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace;
+  color: var(--eb-text);
+  margin: 0;
+  padding: 8px 10px;
+  background: rgba(var(--eb-text-rgb), 0.04);
+  border-radius: 6px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 180px;
+  overflow-y: auto;
+}
+
+.v2-error-boundary-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.v2-error-boundary-primary {
+  flex: 1;
+  min-width: 140px;
+  height: 42px;
+  padding: 0 18px;
+  border: none;
+  border-radius: 999px;
+  background: var(--eb-accent);
+  color: #fff;
+  font: 600 14px/1 var(--v2-font-body, sans-serif);
+  cursor: pointer;
+  transition: filter 120ms cubic-bezier(.4, 0, .2, 1);
+}
+.v2-error-boundary-primary:hover { filter: brightness(1.08); }
+
+.v2-error-boundary-secondary {
+  flex: 1;
+  min-width: 140px;
+  height: 42px;
+  padding: 0 18px;
+  border: 1px solid var(--eb-hairline);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--eb-text-meta);
+  font: 500 14px/1 var(--v2-font-body, sans-serif);
+  cursor: pointer;
+  transition: background 120ms cubic-bezier(.4, 0, .2, 1),
+              color 120ms cubic-bezier(.4, 0, .2, 1);
+}
+.v2-error-boundary-secondary:hover {
+  background: rgba(var(--eb-text-rgb), 0.04);
+  color: var(--eb-text);
+}

--- a/src/v2/components/ErrorBoundary.jsx
+++ b/src/v2/components/ErrorBoundary.jsx
@@ -1,0 +1,108 @@
+import { Component } from 'react'
+import './ErrorBoundary.css'
+
+// Defense in depth — catches render-time errors so a thrown exception in any
+// v2 surface doesn't black-screen the app the way the TDZ bug did on
+// 2026-05-09. React doesn't surface render errors to the console as hard
+// failures; they propagate to the nearest error boundary, which by default
+// at the root just unmounts the tree (leaving the dark fallback bg from
+// :root tokens with no React content). Without a boundary, the user sees
+// nothing.
+//
+// On catch: store error info in state, render a recoverable fallback, and
+// fire a fetch to /api/logs so the server captures the stack for triage.
+// Reload button forces a fresh mount; if the bug is in user-state (corrupt
+// localStorage), Clear local state offers a recovery path.
+export default class ErrorBoundary extends Component {
+  constructor(props) {
+    super(props)
+    this.state = { error: null, errorInfo: null }
+  }
+
+  static getDerivedStateFromError(error) {
+    return { error }
+  }
+
+  componentDidCatch(error, errorInfo) {
+    this.setState({ errorInfo })
+    // Best-effort log to server. Doesn't await; offline-safe.
+    try {
+      fetch('/api/logs/client-error', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          message: error?.message || String(error),
+          stack: error?.stack || null,
+          componentStack: errorInfo?.componentStack || null,
+          url: typeof window !== 'undefined' ? window.location.href : null,
+          userAgent: typeof navigator !== 'undefined' ? navigator.userAgent : null,
+          appVersion: typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : 'unknown',
+        }),
+      }).catch(() => { /* offline / endpoint missing — fallback UI still works */ })
+    } catch { /* swallow */ }
+  }
+
+  handleReload = () => {
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.getRegistrations().then(regs => {
+        regs.forEach(r => r.unregister())
+      }).catch(() => {})
+    }
+    window.location.reload()
+  }
+
+  handleClearLocal = () => {
+    if (!confirm('Clear local state? This wipes localStorage (settings, labels, sync queue) on this device. Server-side tasks/routines are not affected.')) return
+    try {
+      localStorage.clear()
+    } catch { /* swallow */ }
+    this.handleReload()
+  }
+
+  render() {
+    if (!this.state.error) return this.props.children
+
+    const message = this.state.error?.message || String(this.state.error)
+    const stack = this.state.error?.stack
+    const componentStack = this.state.errorInfo?.componentStack
+
+    return (
+      <div className="v2-error-boundary">
+        <div className="v2-error-boundary-card">
+          <div className="v2-error-boundary-emoji" aria-hidden="true">🪃</div>
+          <h1 className="v2-error-boundary-title">Boomerang hit a snag</h1>
+          <p className="v2-error-boundary-body">
+            Something broke while rendering. The error has been logged. Reloading usually fixes transient issues; if it keeps happening, clearing local state is a safe escape hatch.
+          </p>
+          <details className="v2-error-boundary-details">
+            <summary>Show details</summary>
+            <div className="v2-error-boundary-detail-block">
+              <div className="v2-error-boundary-detail-label">Message</div>
+              <pre>{message}</pre>
+            </div>
+            {stack && (
+              <div className="v2-error-boundary-detail-block">
+                <div className="v2-error-boundary-detail-label">Stack</div>
+                <pre>{stack}</pre>
+              </div>
+            )}
+            {componentStack && (
+              <div className="v2-error-boundary-detail-block">
+                <div className="v2-error-boundary-detail-label">Component stack</div>
+                <pre>{componentStack}</pre>
+              </div>
+            )}
+          </details>
+          <div className="v2-error-boundary-actions">
+            <button type="button" className="v2-error-boundary-primary" onClick={this.handleReload}>
+              Reload
+            </button>
+            <button type="button" className="v2-error-boundary-secondary" onClick={this.handleClearLocal}>
+              Clear local state &amp; reload
+            </button>
+          </div>
+        </div>
+      </div>
+    )
+  }
+}

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,17 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-09
 
+- feat(ui): v2 ErrorBoundary + early data-ui/data-theme application [S]
+  - **Why.** The 2026-05-09 TDZ bug rendered a black screen with no surfaced error because React unmounts on uncaught render exceptions and v2's :root tokens fall through to dark fallback bg with no content. Adding a top-level error boundary at AppV2's wrapper means render-time failures show a recoverable fallback instead of a dead app, AND the stack hits `/api/logs/client-error` for triage.
+  - **`ErrorBoundary.jsx` + `.css`.** Class component (React error boundaries require classes). `getDerivedStateFromError` + `componentDidCatch`. Fallback UI: 🪃 + "Boomerang hit a snag" + collapsible details (message, stack, component stack) + Reload button (also unregisters service worker) + "Clear local state & reload" button (wipes localStorage with a confirm before doing so). All token-driven so it adapts to dark mode; falls back to inline defaults if `data-ui` somehow isn't set yet.
+  - **`src/App.jsx` wiring.** v2 path wraps `<AppV2>` in `<ErrorBoundary>`. v1 stays unwrapped — legacy surface, no need to add behavior.
+  - **`server.js` `/api/logs/client-error` endpoint.** Receives `{message, stack, componentStack, url, userAgent, appVersion}` from the boundary and prints to the server log via the `[CLIENT-ERROR]` prefix. Best-effort — no DB write, just visibility for triage.
+  - **`index.html` early-paint script** now applies both `data-ui="v2"` (when not opted into v1) AND `data-theme` (when settings.theme is set, light OR dark) BEFORE React mounts. Without this, an error during AppV2's first render would show the boundary in light mode regardless of user preference, since data-ui was previously only set in AppV2's mount effect.
+  - **Dark-mode audit.** Walked every v2 surface for hardcoded colors that wouldn't swap. All `var(--v2-*)` token references adapt cleanly. `#fff` text is always paired with `var(--v2-accent)` filled buttons (orange + white reads on both modes). Hardcoded RGB tints (alert-tinted card backgrounds, hover tints, etc.) are low-alpha and read on both modes. Active-state pattern (`background: var(--v2-text); color: var(--v2-bg)`) inverts cleanly across modes. No surface flagged for follow-up.
+  - **Verification.** `npm run lint` clean. `npm test` smoke passes. Bundle: 762KB precache (up from 759KB).
+  - New: `src/v2/components/ErrorBoundary.jsx`, `src/v2/components/ErrorBoundary.css`
+  - Modified: `src/App.jsx`, `index.html`, `server.js`
+
 - docs(v2): park "web push deprecation trial" decision for after v2 → main merge [XS]
   - Pushover is now the recommended primary on iOS but web push is still live with all its plumbing. Logged a parking-lot bullet that explicitly schedules a tap-rate / completion-rate review in Engagement Analytics 2 weeks post-v2-merge, with concrete go / no-go criteria and a rough scope estimate (~250-400 LOC net delete) if go.
   - Modified: `wiki/V2-State.md`


### PR DESCRIPTION
## Summary

Defense-in-depth pre-feature-complete + dark-mode audit pass.

### ErrorBoundary

Class component wraps `<AppV2 />` at the router level. Catches render-time exceptions (TDZ, undefined hook return, broken third-party module — same class of bug that black-screened v2 earlier today). On catch:

- Renders a recoverable fallback (🪃 + collapsible message/stack/component-stack details + Reload button + "Clear local state & reload" button with confirm)
- Best-effort POSTs the error to `/api/logs/client-error` for server-side triage via `[CLIENT-ERROR]` log lines

v1 stays unwrapped — legacy escape hatch with no need to add behavior.

### Early-paint token application

`index.html` script now applies BOTH `data-ui="v2"` AND `data-theme` (light or dark, from `settings.theme`) BEFORE React mounts. Without this, an exception during AppV2's first render would have shown the boundary fallback in light mode regardless of user preference, since `data-ui` was previously only set in AppV2's mount `useEffect`.

### Dark-mode audit

Walked every v2 surface for hardcoded colors:
- All `var(--v2-*)` token references adapt cleanly via the dark-mode token swap.
- `#fff` text only appears on `var(--v2-accent)` filled buttons (orange + white reads on both modes).
- Hardcoded RGB tints (alert-card backgrounds, hover tints, etc.) are low-alpha and visually neutral on both backgrounds.
- Active-state pattern (`background: var(--v2-text); color: var(--v2-bg)`) inverts cleanly between modes.
- No surface flagged for follow-up. Full per-surface dark-mode QA still parked in V2-State for post-merge if desired, but nothing here will break or look broken.

## Test plan
- [x] `npm run lint` clean
- [x] `npm test` smoke passes — bundle 762KB
- [ ] CI build green
- [ ] Manual: throw a deliberate error in AppV2 (e.g. `throw new Error('test')` at the top of render) → boundary shows fallback with stack trace; Reload button reloads; server log shows `[CLIENT-ERROR]`. Toggle dark mode → boundary fallback adapts.

https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_