### PR TITLE
chore(ui): terminal theme PR I — stress-test convention + smoke test + docs

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -7,6 +7,9 @@ echo "==> Pre-push: running checks..."
 echo "==> Lint..."
 npm run lint --silent || { echo "BLOCKED: lint failed"; exit 1; }
 
+echo "==> Terminal-title convention..."
+npm run check:terminal-titles --silent || { echo "BLOCKED: terminal-title check failed (see CLAUDE.md → Terminal Theme Stress Test)"; exit 1; }
+
 echo "==> Smoke test (build + server + verify)..."
 npm run test || { echo "BLOCKED: smoke test failed"; exit 1; }
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -769,6 +769,40 @@ These five primitives are the v2 task-surface language. Every subsequent v2 surf
 
 **End state.** After all 8 PRs ship and a 1-2 week opt-in period validates v2, flip the default to `'v2'`, leave v1 reachable via `?ui=v1` for one release, then delete `src/AppV1.jsx` + `src/components/` and rename `src/v2/components/` → `src/components/`.
 
+### Terminal Theme Stress Test (2026-05-10)
+
+**Working hypothesis: terminal may become the default forever.** PR A–H shipped a four-palette family — Light, Dark, Terminal Dark (GitHub Dark), Terminal Light (GitHub Light) — with terminal-specific structural overrides (ASCII flourishes, monospace stack, bracket toggles, `$ verb` modal headers, `// manage` section, density signals on TaskCard). The user is now stress-testing whether terminal feels right as the daily driver. Light/dark stay maintained as defensive baseline.
+
+**The convention while we stress-test:**
+
+1. **Don't widen JSX divergence for new features.** The existing theme-aware plumbing — `terminalTitle` on ModalShell + ConfirmDialog, `terminalCommand` on EmptyState, `data-terminal-cmd` attr on `.v2-edit-action-label` spans, `useTerminalMode` hook — is enough. Don't introduce new patterns. New features go terminal-first OR theme-agnostic; they should not branch on theme.
+
+2. **CSS overrides are still cheap.** Adding selectors gated on `[data-theme^="terminal"]` is free (gating cleanly, no leakage). Use those for visual flourishes without thinking about it.
+
+3. **New ModalShell call sites must include `terminalTitle`.** Smoke test in `scripts/check-terminal-titles.js` runs in CI / pre-push to catch silent drift. Run via `npm run check:terminal-titles`.
+
+4. **Density signals on TaskCard are currently terminal-only by user preference (PR G, 2026-05-10).** They ship in markup always, hidden by CSS in non-terminal themes. **Graduate criteria:** if usage validates that the user wants `[X/Y]` counter, `🔥N` streak, and one-line notes preview in their daily flow, drop the `[data-theme^="terminal"]` gate in `terminal/cards.css` and let any theme show them. Do NOT add a fourth terminal-only TaskCard signal without revisiting this.
+
+5. **Decision criterion for "terminal forever."** If the user is still in `theme: 'terminal-dark'` (or `'terminal-light'`) after ~30 days of daily use, terminal becomes the default for new installs and Light/Dark deprecation timeline starts. Until then, all four palettes stay live and equal in the picker.
+
+6. **What "terminal forever" means structurally:**
+   - Light + Dark palettes get marked deprecated in tokens.css (kept compiling for 1-2 releases)
+   - Picker collapses from 4 options to "Theme: Terminal Dark / Terminal Light"
+   - `[data-theme^="terminal"]` selectors lose their guard (terminal IS v2)
+   - Density signals graduate to always-on
+   - `useTerminalMode` hook + `terminalTitle`/`terminalCommand` props get unified — modal titles use the `$ verb` form unconditionally, no fallback
+   - `src/v2/terminal/` directory contents merge into the regular component CSS
+
+7. **What "terminal didn't stick" means structurally:**
+   - `rm -rf src/v2/terminal/`
+   - Drop `'terminal-dark'`/`'terminal-light'` from picker, leaving Light + Dark
+   - Remove `terminalTitle` / `terminalCommand` props from ModalShell + EmptyState
+   - Delete `useTerminalMode` hook
+   - Reset density signals (delete from TaskCard JSX)
+   - Migration shim in `loadSettings()` flips `terminal-*` → `dark`
+
+The whole thing was designed so either pivot is cheap. Don't make it expensive by piling on more terminal-only features without revisiting whether they should be terminal-only.
+
 ## Additional Notes
 - Single developer (ryakel) — no PR review process needed.
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "vite build",
     "start": "node server.js",
     "lint": "eslint .",
