### PR TITLE
fix(ui): v2 header pill + swipe slider + routine spawn-now feedback

### DIFF
--- a/src/v2/AppV2.jsx
+++ b/src/v2/AppV2.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { ListChecks, Settings as SettingsIcon, FolderKanban, BarChart3, History, ChevronRight, CheckCircle2, RotateCw, Upload } from 'lucide-react'
 import Header from './components/Header'
 import ModalShell from './components/ModalShell'
@@ -110,6 +110,18 @@ export default function AppV2() {
   useExternalSync(tasks, updateTask)
   useSizeAutoInfer(tasks, updateTask)
   const prefetchToast = useToastPrefetch(tasks, updateTask)
+
+  // Routine-id set for routines with an active instance on the list. Drives
+  // the "Already on list" disabled state on the RoutinesModal Spawn now button.
+  const activeRoutineIds = useMemo(() => {
+    const s = new Set()
+    for (const t of tasks) {
+      if (t.routine_id && !['done', 'completed', 'cancelled'].includes(t.status)) {
+        s.add(t.routine_id)
+      }
+    }
+    return s
+  }, [tasks])
   const { packages, addPackage, removePackage, refresh: refreshPackage, refreshAll: refreshAllPackages } = usePackages()
   usePackageNotifications(packages)
   // Trello status push lives at this level so handleComplete / status-change
@@ -754,9 +766,19 @@ export default function AppV2() {
         onTogglePause={togglePause}
         onUpdate={updateRoutine}
         onSpawnNow={(routineId) => {
+          // Guard at the call site: if an instance of this routine is still
+          // active on the list, refuse the spawn. Stops the "tap 10 times,
+          // get 10 duplicates" footgun the user hit.
+          const hasActive = tasks.some(t =>
+            t.routine_id === routineId &&
+            !['done', 'completed', 'cancelled'].includes(t.status)
+          )
+          if (hasActive) return null
           const task = spawnNow(routineId)
           if (task) addSpawnedTasks([task])
+          return task
         }}
+        activeRoutineIds={activeRoutineIds}
         onSkipCycle={skipCycle}
         onClose={() => { setShowRoutines(false); setEditRoutineId(null) }}
         editRoutineId={editRoutineId}

--- a/src/v2/components/Header.jsx
+++ b/src/v2/components/Header.jsx
@@ -168,24 +168,6 @@ export default function Header({
       )}
 
       <nav className="v2-header-actions">
-        {todayCount > 0 ? (
-          <button
-            className="v2-header-today"
-            onClick={onOpenDone}
-            title="Tap to open the Done list"
-          >
-            <span className="v2-header-today-count">{todayCount}</span>
-            <span className="v2-header-today-label">today</span>
-          </button>
-        ) : hasDone ? (
-          <button
-            className="v2-header-today v2-header-today-link"
-            onClick={onOpenDone}
-            title="Tap to open the Done list"
-          >
-            Done
-          </button>
-        ) : null}
         {onOpenWhatNow && (
           <button className="v2-header-whatnow" onClick={onOpenWhatNow}>
             <Target size={14} strokeWidth={2} />

--- a/src/v2/components/RoutinesModal.css
+++ b/src/v2/components/RoutinesModal.css
@@ -124,6 +124,31 @@
   filter: brightness(1.08);
 }
 
+/* Brief feedback states on the Spawn now button. 'spawned' shows ✓ + "Spawned"
+ * for 1.5s after a successful tap; 'blocked' shows "Already on list" when an
+ * instance of this routine is still active. Both lock the button so a frenzied
+ * user can't keep spawning duplicates. */
+.v2-routine-action-spawn-spawned {
+  background: var(--v2-energy-errand);
+  border-color: var(--v2-energy-errand);
+}
+.v2-routine-action-spawn-spawned:hover {
+  background: var(--v2-energy-errand);
+}
+.v2-routine-action-spawn-blocked {
+  background: rgba(var(--v2-text-rgb), 0.08);
+  color: var(--v2-text-meta);
+  border-color: var(--v2-hairline);
+}
+.v2-routine-action-spawn-blocked:hover {
+  background: rgba(var(--v2-text-rgb), 0.08);
+  color: var(--v2-text-meta);
+  filter: none;
+}
+.v2-routine-action[disabled] {
+  cursor: default;
+}
+
 .v2-routine-action-danger {
   color: var(--v2-alert-overdue);
 }

--- a/src/v2/components/RoutinesModal.jsx
+++ b/src/v2/components/RoutinesModal.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { Plus, Play, Pause, Pencil, Trash2, RotateCw, FastForward, X, ChevronUp, ChevronDown } from 'lucide-react'
+import { Plus, Play, Pause, Pencil, Trash2, RotateCw, FastForward, X, ChevronUp, ChevronDown, Check } from 'lucide-react'
 import { loadLabels, RECURRENCE_OPTIONS, formatCadence, getNextDueDate } from '../../store'
 import ModalShell from './ModalShell'
 import EmptyState from './EmptyState'
@@ -37,8 +37,13 @@ function formatLastDone(routine) {
   return `done ${days}d ago`
 }
 
-function RoutineRow({ routine, expanded, onToggleExpand, onSpawnNow, onSkipCycle, onEdit, onTogglePause, onDelete }) {
+function RoutineRow({ routine, expanded, onToggleExpand, onSpawnNow, onSkipCycle, onEdit, onTogglePause, onDelete, hasActiveTask }) {
   const [confirmDelete, setConfirmDelete] = useState(false)
+  // 'idle' | 'spawned' — local tap feedback so the user sees a check icon
+  // immediately on tap. Reverts after 1500ms. Blocked state (an instance is
+  // already active) is rendered straight from `hasActiveTask` and is sticky;
+  // no time-based reversion since the underlying condition isn't transient.
+  const [spawnState, setSpawnState] = useState('idle')
   useEffect(() => { if (!expanded) setConfirmDelete(false) }, [expanded])
 
   const cadenceLabel = formatCadence(routine)
@@ -46,6 +51,13 @@ function RoutineRow({ routine, expanded, onToggleExpand, onSpawnNow, onSkipCycle
     ? ` · ${DAY_OF_WEEK_SHORT[routine.schedule_day_of_week]}`
     : ''
   const completeCount = routine.completed_history?.length || 0
+
+  const handleSpawn = () => {
+    if (hasActiveTask) return  // button is disabled in this state, but defensive
+    onSpawnNow(routine.id)
+    setSpawnState('spawned')
+    setTimeout(() => setSpawnState('idle'), 1500)
+  }
 
   return (
     <li className={`v2-routine-row${expanded ? ' v2-routine-row-expanded' : ''}${routine.paused ? ' v2-routine-row-paused' : ''}`}>
@@ -66,8 +78,23 @@ function RoutineRow({ routine, expanded, onToggleExpand, onSpawnNow, onSkipCycle
             <div className="v2-routine-notes">{routine.notes}</div>
           )}
           <div className="v2-routine-actions">
-            <button className="v2-routine-action v2-routine-action-primary" onClick={() => onSpawnNow(routine.id)} title="Create a one-off task now without affecting the schedule">
-              <Plus size={14} strokeWidth={2} /> Spawn now
+            <button
+              className={`v2-routine-action v2-routine-action-primary${
+                spawnState === 'spawned' ? ' v2-routine-action-spawn-spawned' : ''
+              }${hasActiveTask ? ' v2-routine-action-spawn-blocked' : ''}`}
+              onClick={handleSpawn}
+              disabled={spawnState !== 'idle' || hasActiveTask}
+              title={hasActiveTask
+                ? "An instance is already on your list — finish or skip it before spawning another"
+                : "Create a one-off task now without affecting the schedule"}
+            >
+              {spawnState === 'spawned' ? (
+                <><Check size={14} strokeWidth={2} /> Spawned</>
+              ) : hasActiveTask ? (
+                <>Already on list</>
+              ) : (
+                <><Plus size={14} strokeWidth={2} /> Spawn now</>
+              )}
             </button>
             {!routine.paused && (
               <button className="v2-routine-action" onClick={() => onSkipCycle(routine.id)} title="Skip this cycle (advance schedule, no task)">
@@ -425,7 +452,7 @@ function RoutineForm({ initial, onSave, onCancel }) {
 
 export default function RoutinesModal({
   open, routines, onAdd, onDelete, onTogglePause, onUpdate, onSpawnNow, onSkipCycle, onClose,
-  editRoutineId, onClearEditRoutineId,
+  editRoutineId, onClearEditRoutineId, activeRoutineIds,
 }) {
   const [view, setView] = useState('list')  // 'list' | 'form'
   const [editing, setEditing] = useState(null)  // routine being edited; null = new
@@ -524,6 +551,7 @@ export default function RoutinesModal({
                         onEdit={(routine) => { setEditing(routine); setView('form') }}
                         onTogglePause={onTogglePause}
                         onDelete={onDelete}
+                        hasActiveTask={activeRoutineIds?.has(r.id) || false}
                       />
                     ))}
                   </ul>
@@ -544,6 +572,7 @@ export default function RoutinesModal({
                         onEdit={(routine) => { setEditing(routine); setView('form') }}
                         onTogglePause={onTogglePause}
                         onDelete={onDelete}
+                        hasActiveTask={activeRoutineIds?.has(r.id) || false}
                       />
                     ))}
                   </ul>

--- a/src/v2/components/TaskCard.jsx
+++ b/src/v2/components/TaskCard.jsx
@@ -13,7 +13,7 @@ const ENERGY_ICONS = { Monitor, Users, MapPin, Palette, Dumbbell }
 // actions stay in EditTaskModal with explicit confirm so the calm aesthetic
 // holds. Swipe-right-to-delete from v1 isn't ported.
 const SWIPE_THRESHOLD = 60       // px before we commit to revealing actions
-const SWIPE_OPEN_OFFSET = -120   // resting position when actions are revealed
+const SWIPE_OPEN_OFFSET = -160   // resting position when actions are revealed; must match .v2-card-swipe-actions width
 const SWIPE_VERT_CANCEL = 12     // px of vertical movement that cancels the swipe
 
 function TaskCard({ task, expanded, onToggleExpand, onComplete, onEdit, onSnooze, weatherByDate, selected }) {

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,12 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-09
 
+- fix(ui): v2 header pill + swipe slider + routine spawn-now feedback [S]
+  - **Header today-count pill removed.** The "10 today" pill in the header was crowding the BOOMERANG wordmark on iPhone width AND duplicating the "X done today" line in the wordmark-tap popover. Dropped the pill from the action nav; the popover keeps the count, accessible via tap-the-wordmark. Header is now: wordmark · What now? · + · ✨ · 📦 · ⋯. (Bigger header redesign deferred to a separate planning conversation — too dense for a snap fix.)
+  - **Swipe slider clipping.** `SWIPE_OPEN_OFFSET` (-120px) didn't match `.v2-card-swipe-actions` width (160px), so when the card snapped open the leftmost 40px of the action panel stayed under the card — Edit's "E" got eaten and the user saw "dit". Bumped the offset to -160 so the card translates exactly the panel width.
+  - **Routine "Spawn now" feedback.** No visual confirmation on tap meant the user tapped 10 times and got 10 duplicate tasks. Two-part fix: (1) AppV2's `onSpawnNow` handler now refuses the spawn if an instance of that routine is still active on the list (returns null silently); (2) RoutineRow takes a `hasActiveTask` prop and renders the button as a disabled "Already on list" state in that case. On a successful tap, the button briefly shows ✓ + "Spawned" for 1500ms before reverting. `activeRoutineIds` Set is memoized in AppV2 from `tasks` and threaded through `RoutinesModal` → each `RoutineRow`.
+  - Modified: `src/v2/components/Header.jsx`, `src/v2/components/TaskCard.jsx`, `src/v2/components/RoutinesModal.jsx`, `src/v2/components/RoutinesModal.css`, `src/v2/AppV2.jsx`
+
 - style(ui): v2 follow-ups unit picker — readable abbreviations (min / hr / day) [XS]
   - Single-letter `h` and `d` looked stranded next to `min`. Switched the unit dropdown to `min` / `hr` / `day`. Internal value tokens stay the same (`'min'`/`'h'`/`'d'`) so existing data and conversion logic are unaffected.
   - Modified: `src/v2/components/RoutinesModal.jsx`


### PR DESCRIPTION
Three bug fixes in one bundle.

## Header today-count pill removed

The "10 today" pill in the header was crowding the BOOMERANG wordmark on iPhone width AND duplicating the "X done today" line in the wordmark-tap popover. Dropped the pill; popover keeps the count, accessible via tap-the-wordmark.

Header is now: `wordmark · What now? · + · ✨ · 📦 · ⋯`

> Bigger header redesign deferred to a separate planning conversation — too dense for a snap fix.

## Swipe slider clipping

`SWIPE_OPEN_OFFSET` (-120px) didn't match `.v2-card-swipe-actions` width (160px), so when the card snapped open the leftmost 40px of the action panel stayed under the card — Edit's "E" got eaten and the user saw "dit". Bumped the offset to -160 so the card translates exactly the panel width.

## Routine "Spawn now" feedback

No visual confirmation on tap meant the user tapped 10 times and got 10 duplicate tasks. Two-part fix:

1. **AppV2's `onSpawnNow` handler** refuses the spawn if an instance of that routine is still active on the list (`status` not in `done/completed/cancelled`).
2. **`RoutineRow`** takes a `hasActiveTask` prop. When `true`, renders the button as a disabled "Already on list" state. On a successful tap, the button briefly shows ✓ + "Spawned" for 1500ms before reverting to "Spawn now".

`activeRoutineIds` Set is memoized in AppV2 from `tasks` and threaded through `RoutinesModal` → each `RoutineRow`.

## Test plan

- [ ] Header no longer shows the orange "X today" pill — wordmark popover still shows "X done today" on tap
- [ ] Swipe a task left → both Edit and Done labels render fully (no "dit" / "lit" clipping)
- [ ] Tap a routine's "Spawn now" → button shows ✓ + "Spawned" for ~1.5s
- [ ] After spawning, "Spawn now" reads "Already on list" and is disabled until the spawned task is completed/skipped
- [ ] Complete the spawned task → "Spawn now" becomes available again


---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_