### PR TITLE
feat(ui): terminal theme PR A — palette, monospace stack, 3-way picker [M]

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,20 +11,22 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600&family=Syne:wght@700;800&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet" />
     <title>Boomerang</title>
     <script>
       // Apply saved UI version + theme before first paint so v2 tokens (and the
-      // chosen dark/light variant) are in scope before React mounts. Critical
-      // for the ErrorBoundary fallback: if AppV2 throws on first render, the
-      // boundary still renders with the right tokens applied.
+      // chosen light/dark/terminal variant) are in scope before React mounts.
+      // Critical for the ErrorBoundary fallback: if AppV2 throws on first
+      // render, the boundary still renders with the right tokens applied.
       try {
         var v = localStorage.getItem('ui_version')
         if (v !== 'v1') document.documentElement.setAttribute('data-ui', 'v2')
         var s = JSON.parse(localStorage.getItem('boom_settings_v1'))
-        if (s && (s.theme === 'light' || s.theme === 'dark')) {
+        var themeColors = { light: '#FFFFFF', dark: '#0B0B0F', terminal: '#0A0E1A' }
+        if (s && themeColors[s.theme]) {
           document.documentElement.setAttribute('data-theme', s.theme)
           var meta = document.querySelector('meta[name="theme-color"]')
-          if (meta) meta.content = s.theme === 'light' ? '#FFFFFF' : '#0B0B0F'
+          if (meta) meta.content = themeColors[s.theme]
         }
       } catch(e) {}
     </script>

--- a/src/v2/AppV2.jsx
+++ b/src/v2/AppV2.jsx
@@ -79,17 +79,19 @@ export default function AppV2() {
   const weather = useWeather()
 
   // Mark the document so v2-namespaced tokens activate. Also apply the saved
-  // theme on mount so the rendered UI matches whatever the Settings dark-mode
-  // toggle reads — without this, settings.theme could be 'dark' (carried over
-  // from another device or previous session) but data-theme would be unset,
-  // making the modal say ON while the rest of the app renders light.
+  // theme on mount so the rendered UI matches whatever the Settings theme
+  // picker reads — without this, settings.theme could be 'dark'/'terminal'
+  // (carried over from another device or previous session) but data-theme
+  // would be unset, making the modal say one thing while the rest of the
+  // app renders another.
   useEffect(() => {
     document.documentElement.setAttribute('data-ui', 'v2')
     const theme = loadSettings().theme
-    if (theme === 'dark' || theme === 'light') {
+    const themeColors = { light: '#FFFFFF', dark: '#0B0B0F', terminal: '#0A0E1A' }
+    if (theme === 'dark' || theme === 'light' || theme === 'terminal') {
       document.documentElement.setAttribute('data-theme', theme)
       const meta = document.querySelector('meta[name="theme-color"]')
-      if (meta) meta.content = theme === 'dark' ? '#0B0B0F' : '#FFFFFF'
+      if (meta) meta.content = themeColors[theme]
     }
     return () => { document.documentElement.removeAttribute('data-ui') }
   }, [])

--- a/src/v2/components/SettingsModal.css
+++ b/src/v2/components/SettingsModal.css
@@ -167,6 +167,55 @@
   border-bottom: none;
 }
 
+/* Stacked variant — used when the control is too wide to share a flex
+ * row with the label (e.g. the 3-way Theme segment on phone widths).
+ * Label sits above; control occupies the full row beneath. */
+.v2-settings-row-stacked {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 12px;
+}
+
+/* Segmented radio control. Three (or N) pill buttons in a single
+ * border-wrapped capsule so it reads as one widget. Active option
+ * fills with the accent color; others stay transparent. */
+.v2-settings-segment {
+  display: inline-flex;
+  align-items: stretch;
+  border: 1px solid var(--v2-hairline);
+  border-radius: var(--v2-radius-pill);
+  padding: 3px;
+  gap: 2px;
+  width: 100%;
+  max-width: 320px;
+}
+
+.v2-settings-segment-btn {
+  flex: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: none;
+  color: var(--v2-text-meta);
+  font: 500 13px/1 var(--v2-font-body);
+  padding: 8px 12px;
+  border-radius: calc(var(--v2-radius-pill) - 4px);
+  cursor: pointer;
+  transition: background var(--v2-dur-quick) var(--v2-ease-standard),
+              color var(--v2-dur-quick) var(--v2-ease-standard);
+}
+
+.v2-settings-segment-btn:hover:not(.v2-settings-segment-btn-active) {
+  background: rgba(var(--v2-text-rgb), 0.05);
+  color: var(--v2-text);
+}
+
+.v2-settings-segment-btn-active {
+  background: var(--v2-accent);
+  color: #fff;
+}
+
 .v2-settings-row-text {
   flex: 1;
   min-width: 0;

--- a/src/v2/components/SettingsModal.jsx
+++ b/src/v2/components/SettingsModal.jsx
@@ -1867,25 +1867,34 @@ export default function SettingsModal({
 
         {activeTab === 'General' && (
           <div className="v2-settings-form">
-            <div className="v2-settings-row">
+            <div className="v2-settings-row v2-settings-row-stacked">
               <div className="v2-settings-row-text">
-                <div className="v2-settings-row-label">Dark mode</div>
-                <div className="v2-settings-row-hint">Light mode flips the off-white background to soft grey and inverts the text palette.</div>
+                <div className="v2-settings-row-label">Theme</div>
+                <div className="v2-settings-row-hint">Light is the default. Dark inverts the palette. Terminal is a monospace navy aesthetic with cyan accents — inspired by init.habits.</div>
               </div>
-              <label className="v2-settings-toggle">
-                <input
-                  type="checkbox"
-                  checked={settings.theme === 'dark'}
-                  onChange={e => {
-                    const theme = e.target.checked ? 'dark' : 'light'
-                    update('theme', theme)
-                    document.documentElement.setAttribute('data-theme', theme)
-                    const meta = document.querySelector('meta[name="theme-color"]')
-                    if (meta) meta.content = theme === 'dark' ? '#0B0B0F' : '#FFFFFF'
-                  }}
-                />
-                <span className="v2-settings-toggle-track"><span className="v2-settings-toggle-thumb" /></span>
-              </label>
+              <div className="v2-settings-segment" role="radiogroup" aria-label="Theme">
+                {[
+                  { value: 'light', label: 'Light', themeColor: '#FFFFFF' },
+                  { value: 'dark', label: 'Dark', themeColor: '#0B0B0F' },
+                  { value: 'terminal', label: 'Terminal', themeColor: '#0A0E1A' },
+                ].map(opt => (
+                  <button
+                    key={opt.value}
+                    type="button"
+                    role="radio"
+                    aria-checked={(settings.theme || 'light') === opt.value}
+                    className={`v2-settings-segment-btn${(settings.theme || 'light') === opt.value ? ' v2-settings-segment-btn-active' : ''}`}
+                    onClick={() => {
+                      update('theme', opt.value)
+                      document.documentElement.setAttribute('data-theme', opt.value)
+                      const meta = document.querySelector('meta[name="theme-color"]')
+                      if (meta) meta.content = opt.themeColor
+                    }}
+                  >
+                    {opt.label}
+                  </button>
+                ))}
+              </div>
             </div>
 
             <div className="v2-settings-row">

--- a/src/v2/tokens.css
+++ b/src/v2/tokens.css
@@ -54,3 +54,65 @@
   --v2-text-faint: rgba(232, 232, 236, 0.35);
   --v2-hairline: rgba(255, 255, 255, 0.08);
 }
+
+/* Terminal theme — third aesthetic mode beyond light/dark.
+ * Inspired by init.habits and classic dev-tool dark themes. Deep-navy
+ * background, monospace everywhere, cyan accents with a soft glow. The
+ * point isn't pixel-perfect retro CRT — it's "this app feels like a
+ * tool, not a product." Layout, spacing, and component contracts stay
+ * identical to the light/dark variants; only the palette and font
+ * stack swap. ASCII flourishes (bracketed labels, checkbox prefixes,
+ * spinner glyphs) layer on in subsequent PRs.
+ *
+ * Why a third theme value instead of a separate data-ui mode? Because
+ * Terminal IS v2 in every structural sense — it just dresses different.
+ * Treating it as a theme means dark↔light↔terminal is one toggle, no
+ * extra flag for users to track. */
+:root[data-ui="v2"][data-theme="terminal"] {
+  /* Type — full monospace stack. JetBrains Mono / SF Mono / Cascadia
+   * preferred where available; fall back to system mono to keep the
+   * bundle lean (no @font-face load for v1.1). */
+  --v2-font-display: 'JetBrains Mono', 'SF Mono', 'Cascadia Code', 'Fira Code', ui-monospace, monospace;
+  --v2-font-body: 'JetBrains Mono', 'SF Mono', 'Cascadia Code', 'Fira Code', ui-monospace, monospace;
+
+  /* Surfaces — deep navy. The cards and bg differ by ~6% lightness so
+   * cards still read as elevated, but the contrast is subtle (terminal
+   * UIs lean flat, not Material-shadowy). */
+  --v2-bg: #0A0E1A;
+  --v2-surface: #0F1424;
+  --v2-text: #D8DEF0;
+  --v2-text-rgb: 216, 222, 240;
+  --v2-text-meta: rgba(216, 222, 240, 0.55);
+  --v2-text-faint: rgba(216, 222, 240, 0.32);
+  --v2-hairline: rgba(120, 140, 200, 0.16);
+
+  /* Accent — cyan, the universal "command-line glow." Replaces the
+   * orange of light/dark. Bright enough to read on the navy bg without
+   * looking radioactive. */
+  --v2-accent: #4FC3F7;
+
+  /* Status — terminal-flavored alarm colors, kept semantically aligned
+   * with light/dark (overdue=red, high-pri=amber). */
+  --v2-alert-overdue: #FF6B6B;
+  --v2-alert-high-pri: #FFB84D;
+
+  /* Energy types — recolored to fit the navy palette. Slightly
+   * desaturated so they don't compete with the cyan accent. */
+  --v2-energy-desk: #7DC4F7;
+  --v2-energy-people: #F0A6CA;
+  --v2-energy-errand: #6FCF97;
+  --v2-energy-confrontation: #F2A07B;
+  --v2-energy-creative: #C5A0E8;
+  --v2-energy-physical: #F0C674;
+
+  /* Soft glow — components opt in via this token. Used sparingly on
+   * the wordmark, primary buttons, the sync indicator. The blur is
+   * small enough not to soften legibility. */
+  --v2-glow: 0 0 8px rgba(79, 195, 247, 0.45);
+
+  /* Slightly softer radii so the look feels "boxy terminal" not
+   * "iOS pill" while still staying tap-friendly. */
+  --v2-radius-pill: 6px;
+  --v2-radius-card: 4px;
+  --v2-radius-modal: 6px;
+}

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,16 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-10
 
+- feat(ui): terminal theme PR A — palette, monospace stack, 3-way picker [M]
+  - **Why.** Light + dark covered the calm-product end of the aesthetic spectrum, but the user wanted a third mode that reads as "this app is a tool, not a product" — inspired by [init.habits](https://inithabits.com) and classic dev-tool dark themes. Deep navy bg, monospace everywhere, cyan accents with a soft glow. Layout/component contracts are unchanged; this PR is purely tokens + the picker.
+  - **Token block.** New `:root[data-ui="v2"][data-theme="terminal"]` variant in `tokens.css`. Bg `#0A0E1A`, surface `#0F1424`, text `#D8DEF0`, accent cyan `#4FC3F7`. Energy types desaturated to fit the navy palette without competing with the accent. Radii dropped from `999px / 14px / 20px` to `6px / 4px / 6px` so cards/pills read "terminal box" instead of "iOS pill." New `--v2-glow` token (subtle cyan blur) reserved for opt-in use by sync/wordmark/buttons in the next theme PRs.
+  - **Font stack.** `JetBrains Mono` from Google Fonts as the primary, `'SF Mono' / 'Cascadia Code' / 'Fira Code' / ui-monospace` fallbacks. Both `--v2-font-display` and `--v2-font-body` collapse to the same monospace stack — no mixed font weights, the typographic flat-out reads as terminal.
+  - **Picker.** Settings → General "Dark mode" toggle becomes a 3-way segmented control (Light / Dark / Terminal). Stacked layout because three pills don't fit alongside the row label on phone width. Wires through to `update('theme', value)` + `data-theme` attr + `meta[name="theme-color"]`. Defaults to `light` when unset (existing users keep their light/dark choice).
+  - **Pre-paint application.** `index.html` inline script extended to recognize `'terminal'` alongside `'light'`/`'dark'` so the navy bg paints before React mounts (no white-flash on terminal theme load).
+  - **Bundle.** 779KB precache (+1KB from token block + segmented control CSS).
+  - **What this PR doesn't do.** ASCII flourishes (bracket buttons, `[ ] / [✓]` checkboxes, `>` section bullets), cursor-blink/spinner sync animations, and command-prompt header styling all land in PR B / C / D as the theme builds out.
+  - Modified: `src/v2/tokens.css`, `src/v2/AppV2.jsx`, `src/v2/components/SettingsModal.jsx`, `src/v2/components/SettingsModal.css`, `index.html`, `wiki/Version-History.md`
+
 - feat(adviser): Sequences PR 5 — Quokka tools for chain editing [S]
   - **Why.** Quokka could read routines but couldn't edit a chain template — no atomic ops on `follow_ups`. Users had to open RoutinesModal manually to add/remove/reorder steps. Now natural-language commands like *"add a 'rinse the brushes' step to the mop routine right after auto-clean"* can do the work.
   - **Four new tools** in `adviserToolsTasks.js`, each capturing the routine's pre-state in their compensation closure for rollback:


### PR DESCRIPTION
## Summary
Terminal theme PR A of 4. Palette + font stack + 3-way picker. Foundation only; ASCII flourishes land in PR B.

## What ships
- **New `data-theme="terminal"`** token block in `tokens.css`. Deep navy bg (`#0A0E1A`), cyan accent (`#4FC3F7`), JetBrains Mono / system mono font stack. Energy types desaturated, radii dropped to 4-6px so cards/pills read "terminal box" instead of "iOS pill"
- **`--v2-glow` token** (subtle cyan blur) reserved for opt-in use by sync/wordmark/buttons in subsequent theme PRs
- **3-way segmented picker** in Settings → General. Replaces the binary "Dark mode" toggle. Stacked layout (label above, control below) because three pills don't fit alongside on phone width
- **Pre-paint hookup** — `index.html` inline script recognizes `'terminal'` so the navy bg paints before React mounts (no white-flash on theme switch)
- **JetBrains Mono** loaded from Google Fonts (preconnect already in place)

## What this PR doesn't do (intentionally)
- No ASCII flourishes (bracket buttons, `[ ] / [✓]` checkboxes, `>` section bullets) — PR B
- No TaskCard reskin — PR C
- No cursor-blink / spinner / `[OK]` sync animations — PR D

## Verification
- `npm run lint` clean
- `npm test` passes
- Bundle: 779KB precache (+1KB)

## Auto-merge
Per session policy. Visual review possible on dev once Portainer cycles.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_