+    "check:terminal-titles": "node scripts/check-terminal-titles.js",
     "test": "sh scripts/smoke-test.sh",
     "prepare": "git config core.hooksPath .githooks || true",
     "preview": "vite preview"

--- a/scripts/check-terminal-titles.js
+++ b/scripts/check-terminal-titles.js
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+// Smoke test for the terminal-theme stress-test convention (CLAUDE.md
+// "Terminal Theme Stress Test"). Scans every v2 component for
+// `<ModalShell` JSX usage and asserts each call site carries a
+// `terminalTitle=` prop.
+//
+// Why: the terminal aesthetic depends on every modal title rendering as
+// `$ verb --flag` instead of regular human copy. New modals will silently
+// drift to the regular title in terminal mode if the prop is forgotten.
+// This script is the guardrail.
+//
+// Run: `npm run check:terminal-titles` (or `node scripts/check-terminal-titles.js`)
+// Exits 0 on clean, 1 on missing props. Suitable for CI / pre-push.
+
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const ROOT = path.resolve(__dirname, '..')
+const V2_DIR = path.join(ROOT, 'src', 'v2')
+
+async function walk(dir, ext, out = []) {
+  const entries = await fs.readdir(dir, { withFileTypes: true })
+  for (const e of entries) {
+    const full = path.join(dir, e.name)
+    if (e.isDirectory()) await walk(full, ext, out)
+    else if (e.isFile() && full.endsWith(ext)) out.push(full)
+  }
+  return out
+}
+
+const offenders = []
+
+// Extract every <ModalShell ...> JSX block by scanning for the open tag
+// then walking the source character-by-character with a brace counter so
+// we don't mistake `>` inside `{() => ...}` for the closing tag boundary.
+function findModalShellTags(src) {
+  const out = []
+  const startRe = /<ModalShell\b/g
+  let m
+  while ((m = startRe.exec(src)) !== null) {
+    let i = m.index + m[0].length
+    let braceDepth = 0
+    let inSingle = false
+    let inDouble = false
+    while (i < src.length) {
+      const ch = src[i]
+      if (!inSingle && !inDouble) {
+        if (ch === '{') braceDepth++
+        else if (ch === '}') braceDepth--
+        else if (braceDepth === 0 && ch === '>') break
+        else if (ch === "'") inSingle = true
+        else if (ch === '"') inDouble = true
+      } else if (inSingle && ch === "'" && src[i - 1] !== '\\') {
+        inSingle = false
+      } else if (inDouble && ch === '"' && src[i - 1] !== '\\') {
+        inDouble = false
+      }
+      i++
+    }
+    out.push({ start: m.index, end: i + 1, body: src.slice(m.index, i + 1) })
+  }
+  return out
+}
+
+const files = await walk(V2_DIR, '.jsx')
+for (const file of files) {
+  const src = await fs.readFile(file, 'utf8')
+  if (file.endsWith('ModalShell.jsx')) continue
+  for (const tag of findModalShellTags(src)) {
+    if (!/\bterminalTitle\s*=/.test(tag.body)) {
+      const line = src.slice(0, tag.start).split('\n').length
+      offenders.push({ file: path.relative(ROOT, file), line, snippet: tag.body.slice(0, 80) })
+    }
+  }
+}
+
+if (offenders.length === 0) {
+  console.log('OK — every <ModalShell> call site has a terminalTitle prop.')
+  process.exit(0)
+}
+
+console.error('FAIL — <ModalShell> call sites missing `terminalTitle` prop:')
+for (const o of offenders) {
+  console.error(`  ${o.file}:${o.line}  ${o.snippet}…`)
+}
+console.error('\nAdd a `terminalTitle="$ verb --flag"` prop. See CLAUDE.md → "Terminal Theme Stress Test".')
+process.exit(1)

