### PR TITLE
style(ui): v2 Settings polish — escalation row, Logs Google filter, build version, 17track gate

### DIFF
--- a/src/v2/components/SettingsModal.css
+++ b/src/v2/components/SettingsModal.css
@@ -727,6 +727,40 @@
   }
 }
 
+/* Single-row escalation: three compact "label [input] h" groups in one line.
+ * Wraps gracefully if the parent sheet is narrower than ~360px (rare — the
+ * settings modal min-width is wider). */
+.v2-notif-stages-inline {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  margin-top: 12px;
+  align-items: center;
+}
+.v2-notif-stage-inline {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+.v2-notif-stage-inline-label {
+  font: 500 12px/1 var(--v2-font-body);
+  color: var(--v2-text-meta);
+  white-space: nowrap;
+}
+.v2-notif-stage-inline-input {
+  width: 64px;
+  padding: 6px 8px;
+  height: 32px;
+  font: 500 13px/1 var(--v2-font-body);
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+.v2-notif-stage-inline-unit {
+  font: 500 12px/1 var(--v2-font-body);
+  color: var(--v2-text-meta);
+}
+
 /* Channel test buttons */
 .v2-notif-tests {
   display: flex;

--- a/src/v2/components/SettingsModal.jsx
+++ b/src/v2/components/SettingsModal.jsx
@@ -172,9 +172,7 @@ const STORAGE_KEY = 'ui_version'
 
 const TABS = ['General', 'AI', 'Labels', 'Integrations', 'Notifications', 'Data', 'Logs', 'Beta']
 
-// All Settings tabs now have v2 implementations. Integrations is a
-// status-summary panel — full OAuth flows still live in v1 because each
-// flow has 6+ states and isn't worth duplicating.
+// All Settings tabs now have v2 implementations.
 const PLACEHOLDER_TABS = new Set()
 const PLACEHOLDER_BODY = {}
 
@@ -692,10 +690,8 @@ function IntegrationsPanel({
       <div className="v2-settings-block">
         <div className="v2-form-label">Status</div>
         <div className="v2-settings-row-hint">
-          OAuth-heavy integrations (Notion, Trello, GCal, Gmail) are configured in v1
-          to avoid duplicating multi-step consent flows. Anthropic is configured in
-          the AI tab. Simple key-only integrations (17track, Pushover) can be set
-          inline below.
+          Connect, configure, and disconnect every integration inline. Tokens are shared
+          across v1 and v2 — you only have to connect once.
         </div>
         <ul className="v2-integrations-list">
           {integrations.map(int => (
@@ -1143,7 +1139,7 @@ function IntegrationsPanel({
                     {int.sync.busy ? 'Syncing…' : 'Sync now'}
                   </button>
                 )}
-                {!['pushover', 'weather', 'trello-config', 'trello-connect', 'gcal-config', 'gcal-connect', 'gmail-config', 'gmail-connect', 'notion-config', 'anthropic'].includes(int.inline) && (
+                {!['api-key', 'pushover', 'weather', 'trello-config', 'trello-connect', 'gcal-config', 'gcal-connect', 'gmail-config', 'gmail-connect', 'notion-config', 'anthropic'].includes(int.inline) && (
                   int.manageInTab ? (
                     <button
                       className="v2-settings-btn"
@@ -1188,16 +1184,6 @@ function IntegrationsPanel({
         </div>
       )}
 
-      <div className="v2-settings-block">
-        <div className="v2-form-label">Why v1 for OAuth?</div>
-        <div className="v2-settings-row-hint">
-          OAuth flows for Notion / Trello / Google Calendar / Gmail each have 4–8 UI
-          states (consent prompt, callback handling, calendar picker, scope error, env-var
-          override, disconnect with confirmation). v2 will absorb them in a future release;
-          for now, v1 → Settings → Integrations does the work, and the resulting tokens are
-          shared between v1 and v2 — connect once, both interfaces benefit.
-        </div>
-      </div>
     </div>
   )
 }
@@ -1357,11 +1343,10 @@ function NotificationsPanel({ settings, update }) {
 
       {/* High-priority escalation */}
       <div className="v2-settings-block">
-        <div className="v2-form-label">High-priority escalation</div>
-        <div className="v2-settings-row-hint">Three-stage cadence as a high-pri task approaches its due date and goes overdue.</div>
         <div className="v2-settings-row">
           <div className="v2-settings-row-text">
-            <div className="v2-settings-row-label">Enable escalation</div>
+            <div className="v2-settings-row-label">High-priority escalation</div>
+            <div className="v2-settings-row-hint">Three-stage cadence as a high-pri task approaches due and goes overdue.</div>
           </div>
           <Toggle
             checked={settings.notif_highpri_escalate !== false}
@@ -1369,34 +1354,37 @@ function NotificationsPanel({ settings, update }) {
           />
         </div>
         {settings.notif_highpri_escalate !== false && (
-          <div className="v2-notif-stages">
-            <div className="v2-notif-stage">
-              <label className="v2-form-label">Before due (h)</label>
+          <div className="v2-notif-stages-inline">
+            <label className="v2-notif-stage-inline">
+              <span className="v2-notif-stage-inline-label">Before due</span>
               <input
-                className="v2-form-input v2-settings-narrow-input"
+                className="v2-form-input v2-notif-stage-inline-input"
                 type="number" min="0.25" max="168" step="0.25"
                 value={settings.notif_freq_highpri_before ?? 24}
                 onChange={e => update('notif_freq_highpri_before', Math.max(0.25, parseFloat(e.target.value) || 0.25))}
               />
-            </div>
-            <div className="v2-notif-stage">
-              <label className="v2-form-label">On due day (h)</label>
+              <span className="v2-notif-stage-inline-unit">h</span>
+            </label>
+            <label className="v2-notif-stage-inline">
+              <span className="v2-notif-stage-inline-label">On due</span>
               <input
-                className="v2-form-input v2-settings-narrow-input"
+                className="v2-form-input v2-notif-stage-inline-input"
                 type="number" min="0.25" max="24" step="0.25"
                 value={settings.notif_freq_highpri_due ?? 1}
                 onChange={e => update('notif_freq_highpri_due', Math.max(0.25, parseFloat(e.target.value) || 0.25))}
               />
-            </div>
-            <div className="v2-notif-stage">
-              <label className="v2-form-label">Overdue (h)</label>
+              <span className="v2-notif-stage-inline-unit">h</span>
+            </label>
+            <label className="v2-notif-stage-inline">
+              <span className="v2-notif-stage-inline-label">Overdue</span>
               <input
-                className="v2-form-input v2-settings-narrow-input"
+                className="v2-form-input v2-notif-stage-inline-input"
                 type="number" min="0.25" max="24" step="0.25"
                 value={settings.notif_freq_highpri_overdue ?? 0.5}
                 onChange={e => update('notif_freq_highpri_overdue', Math.max(0.25, parseFloat(e.target.value) || 0.25))}
               />
-            </div>
+              <span className="v2-notif-stage-inline-unit">h</span>
+            </label>
           </div>
         )}
       </div>
@@ -1683,10 +1671,9 @@ function ServerLogsPanel() {
 
   useEffect(() => { fetchLogs() }, [fetchLogs])
 
-  const FILTERS = ['all', 'Gmail', 'GCal', 'Push', 'Email', 'DB', 'SSE', 'error']
+  const FILTERS = ['all', 'Google', 'Push', 'Email', 'DB', 'SSE', 'error']
   const FILTER_PATTERNS = {
-    Gmail: ['[Gmail]'],
-    GCal: ['[GCal]', '[GCalSync]'],
+    Google: ['[Gmail]', '[GCal]', '[GCalSync]'],
     Push: ['[Push]'],
     Email: ['[Email]'],
     DB: ['[DB]'],
@@ -1975,6 +1962,14 @@ export default function SettingsModal({
                 onChange={e => update('max_open_tasks', parseInt(e.target.value) || 0)}
               />
             </div>
+
+            <div className="v2-settings-row">
+              <div className="v2-settings-row-text">
+                <div className="v2-settings-row-label">Build</div>
+                <div className="v2-settings-row-hint">Static identifier of the running build.</div>
+              </div>
+              <code className="v2-settings-build">{__APP_VERSION__}</code>
+            </div>
           </div>
         )}
 
@@ -2126,12 +2121,6 @@ export default function SettingsModal({
               <p className="v2-settings-hint">
                 URL escape hatch: <code>?ui=v1</code> or <code>?ui=v2</code> sets the flag and reloads.
               </p>
-            </div>
-
-            <div className="v2-settings-block">
-              <h3 className="v2-settings-heading">Build</h3>
-              <p className="v2-settings-body">Static identifier of the running build — never overwritten by autosave.</p>
-              <code className="v2-settings-build">{__APP_VERSION__}</code>
             </div>
 
             <div className="v2-settings-block">

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,13 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-09
 
+- style(ui): v2 Settings polish — escalation row, Logs Google filter, build version, 17track gate [S]
+  - **Notifications → High-priority escalation.** Three-stage cadence collapsed to a single inline row (`Before due [24] h · On due [1] h · Overdue [0.5] h`). The enable toggle moves up alongside the section label so the whole control fits without burning vertical space on a separate "Enable escalation" row. New `.v2-notif-stages-inline` flex layout in CSS; the old `.v2-notif-stages` grid remains for any other call site.
+  - **Logs filter.** Combined the separate `Gmail` and `GCal` filter chips into a single `Google` chip that matches `[Gmail]`, `[GCal]`, and `[GCalSync]` log lines. Verified against actual log call sites — the two real prefixes (`[Gmail]`, `[GCal]`) cover every Google integration log line that either old chip would have caught.
+  - **Build version moved to General.** Was in the Beta tab as a heading + paragraph + code chip; now lives as a row in the General tab next to the other settings, using `.v2-settings-row` styling for visual parity. Beta tab no longer surfaces `__APP_VERSION__`.
+  - **17track row gate fix.** Added `'api-key'` to the IntegrationsPanel action-button allow-list so the 17track row no longer renders the "Connect/Manage in v1" fallback button alongside the inline API-key field. Removed the stale "Why v1 for OAuth?" trailing note now that Trello / GCal / Gmail all have native v2 connect flows. Status panel copy updated to drop the "OAuth-heavy integrations are configured in v1" disclaimer.
+  - Modified: `src/v2/components/SettingsModal.jsx`, `src/v2/components/SettingsModal.css`
+
 - feat(ui): v2 ErrorBoundary + early data-ui/data-theme application [S]
   - **Why.** The 2026-05-09 TDZ bug rendered a black screen with no surfaced error because React unmounts on uncaught render exceptions and v2's :root tokens fall through to dark fallback bg with no content. Adding a top-level error boundary at AppV2's wrapper means render-time failures show a recoverable fallback instead of a dead app, AND the stack hits `/api/logs/client-error` for triage.
   - **`ErrorBoundary.jsx` + `.css`.** Class component (React error boundaries require classes). `getDerivedStateFromError` + `componentDidCatch`. Fallback UI: 🪃 + "Boomerang hit a snag" + collapsible details (message, stack, component stack) + Reload button (also unregisters service worker) + "Clear local state & reload" button (wipes localStorage with a confirm before doing so). All token-driven so it adapts to dark mode; falls back to inline defaults if `data-ui` somehow isn't set yet.


### PR DESCRIPTION
## Summary

Five small Settings cleanups from screenshot review:

- **Notifications → High-priority escalation.** Three-stage cadence collapsed to a single inline row (`Before due [24] h · On due [1] h · Overdue [0.5] h`). Enable toggle moves up next to the section label, freeing a full row of vertical space.
- **Logs filter.** `Gmail` and `GCal` chips merged into a single `Google` chip that matches `[Gmail]`, `[GCal]`, and `[GCalSync]` log lines. Verified against actual log call sites — the two real prefixes (`[Gmail]`, `[GCal]`) cover every Google integration log line that either old chip would have caught.
- **Build version → General tab.** Was a heading + paragraph + code chip in the Beta tab. Now a row in the General tab using `.v2-settings-row` styling for visual parity. Beta tab no longer surfaces `__APP_VERSION__`.
- **17track row gate fix.** Added `'api-key'` to the IntegrationsPanel action-button allow-list so the 17track row no longer renders the "Connect/Manage in v1" fallback button alongside the inline API-key field.
- **Stale OAuth note removed.** Deleted "Why v1 for OAuth?" trailing block — Trello / GCal / Gmail all have native v2 connect flows now. Status panel lead-in copy also softened to drop the "OAuth-heavy integrations are configured in v1" disclaimer.

## Test plan

- [ ] Open Settings → Notifications → escalation renders as one row, fits without horizontal scroll on iPhone-width
- [ ] Open Settings → Logs → click `Google` filter, verify `[Gmail]`/`[GCal]` log lines surface
- [ ] Open Settings → General → build version row displays at the bottom
- [ ] Open Settings → Beta → no build version anymore
- [ ] Open Settings → Integrations → 17track row shows API-key field with no v1 fallback button
- [ ] Open Settings → Integrations → no "Why v1 for OAuth?" block at the bottom


---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_