### PR TITLE
feat(ui): terminal theme PR G — TaskCard density (terminal-only)

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -479,6 +479,43 @@ export function computeStreak(tasks, settings) {
   return streak
 }
 
+// Per-routine streak — counts consecutive cadence cycles completed without
+// a miss, walking back from the most recent completion. A "miss" is a gap
+// between two consecutive `completed_history` entries that exceeds 1.5×
+// the cadence interval. Returns 0 if the routine has never been completed.
+//
+// Used by TaskCard to render a small `🔥N` indicator next to routine-spawned
+// tasks in terminal mode (PR G density). Per-routine, not per-task — every
+// task spawned by routine X shares the same routine streak number.
+export function computeRoutineStreak(routine) {
+  const history = routine?.completed_history || []
+  if (history.length === 0) return 0
+  if (history.length === 1) return 1
+
+  const tolerance = cadenceIntervalMs(routine.cadence, routine.custom_days) * 1.5
+  let streak = 1
+  for (let i = history.length - 1; i > 0; i--) {
+    const a = new Date(history[i]).getTime()
+    const b = new Date(history[i - 1]).getTime()
+    if (a - b <= tolerance) streak++
+    else break
+  }
+  return streak
+}
+
+function cadenceIntervalMs(cadence, customDays) {
+  const day = 24 * 60 * 60 * 1000
+  switch (cadence) {
+    case 'daily': return day
+    case 'weekly': return 7 * day
+    case 'monthly': return 30 * day
+    case 'quarterly': return 91 * day
+    case 'annually': return 365 * day
+    case 'custom': return (customDays || 1) * day
+    default: return day
+  }
+}
+
 // Activity log — tracks task lifecycle events for recovery
 const MAX_ACTIVITY_LOG = 500
 

--- a/src/v2/AppV2.jsx
+++ b/src/v2/AppV2.jsx
@@ -41,7 +41,7 @@ import { useNotionSync } from '../hooks/useNotionSync'
 import { useGCalSync } from '../hooks/useGCalSync'
 import { useKeyboardShortcuts } from '../hooks/useKeyboardShortcuts'
 import { inferSize, trelloUpdateCard, serverSkipAdvanceTask } from '../api'
-import { loadLabels, loadSettings, saveSettings, saveLabels, sortTasks, computeDailyStats, computeStreak, logActivity } from '../store'
+import { loadLabels, loadSettings, saveSettings, saveLabels, sortTasks, computeDailyStats, computeStreak, computeRoutineStreak, logActivity } from '../store'
 import './AppV2.css'
 
 export default function AppV2() {
@@ -239,6 +239,16 @@ export default function AppV2() {
   const settingsForRings = loadSettings()
   const dailyStats = computeDailyStats(tasks)
   const streak = computeStreak(tasks, settingsForRings)
+  // Per-routine streak map → threaded down to TaskCard so routine-spawned
+  // tasks can render an inline 🔥N. Recomputed only when `routines` changes.
+  const routineStreaks = useMemo(() => {
+    const map = {}
+    for (const r of routines) {
+      const s = computeRoutineStreak(r)
+      if (s > 0) map[r.id] = s
+    }
+    return map
+  }, [routines])
   // Flat ordered list for desktop keyboard nav (j/k). Mirrors the visual order:
   // doing → stale → up next → waiting → snoozed → backlog → projects.
   const visibleTasks = isDesktop
@@ -519,6 +529,7 @@ export default function AppV2() {
           onSnooze={handleSnooze}
           onSkipAdvance={handleSkipAdvance}
           weatherByDate={weather.enabled ? weather.byDate : null}
+          routineStreaks={routineStreaks}
         />
       ))}
     </>
@@ -615,6 +626,7 @@ export default function AppV2() {
                     onSnooze={handleSnooze}
                     onSkipAdvance={handleSkipAdvance}
                     weatherByDate={weather.enabled ? weather.byDate : null}
+                    routineStreaks={routineStreaks}
                   />
                 ))}
               </>
