### PR TITLE
feat(routines): Sequences PR 2 — chain-break confirmation [S]

### DIFF
--- a/src/v2/AppV2.jsx
+++ b/src/v2/AppV2.jsx
@@ -23,6 +23,7 @@ import TaskListToolbar from './components/TaskListToolbar'
 import MarkdownImportModal from './components/MarkdownImportModal'
 import Toast from './components/Toast'
 import FloatingCapture from './components/FloatingCapture'
+import ConfirmDialog from './components/ConfirmDialog'
 import { useTasks } from '../hooks/useTasks'
 import { useRoutines, enhanceSpawnedTasks } from '../hooks/useRoutines'
 import { useNotifications } from '../hooks/useNotifications'
@@ -373,21 +374,51 @@ export default function AppV2() {
     closeTopModal,
   })
 
+  // Sequences PR 2: chain-break confirmation gate. When a task with queued
+  // follow-ups is about to be deleted / cancelled / moved to backlog / moved
+  // to projects, pop a modal warning that the chain will stop. Completion
+  // (`status='done'`) goes through `handleComplete` and ADVANCES the chain
+  // — never gated. Going FROM backlog/project back to active is also fine.
+  const [chainConfirm, setChainConfirm] = useState(null)
+  const gateOnChainBreak = useCallback((task, actionLabel, confirmLabel, proceed) => {
+    const len = Array.isArray(task?.follow_ups) ? task.follow_ups.length : 0
+    if (len === 0) { proceed(); return }
+    setChainConfirm({
+      title: 'Stop the follow-up chain?',
+      body: `This task has ${len} follow-up step${len === 1 ? '' : 's'} queued. ${actionLabel} will stop the chain — the queued step${len === 1 ? '' : 's'} won't spawn.`,
+      confirmLabel,
+      onConfirm: () => { setChainConfirm(null); proceed() },
+    })
+  }, [])
+
   const handleStatusChange = useCallback((id, newStatus) => {
     if (newStatus === 'done') { handleComplete(id); return }
-    changeStatus(id, newStatus)
-    // Push the new status to Trello if the task has a linked card.
     const task = tasks.find(t => t.id === id)
-    if (task?.trello_card_id) pushStatusToTrello(task, newStatus)
-  }, [handleComplete, changeStatus, tasks, pushStatusToTrello])
+    const chainBreaking = ['cancelled', 'backlog', 'project'].includes(newStatus)
+    const proceed = () => {
+      changeStatus(id, newStatus)
+      if (task?.trello_card_id) pushStatusToTrello(task, newStatus)
+    }
+    if (chainBreaking) {
+      gateOnChainBreak(task, `Moving to ${newStatus === 'cancelled' ? 'cancelled' : newStatus}`, 'Stop chain', proceed)
+    } else {
+      proceed()
+    }
+  }, [handleComplete, changeStatus, tasks, pushStatusToTrello, gateOnChainBreak])
 
   const handleBacklog = useCallback((id, toBacklog) => {
-    updateTask(id, { status: toBacklog ? 'backlog' : 'not_started', last_touched: new Date().toISOString() })
-  }, [updateTask])
+    const apply = () => updateTask(id, { status: toBacklog ? 'backlog' : 'not_started', last_touched: new Date().toISOString() })
+    if (!toBacklog) { apply(); return }
+    const task = tasks.find(t => t.id === id)
+    gateOnChainBreak(task, 'Moving to backlog', 'Stop chain & move', apply)
+  }, [updateTask, tasks, gateOnChainBreak])
 
   const handleProject = useCallback((id, toProject) => {
-    updateTask(id, { status: toProject ? 'project' : 'not_started', last_touched: new Date().toISOString() })
-  }, [updateTask])
+    const apply = () => updateTask(id, { status: toProject ? 'project' : 'not_started', last_touched: new Date().toISOString() })
+    if (!toProject) { apply(); return }
+    const task = tasks.find(t => t.id === id)
+    gateOnChainBreak(task, 'Moving to projects', 'Stop chain & move', apply)
+  }, [updateTask, tasks, gateOnChainBreak])
 
   const handleConvertToRoutine = useCallback((taskId, { title, cadence, customDays, tags, notes }) => {
     const routine = addRoutine(title, cadence, customDays, tags, notes)
@@ -402,14 +433,19 @@ export default function AppV2() {
   }, [uncompleteTask, pushStatusToTrello])
 
   // Archive the Trello card on delete so the next inbound sync doesn't
-  // re-import the task. Mirrors v1 handleDelete.
+  // re-import the task. Mirrors v1 handleDelete. Also gated on chain-break
+  // — if the task has queued follow-ups, the user gets a confirmation
+  // modal before the delete proceeds.
   const handleDelete = useCallback((id) => {
     const task = tasks.find(t => t.id === id)
-    if (task?.trello_card_id) {
-      trelloUpdateCard(task.trello_card_id, { closed: true }).catch(() => {})
+    const proceed = () => {
+      if (task?.trello_card_id) {
+        trelloUpdateCard(task.trello_card_id, { closed: true }).catch(() => {})
+      }
+      deleteTask(id)
     }
-    deleteTask(id)
-  }, [tasks, deleteTask])
+    gateOnChainBreak(task, 'Deleting', 'Stop chain & delete', proceed)
+  }, [tasks, deleteTask, gateOnChainBreak])
 
   const handleRestore = useCallback((snapshot) => {
     setTasks(prev => [snapshot, ...prev])
@@ -816,6 +852,17 @@ export default function AppV2() {
           }
         }}
         onOpenWhatNow={() => setShowWhatNow(true)}