--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -29,6 +29,14 @@ Browser (React PWA)
 
 **v1/v2 routing** (`src/App.jsx`): Thin router that reads `localStorage.ui_version` (default `'v1'`) and renders either `AppV1` (`src/AppV1.jsx` — the existing component) or `AppV2` (`src/v2/AppV2.jsx` — the in-progress redesign). URL escape hatch: `?ui=v2` and `?ui=v1` set the flag and strip themselves from the URL so deep-link params (`?task=X`) survive. `data-ui-version` is mirrored on the documentElement; v2 also sets `data-ui="v2"` so its namespaced design tokens (`src/v2/tokens.css`, all `--v2-*`) activate without leaking into v1. v2 reuses every server endpoint, every hook, every context, `api.js`, `store.js`, `db.js` — only the React component tree and CSS fork. Users opt in via Settings → Beta tab.
 
+**Theme palette family** (`data-theme` attribute on documentElement): four values — `light` (default), `dark`, `terminal-dark` (GitHub Dark colors + monospace), `terminal-light` (GitHub Light colors + monospace). Light + dark token defaults live in `src/v2/tokens.css`; terminal sub-palettes live in `src/v2/terminal/palette-{dark,light}.css`. Structural ASCII flourishes (wordmark cursor, bracket buttons, section bullets, density signals) live in `src/v2/terminal/{wordmark,sections,cards,controls}.css`, all gated on `[data-theme^="terminal"]` so light/dark cannot see them. Migration shim in `loadSettings()` upgrades legacy `'terminal'` → `'terminal-dark'`. Theme-aware JSX (modal titles, empty states, manage-section labels) flows through:
+- `useTerminalMode()` hook in `src/v2/hooks/useTerminalMode.js` — MutationObserver on `data-theme`, returns true when prefix matches `terminal-`
+- `terminalTitle` prop on `ModalShell` + `ConfirmDialog` — overrides the regular `title` when terminal mode is active
+- `terminalCommand` prop on `EmptyState` — short-circuits the icon+title+body tree to a `// comment` line
+- `data-terminal-cmd` attr on `.v2-edit-action-label` spans — visible label swaps via CSS `attr()` to its CLI form (`$ archive`, `$ delete --confirm`, etc.)
+
+Convention smoke test: `scripts/check-terminal-titles.js` (wired into the pre-push hook) asserts every `<ModalShell>` JSX call site carries `terminalTitle`. Run via `npm run check:terminal-titles`. See CLAUDE.md → "Terminal Theme Stress Test" for the policy on what's terminal-only vs theme-agnostic going forward.
+
 ## Data Flow
 
 1. **On app load**: React renders immediately from localStorage (fast first paint). An SSE connection opens to `/api/events`, which returns the current server version. The client then fetches `GET /api/data` and hydrates React state and localStorage from SQLite. If the server is empty, the client pushes its localStorage state up.

--- a/wiki/Features.md
+++ b/wiki/Features.md
@@ -4,6 +4,21 @@
 
 Every task always comes back. Dismissal is never free — every "not now" requires a "then when."
 
+## Themes
+
+Four palettes, picked in Settings → General → Theme:
+
+| Theme | Look |
+|---|---|
+| **Light** | Wheneri-style — warm orange accent, soft pastels, rounded pills, generous whitespace |
+| **Dark** | Same layout language, dark canvas |
+| **Terminal Dark** | GitHub Dark code-editor aesthetic — monospace stack, cyan-blue accent on `#0D1117` canvas, `$ boomerang_` blinking-cursor wordmark, ASCII flourishes (`[ ]` task prefix, `[ Done ]` bracket buttons, `> SECTION [3]` chevron labels), `[off] [on]` bracket toggles in Settings, density signals on TaskCard (`[3/5]` checklist counter, `🔥N` routine streak, one-line notes preview) |
+| **Terminal Light** | Same monospace aesthetic on a white canvas with GitHub Light colors (deep-link blue `#0969DA`, `#1F2328` text). Same density signals, same ASCII structure |
+
+Modal headers in terminal mode read as commands: `$ task --new`, `$ snooze`, `$ what-now`, `$ settings`, `$ quokka`, `$ delete --confirm`. Empty states render as `// comment` lines. Light + Dark stay calm and unchanged.
+
+**Home-screen surfaces (opt-in, theme-aware):** Settings → General → Home screen offers two toggles. The 7-day calendar strip renders above the task list with activity-intensity dots/blocks per day; the goal progress bar sits below the list and tracks `tasksToday / daily_task_goal`. Both render as cards in light/dark, bare monospace strip + block characters in terminal mode.
+
 ## Task Management
 
 - **Quick add** — type and hit Enter from the bottom bar to instantly create a task

