### PR TITLE
feat(ui): terminal theme PR D — sync animations [S]

### DIFF
--- a/src/v2/terminal.css
+++ b/src/v2/terminal.css
@@ -70,6 +70,64 @@
   color: var(--v2-alert-high-pri);
 }
 
+/* === Sync-state animations (PR D) ===================================
+ * Light/dark themes use a letter-by-letter wave bounce + green flash
+ * for the saving / just-synced states. That feels brand-y and a little
+ * playful — wrong vibe for the terminal theme. Replace with status
+ * conventions terminals actually use:
+ *
+ *   saving      → cycling spinner glyph at the cursor position
+ *                 (| / - \ — the universal CLI loading indicator)
+ *   just-synced → static green ✓ for the 700ms hold
+ *   idle        → blinking _ cursor (already from PR B)
+ *   degraded    → blinking _ in amber (already from PR B)
+ *   offline     → blinking _ in red    (already from PR B)
+ *
+ * The letters themselves stay solid — no bounce, no flash — so the
+ * spinner / checkmark at the trailing cursor position is the sole
+ * channel for state. Reads as a CLI status line.
+ *
+ * The `content` property is animatable in modern browsers (Chrome 105+,
+ * Safari 16.4+, Firefox 110+, all from 2022-2023) — that's how we cycle
+ * the spinner glyphs. Older browsers fall back to the static `|` from
+ * the saving::after content declaration. */
+
+:root[data-ui="v2"][data-theme="terminal"] .v2-header-wordmark[data-sync-state="saving"]::after {
+  content: '|';
+  color: var(--v2-accent);
+  animation: v2-terminal-spinner 0.6s steps(4) infinite;
+}
+
+@keyframes v2-terminal-spinner {
+  0%   { content: '|'; }
+  25%  { content: '/'; }
+  50%  { content: '-'; }
+  75%  { content: '\\'; }
+  100% { content: '|'; }
+}
+
+/* Mute the letter bounce during saving — clean letters + spinner is the
+ * terminal language. Same for just-synced (no green wash on letters). */
+:root[data-ui="v2"][data-theme="terminal"] .v2-header-wordmark[data-sync-state="saving"] .v2-header-wordmark-letter,
+:root[data-ui="v2"][data-theme="terminal"] .v2-header-wordmark[data-sync-state="just-synced"] .v2-header-wordmark-letter {
+  animation: none;
+  color: var(--v2-text);
+  transform: none;
+}
+
+:root[data-ui="v2"][data-theme="terminal"] .v2-header-wordmark[data-sync-state="just-synced"]::after {
+  content: '\2713';  /* ✓ */
+  color: var(--v2-energy-errand);
+  animation: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :root[data-ui="v2"][data-theme="terminal"] .v2-header-wordmark[data-sync-state="saving"]::after {
+    animation: none;
+    content: '*';
+  }
+}
+
 /* === Section labels ==================================================
  * Light/dark: "✦ DOING                3" — sparkle bullet + plain count.
  * Terminal: "> DOING               [3]" — chevron prompt + bracketed

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,21 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-10
 
+- feat(ui): terminal theme PR D — sync animations [S]
+  - **Why.** Light/dark themes use a letter-by-letter wave bounce + green flash for the saving / just-synced sync states. Brand-y, slightly playful — wrong vibe for terminal. PR D replaces those with status conventions terminals actually use.
+  - **Sync states in terminal mode.**
+    - `saving` → cycling spinner glyph at the cursor position (`| / - \` — the universal CLI loading indicator). 0.6s `steps(4)` rotation, cyan accent color.
+    - `just-synced` → static `✓` (green via `--v2-energy-errand`) for the 700ms hold, then back to idle cursor.
+    - `idle` → blinking `_` cursor (PR B).
+    - `degraded` → blinking `_` in amber (PR B).
+    - `offline` → blinking `_` in red (PR B).
+  - **Letter behavior.** The bounce wave and green flash on individual letters are muted in terminal mode for both `saving` and `just-synced`. Letters stay solid; the spinner / checkmark at the cursor position is the sole channel for state. Reads as a CLI status line, not a brand animation.
+  - **Implementation.** Uses CSS `content` animation — `@keyframes` cycle through `|` / `/` / `-` / `\\`. Modern-browser support landed 2022-2023 (Chrome 105+, Safari 16.4+, Firefox 110+). Older browsers fall back to the static `|` from the `::after` content declaration.
+  - **Reduced-motion.** Spinner glyph stays static at `*` instead of cycling.
+  - **Bundle.** 779KB precache (CSS-only, ~1KB source).
+  - **Terminal theme is now feature-complete for the PR set in V2-State.md.** Future polish (e.g. `[OK]/[ERR]/[BUSY]` badges next to the wordmark, command-prompt style for the brand popover, alternate cadences) can land as smaller follow-ups based on usage.
+  - Modified: `src/v2/terminal.css`, `wiki/Version-History.md`
+
 - feat(ui): terminal theme PR C — TaskCard ASCII flourishes [S]
   - **Why.** Cards picked up the theme's palette + radii from PR A, but they still read as "v2 cards in dark blue." PR C makes them feel like rows in CLI task-list output.
   - **Title prefix.** `[ ] ` checkbox affordance prepended to every task title via `.v2-card-title::before`. Universal terminal TODO marker — Active tasks still aren't done so they always show the empty checkbox; once they complete they leave the active list anyway, so a `[✓]` state isn't needed in this view.


### PR DESCRIPTION
## Summary
Terminal theme PR D of 4 — final piece. Replaces brand-y sync animations with CLI status conventions.

## Sync states in terminal mode
| State | Treatment |
|---|---|
| `saving` | Cycling spinner glyph at cursor: `| / - \`. 0.6s `steps(4)` rotation, cyan |
| `just-synced` | Static `✓` (green) for the 700ms hold, then back to idle cursor |
| `idle` | Blinking `_` cursor (from PR B) |
| `degraded` | Blinking `_` in amber (from PR B) |
| `offline` | Blinking `_` in red (from PR B) |

Letters stay solid during saving + just-synced — the brand-y wave bounce + green-letter flash are muted. Spinner / checkmark at the cursor is the sole channel for state. Reads as a CLI status line.

## Implementation note
Uses CSS `content` animation in `@keyframes`, cycling through `|` / `/` / `-` / `\\`. Modern-browser support landed 2022-2023 (Chrome 105+, Safari 16.4+, Firefox 110+). Older browsers fall back to the static `|` from the `::after` content declaration — graceful degradation.

## Reduced-motion
Spinner stays at `*` instead of cycling.

## Verification
- `npm run lint` clean
- `npm test` passes
- Bundle: 779KB precache (~1KB CSS source)

## Terminal theme is feature-complete after this PR
Future polish (`[OK]/[ERR]/[BUSY]` status badges, command-prompt brand popover, alternate spinner cadences, ASCII-art empty states) can land as small follow-ups based on usage.

## Auto-merge
Per session policy.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_