### PR TITLE
fix(ui): v2 FloatingCapture — target icon stays visible on what-now

### DIFF
--- a/src/v2/components/FloatingCapture.css
+++ b/src/v2/components/FloatingCapture.css
@@ -110,6 +110,16 @@
   color: #fff;
 }
 
+/* In-card target keeps the orange-fill / black-rings treatment from the
+ * standalone FAB so it visibly persists as the same affordance — same
+ * pattern as the in-card + on the quick-add side. Tapping it closes
+ * the card (toggle behavior). */
+.v2-fc-button-anchor.v2-fc-button-whatnow {
+  background: var(--v2-accent);
+  color: #000;
+  border-color: var(--v2-accent);
+}
+
 .v2-fc-button-anchor:hover:not(:disabled) {
   transform: none;
   box-shadow: none;

--- a/src/v2/components/FloatingCapture.jsx
+++ b/src/v2/components/FloatingCapture.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { Plus, Target, X } from 'lucide-react'
+import { Plus, Target } from 'lucide-react'
 import './FloatingCapture.css'
 
 // Right-edge speed-dial. Two circles stacked at the lower-right of the
@@ -134,11 +134,11 @@ export default function FloatingCapture({ onAddTask, onOpenWhatNow }) {
             </div>
             <button
               type="button"
-              className="v2-fc-button v2-fc-button-anchor"
+              className="v2-fc-button v2-fc-button-anchor v2-fc-button-whatnow"
               onClick={() => setMode('idle')}
               aria-label="Close"
             >
-              <X size={20} strokeWidth={1.75} />
+              <Target size={20} strokeWidth={2} />
             </button>
           </div>
         ) : (

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,10 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-09
 
+- fix(ui): v2 FloatingCapture — target icon stays visible when what-now card opens [XS]
+  - The target FAB was being replaced by a generic X close button when the card opened — making it look like the FAB had been "covered" by the card. Now the target icon stays at the right end of the card (same role as the `+` icon at the right of the quick-add input pill — visually persistent affordance, tap to toggle closed). Same orange-fill / black-rings treatment as the standalone FAB. Removed the unused X import.
+  - Modified: `src/v2/components/FloatingCapture.jsx`, `src/v2/components/FloatingCapture.css`
+
 - fix(ui): v2 FloatingCapture — what-now card inflates from FAB footprint [XS]
   - The taller what-now card (85px) was using the same scaleX-only animation as the 48px add card. Result: at frame 1 the full vertical height appeared instantly while only the width animated, reading as a "slam" instead of an emergence. Added a separate `v2-fc-card-whatnow-in` keyframe that scales BOTH axes from the FAB footprint (`scaleX(0.13) scaleY(0.55) → 1`) with `transform-origin: right bottom`. The card now visually inflates out of the FAB's last position. Add card unchanged.
   - Modified: `src/v2/components/FloatingCapture.css`


### PR DESCRIPTION
## Summary

Target FAB was being replaced by a generic X close button when the what-now card opened — making it look like the FAB had been "covered" by the card. Now the target icon stays at the right end of the card (same role the `+` icon plays at the right of the quick-add input pill: visually persistent affordance, tap to toggle closed). Same orange-fill / black-rings treatment as the standalone FAB.

## Test plan

- [ ] Tap target → card opens with chips + the target icon still visible at the right (no X)
- [ ] Tap target inside the open card → card closes
- [ ] Tap outside → card closes (unchanged)
- [ ] Visual: in-card target icon matches the standalone FAB style (orange + black rings)


---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_