### PR TITLE
feat(ui): terminal theme PR B — wordmark prompt + section bullets [S]

### DIFF
--- a/src/v2/AppV2.css
+++ b/src/v2/AppV2.css
@@ -1,4 +1,5 @@
 @import './tokens.css';
+@import './terminal.css';
 
 .v2-app {
   position: fixed;

--- a/src/v2/terminal.css
+++ b/src/v2/terminal.css
@@ -1,0 +1,129 @@
+/* Terminal theme aesthetic overrides — only kick in when
+ * `data-ui="v2"` AND `data-theme="terminal"`. Keeps the layout/component
+ * contracts of v2 intact; just dresses them in ASCII flourishes (bracket
+ * brackets, command-prompt prefixes, blinking cursor) and tighter
+ * monospace spacing.
+ *
+ * Why not inline these in each component's CSS? Two reasons:
+ * (1) Theme-specific overrides clustered in one place make it easier to
+ *     audit "what does terminal mode change?" and to delete the theme
+ *     cleanly later if it doesn't catch on.
+ * (2) Component CSS stays neutral — light + dark stay the canonical
+ *     appearance, terminal is the mood.
+ */
+
+/* === Wordmark ========================================================
+ * Light/dark: "BOOMERANG" in bold display. Terminal: lowercase
+ * `$ boomerang_` with a leading prompt and a blinking trailing cursor —
+ * reads as a CLI invocation. The existing letter-span structure stays
+ * intact (so the saving wave bounce still works); we just lowercase the
+ * letters via text-transform and decorate the wrapper. */
+
+:root[data-ui="v2"][data-theme="terminal"] .v2-header-wordmark {
+  text-transform: lowercase;
+  letter-spacing: 0;
+  /* Slightly larger than the default 14px so the lowercase mono letters
+   * keep enough optical weight against the prompt + cursor. */
+  font-size: 15px;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0;
+}
+
+:root[data-ui="v2"][data-theme="terminal"] .v2-header-wordmark::before {
+  content: "$ ";
+  color: var(--v2-text-meta);
+  font-weight: 500;
+  margin-right: 2px;
+  /* Don't catch the wave animation that targets letter spans — pseudo-
+   * elements can't have --letter-index, so they're naturally exempt. */
+}
+
+:root[data-ui="v2"][data-theme="terminal"] .v2-header-wordmark::after {
+  content: "_";
+  color: var(--v2-accent);
+  margin-left: 2px;
+  font-weight: 700;
+  /* Blink at terminal-typical cadence. `steps(2)` gives the
+   * hard on/off cut instead of a smooth fade — that's the look. */
+  animation: v2-terminal-cursor-blink 1.1s steps(2) infinite;
+}
+
+@keyframes v2-terminal-cursor-blink {
+  0%, 49%   { opacity: 1; }
+  50%, 100% { opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :root[data-ui="v2"][data-theme="terminal"] .v2-header-wordmark::after {
+    animation: none;
+    opacity: 1;
+  }
+}
+
+/* When the wordmark is in degraded/offline state (red/amber) the cursor
+ * matches that color so the whole element reads as one alarmed unit. */
+:root[data-ui="v2"][data-theme="terminal"] .v2-header-wordmark[data-sync-state="offline"]::after {
+  color: var(--v2-alert-overdue);
+}
+:root[data-ui="v2"][data-theme="terminal"] .v2-header-wordmark[data-sync-state="degraded"]::after {
+  color: var(--v2-alert-high-pri);
+}
+
+/* === Section labels ==================================================
+ * Light/dark: "✦ DOING                3" — sparkle bullet + plain count.
+ * Terminal: "> DOING               [3]" — chevron prompt + bracketed
+ * count. Read as listing rows in a CLI output. */
+
+:root[data-ui="v2"][data-theme="terminal"] .v2-section-label-bullet {
+  font-size: 0;  /* hide the sparkle character */
+}
+
+:root[data-ui="v2"][data-theme="terminal"] .v2-section-label-bullet::before {
+  content: ">";
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--v2-accent);
+  /* Subtle glow so the chevron pulses with the same cyan-on-dark feel
+   * as the rest of the theme. Falls back gracefully if --v2-glow isn't
+   * set (other themes); never applied because we're under the terminal
+   * selector here. */
+  text-shadow: var(--v2-glow);
+}
+
+:root[data-ui="v2"][data-theme="terminal"] .v2-section-label-count::before {
+  content: "[";
+  color: var(--v2-text-faint);
+  margin-right: 1px;
+}
+
+:root[data-ui="v2"][data-theme="terminal"] .v2-section-label-count::after {
+  content: "]";
+  color: var(--v2-text-faint);
+  margin-left: 1px;
+}
+
+/* === Empty states ====================================================
+ * Lucide icons stay (their stroke color picks up var(--v2-text-meta) so
+ * they look fine in terminal). The icon backdrop circle gets squared
+ * off to match the boxy radii of the theme. */
+
+:root[data-ui="v2"][data-theme="terminal"] .v2-empty-icon {
+  border-radius: var(--v2-radius-card);  /* picks up the 4px terminal value */
+}
+
+/* === Brand popover ===================================================
+ * Sync row icon (currently `●`) gets bracketed for status-line vibes:
+ * "[●] Synced ✓" instead of "● Synced ✓". This is purely visual flair;
+ * the dot still picks up its sync-state color. */
+
+:root[data-ui="v2"][data-theme="terminal"] .v2-header-popover-sync .v2-header-popover-row-icon::before {
+  content: "[";
+  color: var(--v2-text-faint);
+  margin-right: 2px;
+}
+:root[data-ui="v2"][data-theme="terminal"] .v2-header-popover-sync .v2-header-popover-row-icon::after {
+  content: "]";
+  color: var(--v2-text-faint);
+  margin-left: 2px;
+}

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,19 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-10
 
+- feat(ui): terminal theme PR B — wordmark prompt + section bullets [S]
+  - **Why.** PR A swapped the palette + font; PR B layers the actual ASCII flourishes that make the theme feel like a CLI instead of just "v2 in dark blue."
+  - **Wordmark.** `BOOMERANG` becomes `$ boomerang_` in terminal mode. Lowercase via `text-transform`, leading `$ ` prompt prefix as `::before`, blinking trailing `_` cursor as `::after` (1.1s `steps(2)` blink — hard on/off cut, not smooth fade). Cursor color picks up the cyan accent in idle state, switches to amber/red when sync goes degraded/offline. Existing letter-span saving wave still fires unchanged because the pseudo-elements aren't part of the spans.
+  - **Section labels.** `✦ DOING                3` becomes `> DOING               [3]`. Sparkle character hidden via `font-size: 0`; chevron prompt rendered as `::before` on the bullet span; brackets wrap the count via `::before` + `::after` on the count span. Reads as a CLI listing row.
+  - **Brand popover sync row.** The `●` indicator gets bracketed: `[●] Synced ✓` for status-line vibes.
+  - **Empty-state icon backdrop** rounds to the smaller terminal `--v2-radius-card` (4px) so the soft circle becomes a boxy square — matches the theme's overall geometry.
+  - **Architecture choice.** All terminal overrides live in a single new `src/v2/terminal.css` (imported from `AppV2.css`) instead of being scattered across each component's stylesheet. Two reasons: (1) easier to audit "what does terminal mode change?", (2) component CSS stays neutral so light + dark remain canonical.
+  - **Reduced-motion.** Cursor blink respects `prefers-reduced-motion` — solid cursor instead of animation.
+  - **Bundle.** 779KB precache (unchanged — terminal.css adds ~3KB of CSS source that compresses into the existing chunk).
+  - **What's still pending.** Bracket buttons, `[ ]/[✓]` checkboxes on TaskCard (PR C). Sync wordmark spinner + `[OK]/[ERR]/[BUSY]` flashes (PR D).
+  - New: `src/v2/terminal.css`
+  - Modified: `src/v2/AppV2.css`, `wiki/Version-History.md`
+
 - feat(ui): terminal theme PR A — palette, monospace stack, 3-way picker [M]
   - **Why.** Light + dark covered the calm-product end of the aesthetic spectrum, but the user wanted a third mode that reads as "this app is a tool, not a product" — inspired by [init.habits](https://inithabits.com) and classic dev-tool dark themes. Deep navy bg, monospace everywhere, cyan accents with a soft glow. Layout/component contracts are unchanged; this PR is purely tokens + the picker.
   - **Token block.** New `:root[data-ui="v2"][data-theme="terminal"]` variant in `tokens.css`. Bg `#0A0E1A`, surface `#0F1424`, text `#D8DEF0`, accent cyan `#4FC3F7`. Energy types desaturated to fit the navy palette without competing with the accent. Radii dropped from `999px / 14px / 20px` to `6px / 4px / 6px` so cards/pills read "terminal box" instead of "iOS pill." New `--v2-glow` token (subtle cyan blur) reserved for opt-in use by sync/wordmark/buttons in the next theme PRs.


### PR DESCRIPTION
## Summary
Terminal theme PR B of 4. Adds the ASCII flourishes that make the theme feel CLI-flavored instead of just "v2 in dark blue."

## What changes (terminal mode only)
- **Wordmark:** `BOOMERANG` → `$ boomerang_` via `text-transform: lowercase` + `::before "$ "` prompt + `::after "_"` blinking cursor (1.1s `steps(2)` blink — hard on/off cut, that's the look). Cursor color follows sync state (cyan idle, amber degraded, red offline). Saving wave still fires.
- **Section labels:** `✦ DOING  3` → `> DOING  [3]`. Sparkle hidden via `font-size: 0`, chevron `>` rendered as `::before`, brackets wrap the count.
- **Brand popover sync row:** `[●] Synced ✓` for status-line vibes
- **Empty-state icon backdrop:** rounds to terminal's `4px` radius so the soft circle becomes a boxy square — matches theme geometry

## Architecture
All terminal overrides live in a single new `src/v2/terminal.css` (imported from `AppV2.css`). Two reasons:
1. Easier to audit "what does terminal mode change?"
2. Component CSS stays neutral — light + dark remain the canonical appearance

## Reduced-motion
Cursor blink respects `prefers-reduced-motion: reduce` → solid cursor instead of animating.

## Verification
- `npm run lint` clean
- `npm test` passes
- Bundle: 779KB precache (terminal.css adds ~3KB source, compresses into the existing chunk)

## Auto-merge
Per session policy. Visual once Portainer cycles.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_