--- a/wiki/V2-State.md
+++ b/wiki/V2-State.md
@@ -131,8 +131,18 @@ All five bugs the user logged from device screenshots have been addressed:
 
 ### Future-direction parking lot
 
-- [ ] **Terminal-aesthetic theme toggle.** Inspiration: [init.habits](https://inithabits.com) — monospace + ASCII-style checkboxes `[ ] / [✓]`, command-prompt header (`user@init.habits $ daily`), tabbed nav (habits / stats / profile), fire-emoji streak indicator, calendar-row date picker, soft glow on a deep-blue terminal palette. Could ship as a third tier beyond light/dark — likely a new `data-ui` mode (e.g. `data-ui="terminal"`) that swaps `tokens.css` for a terminal-specific palette + monospace font stack, leaving the layout/component contracts untouched. Not a v2 ship item; revisit after the dev → main merge.
-  - **Terminal-flavored loading/sync animations.** The current `BOOMERANG` wordmark wave (PR #58) — letter-by-letter bounce on saving, green flash on done, yellow/red for degraded/offline — translates beautifully to the terminal aesthetic. Ideas to carry forward into the terminal theme: ASCII spinner glyphs (`| / - \`) cycling per letter instead of bounce; cursor blink on the trailing `_` while saving; `[OK]` / `[ERR]` / `[BUSY]` bracketed status flashes that match terminal status conventions; `loading…` ellipsis dot-cycling; output-line scroll for status messages instead of a popover. Same state machine (`idle / saving / just-synced / degraded / offline`) drives a different visual vocabulary.
+- [x] **Terminal aesthetic — shipped 2026-05-10 (PR A–I).** Originally parked as "third tier beyond light/dark." Shipped as a four-palette family: `light`, `dark`, `terminal-dark` (GitHub Dark), `terminal-light` (GitHub Light), with terminal-specific structural overrides in `src/v2/terminal/` (palette files + wordmark + sections + cards + controls).
+  - **PR A** — palette swap, monospace stack, 3-way picker
+  - **PR B** — `$ boomerang_` wordmark with blinking cursor + chevron section bullets
+  - **PR C** — `[ ]` task-title prefix + `[ Done ]` bracket buttons + soft cyan glow
+  - **PR D** — sync-state animations (`| / - \\` spinner, `✓` confirmation, status-line cursor color shift)
+  - **PR E** — split into `terminal-dark` + `terminal-light` sub-palettes, refactored monolith into `src/v2/terminal/` directory
+  - **PR F** — `$ verb --flag` modal headers (16 modals), `// manage` section in EditTaskModal, `[off] [on]` bracket toggles, `// comment`-style empty states, `useTerminalMode` hook
+  - **PR G** — TaskCard density (terminal-only): inline `[X/Y]` checklist counter, `🔥N` routine streak, one-line notes preview
+  - **PR H** — opt-in `WeekStrip` (7-day calendar) + `GoalProgressBar` on the home screen, theme-aware visuals
+  - **PR I** — convention lockdown + smoke test (`scripts/check-terminal-titles.js`, wired to pre-push) + visual QA + this doc reorg
+
+  **Now stress-testing whether terminal becomes the default forever** (see CLAUDE.md → "Terminal Theme Stress Test"). Light + dark stay maintained as defensive baseline. Decision criterion: ~30 days of daily use in `terminal-*` → terminal becomes the default for new installs and Light/Dark deprecation timeline starts. The whole stack was built so either pivot is cheap (CSS gates remove cleanly; `terminalTitle`/`terminalCommand` props delete or graduate; `useTerminalMode` hook deletes; `terminal/` directory either merges into the regular component CSS or `rm -rf`'s).
 
 - [x] **Smart follow-up sequences — PR 1 shipped.** Completion-triggered task chains (`follow_ups` JSON column on tasks + routines, migration 023). Routine form has a step editor; spawned task instances inherit the chain; each completion walks the chain forward. Full spec in `wiki/Sequences.md`. Remaining slices: PR 2 delete prompt for mid-chain tasks, PR 3 skip-and-advance, PR 4 AI-mediated edit reconciliation, PR 5 Quokka tools (`add_follow_up` / `edit_follow_up` / `remove_follow_up` / `reorder_follow_ups`).
 

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,26 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-10
 
+- chore(ui): terminal theme PR I — stress-test convention + smoke test + docs [S]
+  - **Why.** PR A–H built four palettes + extensive terminal-only treatments (CSS overrides, `terminalTitle`/`terminalCommand` props on 16 modals + 7 empty states, three TaskCard density signals hidden from light/dark, bracket toggles, manage-section reflow). The user's working hypothesis: "terminal might become the default forever — let's stress-test that, but be careful about creating more divergence in the meantime." PR I writes that down so subsequent work doesn't accidentally widen the gap.
+  - **CLAUDE.md → "Terminal Theme Stress Test" section.** Documents the working hypothesis + the convention while we stress-test:
+    1. Don't widen JSX divergence for new features — existing plumbing is enough; new features go terminal-first OR theme-agnostic, not theme-branched
+    2. CSS overrides under `[data-theme^="terminal"]` are still cheap; use them for visual flourishes
+    3. New `<ModalShell>` call sites must include `terminalTitle` (smoke test enforces)
+    4. Density signals on TaskCard are terminal-only by user preference (PR G); graduate criteria documented — drop the gate if usage validates
+    5. Decision criterion for "terminal forever": ~30 days of daily use in `terminal-*` → terminal becomes default; Light/Dark deprecation timeline starts
+    6. Structural plan for both pivots: "terminal forever" (lock in, deprecate light/dark, drop CSS gates) and "terminal didn't stick" (rm -rf src/v2/terminal/, drop variants from picker, delete useTerminalMode + theme-aware props)
+  - **Smoke test: `scripts/check-terminal-titles.js`.** Scans every v2 component for `<ModalShell` JSX and asserts each call site carries a `terminalTitle=` prop. Uses a brace-counting parser (not naive regex) so JSX with embedded arrow functions like `onClose={() => setOpen(false)}` doesn't trip on the inner `>`. Wired into:
+    - `npm run check:terminal-titles` script in package.json
+    - `.githooks/pre-push` between lint and smoke test, with a clear failure message pointing to the CLAUDE.md section
+    - Run on PR I baseline: clean — all 15 `<ModalShell>` call sites have `terminalTitle`
+  - **wiki/V2-State.md.** Flipped "Terminal-aesthetic theme toggle" parking-lot bullet from `[ ]` to `[x]` with a full PR A–I summary + the stress-test note pointing to CLAUDE.md.
+  - **wiki/Architecture.md.** Added "Theme palette family" subsection under Component Architecture documenting the four `data-theme` values, the directory layout (`src/v2/terminal/`), the migration shim, the theme-aware JSX hooks/props (`useTerminalMode`, `terminalTitle`, `terminalCommand`, `data-terminal-cmd`), and the smoke-test convention.
+  - **wiki/Features.md.** New "Themes" section near the top with a 4-row table covering Light / Dark / Terminal Dark / Terminal Light, plus a paragraph on `$ verb` modal headers and the opt-in home-screen surfaces (week strip + goal bar).
+  - **No code shipped beyond the smoke test.** This is the lockdown PR — code is the docs + the guardrail. Visual QA pass is a manual session in browser, not a code change.
+  - Modified: `CLAUDE.md`, `wiki/V2-State.md`, `wiki/Architecture.md`, `wiki/Features.md`, `wiki/Version-History.md`, `package.json` (added `check:terminal-titles` script), `.githooks/pre-push` (added the check between lint and smoke test)
+  - Added: `scripts/check-terminal-titles.js`
+
 - feat(ui): terminal theme PR H — home-screen 7-day strip + goal progress bar (opt-in) [M]
   - **Why.** init.habits puts a daily-rhythm strip at the top of its main view and a goal progress bar at the bottom — both surface "where am I in my day?" without the user having to open Analytics or do math. PR H adds those two surfaces to v2's home screen, opt-in (default off) and theme-aware so they fit any palette.
   - **`WeekStrip` component (new).** 7-day calendar row rendered above the first task section. Each day cell shows day-of-week label + date number + an activity-intensity indicator. Today is highlighted; future days dim to 0.55 opacity. Activity intensity buckets:


### PR DESCRIPTION
## Summary

PR A–H built the terminal theme. PR I locks down the convention so subsequent work doesn't accidentally widen the gap between terminal and the other themes while we stress-test whether terminal becomes the default forever.

**Working hypothesis:** terminal might become the daily-driver default. Light + Dark stay maintained as defensive baseline. Decision after ~30 days of daily use.

## What's in this PR

**`CLAUDE.md` → "Terminal Theme Stress Test" section.** Documents:
1. **Don't widen JSX divergence for new features.** Existing plumbing (`useTerminalMode`, `terminalTitle`, `terminalCommand`, `data-terminal-cmd`) is enough. New features go terminal-first OR theme-agnostic — not theme-branched.
2. **CSS overrides under `[data-theme^="terminal"]` are still cheap.** Visual flourishes are free.
3. **New `<ModalShell>` call sites must include `terminalTitle`.** Smoke test enforces.
4. **TaskCard density signals are terminal-only by user preference (PR G).** Graduate criteria documented — drop the gate if usage validates them.
5. **Decision criterion for "terminal forever":** ~30 days in `terminal-*` → terminal becomes default; Light/Dark deprecation timeline starts.
6. **Structural plan for both pivots:**
   - **Terminal forever** → deprecate light/dark, drop CSS gates, density signals graduate to always-on, `terminal/` directory merges into regular component CSS
   - **Terminal didn't stick** → `rm -rf src/v2/terminal/`, drop `terminal-*` from picker, remove `useTerminalMode` + theme-aware props, migration shim flips `terminal-*` → `dark`

**Smoke test: `scripts/check-terminal-titles.js`.** Scans every v2 `.jsx` for `<ModalShell` JSX and asserts each call site carries a `terminalTitle=` prop. Uses a brace-counting parser (not naive regex) so JSX with `onClose={() => setOpen(false)}` doesn't trip on the inner `>`. Wired into:
- `npm run check:terminal-titles` script
- `.githooks/pre-push` between lint and smoke test, with a clear failure pointer to CLAUDE.md
- Baseline run: clean — all 15 `<ModalShell>` call sites have the prop

**Doc updates:**
- `wiki/V2-State.md` — flipped "Terminal-aesthetic theme toggle" parking-lot bullet from `[ ]` to `[x]` with full PR A–I summary
- `wiki/Architecture.md` — new "Theme palette family" subsection covering the four `data-theme` values, directory layout, migration shim, theme-aware JSX hooks/props, smoke-test convention
- `wiki/Features.md` — new "Themes" section near the top with 4-row table + opt-in home-screen surfaces

**No app code shipped.** PR I is the lockdown — code is the docs + the guardrail.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run check:terminal-titles` — OK (15/15 modals)
- [x] `npm run build` succeeds
- [x] `npm audit` — 0 vulnerabilities
- [x] Pre-push hook runs the new check (verified locally)

**Visual QA still to do (manual session in browser):**
- [ ] Cycle Light → Dark → Term Dark → Term Light through every modal
- [ ] Confirm `terminalTitle` shows up everywhere in terminal mode, regular `title` in light/dark
- [ ] Toggle each `[off] [on]` in Settings — confirm bracket render in terminal mode, iOS pill in light/dark
- [ ] Add a task with notes + 3/5 checklist — confirm density signals show in terminal only
- [ ] Enable the home-screen surfaces (week strip + goal bar) — confirm theme-appropriate visuals across all 4

https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_