### PR TITLE
feat(ui): terminal theme PR H — home-screen 7-day strip + goal progress bar (opt-in)

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -49,6 +49,12 @@ export const DEFAULT_SETTINGS = {
   sort_by: 'age',
   daily_task_goal: 3,
   daily_points_goal: 15,
+  // Home-screen surfaces (PR H, opt-in). When true, AppV2 renders a 7-day
+  // calendar strip above the first task section / a daily-goal progress bar
+  // below the last section. Theme-aware visuals (cards in light/dark, bare
+  // monospace strip + block-character bar in terminal).
+  show_week_strip: false,
+  show_goal_progress: false,
   vacation_mode: false,
   vacation_started: null,
   trello_api_key: '',

--- a/src/v2/AppV2.jsx
+++ b/src/v2/AppV2.jsx
@@ -21,6 +21,8 @@ import AnalyticsModal from './components/AnalyticsModal'
 import KanbanBoard from './components/KanbanBoard'
 import TaskListToolbar from './components/TaskListToolbar'
 import MarkdownImportModal from './components/MarkdownImportModal'
+import WeekStrip from './components/WeekStrip'
+import GoalProgressBar from './components/GoalProgressBar'
 import Toast from './components/Toast'
 import FloatingCapture from './components/FloatingCapture'
 import ConfirmDialog from './components/ConfirmDialog'
@@ -669,11 +671,17 @@ export default function AppV2() {
           />
         ) : (
           <div className="v2-list">
+            {settingsForRings.show_week_strip && (
+              <WeekStrip tasks={tasks} dailyTaskGoal={settingsForRings.daily_task_goal || 3} />
+            )}
             {renderSection('Doing', sortedDoing)}
             {renderSection('Stale', sortedStale)}
             {renderSection('Up next', sortedUpNext)}
             {renderSection('Waiting', sortedWaiting)}
             {renderSection('Snoozed', sortedSnoozed)}
+            {settingsForRings.show_goal_progress && (
+              <GoalProgressBar tasksToday={dailyStats.tasksToday} goal={settingsForRings.daily_task_goal || 3} />
+            )}
           </div>
         )}
       </main>

