### PR TITLE
fix(ui): v2 header iOS status bar overlap [XS]

### DIFF
--- a/src/v2/components/Header.css
+++ b/src/v2/components/Header.css
@@ -2,7 +2,11 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 14px 16px;
+  /* iOS PWA in standalone mode uses `apple-mobile-web-app-status-bar-style:
+   * black-translucent`, which lets the system status bar (clock, battery)
+   * render OVER our header. Add safe-area padding so our content sits below
+   * the status bar instead of behind the iPhone's clock display. */
+  padding: max(14px, env(safe-area-inset-top, 0px)) 16px 14px;
   border-bottom: 1px solid var(--v2-hairline);
   background: var(--v2-bg);
   position: sticky;
@@ -315,7 +319,7 @@
 
 @media (min-width: 601px) {
   .v2-header {
-    padding: 16px 24px;
+    padding: max(16px, env(safe-area-inset-top, 0px)) 24px 16px;
   }
 }
 

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -4,6 +4,15 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ---
 
+## 2026-05-10
+
+- fix(ui): v2 header — iOS status bar overlap on PWA [XS]
+  - **Bug.** With `apple-mobile-web-app-status-bar-style: black-translucent` (set in `index.html`), iOS PWA in standalone mode renders the system status bar (clock, signal, battery) OVER the app's content — the BOOMERANG wordmark area got the iPhone's clock display rendered on top of it, producing the "B 22:25 MERANG" overlap visible in v1.0.0 prod.
+  - **Fix.** `.v2-header` `padding-top` now uses `max(14px, env(safe-area-inset-top, 0px))` (and `max(16px, ...)` on the `min-width: 601px` desktop variant) so our header content sits below the iOS status bar instead of behind it. The `viewport-fit=cover` meta tag is already in place. Header background remains a solid `var(--v2-bg)` so the status bar's text reads on a contrasting surface.
+  - Modified: `src/v2/components/Header.css`
+
+---
+
 ## 2026-05-09
 
 - fix(ui): v2 FloatingCapture — target icon stays visible when what-now card opens [XS]


### PR DESCRIPTION
## Summary
- Adds `safe-area-inset-top` padding to the v2 header so the iOS PWA status bar (clock, signal, battery) no longer renders on top of the BOOMERANG wordmark
- Visible in v1.0.0 prod as "B 22:25 MERANG" overlap

## Root cause
`index.html` sets `apple-mobile-web-app-status-bar-style: black-translucent` (standard PWA pattern for full-bleed UIs). This makes the iOS system status bar render over app content. The v2 `.v2-header` had `padding: 14px 16px` with no safe-area accommodation, so the iPhone clock landed on the wordmark.

## Fix
- Mobile: `padding: max(14px, env(safe-area-inset-top, 0px)) 16px 14px`
- Desktop (≥601px): `padding: max(16px, env(safe-area-inset-top, 0px)) 24px 16px`

`viewport-fit=cover` meta tag is already in `index.html` so `env(safe-area-inset-top)` resolves correctly.

## Auto-tag
This will bump `v1.0.0 → v1.0.1` per workflow rules (`fix:patch`).

## Test plan
- [ ] On the deployed v1.0.1, open PWA on iOS in standalone (Home Screen) mode
- [ ] Verify the BOOMERANG wordmark is below the iPhone clock, not behind it
- [ ] Verify desktop browser (no safe-area-inset) still gets the original 14px / 16px top padding

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_