### PR TITLE
fix(ui): v2 RoutinesModal — drop duplicate header on form view

### DIFF
--- a/src/v2/components/RoutinesModal.css
+++ b/src/v2/components/RoutinesModal.css
@@ -177,36 +177,25 @@
   flex-direction: column;
 }
 
-.v2-routine-form-top {
-  display: flex;
-  align-items: center;
-  gap: 14px;
-  margin-bottom: 8px;
-  margin-top: -28px; /* tighten against modal top hairline */
-}
-
+/* Back-to-list link sits inline at the top of the form body. The form's
+ * own h1 is gone — the modal header carries the title now. */
 .v2-routine-back {
-  height: 32px;
-  padding: 0 12px;
+  align-self: flex-start;
+  height: 28px;
+  padding: 0 10px;
   border-radius: var(--v2-radius-pill);
   background: transparent;
   color: var(--v2-text-meta);
   border: 1px solid var(--v2-hairline);
   font: 500 12px/1 var(--v2-font-body);
   cursor: pointer;
+  margin-bottom: 4px;
   transition: background var(--v2-dur-quick) var(--v2-ease-standard),
               color var(--v2-dur-quick) var(--v2-ease-standard);
 }
-
 .v2-routine-back:hover {
   background: rgba(var(--v2-text-rgb), 0.04);
   color: var(--v2-text);
-}
-
-.v2-routine-form-title {
-  font: 700 22px/1.2 var(--v2-font-display);
-  letter-spacing: -0.01em;
-  margin: 0;
 }
 
 /* Follow-ups editor on the routine form. Each step is a small card with

--- a/src/v2/components/RoutinesModal.jsx
+++ b/src/v2/components/RoutinesModal.jsx
@@ -283,10 +283,7 @@ function RoutineForm({ initial, onSave, onCancel }) {
 
   return (
     <div className="v2-routine-form">
-      <div className="v2-routine-form-top">
-        <button className="v2-routine-back" onClick={onCancel}>← Back</button>
-        <h2 className="v2-routine-form-title">{isNew ? 'New routine' : 'Edit routine'}</h2>
-      </div>
+      <button type="button" className="v2-routine-back" onClick={onCancel}>← Back to routines</button>
 
       <input
         className="v2-form-input v2-form-title"
@@ -488,7 +485,7 @@ export default function RoutinesModal({
     <ModalShell
       open={open}
       onClose={onClose}
-      title={view === 'form' ? '' : 'Routines'}
+      title={view === 'form' ? (editing ? 'Edit routine' : 'New routine') : 'Routines'}
       subtitle={view === 'list' && routines.length > 0
         ? `${active.length} active${paused.length ? ` · ${paused.length} paused` : ''}`
         : undefined}

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,10 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-09
 
+- fix(ui): v2 RoutinesModal — drop duplicate header on form view [XS]
+  - The form view rendered its own `← Back · New routine` bar below the ModalShell header (which had an empty title slot). Stacked headers wasted vertical space and looked wrong on iPhone width. Fix: pass the form title (`New routine` / `Edit routine`) into ModalShell so it renders in the modal's normal title slot. Removed the duplicate `<h2 class="v2-routine-form-title">` and its wrapper. Back link kept as a small inline pill above the title input so users can still return to the list view without closing the modal.
+  - Modified: `src/v2/components/RoutinesModal.jsx`, `src/v2/components/RoutinesModal.css`
+
 - feat(routines): Sequences PR 1 — completion-triggered follow-up chains [M]
   - **What.** Routines can hold an ordered template of follow-up steps. When a routine spawns a task instance, the template is copied onto the spawned task. Completing the spawned task spawns the next step with `due_date` derived from `now + step.offset_minutes`, and the chain walks forward as each step is completed. Use case (the user's mop): clean floors → auto-clean mop (offset 0) → empty tanks (30 min) → put back (2 days).
   - **Schema.** Migration 023 adds `follow_ups_json TEXT DEFAULT '[]'` to both `tasks` and `routines`. Step shape: `{id, title, offset_minutes, energy_type?, energy_level?, notes?}`. Routines hold the template; tasks hold the live in-flight chain. PR 1 editor exposes title + offset only — energy/notes can be added later or filled in by the background size-inference hook.


### PR DESCRIPTION
## Summary

The Routines form view was rendering its own back+title bar below the ModalShell header, which had an empty title slot. Two stacked headers wasted vertical space and looked wrong on iPhone width.

**Fix:** pass the form title (`New routine` / `Edit routine`) into ModalShell so it renders in the modal's normal title slot. Removed the duplicate `<h2 class="v2-routine-form-title">` and its wrapper. Back link kept as a small inline pill above the title input so users can still return to the list view without closing the modal.

## Test plan

- [ ] Open Routines → "+ New routine" → modal title shows "New routine" in the header alongside the X (no empty slot, no duplicate h2 below)
- [ ] Tap "← Back to routines" → returns to list view, modal title flips back to "Routines"
- [ ] Edit an existing routine → title shows "Edit routine"
- [ ] X close button still closes the whole modal


---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_