### PR TITLE
feat(ui): terminal theme PR F — control language

### DIFF
--- a/src/v2/AppV2.jsx
+++ b/src/v2/AppV2.jsx
@@ -590,12 +590,14 @@ export default function AppV2() {
                 icon={ListChecks}
                 title="Type to search"
                 body="Searches every task — active, done, backlog, or project."
+                terminalCommand="// type a query — searches active, done, backlog, projects"
               />
             ) : searchResults.length === 0 ? (
               <EmptyState
                 icon={ListChecks}
                 title="No matches"
                 body={`Nothing matches "${searchQuery}". Try a different keyword.`}
+                terminalCommand={`// no matches for "${searchQuery}"`}
               />
             ) : (
               <>
@@ -625,6 +627,9 @@ export default function AppV2() {
             body={activeFilter !== 'all' ? 'Tap All above to clear the filter.' : 'No active tasks right now. Tap the + above to add one.'}
             cta={activeFilter !== 'all' ? 'Show all' : 'Add task'}
             ctaOnClick={activeFilter !== 'all' ? () => setActiveFilter('all') : () => setShowAdd(true)}
+            terminalCommand={activeFilter !== 'all'
+              ? '// no matches under this filter — clear it to see everything'
+              : '// no active tasks. that\'s either bold or concerning. press + to add.'}
           />
         ) : isDesktop ? (
           <KanbanBoard
@@ -705,7 +710,7 @@ export default function AppV2() {
 
       {/* More-menu sheet. Each row's icon is tinted to match v1's color hint
           system so users can recognize destinations at a glance. */}
-      <ModalShell open={showMenu} onClose={() => setShowMenu(false)} title="More" width="narrow">
+      <ModalShell open={showMenu} onClose={() => setShowMenu(false)} title="More" terminalTitle="$ menu" width="narrow">
         <ul className="v2-more-menu">
           <li>
             <button className="v2-more-row" onClick={() => { setShowMenu(false); setShowSettings(true) }}>
@@ -767,7 +772,7 @@ export default function AppV2() {
         }}
       />
 
-      <ModalShell open={showHelp} onClose={() => setShowHelp(false)} title="Keyboard shortcuts" width="narrow">
+      <ModalShell open={showHelp} onClose={() => setShowHelp(false)} title="Keyboard shortcuts" terminalTitle="$ help --keys" width="narrow">
         <ul className="v2-shortcut-list">
           {[
             { keys: ['n'], desc: 'New task' },

--- a/src/v2/components/ActivityLog.jsx
+++ b/src/v2/components/ActivityLog.jsx
@@ -63,7 +63,7 @@ export default function ActivityLog({ open, onRestore, onClose }) {
   }
 
   return (
-    <ModalShell open={open} onClose={onClose} title="Activity log" width="wide">
+    <ModalShell open={open} onClose={onClose} title="Activity log" terminalTitle="$ log" width="wide">
       <div className="v2-activity-toolbar">
         <div className="v2-activity-filters">
           <button
@@ -91,6 +91,7 @@ export default function ActivityLog({ open, onRestore, onClose }) {
           icon={History}
           title="No activity yet"
           body="Edits, completions, and deletes show up here as you work."
+          terminalCommand="// log empty — edits, completions, and deletes will appear here"
         />
       ) : (
         <ul className="v2-activity-list">

--- a/src/v2/components/AddTaskModal.jsx
+++ b/src/v2/components/AddTaskModal.jsx
@@ -43,7 +43,7 @@ export default function AddTaskModal({ open, onAdd, onClose }) {
   const priorityLabel = priorityState === 'high' ? '! High' : priorityState === 'low' ? '↓ Low' : 'Normal'
 
   return (
-    <ModalShell open={open} onClose={onClose} title="New task" width="narrow">
+    <ModalShell open={open} onClose={onClose} title="New task" terminalTitle="$ task --new" width="narrow">
       <input
         ref={titleRef}
         className="v2-form-input v2-form-title"

--- a/src/v2/components/AdviserModal.jsx
+++ b/src/v2/components/AdviserModal.jsx
@@ -221,7 +221,7 @@ export default function AdviserModal({ open, adviser, onClose, onAfterCommit }) 
   }
 
   return (
-    <ModalShell open={open} onClose={onClose} title="Quokka" width="wide">
+    <ModalShell open={open} onClose={onClose} title="Quokka" terminalTitle="$ quokka" width="wide">
       <div className="v2-adviser-toolbar">
         <button
           className="v2-adviser-tool-btn"

--- a/src/v2/components/AnalyticsModal.jsx
+++ b/src/v2/components/AnalyticsModal.jsx
@@ -141,7 +141,7 @@ export default function AnalyticsModal({ open, onClose }) {
   }, [history, metric])
 
   return (
-    <ModalShell open={open} onClose={onClose} title="Analytics" width="wide">
+    <ModalShell open={open} onClose={onClose} title="Analytics" terminalTitle="$ stats" width="wide">
       {/* Range + metric controls */}
       <div className="v2-analytics-toolbar">
         <div className="v2-analytics-range">

--- a/src/v2/components/ConfirmDialog.jsx
+++ b/src/v2/components/ConfirmDialog.jsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react'
+import { useTerminalMode } from '../hooks/useTerminalMode'
 import './ConfirmDialog.css'
 
 // Generic confirm-dialog primitive for v2. Two-button modal — destructive
@@ -14,13 +15,16 @@ import './ConfirmDialog.css'
 export default function ConfirmDialog({
   open,
   title,
+  terminalTitle,
   body,
   confirmLabel = 'Confirm',
+  terminalConfirmLabel,
   cancelLabel = 'Cancel',
   tone = 'danger',
   onConfirm,
   onCancel,
 }) {
+  const terminal = useTerminalMode()
   // Escape closes; Enter doesn't auto-confirm because the destructive action
   // shouldn't be one keystroke away.
   useEffect(() => {
@@ -35,7 +39,7 @@ export default function ConfirmDialog({
   return (
     <div className="v2-confirm-overlay" onClick={onCancel} role="dialog" aria-modal="true" aria-labelledby="v2-confirm-title">
       <div className="v2-confirm" onClick={e => e.stopPropagation()}>
-        <h3 id="v2-confirm-title" className="v2-confirm-title">{title}</h3>
+        <h3 id="v2-confirm-title" className="v2-confirm-title">{terminal && terminalTitle ? terminalTitle : title}</h3>
         {body && <p className="v2-confirm-body">{body}</p>}
         <div className="v2-confirm-actions">
           <button type="button" className="v2-confirm-btn v2-confirm-btn-cancel" onClick={onCancel}>
@@ -47,7 +51,7 @@ export default function ConfirmDialog({
             onClick={onConfirm}
             autoFocus
           >
-            {confirmLabel}
+            {terminal && terminalConfirmLabel ? terminalConfirmLabel : confirmLabel}
           </button>
         </div>
       </div>

--- a/src/v2/components/DoneList.jsx
+++ b/src/v2/components/DoneList.jsx
@@ -95,7 +95,7 @@ export default function DoneList({ open, onClose, onUncomplete }) {
   )
 
   return (
-    <ModalShell open={open} onClose={onClose} title="Done" width="wide">
+    <ModalShell open={open} onClose={onClose} title="Done" terminalTitle="$ done --list" width="wide">
       {loading && <div className="v2-done-loading">Loading…</div>}
 
       {!loading && doneTasks.length === 0 && (
@@ -103,6 +103,7 @@ export default function DoneList({ open, onClose, onUncomplete }) {
           icon={CheckCircle2}
           title="Nothing completed yet"
           body="You'll see your wins here as you finish tasks."
+          terminalCommand="// no completions yet — they show up here as you finish tasks"
         />
       )}
 

--- a/src/v2/components/EditTaskModal.css
+++ b/src/v2/components/EditTaskModal.css
@@ -74,14 +74,60 @@
   cursor: pointer;
 }
 
+/* The Manage section — destructive + admin actions grouped under a
+ * subtle header so they read as a distinct cluster, not just more
+ * buttons in the form flow. The hairline + label do the visual
+ * grouping; in terminal mode the label becomes `// manage` via the
+ * data-terminal-cmd CSS swap below. */
+.v2-edit-manage {
+  margin-top: 24px;
+  padding-top: 20px;
+  border-top: 1px solid var(--v2-hairline);
+}
+
+.v2-edit-manage-label {
+  font: 600 11px/1 var(--v2-font-body);
+  color: var(--v2-text-faint);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin-bottom: 12px;
+  text-align: center;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-edit-manage-label {
+  letter-spacing: 0;
+  /* Lowercase the visible "Manage" text in terminal mode without
+   * touching the JSX so light/dark stay capitalized cleanly. */
+  text-transform: lowercase;
+  text-align: left;
+  font-size: 12px;
+  color: var(--v2-text-meta);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-edit-manage-label::before {
+  content: "// ";
+  color: var(--v2-text-faint);
+}
+
 .v2-edit-actions-row {
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
   gap: 8px;
-  margin-top: 24px;
-  padding-top: 20px;
-  border-top: 1px solid var(--v2-hairline);
+}
+
+/* Terminal-mode action label swap. JSX renders both `Backlog` (visible
+ * by default) and a data-terminal-cmd attribute holding `$ archive`. In
+ * terminal mode, the visible text is hidden via font-size 0 and the
+ * attribute is rendered via ::before. Reads as a CLI subcommand. */
+:root[data-ui="v2"][data-theme^="terminal"] .v2-edit-action-label {
+  font-size: 0;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-edit-action-label::before {
+  content: attr(data-terminal-cmd);
+  font-size: 12px;
+  font-family: var(--v2-font-body);
 }
 
 .v2-edit-action {

--- a/src/v2/components/EditTaskModal.jsx
+++ b/src/v2/components/EditTaskModal.jsx
@@ -206,7 +206,7 @@ export default function EditTaskModal({ task, onSave, onClose, onDelete, onBackl
   }, [confirmDelete])
 
   return (
-    <ModalShell open={!!task} onClose={onClose} title="Edit task" width="narrow">
+    <ModalShell open={!!task} onClose={onClose} title="Edit task" terminalTitle="$ task --edit" width="narrow">
       <input
         className="v2-form-input v2-form-title"
         placeholder="What needs doing?"
@@ -845,55 +845,58 @@ export default function EditTaskModal({ task, onSave, onClose, onDelete, onBackl
         )}
       </div>
 
-      <div className="v2-form-section v2-edit-actions-row">
-        <button
-          className="v2-edit-action"
-          onClick={() => { onBacklog(task.id, true); onClose() }}
-          title="Move to backlog"
-        >
-          <Archive size={14} strokeWidth={1.75} /> Backlog
-        </button>
-        <button
-          className="v2-edit-action"
-          onClick={() => { onProject(task.id, true); onClose() }}
-          title="Move to projects"
-        >
-          <FolderKanban size={14} strokeWidth={1.75} /> Projects
-        </button>
-        {!task.routine_id && !makeRecurring && (
+      <div className="v2-form-section v2-edit-manage">
+        <div className="v2-edit-manage-label">Manage</div>
+        <div className="v2-edit-actions-row">
           <button
             className="v2-edit-action"
-            onClick={() => setMakeRecurring(true)}
-            title="Convert this task into a recurring routine"
+            onClick={() => { onBacklog(task.id, true); onClose() }}
+            title="Move to backlog"
           >
-            <RotateCw size={14} strokeWidth={1.75} /> Make recurring
+            <Archive size={14} strokeWidth={1.75} /> <span className="v2-edit-action-label" data-terminal-cmd="$ archive">Backlog</span>
           </button>
-        )}
-        {!confirmDelete ? (
           <button
             className="v2-edit-action"
-            onClick={() => setConfirmDelete(true)}
-            title="Delete task"
+            onClick={() => { onProject(task.id, true); onClose() }}
+            title="Move to projects"
           >
-            <Trash2 size={14} strokeWidth={1.75} /> Delete
+            <FolderKanban size={14} strokeWidth={1.75} /> <span className="v2-edit-action-label" data-terminal-cmd="$ move-to-projects">Projects</span>
           </button>
-        ) : (
-          <div className="v2-edit-confirm-delete">
-            <span className="v2-edit-confirm-label">Delete?</span>
-            <button
-              className="v2-edit-action v2-edit-action-confirm-yes"
-              onClick={() => { onDelete(task.id); onClose() }}
-            >
-              Yes
-            </button>
+          {!task.routine_id && !makeRecurring && (
             <button
               className="v2-edit-action"
-              onClick={() => setConfirmDelete(false)}
+              onClick={() => setMakeRecurring(true)}
+              title="Convert this task into a recurring routine"
             >
-              No
+              <RotateCw size={14} strokeWidth={1.75} /> <span className="v2-edit-action-label" data-terminal-cmd="$ make-recurring">Make recurring</span>
             </button>
-          </div>
-        )}
+          )}
+          {!confirmDelete ? (
+            <button
+              className="v2-edit-action v2-edit-action-danger"
+              onClick={() => setConfirmDelete(true)}
+              title="Delete task"
+            >
+              <Trash2 size={14} strokeWidth={1.75} /> <span className="v2-edit-action-label" data-terminal-cmd="$ delete --confirm">Delete</span>
+            </button>
+          ) : (
+            <div className="v2-edit-confirm-delete">
+              <span className="v2-edit-confirm-label">Delete?</span>
+              <button
+                className="v2-edit-action v2-edit-action-confirm-yes"
+                onClick={() => { onDelete(task.id); onClose() }}
+              >
+                Yes
+              </button>
+              <button
+                className="v2-edit-action"
+                onClick={() => setConfirmDelete(false)}
+              >
+                No
+              </button>
+            </div>
+          )}
+        </div>
       </div>
 
       <button

--- a/src/v2/components/EmptyState.jsx
+++ b/src/v2/components/EmptyState.jsx
@@ -1,6 +1,25 @@
+import { useTerminalMode } from '../hooks/useTerminalMode'
 import './EmptyState.css'
 
-export default function EmptyState({ icon: Icon, title, body, cta, ctaOnClick }) {
+// Calm empty/placeholder primitive. In terminal mode, optional
+// `terminalCommand` short-circuits the icon + title + body + CTA tree
+// and renders a single `// comment` line instead — same vibe as a CLI
+// "no results" output. Callers pass both forms so light/dark stay
+// canonical and terminal feels native.
+export default function EmptyState({ icon: Icon, title, body, cta, ctaOnClick, terminalCommand }) {
+  const terminal = useTerminalMode()
+  if (terminal && terminalCommand) {
+    return (
+      <div className="v2-empty v2-empty-terminal">
+        <p className="v2-empty-terminal-line">{terminalCommand}</p>
+        {cta && (
+          <button className="v2-empty-cta" onClick={ctaOnClick}>
+            {cta}
+          </button>
+        )}
+      </div>
+    )
+  }
   return (
     <div className="v2-empty">
       {Icon && (

--- a/src/v2/components/MarkdownImportModal.jsx
+++ b/src/v2/components/MarkdownImportModal.jsx
@@ -59,7 +59,7 @@ export default function MarkdownImportModal({ open, onImport, onClose }) {
   }
 
   return (
-    <ModalShell open={open} onClose={handleClose} title="Import from Markdown" width="wide">
+    <ModalShell open={open} onClose={handleClose} title="Import from Markdown" terminalTitle="$ import --markdown" width="wide">
       {!parsed ? (
         <div className="v2-md-import">
           <div className="v2-md-import-hint">

--- a/src/v2/components/ModalShell.jsx
+++ b/src/v2/components/ModalShell.jsx
@@ -1,8 +1,10 @@
 import { useEffect } from 'react'
 import { X } from 'lucide-react'
+import { useTerminalMode } from '../hooks/useTerminalMode'
 import './ModalShell.css'
 
-export default function ModalShell({ open, onClose, title, subtitle, children, width = 'narrow' }) {
+export default function ModalShell({ open, onClose, title, terminalTitle, subtitle, children, width = 'narrow' }) {
+  const terminal = useTerminalMode()
   useEffect(() => {
     if (!open) return
     const onKey = (e) => { if (e.key === 'Escape') onClose() }
@@ -24,7 +26,7 @@ export default function ModalShell({ open, onClose, title, subtitle, children, w
           <X size={18} strokeWidth={1.75} />
         </button>
         <header className="v2-modal-header">
-          <h1 className="v2-modal-title">{title}</h1>
+          <h1 className="v2-modal-title">{terminal && terminalTitle ? terminalTitle : title}</h1>
           {subtitle && <p className="v2-modal-subtitle">{subtitle}</p>}
         </header>
         <div className="v2-modal-body">

--- a/src/v2/components/PackagesModal.jsx
+++ b/src/v2/components/PackagesModal.jsx
@@ -194,7 +194,7 @@ export default function PackagesModal({
   }
 
   return (
-    <ModalShell open={open} onClose={onClose} title="Packages" width="wide">
+    <ModalShell open={open} onClose={onClose} title="Packages" terminalTitle="$ packages" width="wide">
       <div className="v2-packages-toolbar">
         <button
           className="v2-package-toolbar-btn"
@@ -248,6 +248,7 @@ export default function PackagesModal({
           icon={PackageIcon}
           title="No packages tracked"
           body="Add a tracking number above to start watching it. Carrier auto-detects from most major carriers."
+          terminalCommand="// no packages tracked — paste a tracking number above"
         />
       ) : (
         <ul className="v2-package-list">

--- a/src/v2/components/ProjectsView.jsx
+++ b/src/v2/components/ProjectsView.jsx
@@ -15,6 +15,7 @@ export default function ProjectsView({ open, tasks, onClose, onComplete, onEdit,
       open={open}
       onClose={onClose}
       title="Projects"
+      terminalTitle="$ projects"
       subtitle={projectTasks.length > 0
         ? `${projectTasks.length} project${projectTasks.length !== 1 ? 's' : ''} · no notifications, take your time`
         : undefined}
@@ -25,6 +26,7 @@ export default function ProjectsView({ open, tasks, onClose, onComplete, onEdit,
           icon={FolderKanban}
           title="No projects yet"
           body={`Move longer-term tasks here so they stop nagging you. Use "Move to projects" in any task's edit modal.`}
+          terminalCommand="// no projects — move long-haul tasks here to stop the nag"
         />
       ) : (
         <div className="v2-projects-list">

--- a/src/v2/components/ReframeModal.jsx
+++ b/src/v2/components/ReframeModal.jsx
@@ -33,6 +33,7 @@ export default function ReframeModal({ task, onReframe, onClose }) {
       open={!!task}
       onClose={onClose}
       title="This one keeps coming back"
+      terminalTitle="$ reframe"
       subtitle={`"${task.title}" has been snoozed ${task.snooze_count} times. What's actually in the way?`}
     >
       {!results ? (

--- a/src/v2/components/RoutinesModal.jsx
+++ b/src/v2/components/RoutinesModal.jsx
@@ -561,6 +561,7 @@ export default function RoutinesModal({
       open={open}
       onClose={onClose}
       title={view === 'form' ? (editing ? 'Edit routine' : 'New routine') : 'Routines'}
+      terminalTitle={view === 'form' ? (editing ? '$ routine --edit' : '$ routine --new') : '$ routines'}
       subtitle={view === 'list' && routines.length > 0
         ? `${active.length} active${paused.length ? ` · ${paused.length} paused` : ''}`
         : undefined}
@@ -581,6 +582,7 @@ export default function RoutinesModal({
               body="Recurring tasks like dentist visits, plant watering, oil changes. Create one to start tracking the rhythm."
               cta="New routine"
               ctaOnClick={() => { setEditing(null); setView('form') }}
+              terminalCommand="// no routines yet. recurring tasks live here — dentist, oil change, water plants."
             />
           ) : (
             <>

--- a/src/v2/components/SettingsModal.jsx
+++ b/src/v2/components/SettingsModal.jsx
@@ -1842,7 +1842,7 @@ export default function SettingsModal({
   }
 
   return (
-    <ModalShell open={open} onClose={onClose} title="Settings" width="wide">
+    <ModalShell open={open} onClose={onClose} title="Settings" terminalTitle="$ settings" width="wide">
       <div className="v2-settings-tabs">
         {TABS.map(tab => (
           <button

--- a/src/v2/components/SnoozeModal.jsx
+++ b/src/v2/components/SnoozeModal.jsx
@@ -54,6 +54,7 @@ export default function SnoozeModal({ task, onSnooze, onClose }) {
       open={!!task}
       onClose={onClose}
       title={task.title}
+      terminalTitle="$ snooze"
       subtitle="When should this come back?"
     >
       {filteredOptions.length === 0 && !showCustom ? (

--- a/src/v2/components/WhatNowModal.jsx
+++ b/src/v2/components/WhatNowModal.jsx
@@ -92,7 +92,7 @@ export default function WhatNowModal({ open, tasks, onClose, onComplete }) {
   }[step]
 
   return (
-    <ModalShell open={open} onClose={handleClose} title="What now?" subtitle={stepTitle} width="narrow">
+    <ModalShell open={open} onClose={handleClose} title="What now?" terminalTitle="$ what-now" subtitle={stepTitle} width="narrow">
       {step === 1 && (
         <ul className="v2-whatnow-options">
           {TIME_OPTIONS.map(opt => (

--- a/src/v2/hooks/useTerminalMode.js
+++ b/src/v2/hooks/useTerminalMode.js
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react'
+
+// Returns true when the active v2 theme is one of the terminal sub-variants
+// ('terminal-dark' or 'terminal-light'). Subscribes to the documentElement's
+// data-theme attribute so the hook re-renders when the user flips themes in
+// SettingsModal — no need to thread settings through component trees.
+//
+// Why a hook + MutationObserver and not a context? Theme changes happen via
+// direct DOM mutation (Settings flips data-theme inline, pre-paint script
+// flips it before React mounts). A MutationObserver picks up both paths
+// without coupling to any specific event bus.
+export function useTerminalMode() {
+  const [isTerminal, setIsTerminal] = useState(() => {
+    if (typeof document === 'undefined') return false
+    const theme = document.documentElement.getAttribute('data-theme') || ''
+    return theme.startsWith('terminal')
+  })
+
+  useEffect(() => {
+    if (typeof document === 'undefined') return
+    const root = document.documentElement
+    const update = () => {
+      const theme = root.getAttribute('data-theme') || ''
+      setIsTerminal(theme.startsWith('terminal'))
+    }
+    const observer = new MutationObserver(update)
+    observer.observe(root, { attributes: true, attributeFilter: ['data-theme'] })
+    update()
+    return () => observer.disconnect()
+  }, [])
+
+  return isTerminal
+}

--- a/src/v2/terminal/controls.css
+++ b/src/v2/terminal/controls.css
@@ -1,0 +1,102 @@
+/* Terminal — Control language overrides.
+ *
+ * iOS-style toggles in Settings get rewritten as `[off] [on]` bracket
+ * pairs in terminal mode. Pure CSS, no JSX changes needed — the
+ * existing `<label>.v2-settings-toggle > <input> + <track> > <thumb>`
+ * structure becomes:
+ *   - track: flex container holding two pseudo-element labels
+ *   - ::before renders `[off]`, ::after renders `[on]`
+ *   - Whichever matches the input's checked state gets the accent
+ *     color; the other reads as faded text
+ *   - thumb is hidden
+ *
+ * Clicking anywhere on the label still toggles the input (because the
+ * <label> wraps the whole row in the markup), so the affordance works
+ * exactly like the iOS slider — you just see brackets instead of a
+ * pill. Light + dark themes are untouched.
+ */
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-settings-toggle-track {
+  width: auto;
+  height: auto;
+  background: transparent !important;
+  border: none;
+  border-radius: 0;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+  padding: 2px 0;
+  font: 500 12px/1 var(--v2-font-body);
+  letter-spacing: 0;
+  transition: none;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-settings-toggle-thumb {
+  display: none;
+}
+
+/* Default (unchecked) — `[off]` is the active selection. */
+:root[data-ui="v2"][data-theme^="terminal"] .v2-settings-toggle-track::before {
+  content: "[off]";
+  color: var(--v2-accent);
+  font-weight: 700;
+  text-shadow: var(--v2-glow);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-settings-toggle-track::after {
+  content: "[on]";
+  color: var(--v2-text-faint);
+  font-weight: 500;
+}
+
+/* Checked — `[on]` becomes the active selection, `[off]` fades. */
+:root[data-ui="v2"][data-theme^="terminal"] .v2-settings-toggle input:checked + .v2-settings-toggle-track::before {
+  color: var(--v2-text-faint);
+  font-weight: 500;
+  text-shadow: none;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-settings-toggle input:checked + .v2-settings-toggle-track::after {
+  color: var(--v2-accent);
+  font-weight: 700;
+  text-shadow: var(--v2-glow);
+}
+
+/* Disabled state — both labels read as faint, no glow. */
+:root[data-ui="v2"][data-theme^="terminal"] .v2-settings-toggle-disabled .v2-settings-toggle-track::before,
+:root[data-ui="v2"][data-theme^="terminal"] .v2-settings-toggle-disabled .v2-settings-toggle-track::after {
+  color: var(--v2-text-faint);
+  font-weight: 500;
+  text-shadow: none;
+}
+
+/* Empty-state terminal-comment renderer.
+ *
+ * `EmptyState` accepts an optional `terminalCommand` prop — when in
+ * terminal mode, that single-string short-circuits the icon + title +
+ * body tree to render as `// no results — try X` style commentary. */
+
+.v2-empty-terminal {
+  padding: 32px 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+}
+
+.v2-empty-terminal-line {
+  margin: 0;
+  font: 500 13px/1.5 var(--v2-font-body);
+  color: var(--v2-text-meta);
+  text-align: center;
+  white-space: pre-wrap;
+}
+
+/* `$` prefix in modal titles + brand-popover — color-key the prompt
+ * separator so the verb stands out from the dollar sign. Targets just
+ * the modal title so menu items / inline copy that incidentally start
+ * with `$` aren't affected. */
+:root[data-ui="v2"][data-theme^="terminal"] .v2-modal-title {
+  font-feature-settings: "ss02" 1;
+  letter-spacing: 0;
+}

--- a/src/v2/terminal/index.css
+++ b/src/v2/terminal/index.css
@@ -19,3 +19,4 @@
 @import './wordmark.css';
 @import './sections.css';
 @import './cards.css';
+@import './controls.css';

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,45 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-10
 
+- feat(ui): terminal theme PR F — control language (bracket toggles, $ verb modal headers, // manage section) [M]
+  - **Why.** PR A–E got terminal mode looking right (palette, monospace, ASCII flourishes, sub-palettes). PR F gets it speaking right — modal headers read as commands, settings toggles read as switch states, destructive actions in EditTaskModal read as a CLI subcommand cluster.
+  - **`useTerminalMode` hook.** New `src/v2/hooks/useTerminalMode.js` — subscribes to the documentElement's `data-theme` attribute via MutationObserver, returns `true` when the theme starts with `terminal-`. Used wherever JSX needs to swap copy or rendering (not pure CSS overrides).
+  - **`$ verb --flag` modal headers.** ModalShell accepts a new optional `terminalTitle` prop; when set + terminal-mode is active, that's rendered instead of the regular `title`. Wired across every v2 modal:
+    - AddTaskModal: `$ task --new`
+    - EditTaskModal: `$ task --edit`
+    - SnoozeModal: `$ snooze`
+    - ReframeModal: `$ reframe`
+    - WhatNowModal: `$ what-now`
+    - SettingsModal: `$ settings`
+    - PackagesModal: `$ packages`
+    - AnalyticsModal: `$ stats`
+    - ProjectsView: `$ projects`
+    - DoneList: `$ done --list`
+    - ActivityLog: `$ log`
+    - RoutinesModal: `$ routines` / `$ routine --new` / `$ routine --edit` (state-dependent)
+    - AdviserModal: `$ quokka`
+    - MarkdownImportModal: `$ import --markdown`
+    - AppV2 More menu: `$ menu`
+    - AppV2 Help modal: `$ help --keys`
+    - ConfirmDialog: prop added, no callers wiring it for now (chain-confirm contextual titles like "Stop the follow-up chain?" carry better signal than a generic `$ confirm`)
+  - **`// manage` section reflow in EditTaskModal.** Destructive + admin actions (Backlog / Projects / Make recurring / Delete) moved into a labeled cluster under a new "Manage" sub-header. Light/dark renders the label as a small uppercase "MANAGE" caption with letter-spacing 0.08em; terminal renders as `// manage` (lowercase, monospace, comment prefix). The hairline + label do the visual grouping; in terminal mode `data-terminal-cmd` attributes on inner spans swap each button's label to its CLI form (`$ archive`, `$ move-to-projects`, `$ make-recurring`, `$ delete --confirm`) via CSS `attr()`. Light/dark show the regular "Backlog" / "Projects" / "Make recurring" / "Delete" labels.
+  - **Bracket-toggle CSS-only override.** `[off] [on]` bracket pairs replace iOS-pill toggles in terminal mode. The existing `<input>+<track>+<thumb>` markup stays unchanged; CSS in `terminal/controls.css` hides the thumb, blanks the track background, and renders both labels via `::before` and `::after` on the track. The active state matches the input's `:checked` state via the sibling combinator. Active label gets the accent color + glow; inactive reads as faded text. Light/dark themes are completely untouched.
+  - **EmptyState `terminalCommand` prop.** `EmptyState` accepts a new optional prop that, when provided + terminal mode is active, short-circuits the icon + title + body + CTA tree to render as a single `// comment` line — same vibe as a CLI "no results" output. Wired into 7 callers covering the main empty-state surfaces:
+    - Home screen (no tasks): `// no active tasks. that's either bold or concerning. press + to add.`
+    - Search empty: `// type a query — searches active, done, backlog, projects`
+    - Search no matches: `// no matches for "..."`
+    - DoneList: `// no completions yet — they show up here as you finish tasks`
+    - ActivityLog: `// log empty — edits, completions, and deletes will appear here`
+    - ProjectsView: `// no projects — move long-haul tasks here to stop the nag`
+    - PackagesModal: `// no packages tracked — paste a tracking number above`
+    - RoutinesModal: `// no routines yet. recurring tasks live here — dentist, oil change, water plants.`
+    Other empty-state callers (Settings sub-tabs, AdviserModal, AnalyticsModal) keep the regular icon-and-body layout — those reads are dense enough that the comment form would lose information.
+  - **Architecture.** New `src/v2/terminal/controls.css` joins the directory; imported via `terminal/index.css`. Holds the bracket-toggle override + empty-state-terminal renderer. Selectors all use `[data-theme^="terminal"]` so both `terminal-dark` and `terminal-light` pick up the same treatment.
+  - **Bundle.** CSS 197.8KB gzip 30.0KB (+~2KB from controls.css + manage section + new pseudo-element rules). JS 801KB gzip 222KB (+~3KB from useTerminalMode hook + threaded props across modals).
+  - **What's not in this PR.** Tap-to-cycle interactions on TaskCard (planned for PR G with the density features), home-screen week strip + goal bar (PR H), polish + visual QA (PR I).
+  - Modified: `src/v2/components/ModalShell.jsx`, `src/v2/components/ConfirmDialog.jsx`, `src/v2/components/EmptyState.jsx`, `src/v2/components/EditTaskModal.jsx`, `src/v2/components/EditTaskModal.css`, `src/v2/components/AddTaskModal.jsx`, `src/v2/components/SnoozeModal.jsx`, `src/v2/components/ReframeModal.jsx`, `src/v2/components/WhatNowModal.jsx`, `src/v2/components/SettingsModal.jsx`, `src/v2/components/PackagesModal.jsx`, `src/v2/components/AnalyticsModal.jsx`, `src/v2/components/ProjectsView.jsx`, `src/v2/components/DoneList.jsx`, `src/v2/components/ActivityLog.jsx`, `src/v2/components/RoutinesModal.jsx`, `src/v2/components/AdviserModal.jsx`, `src/v2/components/MarkdownImportModal.jsx`, `src/v2/AppV2.jsx`, `src/v2/terminal/index.css`, `wiki/Version-History.md`
+  - Added: `src/v2/hooks/useTerminalMode.js`, `src/v2/terminal/controls.css`
+
 - refactor(ui): terminal theme PR E — palette family + directory split [M]
   - **Why.** Terminal theme shipped as a single `data-theme="terminal"` value with one navy/cyan palette baked into `tokens.css` and `terminal.css`. To go deeper into the aesthetic and let the theme branch into sub-palettes (GitHub Dark, GitHub Light), the structure had to grow up. This PR is the foundation for the rest of the v2-polish-terminal-v2 set.
   - **Two sub-palettes.** Single `'terminal'` value retired in favor of:


### PR DESCRIPTION
## Summary

PR A–E got terminal mode looking right (palette, monospace, ASCII flourishes, sub-palettes). PR F gets it speaking right — modal headers read as commands, settings toggles read as switch states, destructive actions in EditTaskModal read as a CLI subcommand cluster.

## What changed

**`useTerminalMode` hook.** New `src/v2/hooks/useTerminalMode.js` — subscribes to documentElement's `data-theme` via MutationObserver, returns `true` when theme starts with `terminal-`. Powers all JSX-level terminal rendering swaps.

**`$ verb --flag` modal headers.** ModalShell accepts new optional `terminalTitle` prop. Wired across 16 modals:

| Modal | Terminal title |
|---|---|
| AddTaskModal | `$ task --new` |
| EditTaskModal | `$ task --edit` |
| SnoozeModal | `$ snooze` |
| ReframeModal | `$ reframe` |
| WhatNowModal | `$ what-now` |
| SettingsModal | `$ settings` |
| PackagesModal | `$ packages` |
| AnalyticsModal | `$ stats` |
| ProjectsView | `$ projects` |
| DoneList | `$ done --list` |
| ActivityLog | `$ log` |
| RoutinesModal | `$ routines` / `$ routine --new` / `$ routine --edit` |
| AdviserModal | `$ quokka` |
| MarkdownImportModal | `$ import --markdown` |
| AppV2 More menu | `$ menu` |
| AppV2 Help modal | `$ help --keys` |

ConfirmDialog also accepts the prop but no callers wire it — chain-confirm contextual titles ("Stop the follow-up chain?") carry better signal than a generic `$ confirm`.

**`// manage` reflow in EditTaskModal.** Backlog / Projects / Make recurring / Delete moved into a labeled "Manage" cluster:
- Light/dark: small uppercase "MANAGE" caption with letter-spacing
- Terminal: `// manage` lowercase comment prefix
- Each button's inner label has a `data-terminal-cmd` attribute holding its CLI form (`$ archive`, `$ move-to-projects`, `$ make-recurring`, `$ delete --confirm`)
- CSS `attr()` swaps the visible text in terminal mode; light/dark show the regular labels

**Bracket-toggle CSS-only override.** `[off] [on]` bracket pairs replace iOS-pill toggles in terminal mode. The existing `<input>+<track>+<thumb>` markup stays unchanged. Pure CSS in `terminal/controls.css`:
- thumb hidden
- track background blanked
- `::before` renders `[off]`, `::after` renders `[on]`
- Active state keyed to the input's `:checked` sibling combinator
- Active label gets accent color + glow; inactive reads as faded text
- Light/dark themes completely untouched

**EmptyState `terminalCommand` prop.** When provided + terminal mode active, short-circuits the icon + title + body + CTA tree to render as a single `// comment` line. Wired into 7 main empty surfaces (home screen, search empty/no-matches, DoneList, ActivityLog, ProjectsView, PackagesModal, RoutinesModal). Sub-tab settings empties keep the regular layout — those reads are dense enough that the comment form would lose information.

## Architecture

New `src/v2/terminal/controls.css` joins the directory; imported via `terminal/index.css`. Holds the bracket-toggle override + empty-state-terminal renderer. Selectors all use `[data-theme^="terminal"]` so both `terminal-dark` and `terminal-light` pick up the same treatment uniformly.

## Bundle

CSS 197.8KB gzip 30.0KB (+~2KB controls.css + manage section + new pseudo-element rules). JS 801KB gzip 222KB (+~3KB useTerminalMode hook + threaded props).

## Test plan

- [x] `npm run lint` clean (only pre-existing warnings)
- [x] `npm run build` succeeds
- [x] `npm audit` — 0 vulnerabilities
- [ ] In terminal-dark: open every modal, confirm each title reads as `$ verb --flag`
- [ ] In terminal-light: same — same titles, white canvas, blue accent
- [ ] Toggle a few Settings switches: should render as `[off] [on]` bracket pairs in terminal mode, iOS sliders in light/dark
- [ ] EditTaskModal: open a task, scroll to bottom, verify "Manage" / `// manage` cluster with all 4 buttons. In terminal, button labels read `$ archive` / `$ move-to-projects` / `$ make-recurring` / `$ delete --confirm`
- [ ] EditTaskModal: click Delete, confirm "Delete?" inline + Yes/No flow still works (no JSX behavior changed)
- [ ] EditTaskModal on a task with `follow_ups`: chain-break ConfirmDialog still pops via the unchanged delete path
- [ ] Open a search with no results: empty state renders as `// no matches for "..."` in terminal mode
- [ ] Switch from terminal to light: all modal titles return to regular form, manage cluster shows uppercase MANAGE caption, toggles return to iOS-pill style

https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_