### PR TITLE
fix(ui): v2 FloatingCapture — orange what-now + iOS keyboard occlusion

### DIFF
--- a/src/v2/components/FloatingCapture.css
+++ b/src/v2/components/FloatingCapture.css
@@ -15,6 +15,10 @@
   gap: 12px;
   align-items: flex-end;
   pointer-events: none;  /* children re-enable; lets list scroll past the gap */
+  /* Smooth the keyboard-occlusion lift so the wrapper rides up with the
+   * keyboard slide-in instead of snapping. Direct style.transform writes
+   * inherit this transition. */
+  transition: transform 200ms cubic-bezier(.4, 0, .2, 1);
 }
 
 .v2-floating-capture > * {
@@ -76,12 +80,18 @@
   filter: brightness(1.06);
 }
 
+/* What-now is also accent — same brand language as quick-add — but uses
+ * black rings so the target glyph reads against the orange instead of
+ * disappearing into white-on-orange. */
 .v2-fc-button-whatnow {
-  color: var(--v2-text-meta);
+  background: var(--v2-accent);
+  border-color: var(--v2-accent);
+  color: #000;
 }
 
-.v2-fc-button-whatnow:hover {
-  color: var(--v2-text);
+.v2-fc-button-whatnow:hover:not(:disabled) {
+  filter: brightness(1.06);
+  color: #000;
 }
 
 /* When a card is open the trailing button (X / +) is anchored to the

--- a/src/v2/components/FloatingCapture.jsx
+++ b/src/v2/components/FloatingCapture.jsx
@@ -64,6 +64,33 @@ export default function FloatingCapture({ onAddTask, onOpenWhatNow }) {
     return () => document.removeEventListener('keydown', onKey)
   }, [mode])
 
+  // iOS keyboard occlusion fix. When the soft keyboard opens, the floating
+  // capture sits at `bottom: 16px` of the layout viewport — but the keyboard
+  // covers the bottom ~40% of the screen, so the input lands behind it and
+  // the user types blind. Use `visualViewport` to detect the occluded
+  // height and translate the wrapper upward by that amount so it floats
+  // just above the keyboard. Resize listener handles keyboard show/hide
+  // and orientation changes.
+  useEffect(() => {
+    if (mode !== 'add') return
+    const vv = window.visualViewport
+    if (!vv) return
+    const wrap = wrapRef.current
+    if (!wrap) return
+    const update = () => {
+      const occluded = Math.max(0, window.innerHeight - vv.height - vv.offsetTop)
+      wrap.style.transform = occluded > 0 ? `translateY(${-occluded}px)` : ''
+    }
+    update()
+    vv.addEventListener('resize', update)
+    vv.addEventListener('scroll', update)
+    return () => {
+      wrap.style.transform = ''
+      vv.removeEventListener('resize', update)
+      vv.removeEventListener('scroll', update)
+    }
+  }, [mode])
+
   const submitAdd = () => {
     const title = draft.trim()
     if (!title) return

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,11 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-09
 
+- fix(ui): v2 FloatingCapture — orange what-now + iOS keyboard occlusion fix [S]
+  - **What-now FAB orange w/ black rings.** Originally hairline-bordered neutral so it didn't compete with the accent-filled `+`. User feedback: both should be brand-accent. Now both circles share the orange fill; what-now uses black `currentColor` so the target/dartboard rings read against the orange (white-on-orange would have lost contrast on the inner ring weights).
+  - **iOS keyboard occlusion.** When the soft keyboard opened, the floating capture sat at `bottom: 16px` of the layout viewport — but the keyboard covered the bottom ~40% of the screen, so the input landed behind it and the user typed blind. Now uses the `visualViewport` API to measure how much of the bottom is occluded and translates the wrapper upward by that amount; `resize` listener handles keyboard show/hide and orientation changes. CSS transition smooths the lift so it rides up with the keyboard slide-in instead of snapping.
+  - Modified: `src/v2/components/FloatingCapture.jsx`, `src/v2/components/FloatingCapture.css`
+
 - fix(ui): v2 update-modal — drop `v` prefix on sha-style versions [XS]
   - `<div className="v2-update-version">v{updateVersion}</div>` rendered `vdev-e1ba2aa` on non-tagged builds. Changed to a conditional prefix: only prepend `v` when the version starts with a digit (i.e. semver like `0.10.0` → `v0.10.0`); sha-style versions like `dev-e1ba2aa` render bare. Future-proof for tagged releases without uglying up the dev sha display.
   - Modified: `src/v2/AppV2.jsx`


### PR DESCRIPTION
## Summary

Two FloatingCapture follow-ups based on tasks-dev testing:

### 1. What-now FAB → orange with black rings
Originally hairline-bordered neutral so it didn't compete with the accent-filled `+`. Both should be brand-accent. Now both circles share the orange fill; what-now uses black `currentColor` so the target rings read against the orange (white-on-orange would have lost contrast on the inner ring weights).

### 2. iOS keyboard occlusion
When the soft keyboard opened, the floating capture sat at `bottom: 16px` of the layout viewport, but the keyboard covered the bottom ~40% of the screen so the input landed behind it (user typed blind). Worked on *second* tap because iOS auto-lifts fixed elements when an already-focused input gets re-focused — but that's a workaround, not a fix.

Fix uses the `visualViewport` API to measure how much of the bottom is occluded and translates the wrapper upward by that amount on first focus. Resize listener handles keyboard show/hide and orientation changes. CSS transition (`transform 200ms`) smooths the lift so it rides up with the keyboard slide-in instead of snapping.

## Test plan

- [ ] What-now FAB renders with orange background, black target rings
- [ ] First tap on `+` → input is visible above the keyboard (no second-tap workaround needed)
- [ ] Close keyboard while card open → wrapper drops back to `bottom: 16px` smoothly
- [ ] Rotate device with the card open → wrapper repositions correctly above the new keyboard position


---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_