### PR TITLE
feat(ui): terminal theme PR C — TaskCard ASCII flourishes [S]

### DIFF
--- a/src/v2/terminal.css
+++ b/src/v2/terminal.css
@@ -127,3 +127,88 @@
   color: var(--v2-text-faint);
   margin-left: 2px;
 }
+
+/* === Task cards ======================================================
+ * Cards already pick up the terminal palette + boxy 4px radii via
+ * tokens. Layered ASCII flourishes here:
+ *   - "[ ] " checkbox prefix on each task title (the universal terminal
+ *     "TODO" affordance — reads as a row in `task-list output`)
+ *   - "[ done ]" bracket wrapping on the primary action button (the
+ *     only one with a text label; icon-only buttons keep the box)
+ *   - Soft cyan glow on the primary button so it pulses with the
+ *     accent — the one place the theme allows itself a little
+ *     ornament beyond pure characters. */
+
+:root[data-ui="v2"][data-theme="terminal"] .v2-card-title::before {
+  content: "[ ] ";
+  color: var(--v2-text-meta);
+  font-weight: 500;
+  /* Using letter-spacing 0 keeps the brackets crisp; the rest of the
+   * line spacing is inherited so the title still aligns with the
+   * action-row buttons below. */
+  letter-spacing: 0;
+}
+
+:root[data-ui="v2"][data-theme="terminal"] .v2-card-action-primary {
+  /* Primary "Done" — wrap the existing icon + label in [ ... ]
+   * brackets so it reads as a CLI subcommand. The icon and text inside
+   * are unchanged; we only decorate the outer button. */
+  box-shadow: var(--v2-glow);
+  font-weight: 700;
+}
+
+:root[data-ui="v2"][data-theme="terminal"] .v2-card-action-primary::before {
+  content: "[ ";
+  margin-right: 2px;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+:root[data-ui="v2"][data-theme="terminal"] .v2-card-action-primary::after {
+  content: " ]";
+  margin-left: 2px;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+/* Skip-advance keeps its amber color but gets the same boxy radius +
+ * subtle outline-glow so it reads as a peer command, not a stranger. */
+:root[data-ui="v2"][data-theme="terminal"] .v2-card-action-skip {
+  border-color: var(--v2-alert-high-pri);
+  background: rgba(255, 184, 77, 0.06);
+}
+
+/* The meta separator `·` becomes a more terminal-y `|` — same line of
+ * text, different glyph that reads as pipe/output separator. */
+:root[data-ui="v2"][data-theme="terminal"] .v2-card-meta-sep {
+  font-size: 0;
+}
+:root[data-ui="v2"][data-theme="terminal"] .v2-card-meta-sep::before {
+  content: "|";
+  font-size: 12px;
+  color: var(--v2-text-faint);
+}
+
+/* === Buttons across modals (ConfirmDialog, ChainReconcileModal) ======
+ * Same bracket treatment for the primary action so destructive confirm
+ * dialogs and Quokka apply-suggestions buttons read as a single visual
+ * language with the in-card primary. Cancel/secondary stays bare. */
+
+:root[data-ui="v2"][data-theme="terminal"] .v2-confirm-btn-danger::before,
+:root[data-ui="v2"][data-theme="terminal"] .v2-reconcile-btn-primary::before {
+  content: "[ ";
+  margin-right: 2px;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.65);
+}
+:root[data-ui="v2"][data-theme="terminal"] .v2-confirm-btn-danger::after,
+:root[data-ui="v2"][data-theme="terminal"] .v2-reconcile-btn-primary::after {
+  content: " ]";
+  margin-left: 2px;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+:root[data-ui="v2"][data-theme="terminal"] .v2-reconcile-btn-primary {
+  box-shadow: var(--v2-glow);
+}

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,17 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-10
 
+- feat(ui): terminal theme PR C — TaskCard ASCII flourishes [S]
+  - **Why.** Cards picked up the theme's palette + radii from PR A, but they still read as "v2 cards in dark blue." PR C makes them feel like rows in CLI task-list output.
+  - **Title prefix.** `[ ] ` checkbox affordance prepended to every task title via `.v2-card-title::before`. Universal terminal TODO marker — Active tasks still aren't done so they always show the empty checkbox; once they complete they leave the active list anyway, so a `[✓]` state isn't needed in this view.
+  - **Primary action button.** "Done" wraps in `[ Done ]` brackets via `::before` / `::after`, plus a subtle cyan `--v2-glow` box-shadow so the primary affordance pulses with the accent — the one place the theme allows itself a little ornament beyond pure characters.
+  - **Skip-advance button.** Amber outline + faint amber background fill so it reads as a peer command in the action row (instead of feeling out of place against the cyan primary).
+  - **Meta separator.** `·` → `|` via `font-size: 0` + `::before`. Pipe reads as terminal output column separator.
+  - **Modal buttons.** Same `[ ... ]` bracket treatment applies to `ConfirmDialog`'s danger button and `ChainReconcileModal`'s primary button so destructive confirms and Quokka apply-suggestions reads as one visual language with the in-card primary. Reconcile primary also gets the cyan glow.
+  - **Bundle.** 779KB precache (terminal.css gained ~1KB CSS source, no measurable bundle change after compression).
+  - **What's still pending.** Sync-state animations: ASCII spinner per letter on saving, `[OK]/[ERR]/[BUSY]` bracketed status flashes (PR D — last theme PR).
+  - Modified: `src/v2/terminal.css`, `wiki/Version-History.md`
+
 - feat(ui): terminal theme PR B — wordmark prompt + section bullets [S]
   - **Why.** PR A swapped the palette + font; PR B layers the actual ASCII flourishes that make the theme feel like a CLI instead of just "v2 in dark blue."
   - **Wordmark.** `BOOMERANG` becomes `$ boomerang_` in terminal mode. Lowercase via `text-transform`, leading `$ ` prompt prefix as `::before`, blinking trailing `_` cursor as `::after` (1.1s `steps(2)` blink — hard on/off cut, not smooth fade). Cursor color picks up the cyan accent in idle state, switches to amber/red when sync goes degraded/offline. Existing letter-span saving wave still fires unchanged because the pseudo-elements aren't part of the spans.


### PR DESCRIPTION
## Summary
Terminal theme PR C of 4. Cards read as rows in CLI task-list output.

## What changes (terminal mode only)
- **`[ ] ` title prefix** — every task title prepended with the universal terminal TODO checkbox affordance via `.v2-card-title::before`
- **`[ Done ]` primary button** — bracket wrapping + subtle cyan `--v2-glow` box-shadow
- **Skip-advance button** — amber outline + faint amber fill so it reads as a peer command in the action row
- **Meta separator** `·` → `|` (pipe = terminal output column separator)
- **Modal primaries** — `ConfirmDialog` danger button and `ChainReconcileModal` primary button get the same `[ ... ]` bracket treatment so destructive confirms and Quokka's apply-suggestions read as one visual language. Reconcile primary also gets the cyan glow.

## What this PR doesn't do
- Sync-state animations (ASCII spinner per letter on saving, `[OK]/[ERR]/[BUSY]` bracketed status flashes) — last theme PR (D)

## Verification
- `npm run lint` clean
- `npm test` passes
- Bundle: 779KB precache (~1KB CSS source added, no measurable change post-compress)

## Auto-merge
Per session policy.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_