### PR TITLE
fix(ui): v2 FloatingCapture — align in-card buttons with standalone FABs

### DIFF
--- a/src/v2/components/FloatingCapture.css
+++ b/src/v2/components/FloatingCapture.css
@@ -121,7 +121,11 @@
   display: flex;
   align-items: center;
   height: 48px;
-  padding: 0 4px 0 14px;
+  /* No right padding — the trailing in-card button (X / +) needs to share
+   * an x-axis with the standalone FAB above. Any padding here would inset
+   * the in-card button and break vertical alignment between the two slots
+   * when one is expanded. */
+  padding: 0 0 0 14px;
   gap: 8px;
   background: var(--v2-surface);
   border: 1px solid var(--v2-hairline);
@@ -155,7 +159,9 @@
   width: min(360px, calc(100vw - 32px));
   height: auto;
   border-radius: 20px;
-  padding: 12px 8px 12px 14px;
+  /* Same alignment principle as the base card: 0 right padding so the
+   * close X shares an x-axis with the FAB above. */
+  padding: 12px 0 12px 14px;
   align-items: flex-start;
 }
 

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,10 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-09
 
+- fix(ui): v2 FloatingCapture — align in-card buttons with standalone FABs [XS]
+  - Card had 4px right padding which inset the trailing in-card button (`+` / `X`) by that much. With the other slot still showing a standalone FAB flush against the wrap edge, the two orange circles fell out of vertical alignment. Drop right padding to 0 on both card variants so every button shares the same x-axis regardless of which slot is expanded.
+  - Modified: `src/v2/components/FloatingCapture.css`
+
 - style(ui): v2 FloatingCapture — heading on what-now card [XS]
   - Five unlabeled time chips ("5 min", "15 min", …) didn't communicate intent on their own — what does tapping a number do? Added a small heading "How much time do you have?" above the chip row. Card grows from a single-row 48px pill into a stacked 80-90px card with rounded-card border-radius (20px instead of 999px); close button aligns to top so it doesn't float against multi-line content.
   - Modified: `src/v2/components/FloatingCapture.jsx`, `src/v2/components/FloatingCapture.css`


### PR DESCRIPTION
## Summary

Card had 4px right padding which inset the trailing in-card button (`+` or `X`) by that much. With the other slot still showing a standalone FAB flush against the wrap edge, the two orange circles fell out of vertical alignment when one slot was expanded.

Drop right padding to 0 on both card variants. Now every button (FAB or in-card) shares the same x-axis regardless of which slot is expanded.

## Test plan

- [ ] Tap `+` → input pill expands. The orange `+` button on the right of the pill aligns vertically with the target FAB above
- [ ] Tap target → chips card expands. The X close button aligns vertically with the `+` FAB below


---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_