### PR TITLE
style(ui): terminal theme — typography scale-down

### DIFF
--- a/src/v2/terminal/index.css
+++ b/src/v2/terminal/index.css
@@ -16,6 +16,7 @@
 
 @import './palette-dark.css';
 @import './palette-light.css';
+@import './typography.css';
 @import './wordmark.css';
 @import './sections.css';
 @import './cards.css';

--- a/src/v2/terminal/typography.css
+++ b/src/v2/terminal/typography.css
@@ -1,0 +1,221 @@
+/* Terminal — Typography scale-down.
+ *
+ * Monospace is denser per-character than proportional fonts at the same
+ * point size, but the existing v2 sizes were tuned for proportional
+ * (Syne display + DM Sans body). When terminal mode swaps to JetBrains
+ * Mono, everything reads chunkier than it should — task titles dominate
+ * the column, modal headers eat half the screen, form labels feel loud.
+ *
+ * Solution: scale common text-bearing classes down 1–4px in terminal
+ * mode. Pure CSS overrides under `[data-theme^="terminal"]`. Light +
+ * dark stay at the calm Wheneri-tuned sizes.
+ *
+ * Why a dedicated file (not inline overrides per component): typography
+ * is structural, not visual flourish. Keeping all the size cuts in one
+ * place makes "what does terminal mode change about text?" one grep
+ * away, and graduating the smaller scale to all themes (if that's where
+ * we land) is one block to delete or de-gate.
+ */
+
+/* === Modal headers ================================================== */
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-modal-title {
+  font: 600 22px/1.2 var(--v2-font-body);
+  letter-spacing: 0;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-modal-subtitle {
+  font: 400 12px/1.4 var(--v2-font-body);
+}
+
+/* === Section labels ================================================ */
+
+/* Already 11px which is fine for monospace; leave as-is. */
+
+/* === TaskCard ======================================================= */
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-title {
+  font: 600 14px/1.35 var(--v2-font-body);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-meta {
+  font: 400 11px/1.4 var(--v2-font-body);
+  margin-top: 4px;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-notes-preview {
+  font: 400 11px/1.4 var(--v2-font-body);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-checklist-inline,
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-routine-streak {
+  font: 500 11px/1 var(--v2-font-body);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-action {
+  font: 500 12px/1 var(--v2-font-body);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-meta-sep::before {
+  font-size: 11px;
+}
+
+/* === EmptyState ===================================================== */
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-empty-title {
+  font: 600 16px/1.25 var(--v2-font-body);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-empty-body {
+  font: 400 12px/1.55 var(--v2-font-body);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-empty-cta {
+  font: 500 12px/1 var(--v2-font-body);
+}
+
+/* === Forms (inputs, textareas, labels, titles) ===================== */
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-input,
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-textarea {
+  font: 400 12px/1.4 var(--v2-font-body);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-title {
+  font: 500 15px/1.3 var(--v2-font-body);
+  padding: 12px 14px;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-label {
+  font-size: 12px;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-hint {
+  font-size: 11px;
+}
+
+/* === Settings rows (largest dense surface) ========================= */
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-settings-row-label {
+  font: 500 12px/1.3 var(--v2-font-body);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-settings-row-hint {
+  font-size: 11px;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-settings-segment-btn,
+:root[data-ui="v2"][data-theme^="terminal"] .v2-settings-segment-4 .v2-settings-segment-btn {
+  font-size: 11px;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-settings-toggle-label {
+  font-size: 12px;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-settings-tab {
+  font-size: 12px;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-settings-build {
+  font-size: 11px;
+}
+
+/* === EditTaskModal manage cluster + action labels ================== */
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-edit-action {
+  font: 500 12px/1 var(--v2-font-body);
+  height: 32px;
+  padding: 0 12px;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-edit-action-label::before {
+  font-size: 11px;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-submit {
+  font-size: 13px;
+}
+
+/* === Header wordmark + brand popover =============================== */
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-header-wordmark {
+  font-size: 13px;
+}
+
+/* === Home-screen surfaces (PR H) =================================== */
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-week-strip-range {
+  font-size: 11px;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-week-strip-label {
+  font-size: 10px;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-week-strip-num {
+  font-size: 13px;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-goal-progress-meta {
+  font-size: 11px;
+}
+
+/* === Task-list filter chips + toolbar =============================== */
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-task-filter-chip,
+:root[data-ui="v2"][data-theme^="terminal"] .v2-task-toolbar-btn,
+:root[data-ui="v2"][data-theme^="terminal"] .v2-task-sort-btn {
+  font-size: 12px;
+}
+
+/* === ConfirmDialog + ChainReconcileModal =========================== */
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-confirm-title {
+  font: 600 16px/1.25 var(--v2-font-body);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-confirm-body {
+  font: 400 12px/1.5 var(--v2-font-body);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-confirm-btn {
+  font-size: 12px;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-reconcile-title {
+  font: 600 16px/1.25 var(--v2-font-body);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-reconcile-body,
+:root[data-ui="v2"][data-theme^="terminal"] .v2-reconcile-row {
+  font-size: 12px;
+}
+
+/* === Toast ========================================================== */
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-toast {
+  font-size: 12px;
+}
+
+/* === Adviser chat ==================================================== */
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-adviser-msg-text,
+:root[data-ui="v2"][data-theme^="terminal"] .v2-adviser-input,
+:root[data-ui="v2"][data-theme^="terminal"] .v2-adviser-tool-btn {
+  font-size: 12px;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-adviser-msg-text {
+  line-height: 1.5;
+}
+
+/* === Subhead labels (added in PR H) ================================ */
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-settings-subhead {
+  font-size: 11px;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-edit-manage-label {
+  font-size: 11px;
+}

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,15 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-10
 
+- style(ui): terminal theme — typography scale-down [S]
+  - **Why.** First in-browser look at the merged terminal aesthetic showed text feeling chunky — task titles dominating the column, modal headers eating half the screen. Monospace is denser per-character than proportional fonts at the same point size, but the v2 sizes were originally tuned for Syne + DM Sans. Swapping to JetBrains Mono at the same numeric sizes overshoots.
+  - **Approach.** New `src/v2/terminal/typography.css` with size overrides under `[data-theme^="terminal"]`. Light + dark stay at the calm Wheneri-tuned sizes. Dedicated file (not inline per component) so "what does terminal change about text?" is one grep, and graduating the smaller scale to all themes (if that's where we land) is one block to delete or de-gate.
+  - **Major reductions:** modal title 32px Syne → 22px mono; empty title 22px Syne → 16px mono; card title 16px → 14px; card meta + notes preview + density spans 12px → 11px; form input/textarea 14px → 12px; form title 18px → 15px; settings row label 14px → 12px; settings row hint → 11px; ConfirmDialog title 16px monospace; Adviser chat → 12px.
+  - **Held steady.** Section labels (already 11px), week-strip range/label (already 11/10px), edit-manage label, header wordmark range — these were already tuned for monospace and stayed.
+  - **Bundle.** CSS 208KB gzip 31.2KB (+~3KB from 100 lines of override rules). JS unchanged.
+  - Modified: `src/v2/terminal/index.css`, `wiki/Version-History.md`
+  - Added: `src/v2/terminal/typography.css`
+
 - chore(ui): terminal theme PR I — stress-test convention + smoke test + docs [S]
   - **Why.** PR A–H built four palettes + extensive terminal-only treatments (CSS overrides, `terminalTitle`/`terminalCommand` props on 16 modals + 7 empty states, three TaskCard density signals hidden from light/dark, bracket toggles, manage-section reflow). The user's working hypothesis: "terminal might become the default forever — let's stress-test that, but be careful about creating more divergence in the meantime." PR I writes that down so subsequent work doesn't accidentally widen the gap.
   - **CLAUDE.md → "Terminal Theme Stress Test" section.** Documents the working hypothesis + the convention while we stress-test:


### PR DESCRIPTION
## Summary

First in-browser look at the merged terminal aesthetic showed text feeling chunky — task titles dominating the column, modal headers eating half the screen. Monospace is denser per-character than proportional fonts at the same point size, but the v2 sizes were originally tuned for Syne + DM Sans. Swapping to JetBrains Mono at the same numeric sizes overshoots.

## Approach

New `src/v2/terminal/typography.css` with size overrides under `[data-theme^="terminal"]`. Light + dark stay at the calm Wheneri-tuned sizes. Dedicated file (not inline per component) so "what does terminal change about text?" is one grep away, and graduating the smaller scale to all themes (if that's where we land) is one block to delete or de-gate. Fits the stress-test convention from PR I.

## Major reductions

| Surface | Before | After |
|---|---|---|
| Modal title | 32px Syne | **22px mono** |
| Empty-state title | 22px Syne | **16px mono** |
| Card title | 16px | **14px** |
| Card meta | 12px | **11px** |
| Notes preview / density spans | 12px | **11px** |
| Card action button | 13px | **12px** |
| Form input/textarea | 14px | **12px** |
| Form title | 18px | **15px** |
| Settings row label | 14px | **12px** |
| Settings row hint | 13px | **11px** |
| ConfirmDialog title | 18px Syne | **16px mono** |
| Adviser chat | 13px | **12px** |
| Header wordmark | 15px | **13px** |

## Held steady

Section labels (already 11px), week-strip range/label (already 11/10px), edit-manage label — these were already tuned for monospace.

## Bundle

CSS 208KB gzip 31.2KB (+~3KB from ~100 lines of override rules). JS unchanged.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run check:terminal-titles` — OK
- [x] `npm run build` succeeds
- [ ] In Term Dark / Term Light: home screen reads tighter — task titles aren't dominating; meta lines fit naturally
- [ ] Open every modal — header + body text feels balanced, not shouty
- [ ] Settings tabs — labels + hints scale together (no orphaned big labels next to small hints)
- [ ] Light + Dark: completely unchanged from before

https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_