--- a/src/v2/components/GoalProgressBar.css
+++ b/src/v2/components/GoalProgressBar.css
@@ -1,0 +1,109 @@
+/* Bottom-of-list goal progress bar. Renders below the last task
+ * section when `show_goal_progress` is on.
+ *
+ * Light/dark — soft pill-track + accent fill + small caption row
+ * Terminal  — monospace block-character bar via CSS overrides at the
+ *             bottom of this file.
+ */
+
+.v2-goal-progress {
+  margin: 16px -4px 8px;
+  padding: 12px 4px;
+  border-top: 1px solid var(--v2-hairline);
+}
+
+.v2-goal-progress-track {
+  position: relative;
+  height: 6px;
+  background: var(--v2-hairline);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.v2-goal-progress-fill {
+  position: absolute;
+  inset: 0 auto 0 0;
+  background: var(--v2-accent);
+  border-radius: 999px;
+  transition: width var(--v2-dur-emphasis) var(--v2-ease-emphasis);
+}
+
+.v2-goal-progress-overshoot {
+  position: absolute;
+  inset: 0 auto 0 0;
+  background: var(--v2-alert-high-pri);
+  border-radius: 999px;
+  transition: width var(--v2-dur-emphasis) var(--v2-ease-emphasis);
+  /* Sits above the fill — visually a "second tier" past 100%. */
+  mix-blend-mode: difference;
+}
+
+.v2-goal-progress-meta {
+  margin-top: 6px;
+  display: flex;
+  justify-content: space-between;
+  font: 500 12px/1.4 var(--v2-font-body);
+  color: var(--v2-text-meta);
+}
+
+.v2-goal-progress-caption {
+  color: var(--v2-text-faint);
+}
+
+.v2-goal-progress-count {
+  color: var(--v2-text);
+  font-weight: 600;
+}
+
+.v2-goal-progress-pct {
+  color: var(--v2-text-meta);
+  font-weight: 500;
+}
+
+/* === Terminal mode override =========================================
+ * Block-character bar. The track becomes a row of `▁` characters; the
+ * fill replaces the leading portion with `█`. Pure CSS via background-
+ * image gradients — render the track as an `▁`-ish baseline character
+ * via ::before, then the fill on top.
+ *
+ * Simpler: keep the track as a thin line, but use a monospaced block
+ * character above it via the meta caption row. We use a leading
+ * `[` `]` bracket pair on the meta caption to read as a CLI status
+ * line: `[10/10] // 100%  goal: 10 tasks`.
+ */
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-goal-progress {
+  margin: 16px 0 8px;
+  padding: 12px 0;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-goal-progress-track {
+  height: 4px;
+  border-radius: 0;
+  background: rgba(var(--v2-text-rgb), 0.10);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-goal-progress-fill {
+  border-radius: 0;
+  box-shadow: var(--v2-glow);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-goal-progress-overshoot {
+  border-radius: 0;
+  mix-blend-mode: normal;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-goal-progress-caption::before {
+  content: "// ";
+  color: var(--v2-text-faint);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-goal-progress-count::before {
+  content: "[";
+  color: var(--v2-text-faint);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-goal-progress-count::after {
+  content: "]";
+  color: var(--v2-text-faint);
+}

--- a/src/v2/components/GoalProgressBar.jsx
+++ b/src/v2/components/GoalProgressBar.jsx
@@ -1,0 +1,42 @@
+import './GoalProgressBar.css'
+
+// Bottom-of-list progress bar. Shows how close the user is to their
+// `daily_task_goal` for today. Opt-in via `show_goal_progress`.
+// Theme-aware: pill-shape filled bar in light/dark, monospace
+// block-character bar in terminal (CSS-only difference).
+//
+// At-goal vs above-goal: bar fills 100% at goal, then a thin amber
+// "stretch" segment past 100% indicates over-achievement.
+
+export default function GoalProgressBar({ tasksToday, goal }) {
+  const safeGoal = goal > 0 ? goal : 3
+  const fraction = safeGoal > 0 ? tasksToday / safeGoal : 0
+  const pct = Math.min(100, Math.round(fraction * 100))
+  const overshoot = fraction > 1
+  const overshootPct = overshoot ? Math.min(100, Math.round((fraction - 1) * 100)) : 0
+
+  return (
+    <div className="v2-goal-progress" role="progressbar" aria-valuenow={tasksToday} aria-valuemin={0} aria-valuemax={safeGoal}>
+      <div className="v2-goal-progress-track">
+        <div
+          className="v2-goal-progress-fill"
+          style={{ width: `${pct}%` }}
+          aria-hidden="true"
+        />
+        {overshoot && (
+          <div
+            className="v2-goal-progress-overshoot"
+            style={{ width: `${overshootPct}%` }}
+            aria-hidden="true"
+          />
+        )}
+      </div>
+      <div className="v2-goal-progress-meta">
+        <span className="v2-goal-progress-caption">Goal: {safeGoal} task{safeGoal === 1 ? '' : 's'}</span>
+        <span className="v2-goal-progress-count">
+          {tasksToday}/{safeGoal} <span className="v2-goal-progress-pct">· {pct}%</span>
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/src/v2/components/SettingsModal.css
+++ b/src/v2/components/SettingsModal.css
@@ -163,6 +163,29 @@
   border-bottom: 1px solid var(--v2-hairline);
 }
 
+/* Sub-heading inside a tab — divides logical groups (e.g. "Home screen"
+ * within General). Visually a small ALL-CAPS caption with extra top
+ * margin so the previous row's bottom border reads as a closer. */
+.v2-settings-subhead {
+  margin: 24px 0 4px;
+  font: 600 11px/1 var(--v2-font-body);
+  color: var(--v2-text-faint);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-settings-subhead {
+  text-transform: lowercase;
+  letter-spacing: 0;
+  font-size: 12px;
+  color: var(--v2-text-meta);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-settings-subhead::before {
+  content: "// ";
+  color: var(--v2-text-faint);
+}
+
 .v2-settings-row:last-child {
   border-bottom: none;
 }

--- a/src/v2/components/SettingsModal.jsx
+++ b/src/v2/components/SettingsModal.jsx
@@ -1962,6 +1962,54 @@ export default function SettingsModal({
               />
             </div>
 
+            <div className="v2-settings-subhead">Home screen</div>
+
+            <div className="v2-settings-row">
+              <div className="v2-settings-row-text">
+                <div className="v2-settings-row-label">Show 7-day strip</div>
+                <div className="v2-settings-row-hint">Calendar row above the task list with activity intensity per day. Renders as cards in light/dark, monospace block characters in terminal.</div>
+              </div>
+              <label className="v2-settings-toggle">
+                <input
+                  type="checkbox"
+                  checked={!!settings.show_week_strip}
+                  onChange={e => update('show_week_strip', e.target.checked)}
+                />
+                <span className="v2-settings-toggle-track"><span className="v2-settings-toggle-thumb" /></span>
+              </label>
+            </div>
+
+            <div className="v2-settings-row">
+              <div className="v2-settings-row-text">
+                <div className="v2-settings-row-label">Show daily goal progress</div>
+                <div className="v2-settings-row-hint">Progress bar below the task list against the daily task goal. Rounded pill in light/dark, block-character bar in terminal.</div>
+              </div>
+              <label className="v2-settings-toggle">
+                <input
+                  type="checkbox"
+                  checked={!!settings.show_goal_progress}
+                  onChange={e => update('show_goal_progress', e.target.checked)}
+                />
+                <span className="v2-settings-toggle-track"><span className="v2-settings-toggle-thumb" /></span>
+              </label>
+            </div>
+
+            <div className="v2-settings-row">
+              <div className="v2-settings-row-text">
+                <label className="v2-settings-row-label" htmlFor="v2-daily-goal">Daily task goal</label>
+                <div className="v2-settings-row-hint">Used by the progress bar + activity intensity on the 7-day strip.</div>
+              </div>
+              <input
+                id="v2-daily-goal"
+                className="v2-form-input v2-settings-compact-input"
+                type="number"
+                min="1"
+                max="50"
+                value={settings.daily_task_goal ?? 3}
+                onChange={e => update('daily_task_goal', parseInt(e.target.value) || 1)}
+              />
+            </div>
+
             <div className="v2-settings-row">
               <div className="v2-settings-row-text">
                 <div className="v2-settings-row-label">Build</div>

--- a/src/v2/components/WeekStrip.css
+++ b/src/v2/components/WeekStrip.css
@@ -1,0 +1,208 @@
+/* 7-day calendar strip. Renders above the task sections when
+ * `show_week_strip` is on. Two visual modes via theme:
+ *
+ *   light/dark — rounded card-style day cells with soft hairline,
+ *                colored intensity dot underneath
+ *   terminal   — bare monospace row, today gets a `*` prefix on its
+ *                date number, intensity rendered as a block char
+ *                (handled via the cards.css terminal overrides at the
+ *                bottom of this file)
+ */
+
+.v2-week-strip {
+  margin: 0 -8px 16px;
+  padding: 0 8px;
+}
+
+.v2-week-strip-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+  padding: 0 4px;
+}
+
+.v2-week-strip-range {
+  font: 500 12px/1 var(--v2-font-body);
+  color: var(--v2-text-meta);
+  letter-spacing: 0.02em;
+}
+
+.v2-week-strip-nav {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: 1px solid var(--v2-hairline);
+  background: transparent;
+  border-radius: var(--v2-radius-pill);
+  color: var(--v2-text-meta);
+  cursor: pointer;
+  transition: background var(--v2-dur-quick) var(--v2-ease-standard),
+              color var(--v2-dur-quick) var(--v2-ease-standard);
+}
+
+.v2-week-strip-nav:hover {
+  color: var(--v2-text);
+  background: rgba(var(--v2-text-rgb), 0.04);
+}
+
+.v2-week-strip-row {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 4px;
+}
+
+.v2-week-strip-day {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 8px 4px;
+  border: 1px solid var(--v2-hairline);
+  border-radius: var(--v2-radius-card);
+  font: 500 11px/1 var(--v2-font-body);
+  background: var(--v2-surface);
+  transition: background var(--v2-dur-quick) var(--v2-ease-standard);
+}
+
+.v2-week-strip-day-today {
+  background: rgba(var(--v2-text-rgb), 0.06);
+  border-color: var(--v2-accent);
+}
+
+.v2-week-strip-day-future {
+  opacity: 0.55;
+}
+
+.v2-week-strip-label {
+  font-size: 10px;
+  color: var(--v2-text-faint);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.v2-week-strip-num {
+  font: 600 16px/1 var(--v2-font-body);
+  color: var(--v2-text);
+}
+
+.v2-week-strip-day-today .v2-week-strip-num {
+  color: var(--v2-accent);
+}
+
+/* Activity intensity bar — soft pastel dot underneath each day. Empty
+ * day = invisible, low = pale, medium = mid, high = full accent. */
+.v2-week-strip-bar {
+  width: 18px;
+  height: 4px;
+  border-radius: 2px;
+  background: transparent;
+}
+
+.v2-week-strip-day-i1 .v2-week-strip-bar {
+  background: rgba(var(--v2-text-rgb), 0.12);
+}
+
+.v2-week-strip-day-i2 .v2-week-strip-bar {
+  background: var(--v2-accent);
+  opacity: 0.55;
+}
+
+.v2-week-strip-day-i3 .v2-week-strip-bar {
+  background: var(--v2-accent);
+  opacity: 1;
+}
+
+/* === Terminal mode override =========================================
+ * Drop the card chrome — bare row of day cells. Each day's number gets
+ * a `*` prefix when it's today. Intensity bar becomes a block character
+ * (▁ ▃ ▆ █) instead of a colored dot.
+ */
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-week-strip {
+  margin: 0 0 16px;
+  padding: 0;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-week-strip-head {
+  padding: 0;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-week-strip-range::before {
+  content: "// ";
+  color: var(--v2-text-faint);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-week-strip-row {
+  gap: 0;
+  border-top: 1px solid var(--v2-hairline);
+  border-bottom: 1px solid var(--v2-hairline);
+  padding: 6px 0;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-week-strip-day {
+  border: none;
+  background: transparent;
+  border-radius: 0;
+  padding: 4px 0;
+  gap: 2px;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-week-strip-day-today {
+  background: transparent;
+  border: none;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-week-strip-label {
+  letter-spacing: 0;
+  text-transform: lowercase;
+  font-size: 11px;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-week-strip-num {
+  font-size: 14px;
+  font-weight: 500;
+  font-family: var(--v2-font-body);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-week-strip-day-today .v2-week-strip-num::before {
+  content: "*";
+  color: var(--v2-accent);
+  margin-right: 1px;
+}
+
+/* Block-character intensity. Hide the card-mode bar, render via ::after
+ * on the day cell. */
+:root[data-ui="v2"][data-theme^="terminal"] .v2-week-strip-bar {
+  display: none;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-week-strip-day::after {
+  content: "·";
+  font-size: 12px;
+  font-family: var(--v2-font-body);
+  color: var(--v2-text-faint);
+  line-height: 1;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-week-strip-day-i1::after {
+  content: "▁";
+  color: var(--v2-text-meta);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-week-strip-day-i2::after {
+  content: "▃";
+  color: var(--v2-accent);
+  opacity: 0.7;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-week-strip-day-i3::after {
+  content: "█";
+  color: var(--v2-accent);
+}

--- a/src/v2/components/WeekStrip.jsx
+++ b/src/v2/components/WeekStrip.jsx
@@ -1,0 +1,130 @@
+import { useMemo, useState } from 'react'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
+import './WeekStrip.css'
+
+// 7-day calendar strip rendered above the task list. Each day cell shows
+// day-of-week label + date number + an activity-intensity indicator
+// (dot in light/dark, block in terminal mode) reflecting how many tasks
+// were completed that day relative to `daily_task_goal`.
+//
+// Opt-in via the `show_week_strip` setting. Theme-aware visuals: rounded
+// card cells in light/dark; bare monospace strip with `*` today marker
+// + block-character intensity in terminal mode (CSS-only difference).
+//
+// Tap a day = no-op for v1. Hook reserved for future "filter list to
+// that day" or "jump to that day" interactions.
+//
+// Week navigation: < prev / next > arrows on the edges. State managed
+// locally — defaults to the week containing today; arrow clicks shift
+// the offset by ±7 days.
+
+const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
+
+function ymd(date) {
+  return date.toISOString().slice(0, 10)
+}
+
+function startOfWeekSunday(date) {
+  const d = new Date(date)
+  d.setHours(0, 0, 0, 0)
+  d.setDate(d.getDate() - d.getDay())
+  return d
+}
+
+export default function WeekStrip({ tasks, dailyTaskGoal }) {
+  const [weekOffset, setWeekOffset] = useState(0)
+
+  // Pre-bucket task completions by ISO date. Cheap; runs on every tasks
+  // change, but the list is bounded and the bucket is just a count.
+  const completionsByDate = useMemo(() => {
+    const map = {}
+    for (const t of tasks) {
+      if (t.status !== 'done' || !t.completed_at) continue
+      const key = ymd(new Date(t.completed_at))
+      map[key] = (map[key] || 0) + 1
+    }
+    return map
+  }, [tasks])
+
+  const days = useMemo(() => {
+    const start = startOfWeekSunday(new Date())
+    start.setDate(start.getDate() + weekOffset * 7)
+    const todayKey = ymd(new Date())
+    const out = []
+    for (let i = 0; i < 7; i++) {
+      const d = new Date(start)
+      d.setDate(d.getDate() + i)
+      const key = ymd(d)
+      const count = completionsByDate[key] || 0
+      const goal = dailyTaskGoal > 0 ? dailyTaskGoal : 3
+      // Intensity: 0 = no completions, 1 = some, 2 = met goal, 3 = exceeded
+      let intensity = 0
+      if (count > 0 && count < goal) intensity = 1
+      else if (count >= goal && count < goal * 2) intensity = 2
+      else if (count >= goal * 2) intensity = 3
+      out.push({
+        date: d,
+        key,
+        label: DAY_LABELS[d.getDay()],
+        dayNumber: d.getDate(),
+        isToday: key === todayKey,
+        isFuture: d > new Date(),
+        count,
+        intensity,
+      })
+    }
+    return out
+  }, [completionsByDate, weekOffset, dailyTaskGoal])
+
+  // Range label — "May 4–10" or "Apr 27–May 3" if straddling a month.
+  const rangeLabel = useMemo(() => {
+    const first = days[0].date
+    const last = days[6].date
+    const firstMonth = first.toLocaleString('en', { month: 'short' })
+    const lastMonth = last.toLocaleString('en', { month: 'short' })
+    if (firstMonth === lastMonth) {
+      return `${firstMonth} ${first.getDate()}–${last.getDate()}`
+    }
+    return `${firstMonth} ${first.getDate()}–${lastMonth} ${last.getDate()}`
+  }, [days])
+
+  return (
+    <div className="v2-week-strip">
+      <div className="v2-week-strip-head">
+        <button
+          className="v2-week-strip-nav"
+          onClick={() => setWeekOffset(o => o - 1)}
+          aria-label="Previous week"
+        >
+          <ChevronLeft size={14} strokeWidth={2} />
+        </button>
+        <span className="v2-week-strip-range">{rangeLabel}</span>
+        <button
+          className="v2-week-strip-nav"
+          onClick={() => setWeekOffset(o => o + 1)}
+          aria-label="Next week"
+        >
+          <ChevronRight size={14} strokeWidth={2} />
+        </button>
+      </div>
+      <ol className="v2-week-strip-row">
+        {days.map(d => (
+          <li
+            key={d.key}
+            className={[
+              'v2-week-strip-day',
+              d.isToday ? 'v2-week-strip-day-today' : '',
+              d.isFuture ? 'v2-week-strip-day-future' : '',
+              `v2-week-strip-day-i${d.intensity}`,
+            ].filter(Boolean).join(' ')}
+            aria-label={`${d.label} ${d.dayNumber}: ${d.count} task${d.count === 1 ? '' : 's'} completed`}
+          >
+            <span className="v2-week-strip-label">{d.label}</span>
+            <span className="v2-week-strip-num">{d.dayNumber}</span>
+            <span className="v2-week-strip-bar" aria-hidden="true" />
+          </li>
+        ))}
+      </ol>
+    </div>
+  )
+}

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,26 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-10
 
+- feat(ui): terminal theme PR H — home-screen 7-day strip + goal progress bar (opt-in) [M]
+  - **Why.** init.habits puts a daily-rhythm strip at the top of its main view and a goal progress bar at the bottom — both surface "where am I in my day?" without the user having to open Analytics or do math. PR H adds those two surfaces to v2's home screen, opt-in (default off) and theme-aware so they fit any palette.
+  - **`WeekStrip` component (new).** 7-day calendar row rendered above the first task section. Each day cell shows day-of-week label + date number + an activity-intensity indicator. Today is highlighted; future days dim to 0.55 opacity. Activity intensity buckets:
+    - 0 (no completions) — empty
+    - 1 (some completions but below daily goal) — pale dot/pale block
+    - 2 (met goal, up to 2× goal) — accent dot at 0.55 opacity / `▃` block
+    - 3 (≥2× goal — over-achievement) — full accent dot / `█` block
+    - `< prev` / `next >` arrows on the row header navigate weeks. State managed locally; defaults to current week. Range label reads as "May 4–10" (or "Apr 27–May 3" if straddling a month boundary).
+    - Tap a day = no-op for v1. Hook reserved for future "filter to that day" / "jump to that day" interactions.
+  - **`GoalProgressBar` component (new).** Renders below the last task section. Shows `tasksToday / daily_task_goal` as a horizontal progress bar with caption row underneath. Bar fills 100% at goal, then a thin amber "stretch" segment past 100% indicates over-achievement. Caption: "Goal: N tasks" + count `3/5 · 60%`.
+  - **Theme-aware visuals (CSS-only, same JSX both modes):**
+    - Light/dark — rounded card-style day cells with hairline border, soft accent-colored intensity bar; pill-shape progress track with rounded fill
+    - Terminal — bare monospace strip (no card chrome), today's date number gets a `*` prefix, intensity rendered as block characters (`▁ ▃ █`); progress bar uses `[N/N]` brackets in the count + `// goal:` comment-prefixed caption + glow shadow on the fill
+  - **Settings.** New "Home screen" subhead in General tab with three rows: 7-day strip toggle, goal progress toggle, daily task goal numeric input. The subhead renders as small uppercase "HOME SCREEN" caption in light/dark and `// home screen` lowercase comment in terminal — same `.v2-settings-subhead` class with terminal-mode CSS override.
+  - **Default state.** Both `show_week_strip` and `show_goal_progress` ship as `false`. Existing users see no change until they opt in. New users start without them so the calm minimal home screen is the first impression.
+  - **Wiring.** AppV2's mobile list (the `<div className="v2-list">`) renders `<WeekStrip>` above the first `renderSection` call when `show_week_strip` is true, and `<GoalProgressBar>` after the last `renderSection` call when `show_goal_progress` is true. Both inside the scroll container so they move with the list. Desktop Kanban view doesn't render either — Kanban is already dense; revisit in PR I if usage warrants.
+  - **Bundle.** CSS 204.2KB gzip 30.9KB (+~5.5KB from the two new component CSS files + subhead override). JS 807KB gzip 223.6KB (+~5KB from the two components + memoized completion bucketing).
+  - Modified: `src/store.js` (added `show_week_strip` + `show_goal_progress` defaults), `src/v2/AppV2.jsx`, `src/v2/components/SettingsModal.jsx`, `src/v2/components/SettingsModal.css`, `wiki/Version-History.md`
+  - Added: `src/v2/components/WeekStrip.jsx`, `src/v2/components/WeekStrip.css`, `src/v2/components/GoalProgressBar.jsx`, `src/v2/components/GoalProgressBar.css`
+
 - feat(ui): terminal theme PR G — TaskCard density (terminal-only) [S]
   - **Why.** init.habits packs more information per row than v2's calm card does — checklist completion at a glance, notes preview without expanding, streak indicator for recurring tasks. PR G ports those three signals into TaskCard, gated on terminal mode so light/dark stay calm.
   - **Inline `[X/Y]` checklist counter.** When a task has any checklist items, the title row gets a small `[3/5]` counter span after the title. CSS-gated to terminal mode — light/dark hide it via `display: none`.


### PR DESCRIPTION
## Summary

init.habits puts a daily-rhythm strip at the top of its main view and a goal progress bar at the bottom — both surface "where am I in my day?" without the user having to open Analytics or do math. PR H ports those two surfaces to v2's home screen, opt-in (default off) and theme-aware so they fit any palette.

## What changed

**`WeekStrip` (new component).** 7-day calendar row above the first task section. Day-of-week label + date number + activity-intensity indicator per day. Today highlighted; future dims to 0.55. `<` / `>` arrows navigate weeks; range label "May 4–10" (or "Apr 27–May 3" if straddling a month).

Activity intensity buckets:
| Bucket | Condition | Light/Dark | Terminal |
|---|---|---|---|
| 0 | no completions | empty | empty |
| 1 | below goal | pale dot | `▁` |
| 2 | met goal, up to 2× | accent dot @ 0.55 | `▃` accent |
| 3 | ≥2× goal | full accent | `█` accent |

Tap a day = no-op for v1. Hook reserved for future "filter to that day" / "jump to that day" interactions.

**`GoalProgressBar` (new component).** Renders below the last task section. Shows `tasksToday / daily_task_goal` as a horizontal bar with caption row underneath. Bar fills 100% at goal, then a thin amber "stretch" segment past 100% indicates over-achievement. Caption: "Goal: N tasks" + count `3/5 · 60%`.

**Theme-aware visuals (CSS-only, same JSX both modes):**
- **Light/Dark** — rounded card-style day cells with hairline border, soft accent-colored intensity bar; pill-shape progress track with rounded fill
- **Terminal** — bare monospace strip (no card chrome), today's date number gets a `*` prefix, intensity rendered as block characters (`▁ ▃ █`); progress bar uses `[N/N]` brackets in count + `// goal:` comment-prefixed caption + glow on the fill

**Settings.** New "Home screen" subhead in General tab with:
- 7-day strip toggle
- Goal progress toggle
- Daily task goal numeric input

The subhead renders as small uppercase "HOME SCREEN" caption in light/dark and `// home screen` lowercase comment in terminal — same `.v2-settings-subhead` class with terminal-mode CSS override.

**Default state.** Both `show_week_strip` and `show_goal_progress` ship as `false`. Existing users see no change until they opt in. New users start with the minimal home screen as the first impression.

**Wiring.** AppV2's mobile `<div className="v2-list">` renders `<WeekStrip>` above the first `renderSection` call when `show_week_strip` is true, and `<GoalProgressBar>` after the last `renderSection` call when `show_goal_progress` is true. Desktop Kanban view doesn't render either — Kanban is already dense; revisit if usage warrants.

## Bundle

CSS 204.2KB gzip 30.9KB (+5.5KB from two new component CSS files + subhead override). JS 807KB gzip 223.6KB (+5KB from two components + memoized completion bucketing).

## Test plan

- [x] `npm run lint` clean (only pre-existing warnings)
- [x] `npm run build` succeeds
- [x] `npm audit` — 0 vulnerabilities
- [ ] Default state: both surfaces hidden, home screen unchanged from before
- [ ] Settings → General → Home screen: enable each toggle, confirm WeekStrip + GoalProgressBar appear without layout jump
- [ ] WeekStrip: complete tasks today, verify today's intensity bar/block updates
- [ ] WeekStrip: navigate to last week (←), confirm it shows past completions correctly
- [ ] WeekStrip: navigate to next week (→), confirm future days dim, no completions
- [ ] GoalProgressBar: with 0/3 done, bar empty + caption reads "0/3 · 0%"
- [ ] GoalProgressBar: with 3/3 done, bar fills, no overshoot
- [ ] GoalProgressBar: with 6/3 done, bar at 100% + amber overshoot segment
- [ ] Theme cycle: enable both surfaces, switch Light → Dark → Term Dark → Term Light. Each renders cleanly in its style — cards in light/dark, monospace + block characters in terminal
- [ ] Disable each toggle: surface disappears cleanly without leaving padding behind

https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_