@@ -653,6 +665,7 @@ export default function AppV2() {
             onSkipAdvance={handleSkipAdvance}
             weatherByDate={weather.enabled ? weather.byDate : null}
             selectedTaskId={selectedTaskId}
+            routineStreaks={routineStreaks}
           />
         ) : (
           <div className="v2-list">
@@ -822,6 +835,7 @@ export default function AppV2() {
         onEdit={handleEdit}
         onSnooze={handleSnooze}
         weatherByDate={weather.enabled ? weather.byDate : null}
+        routineStreaks={routineStreaks}
       />
       <DoneList
         open={showDone}

--- a/src/v2/components/KanbanBoard.jsx
+++ b/src/v2/components/KanbanBoard.jsx
@@ -45,7 +45,7 @@ function KanbanColumn({
   title, tasks, defaultStatus, onAddTask,
   dragOverColumn, onDragOver, onDrop, onDragStart, draggingId,
   expandedTaskId, onToggleExpand, onComplete, onEdit, onSnooze, onSkipAdvance, weatherByDate,
-  selectedTaskId,
+  selectedTaskId, routineStreaks,
 }) {
   const acceptsDrop = !!defaultStatus
   const isDropTarget = dragOverColumn === defaultStatus && acceptsDrop
@@ -88,6 +88,7 @@ function KanbanColumn({
               onSkipAdvance={onSkipAdvance}
               weatherByDate={weatherByDate}
               selected={selectedTaskId === t.id}
+              routineStreaks={routineStreaks}
             />
           </div>
         ))}
@@ -103,7 +104,7 @@ export default function KanbanBoard({
   doingTasks, staleTasks, upNextTasks, waitingTasks, snoozedTasks, backlogTasks, projectTasks,
   onAddTask, onStatusChange,
   expandedTaskId, onToggleExpand, onComplete, onEdit, onSnooze, onSkipAdvance, weatherByDate,
-  selectedTaskId,
+  selectedTaskId, routineStreaks,
 }) {
   const dragRef = useRef(null)
   const [dragOverColumn, setDragOverColumn] = useState(null)
@@ -140,7 +141,7 @@ export default function KanbanBoard({
   }, [staleTasks, doingTasks, upNextTasks, waitingTasks])
 
   const dragCallbacks = { dragOverColumn, onDragOver: handleDragOver, onDrop: handleDrop, onDragStart: handleDragStart, draggingId }
-  const cardCallbacks = { expandedTaskId, onToggleExpand, onComplete, onEdit, onSnooze, onSkipAdvance, weatherByDate, selectedTaskId }
+  const cardCallbacks = { expandedTaskId, onToggleExpand, onComplete, onEdit, onSnooze, onSkipAdvance, weatherByDate, selectedTaskId, routineStreaks }
 
   return (
     <div className="v2-kanban">

--- a/src/v2/components/ProjectsView.jsx
+++ b/src/v2/components/ProjectsView.jsx
@@ -6,7 +6,7 @@ import EmptyState from './EmptyState'
 import TaskCard from './TaskCard'
 import './ProjectsView.css'
 
-export default function ProjectsView({ open, tasks, onClose, onComplete, onEdit, onSnooze, weatherByDate }) {
+export default function ProjectsView({ open, tasks, onClose, onComplete, onEdit, onSnooze, weatherByDate, routineStreaks }) {
   const [expandedTaskId, setExpandedTaskId] = useState(null)
   const projectTasks = sortTasks(tasks.filter(t => t.status === 'project'), 'name')
 
@@ -40,6 +40,7 @@ export default function ProjectsView({ open, tasks, onClose, onComplete, onEdit,
               onEdit={onEdit}
               onSnooze={onSnooze}
               weatherByDate={weatherByDate}
+              routineStreaks={routineStreaks}
             />
           ))}
         </div>

--- a/src/v2/components/TaskCard.jsx
+++ b/src/v2/components/TaskCard.jsx
@@ -16,7 +16,7 @@ const SWIPE_THRESHOLD = 60       // px before we commit to revealing actions
 const SWIPE_OPEN_OFFSET = -160   // resting position when actions are revealed; must match .v2-card-swipe-actions width
 const SWIPE_VERT_CANCEL = 12     // px of vertical movement that cancels the swipe
 
-function TaskCard({ task, expanded, onToggleExpand, onComplete, onEdit, onSnooze, onSkipAdvance, weatherByDate, selected }) {
+function TaskCard({ task, expanded, onToggleExpand, onComplete, onEdit, onSnooze, onSkipAdvance, weatherByDate, selected, routineStreaks }) {
   const overdue = isOverdue(task)
   const stale = isStale(task)
   const snoozed = isSnoozed(task)
@@ -43,6 +43,19 @@ function TaskCard({ task, expanded, onToggleExpand, onComplete, onEdit, onSnooze
   const checklists = Array.isArray(task.checklists) ? task.checklists : []
   const totalItems = checklists.reduce((n, cl) => n + (cl.items?.length || 0), 0)
   const checkedItems = checklists.reduce((n, cl) => n + (cl.items?.filter(i => i.completed).length || 0), 0)
+
+  // Routine streak — only renders for routine-spawned tasks. The map is
+  // computed once at AppV2 level and threaded down; missing key is fine
+  // (one-off tasks). Currently CSS-gated to terminal mode; the markup
+  // ships in every theme so flipping the gate later is a one-line change.
+  const routineStreak = task.routine_id && routineStreaks ? routineStreaks[task.routine_id] : 0
+
+  // First-line notes preview for the collapsed card. Trimmed + first
+  // newline cut so a multi-line notes string renders as a single sentence.
+  // CSS clamps to one line and hides this outside terminal mode.
+  const notesPreview = task.notes
+    ? task.notes.replace(/\s+/g, ' ').trim().slice(0, 140)
+    : ''
 
   // Swipe state — kept local to TaskCard so each card swipes independently.
   const [swipeX, setSwipeX] = useState(0)
@@ -141,7 +154,22 @@ function TaskCard({ task, expanded, onToggleExpand, onComplete, onEdit, onSnooze
     >
       <button type="button" className="v2-card-main" onClick={onMainClick}>
         <div className="v2-card-content">
-          <div className="v2-card-title">{task.title}</div>
+          <div className="v2-card-title">
+            {task.title}
+            {totalItems > 0 && (
+              <span className="v2-card-checklist-inline" aria-label={`${checkedItems} of ${totalItems} checklist items done`}>
+                [{checkedItems}/{totalItems}]
+              </span>
+            )}
+            {routineStreak > 0 && (
+              <span className="v2-card-routine-streak" aria-label={`Routine streak: ${routineStreak}`}>
+                🔥{routineStreak}
+              </span>
+            )}
+          </div>
+          {!expanded && notesPreview && (
+            <div className="v2-card-notes-preview" aria-hidden="true">{notesPreview}</div>
+          )}
           {(meta.length > 0 || weatherDay) && (
             <div className="v2-card-meta">
               {meta.map((m, i) => (

--- a/src/v2/terminal/cards.css
+++ b/src/v2/terminal/cards.css
@@ -42,6 +42,67 @@
   background: rgba(255, 184, 77, 0.06);
 }
 
+/* === Card density (PR G, terminal-only) ============================
+ * Three small additions to the collapsed task card that lift the data
+ * density of the daily list to match init.habits. All three are
+ * gated on terminal mode by user preference (2026-05-10) — extending
+ * to light/dark later is a 1-line change (drop the data-theme prefix
+ * scope) once usage validates.
+ *
+ *   1. [X/Y] checklist counter inline after the title
+ *   2. 🔥N routine-streak indicator inline after the title (or after
+ *      the counter if both present)
+ *   3. One-line clamped notes preview as a sub-row under the title
+ *
+ * Markup for all three ships in every theme; CSS hides them outside
+ * terminal mode via display:none.
+ */
+
+.v2-card-checklist-inline,
+.v2-card-routine-streak,
+.v2-card-notes-preview {
+  display: none;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-checklist-inline {
+  display: inline;
+  font: 500 12px/1 var(--v2-font-body);
+  color: var(--v2-text-faint);
+  margin-left: 8px;
+  letter-spacing: 0;
+  /* Pulled toward the title baseline; superscript-ish without actually
+   * shrinking. The title sits at the same line, the counter floats next
+   * to it. */
+  vertical-align: baseline;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-routine-streak {
+  display: inline;
+  font: 500 12px/1 var(--v2-font-body);
+  color: var(--v2-alert-high-pri);
+  margin-left: 8px;
+  letter-spacing: 0;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-notes-preview {
+  display: -webkit-box;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-top: 2px;
+  font: 400 12px/1.4 var(--v2-font-body);
+  color: var(--v2-text-meta);
+  letter-spacing: 0;
+  /* Comment-ish prefix so the line reads as inline notes attached to
+   * the task, not a stray paragraph. */
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-notes-preview::before {
+  content: "// ";
+  color: var(--v2-text-faint);
+}
+
 /* The meta separator `·` becomes a more terminal-y `|` — pipe/output
  * separator. */
 :root[data-ui="v2"][data-theme^="terminal"] .v2-card-meta-sep {

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,16 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-10
 
+- feat(ui): terminal theme PR G — TaskCard density (terminal-only) [S]
+  - **Why.** init.habits packs more information per row than v2's calm card does — checklist completion at a glance, notes preview without expanding, streak indicator for recurring tasks. PR G ports those three signals into TaskCard, gated on terminal mode so light/dark stay calm.
+  - **Inline `[X/Y]` checklist counter.** When a task has any checklist items, the title row gets a small `[3/5]` counter span after the title. CSS-gated to terminal mode — light/dark hide it via `display: none`.
+  - **One-line notes preview.** When a task has notes, the collapsed card renders a clamped first-line preview as a sub-row under the title (with a `// ` comment prefix so it reads as inline notes attached to the task). Trims to 140 chars + first newline cut so multi-line notes render as a single sentence. CSS-gated to terminal mode + collapsed state — expanded view still shows full notes via the existing `.v2-card-notes` block.
+  - **Routine streak indicator.** Tasks with `task.routine_id` show a small `🔥N` indicator after the title (or after the checklist counter if both present). New `computeRoutineStreak(routine)` in `src/store.js` walks `completed_history` from newest to oldest, counting consecutive entries spaced ≤1.5× the cadence interval. Cadence intervals: daily=1d, weekly=7d, monthly=30d, quarterly=91d, annually=365d, custom=N×days. Returns 0 for never-completed routines.
+  - **`routineStreaks` prop.** AppV2 builds a memoized `Record<routineId, number>` map from the live `routines` array via `useMemo`, threads it down through `renderSection` (mobile list), `KanbanBoard` (desktop), `ProjectsView`, and the search-results path. Recomputed only when `routines` changes — completing a routine instance bumps the array, which rebuilds the map.
+  - **CSS architecture.** All three new spans (`.v2-card-checklist-inline`, `.v2-card-routine-streak`, `.v2-card-notes-preview`) ship with `display: none` in the base CSS. Terminal-mode CSS in `src/v2/terminal/cards.css` flips them to `display: inline` (or `display: -webkit-box` for the clamped notes line). Adding to light/dark later is a one-line change (drop the data-theme prefix scope).
+  - **Bundle.** CSS 198.6KB gzip 30.1KB (+~1KB from the density rules). JS 802KB gzip 222KB (+~1KB from the streak computation + map build).
+  - Modified: `src/store.js`, `src/v2/components/TaskCard.jsx`, `src/v2/components/KanbanBoard.jsx`, `src/v2/components/ProjectsView.jsx`, `src/v2/AppV2.jsx`, `src/v2/terminal/cards.css`, `wiki/Version-History.md`
+
 - feat(ui): terminal theme PR F — control language (bracket toggles, $ verb modal headers, // manage section) [M]
   - **Why.** PR A–E got terminal mode looking right (palette, monospace, ASCII flourishes, sub-palettes). PR F gets it speaking right — modal headers read as commands, settings toggles read as switch states, destructive actions in EditTaskModal read as a CLI subcommand cluster.
   - **`useTerminalMode` hook.** New `src/v2/hooks/useTerminalMode.js` — subscribes to the documentElement's `data-theme` attribute via MutationObserver, returns `true` when the theme starts with `terminal-`. Used wherever JSX needs to swap copy or rendering (not pure CSS overrides).


### PR DESCRIPTION
## Summary

init.habits packs more information per row than v2's calm card does — checklist completion at a glance, notes preview without expanding, streak indicator for recurring tasks. PR G ports those three signals into TaskCard, gated on terminal mode so light/dark stay calm.

## What changed

**Three new card signals** (all gated to terminal mode):

1. **Inline `[X/Y]` checklist counter** on the title row when any checklist items exist — e.g., `[ ] Fix backend auth [3/5]`
2. **One-line `//`-prefixed notes preview** as a sub-row under the title (clamped to 1 line, 140 char trim + first-newline cut) — e.g., `// remember to rotate the JWT signing key first`
3. **`🔥N` routine streak indicator** for tasks with `task.routine_id` — e.g., `[ ] Water plants 🔥7`

In terminal mode, a routine task with everything looks like:
```
[ ] Water plants [3/5] 🔥7
// each pot gets ~200ml — check soil before extras
overdue · physical | level 2
```

**Streak computation.** New `computeRoutineStreak(routine)` in `src/store.js` walks `completed_history` newest→oldest, counts consecutive entries spaced ≤1.5× the cadence interval. Cadence intervals: daily=1d, weekly=7d, monthly=30d, quarterly=91d, annually=365d, custom=N×days. Returns 0 for never-completed routines.

**Wiring.** AppV2 builds a memoized `Record<routineId, number>` map from `routines` via `useMemo` and threads it down through `renderSection` (mobile list), `KanbanBoard` (desktop), `ProjectsView`, and the search-results path. Recomputed only when `routines` changes.

**CSS architecture.** All three new spans (`.v2-card-checklist-inline`, `.v2-card-routine-streak`, `.v2-card-notes-preview`) ship with `display: none` in the base CSS. Terminal-mode CSS in `src/v2/terminal/cards.css` flips them to visible. Adding to light/dark later is a one-line change (drop the data-theme prefix scope).

## Bundle

CSS 198.6KB gzip 30.1KB (+~1KB density rules). JS 802KB gzip 222KB (+~1KB streak computation + map build).

## Test plan

- [x] `npm run lint` clean (only pre-existing warnings)
- [x] `npm run build` succeeds
- [x] `npm audit` — 0 vulnerabilities
- [ ] Light/Dark: cards render unchanged — no checklist counter, no notes preview, no streak indicator
- [ ] Terminal-dark/Terminal-light: add a task with notes + a 3/5 checklist, verify the collapsed card shows `[3/5]` after title and the notes preview as a `// ` line below
- [ ] Terminal mode: complete a routine 3 times in close succession, verify routine-spawned tasks show `🔥3` after the title
- [ ] Terminal mode: never-completed routine spawn shows no fire emoji (streak 0)
- [ ] Expand a card with notes preview: full notes still render in the expanded view, preview is hidden (only collapsed shows it)
- [ ] Long notes (multi-line, 200+ chars): preview clamps to one line cleanly, no overflow

https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_