### PR TITLE
style(ui): v2 FloatingCapture — heading on what-now card

### DIFF
--- a/src/v2/components/FloatingCapture.css
+++ b/src/v2/components/FloatingCapture.css
@@ -147,9 +147,30 @@
   width: min(320px, calc(100vw - 32px));
 }
 
+/* What-now card is taller (heading row + chips row) so it can't keep
+ * the pill defaults — drop the 999px radius and the fixed 48px height,
+ * use vertical padding, align the close button to the top so it doesn't
+ * float in the middle of the multi-line content. */
 .v2-fc-card-whatnow {
   width: min(360px, calc(100vw - 32px));
-  padding-left: 8px;
+  height: auto;
+  border-radius: 20px;
+  padding: 12px 8px 12px 14px;
+  align-items: flex-start;
+}
+
+.v2-fc-card-body {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.v2-fc-card-heading {
+  font: 500 13px/1.2 var(--v2-font-body);
+  color: var(--v2-text);
+  letter-spacing: -0.005em;
 }
 
 .v2-fc-input {

--- a/src/v2/components/FloatingCapture.jsx
+++ b/src/v2/components/FloatingCapture.jsx
@@ -117,17 +117,20 @@ export default function FloatingCapture({ onAddTask, onOpenWhatNow }) {
       <div className={`v2-fc-slot v2-fc-slot-whatnow${mode === 'whatnow' ? ' v2-fc-slot-open' : ''}`}>
         {mode === 'whatnow' ? (
           <div className="v2-fc-card v2-fc-card-whatnow">
-            <div className="v2-fc-chips">
-              {CAPACITIES.map(c => (
-                <button
-                  key={c.id}
-                  type="button"
-                  className="v2-fc-chip"
-                  onClick={() => pickCapacity(c)}
-                >
-                  {c.label}
-                </button>
-              ))}
+            <div className="v2-fc-card-body">
+              <div className="v2-fc-card-heading">How much time do you have?</div>
+              <div className="v2-fc-chips">
+                {CAPACITIES.map(c => (
+                  <button
+                    key={c.id}
+                    type="button"
+                    className="v2-fc-chip"
+                    onClick={() => pickCapacity(c)}
+                  >
+                    {c.label}
+                  </button>
+                ))}
+              </div>
             </div>
             <button
               type="button"

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,10 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-09
 
+- style(ui): v2 FloatingCapture — heading on what-now card [XS]
+  - Five unlabeled time chips ("5 min", "15 min", …) didn't communicate intent on their own — what does tapping a number do? Added a small heading "How much time do you have?" above the chip row. Card grows from a single-row 48px pill into a stacked 80-90px card with rounded-card border-radius (20px instead of 999px); close button aligns to top so it doesn't float against multi-line content.
+  - Modified: `src/v2/components/FloatingCapture.jsx`, `src/v2/components/FloatingCapture.css`
+
 - fix(ui): v2 FloatingCapture — orange what-now + iOS keyboard occlusion fix [S]
   - **What-now FAB orange w/ black rings.** Originally hairline-bordered neutral so it didn't compete with the accent-filled `+`. User feedback: both should be brand-accent. Now both circles share the orange fill; what-now uses black `currentColor` so the target/dartboard rings read against the orange (white-on-orange would have lost contrast on the inner ring weights).
   - **iOS keyboard occlusion.** When the soft keyboard opened, the floating capture sat at `bottom: 16px` of the layout viewport — but the keyboard covered the bottom ~40% of the screen, so the input landed behind it and the user typed blind. Now uses the `visualViewport` API to measure how much of the bottom is occluded and translates the wrapper upward by that amount; `resize` listener handles keyboard show/hide and orientation changes. CSS transition smooths the lift so it rides up with the keyboard slide-in instead of snapping.


### PR DESCRIPTION
## Summary

Five unlabeled time chips (`5 min` / `15 min` / …) didn't communicate intent on their own — tapping a number is meaningless without context.

Added a small heading **"How much time do you have?"** above the chip row. Card grows from a single-row 48px pill into a stacked ~80px card; rounded-card border-radius (20px) replaces the pill 999px; close X aligns to top so it doesn't float against multi-line content.

## Test plan

- [ ] Tap target FAB → card opens with "How much time do you have?" heading visible above the chips
- [ ] Card animation still smooth (scaleX from right edge)
- [ ] Tap a chip → opens WhatNowModal as before
- [ ] Close X stays anchored to the right edge


---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_