+      />
+
+      <ConfirmDialog
+        open={!!chainConfirm}
+        title={chainConfirm?.title || ''}
+        body={chainConfirm?.body || ''}
+        confirmLabel={chainConfirm?.confirmLabel || 'Confirm'}
+        cancelLabel="Keep task"
+        tone="danger"
+        onConfirm={() => chainConfirm?.onConfirm?.()}
+        onCancel={() => setChainConfirm(null)}
       />
 
       {toast && (

--- a/src/v2/components/ConfirmDialog.css
+++ b/src/v2/components/ConfirmDialog.css
@@ -1,0 +1,99 @@
+/* Generic v2 confirm dialog. Renders above modals (z-index 200 — same as
+ * SettingsModal's local pattern) so it can pop on top of an open
+ * EditTaskModal etc. Centered card, max-width, ample padding. The action
+ * row keeps Cancel left and the destructive Confirm right per Apple/iOS
+ * convention so destructive actions don't sit under the thumb. */
+
+.v2-confirm-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 200;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  animation: v2-confirm-overlay-in var(--v2-dur-quick) ease-out;
+}
+
+@keyframes v2-confirm-overlay-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.v2-confirm {
+  background: var(--v2-surface);
+  color: var(--v2-text);
+  border-radius: 16px;
+  padding: 24px;
+  max-width: 380px;
+  width: 100%;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.25);
+  animation: v2-confirm-in var(--v2-dur-standard) var(--v2-ease-emphasis);
+}
+
+@keyframes v2-confirm-in {
+  from { opacity: 0; transform: translateY(8px) scale(0.97); }
+  to { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+.v2-confirm-title {
+  font: 700 18px/1.2 var(--v2-font-display);
+  margin: 0 0 8px;
+}
+
+.v2-confirm-body {
+  font: 400 13px/1.5 var(--v2-font-body);
+  color: var(--v2-text-meta);
+  margin: 0 0 18px;
+}
+
+.v2-confirm-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.v2-confirm-btn {
+  border-radius: var(--v2-radius-pill);
+  padding: 8px 16px;
+  font: 600 13px/1 var(--v2-font-body);
+  cursor: pointer;
+  border: 1px solid var(--v2-hairline);
+  background: transparent;
+  color: var(--v2-text);
+  transition: background var(--v2-dur-quick) var(--v2-ease-standard),
+              color var(--v2-dur-quick) var(--v2-ease-standard),
+              filter var(--v2-dur-quick) var(--v2-ease-standard);
+}
+
+.v2-confirm-btn-cancel:hover {
+  background: rgba(var(--v2-text-rgb), 0.05);
+}
+
+.v2-confirm-btn-danger {
+  background: var(--v2-alert-overdue);
+  border-color: var(--v2-alert-overdue);
+  color: #fff;
+}
+
+.v2-confirm-btn-danger:hover {
+  filter: brightness(1.06);
+}
+
+.v2-confirm-btn-primary {
+  background: var(--v2-accent);
+  border-color: var(--v2-accent);
+  color: #fff;
+}
+
+.v2-confirm-btn-primary:hover {
+  filter: brightness(1.06);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .v2-confirm-overlay,
+  .v2-confirm {
+    animation: none;
+  }
+}

--- a/src/v2/components/ConfirmDialog.jsx
+++ b/src/v2/components/ConfirmDialog.jsx
@@ -1,0 +1,56 @@
+import { useEffect } from 'react'
+import './ConfirmDialog.css'
+
+// Generic confirm-dialog primitive for v2. Two-button modal — destructive
+// confirm + cancel. Used wherever an action needs to pause for a "are you
+// sure?" gate that benefits from full focus (something modal would dismiss
+// like a tooltip can't carry).
+//
+// The state-owner passes `open=true` + `onConfirm` + `onCancel`. Title,
+// body text, and confirm-button label are owned by the caller so each site
+// can frame the question in its own voice (e.g. "Stop the follow-up chain?"
+// vs "Clear all data?"). `tone="danger"` flips the confirm button into the
+// red treatment used by Settings' destructive ops.
+export default function ConfirmDialog({
+  open,
+  title,
+  body,
+  confirmLabel = 'Confirm',
+  cancelLabel = 'Cancel',
+  tone = 'danger',
+  onConfirm,
+  onCancel,
+}) {
+  // Escape closes; Enter doesn't auto-confirm because the destructive action
+  // shouldn't be one keystroke away.
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e) => { if (e.key === 'Escape') onCancel?.() }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [open, onCancel])
+
+  if (!open) return null
+
+  return (
+    <div className="v2-confirm-overlay" onClick={onCancel} role="dialog" aria-modal="true" aria-labelledby="v2-confirm-title">
+      <div className="v2-confirm" onClick={e => e.stopPropagation()}>
+        <h3 id="v2-confirm-title" className="v2-confirm-title">{title}</h3>
+        {body && <p className="v2-confirm-body">{body}</p>}
+        <div className="v2-confirm-actions">
+          <button type="button" className="v2-confirm-btn v2-confirm-btn-cancel" onClick={onCancel}>
+            {cancelLabel}
+          </button>
+          <button
+            type="button"
+            className={`v2-confirm-btn v2-confirm-btn-${tone}`}
+            onClick={onConfirm}
+            autoFocus
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/wiki/Sequences.md
+++ b/wiki/Sequences.md
@@ -87,11 +87,9 @@ Both copy `routine.follow_ups` onto the spawned task. The walk takes over from t
 
 ---
 
-## Open questions / Roadmap
+## Roadmap
 
-The user has signed off on the following follow-up PRs (in order):
-
-- **PR 2 — Delete prompt.** Deleting (or moving to backlog/projects/cancelled) a task that has non-empty `follow_ups` opens a modal asking: *"This task has N follow-ups queued. Delete this step only (chain stops), or cancel the whole chain?"*
+- **PR 2 — Chain-break confirmation (SHIPPED).** When a task with queued follow-ups is about to be deleted, moved to backlog, moved to projects, or cancelled, a `ConfirmDialog` warns: *"This task has N follow-up step(s) queued. {Action} will stop the chain — the queued step(s) won't spawn."* Two options: confirm-with-stop (red), or "Keep task" (cancel). Completion is intentionally ungated since `done`/`completed` ADVANCE the chain — they don't break it. Implementation: `gateOnChainBreak()` helper in `AppV2.jsx` wraps `handleDelete`/`handleBacklog`/`handleProject`/`handleStatusChange`. Reusable `src/v2/components/ConfirmDialog.jsx` + `.css`.
 - **PR 3 — Skip & advance.** Button on a chain-step task that marks it `cancelled` with `skipped: true`, then runs the spawn logic anyway. Activity log distinguishes skip from completion.
 - **PR 4 — AI-mediated edit reconciliation.** Editing a step (live OR template) pops a small Quokka modal: *"You changed X. Want me to update the rest of the chain to match?"* AI suggests per-step diffs, user accepts/rejects.
 - **PR 5 — Quokka tools.** `add_follow_up`, `edit_follow_up`, `remove_follow_up`, `reorder_follow_ups` so chains can be created/edited via natural language.

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,15 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-10
 
+- feat(routines): Sequences PR 2 — chain-break confirmation [S]
+  - **Why.** PR 1 shipped follow-up chains, but a user could silently kill a chain by deleting the parent task / moving it to backlog / cancelling it without realizing the queued steps wouldn't spawn. After running mop chains for a few days the user wanted an explicit warning before destructive actions on chain-bearing tasks.
+  - **Behavior.** Any task with `follow_ups.length > 0` triggers a `ConfirmDialog` before delete / cancel / move-to-backlog / move-to-projects: *"Stop the follow-up chain? This task has N follow-up step(s) queued. {Action} will stop the chain — the queued step(s) won't spawn."* Two options: confirm-with-stop (red destructive button) or "Keep task" (cancel). Completion is intentionally ungated since `done` ADVANCES the chain via `spawnNextChainStep` — completing isn't "breaking" the chain, it's how the chain walks forward.
+  - **Implementation.** `gateOnChainBreak(task, actionLabel, confirmLabel, proceed)` helper in `AppV2.jsx` wraps the four destructive handlers (`handleDelete` / `handleBacklog` / `handleProject` / `handleStatusChange` for `cancelled`). Empty-chain tasks short-circuit and proceed immediately — no behavior change. State lives in `chainConfirm` set on `AppV2`.
+  - **Reusable confirm primitive.** Extracted the dialog pattern from `SettingsModal.jsx`'s inline confirm into `src/v2/components/ConfirmDialog.jsx` + `.css`. Props: `open` / `title` / `body` / `confirmLabel` / `cancelLabel` / `tone` (`'danger'` or `'primary'`) / `onConfirm` / `onCancel`. Escape-to-close. Future destructive flows (skip-and-advance, clear-all-data, etc.) can reuse it.
+  - **Verification.** `npm run lint` clean. `npm test` smoke test passes. Bundle: 770KB precache (up from 768KB).
+  - New: `src/v2/components/ConfirmDialog.jsx`, `src/v2/components/ConfirmDialog.css`
+  - Modified: `src/v2/AppV2.jsx`, `wiki/Sequences.md`
+
 - fix(ui): v2 header — iOS status bar overlap on PWA [XS]
   - **Bug.** With `apple-mobile-web-app-status-bar-style: black-translucent` (set in `index.html`), iOS PWA in standalone mode renders the system status bar (clock, signal, battery) OVER the app's content — the BOOMERANG wordmark area got the iPhone's clock display rendered on top of it, producing the "B 22:25 MERANG" overlap visible in v1.0.0 prod.
   - **Fix.** `.v2-header` `padding-top` now uses `max(14px, env(safe-area-inset-top, 0px))` (and `max(16px, ...)` on the `min-width: 601px` desktop variant) so our header content sits below the iOS status bar instead of behind it. The `viewport-fit=cover` meta tag is already in place. Header background remains a solid `var(--v2-bg)` so the status bar's text reads on a contrasting surface.


### PR DESCRIPTION
## Summary
Sequences PR 2 of 5. Warns before destructive actions break an in-flight follow-up chain.

## Behavior
- Any task with `follow_ups.length > 0` triggers a `ConfirmDialog` before delete / cancel / move-to-backlog / move-to-projects
- Title: *"Stop the follow-up chain?"* — body explains how many steps are queued and which won't spawn
- Two options: `Stop chain & {action}` (red destructive) and `Keep task` (cancel)
- Completion is intentionally ungated — `done`/`completed` ADVANCES the chain via `spawnNextChainStep`, doesn't break it

## Implementation
- `gateOnChainBreak(task, actionLabel, confirmLabel, proceed)` helper in `AppV2.jsx`
- Wraps the four destructive handlers (`handleDelete` / `handleBacklog` / `handleProject` / `handleStatusChange` for cancelled)
- Empty-chain tasks short-circuit and proceed immediately — no friction added for the common case
- New reusable `src/v2/components/ConfirmDialog.jsx` + `.css` (extracted from `SettingsModal.jsx`'s inline confirm so future destructive flows can reuse it)

## Verification
- `npm run lint` clean (only pre-existing warnings)
- `npm test` smoke test passes (770KB precache bundle, +2KB from ConfirmDialog)

## Auto-merge
Per session policy. `feat:` prefix bumps `v1.0.1 → v1.1.0` on next dev → main milestone (this PR lands on dev only, no immediate prod build).

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_