### PR TITLE
style(ui): v2 follow-ups unit picker — readable abbreviations

### DIFF
--- a/src/v2/components/RoutinesModal.jsx
+++ b/src/v2/components/RoutinesModal.jsx
@@ -174,8 +174,8 @@ function FollowUpStepRow({ step, index, isFirst, isLast, onChange, onRemove, onM
           }}
         >
           <option value="min">min</option>
-          <option value="h">h</option>
-          <option value="d">d</option>
+          <option value="h">hr</option>
+          <option value="d">day</option>
         </select>
         <span className="v2-followups-step-spacer" />
         <button

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,10 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-09
 
+- style(ui): v2 follow-ups unit picker — readable abbreviations (min / hr / day) [XS]
+  - Single-letter `h` and `d` looked stranded next to `min`. Switched the unit dropdown to `min` / `hr` / `day`. Internal value tokens stay the same (`'min'`/`'h'`/`'d'`) so existing data and conversion logic are unaffected.
+  - Modified: `src/v2/components/RoutinesModal.jsx`
+
 - fix(ui): v2 RoutinesModal — drop duplicate header on form view [XS]
   - The form view rendered its own `← Back · New routine` bar below the ModalShell header (which had an empty title slot). Stacked headers wasted vertical space and looked wrong on iPhone width. Fix: pass the form title (`New routine` / `Edit routine`) into ModalShell so it renders in the modal's normal title slot. Removed the duplicate `<h2 class="v2-routine-form-title">` and its wrapper. Back link kept as a small inline pill above the title input so users can still return to the list view without closing the modal.
   - Modified: `src/v2/components/RoutinesModal.jsx`, `src/v2/components/RoutinesModal.css`


### PR DESCRIPTION
## Summary

Single-letter `h` and `d` looked stranded next to `min` in the follow-ups offset unit dropdown. Switched display to `min` / `hr` / `day`. Internal value tokens (`'min'` / `'h'` / `'d'`) unchanged so existing data round-trips identically — just relabeling the dropdown.

## Test plan

- [ ] Open a routine with follow-ups → unit dropdown reads `min` / `hr` / `day`
- [ ] Existing chains still load with the right unit selected


---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_