### PR TITLE
style(ui): terminal theme — strip modern app chrome (flatten)

### DIFF
--- a/src/v2/terminal/flatten.css
+++ b/src/v2/terminal/flatten.css
@@ -1,0 +1,448 @@
+/* Terminal — Strip modern app chrome.
+ *
+ * The previous PRs (A–I) painted terminal text + ASCII flourishes on top
+ * of a fundamentally modern card-based UI: rounded card surfaces with
+ * borders, filled accent buttons, glowing FAB, drop-shadowed modals,
+ * pill-shaped action chrome. Reads as "modern app in monospace," not as
+ * a CLI tool.
+ *
+ * This file flattens it. Every override under `[data-theme^="terminal"]`
+ * removes a piece of chrome that doesn't belong in a terminal aesthetic:
+ *
+ *   - Card surface elevation → flat rows on the page bg, separated by
+ *     a single hairline rule
+ *   - Status border-left (overdue/high-pri) → leading [!] / [*] glyph
+ *     on the title via the existing ::before machinery
+ *   - Filled "Done" button → bordered `[ Done ]` text with accent-color
+ *     hover wash, no fill, no shadow
+ *   - Pill-shaped action buttons (snooze/edit/skip) → flat squared
+ *     borders, no hover bg pill
+ *   - Energy chip pill → bare inline icon + text
+ *   - Modal sheet rounded-corner + drop-shadow → flat rectangle with a
+ *     hairline border, square corners, deeper overlay scrim
+ *   - FAB circular fill + shadow + glow → flat square `[+]` glyph in
+ *     a thin accent-bordered box
+ *   - Form submit primary fill → bracketed `[ Save ]` text, no fill
+ *   - EditTaskModal manage-cluster pills → bordered text rows that
+ *     read as command rows
+ *   - Toast pill → flat status line
+ *   - Settings segment-control pill cluster → joined-border tab strip
+ *
+ * Light + dark are completely untouched. The whole file is one selector
+ * scope; deleting the file removes every flattening override at once.
+ */
+
+/* === TaskCard ======================================================= */
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card {
+  background: transparent;
+  border: none;
+  border-top: 1px solid var(--v2-hairline);
+  border-radius: 0;
+  box-shadow: none;
+  transition: none;
+}
+
+/* First card in any list-context sits flush against the section label
+ * or page top — no extra hairline. (`adjacent-sibling` covers section
+ * labels; `:first-child` covers raw lists.) */
+:root[data-ui="v2"][data-theme^="terminal"] .v2-section-label + .v2-card-swipe-wrap > .v2-card,
+:root[data-ui="v2"][data-theme^="terminal"] .v2-section-label + .v2-card,
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-swipe-wrap:first-child > .v2-card,
+:root[data-ui="v2"][data-theme^="terminal"] .v2-list > .v2-card-swipe-wrap:first-of-type > .v2-card {
+  border-top: none;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card:hover {
+  background: rgba(var(--v2-text-rgb), 0.02);
+  border-color: var(--v2-hairline);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-expanded-state {
+  background: rgba(var(--v2-text-rgb), 0.025);
+  box-shadow: none;
+}
+
+/* Status: replace the colored 2px left border with a leading [!] / [*]
+ * on the title. The existing PR C terminal selector painted `[ ] ` as
+ * the title prefix; for overdue / high-pri we override that prefix
+ * with the status glyph + matching color. */
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-overdue,
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-high-pri {
+  border-left: none;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-overdue .v2-card-title::before {
+  content: "[!] ";
+  color: var(--v2-alert-overdue);
+  font-weight: 700;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-high-pri .v2-card-title::before {
+  content: "[*] ";
+  color: var(--v2-alert-high-pri);
+  font-weight: 700;
+}
+
+/* Energy chip — drop the pill bg, become inline icon + bolts only. */
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-energy {
+  background: transparent;
+  border-radius: 0;
+  padding: 0 4px;
+}
+
+/* Card action buttons — strip pill chrome. Snooze + Edit + Skip become
+ * flat squared boxes; Done becomes bracketed accent-color text. */
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-action {
+  height: auto;
+  min-width: 28px;
+  padding: 4px 10px;
+  border-radius: 0;
+  border: 1px solid var(--v2-hairline);
+  background: transparent;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-action:hover {
+  background: transparent;
+  border-color: var(--v2-text-meta);
+  color: var(--v2-text);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-action:active {
+  transform: none;
+  background: rgba(var(--v2-text-rgb), 0.06);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-action-primary {
+  background: transparent;
+  color: var(--v2-accent);
+  border: 1px solid var(--v2-accent);
+  box-shadow: none;
+  text-shadow: var(--v2-glow);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-action-primary:hover {
+  background: rgba(88, 166, 255, 0.08);
+  filter: none;
+  color: var(--v2-accent);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-action-primary svg {
+  color: var(--v2-accent);
+}
+
+/* The PR C `[ ` / ` ]` brackets used a translucent white that read
+ * against the orange fill. Now that the button is transparent, match
+ * the bracket color to the rest of the button (accent). */
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-action-primary::before,
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-action-primary::after {
+  color: var(--v2-accent);
+  font-weight: 700;
+}
+
+/* Skip-advance: keep amber but flatten. */
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-action-skip {
+  background: transparent;
+  border-color: var(--v2-alert-high-pri);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-action-skip:hover {
+  background: rgba(255, 184, 77, 0.08);
+}
+
+/* Card swipe-action panel (mobile) — flat. */
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-swipe-action {
+  border-radius: 0;
+}
+
+/* === ModalShell + sheets ============================================ */
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-modal-overlay {
+  background: rgba(0, 0, 0, 0.70);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-modal {
+  background: var(--v2-bg);
+  border: 1px solid var(--v2-hairline);
+  border-radius: 0;
+  box-shadow: none;
+}
+
+@media (min-width: 768px) {
+  :root[data-ui="v2"][data-theme^="terminal"] .v2-modal {
+    border-radius: 0;
+    box-shadow: none;
+  }
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-modal-close {
+  background: transparent;
+  border: 1px solid var(--v2-hairline);
+  border-radius: 0;
+  width: 28px;
+  height: 28px;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-modal-close:hover {
+  background: rgba(var(--v2-text-rgb), 0.06);
+  border-color: var(--v2-text-meta);
+}
+
+/* === FloatingCapture (FAB) ========================================= */
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-fc-button {
+  width: 36px;
+  height: 36px;
+  border-radius: 0;
+  border: 1px solid var(--v2-accent);
+  background: transparent;
+  color: var(--v2-accent);
+  box-shadow: none;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-fc-button:hover:not(:disabled) {
+  transform: none;
+  box-shadow: none;
+  background: rgba(88, 166, 255, 0.10);
+  filter: none;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-fc-button:active:not(:disabled) {
+  transform: none;
+  background: rgba(88, 166, 255, 0.18);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-fc-button-add,
+:root[data-ui="v2"][data-theme^="terminal"] .v2-fc-button-whatnow {
+  background: transparent;
+  color: var(--v2-accent);
+  border-color: var(--v2-accent);
+  text-shadow: var(--v2-glow);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-fc-button-anchor.v2-fc-button-add,
+:root[data-ui="v2"][data-theme^="terminal"] .v2-fc-button-anchor.v2-fc-button-whatnow {
+  background: transparent;
+  color: var(--v2-accent);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-fc-card,
+:root[data-ui="v2"][data-theme^="terminal"] .v2-fc-card-whatnow {
+  background: var(--v2-bg);
+  border: 1px solid var(--v2-accent);
+  border-radius: 0;
+  box-shadow: var(--v2-glow);
+  height: auto;
+  min-height: 36px;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-fc-chip {
+  border-radius: 0;
+  background: transparent;
+  border-color: var(--v2-hairline);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-fc-chip:hover {
+  border-color: var(--v2-accent);
+  background: rgba(88, 166, 255, 0.06);
+}
+
+/* === Form submit + form pills ===================================== */
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-submit {
+  background: transparent;
+  color: var(--v2-accent);
+  border: 1px solid var(--v2-accent);
+  border-radius: 0;
+  height: 40px;
+  text-shadow: var(--v2-glow);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-submit:hover:not(:disabled) {
+  background: rgba(88, 166, 255, 0.10);
+  filter: none;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-submit:active:not(:disabled) {
+  transform: none;
+  background: rgba(88, 166, 255, 0.18);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-submit::before {
+  content: "[ ";
+  color: var(--v2-accent);
+  font-weight: 500;
+}
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-submit::after {
+  content: " ]";
+  color: var(--v2-accent);
+  font-weight: 500;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-input,
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-textarea,
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-title {
+  border-radius: 0;
+  background: transparent;
+  border: 1px solid var(--v2-hairline);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-input:focus,
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-textarea:focus,
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-title:focus {
+  border-color: var(--v2-accent);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-label-pill,
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-pri-toggle {
+  border-radius: 0;
+  background: transparent;
+  border: 1px solid var(--v2-hairline);
+}
+
+/* === EditTaskModal manage cluster ================================== */
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-edit-action {
+  border-radius: 0;
+  background: transparent;
+  border: 1px solid var(--v2-hairline);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-edit-action:hover {
+  background: rgba(var(--v2-text-rgb), 0.06);
+  border-color: var(--v2-text-meta);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-edit-action-danger {
+  border-color: var(--v2-alert-overdue);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-edit-action-danger:hover {
+  background: rgba(248, 81, 73, 0.08);
+  border-color: var(--v2-alert-overdue);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-edit-action-confirm-yes {
+  background: transparent;
+  color: var(--v2-alert-overdue);
+  border-color: var(--v2-alert-overdue);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-edit-action-confirm-yes:hover {
+  background: rgba(248, 81, 73, 0.12);
+  filter: none;
+}
+
+/* === Toast ========================================================= */
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-toast {
+  border-radius: 0;
+  background: var(--v2-bg);
+  color: var(--v2-text);
+  border: 1px solid var(--v2-accent);
+  box-shadow: var(--v2-glow);
+}
+
+/* === Settings segmented control =================================== */
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-settings-segment {
+  border-radius: 0;
+  border: none;
+  padding: 0;
+  gap: 0;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-settings-segment-btn {
+  border-radius: 0;
+  border: 1px solid var(--v2-hairline);
+  border-right-width: 0;
+  background: transparent;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-settings-segment-btn:last-child {
+  border-right-width: 1px;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-settings-segment-btn:hover:not(.v2-settings-segment-btn-active) {
+  background: rgba(var(--v2-text-rgb), 0.05);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-settings-segment-btn-active {
+  background: transparent;
+  color: var(--v2-accent);
+  border-color: var(--v2-accent);
+  position: relative;
+  z-index: 1;
+  text-shadow: var(--v2-glow);
+}
+
+/* === Settings rows + toggles ====================================== */
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-settings-toggle-disabled {
+  opacity: 0.5;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-settings-build {
+  border-radius: 0;
+  background: transparent;
+  border: 1px solid var(--v2-hairline);
+  padding: 4px 8px;
+}
+
+/* === Compact input on Settings number rows ======================== */
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-settings-compact-input {
+  border-radius: 0;
+}
+
+/* === Section labels — add a trailing rule so the label reads as a
+ *      listing header rather than just floating text. */
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-section-label {
+  border-bottom: 1px solid var(--v2-hairline);
+  padding-bottom: 4px;
+  margin-bottom: 0;
+}
+
+/* === Confirm dialog + Reconcile modal ============================== */
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-confirm,
+:root[data-ui="v2"][data-theme^="terminal"] .v2-reconcile {
+  background: var(--v2-bg);
+  border: 1px solid var(--v2-hairline);
+  border-radius: 0;
+  box-shadow: none;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-confirm-overlay,
+:root[data-ui="v2"][data-theme^="terminal"] .v2-reconcile-overlay {
+  background: rgba(0, 0, 0, 0.70);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-confirm-btn,
+:root[data-ui="v2"][data-theme^="terminal"] .v2-reconcile-btn {
+  border-radius: 0;
+  background: transparent;
+  border: 1px solid var(--v2-hairline);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-confirm-btn-danger {
+  color: var(--v2-alert-overdue);
+  border-color: var(--v2-alert-overdue);
+  background: transparent;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-confirm-btn-danger:hover {
+  background: rgba(248, 81, 73, 0.10);
+  filter: none;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-reconcile-btn-primary {
+  color: var(--v2-accent);
+  border-color: var(--v2-accent);
+  background: transparent;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-reconcile-btn-primary:hover {
+  background: rgba(88, 166, 255, 0.08);
+}

--- a/src/v2/terminal/index.css
+++ b/src/v2/terminal/index.css
@@ -17,6 +17,7 @@
 @import './palette-dark.css';
 @import './palette-light.css';
 @import './typography.css';
+@import './flatten.css';
 @import './wordmark.css';
 @import './sections.css';
 @import './cards.css';

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,25 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-10
 
+- style(ui): terminal theme — strip modern app chrome (flatten) [M]
+  - **Why.** PR A–I shipped terminal text + ASCII flourishes on top of a fundamentally modern card-based UI: rounded card surfaces with borders, filled accent buttons, glowing FAB, drop-shadowed modals, pill-shaped action chrome. Reads as "modern app in monospace," not as a CLI tool. User feedback after first in-browser look: didn't go far enough. PR J flattens the chrome.
+  - **TaskCard.** Surface bg dropped, border + border-radius dropped, box-shadow dropped. Cards become flat rows on `var(--v2-bg)`, separated by a single hairline `border-top` (skipped on the first card after a section label or at top of list). Hover gets a faint 2% bg tint instead of an accent border. Expanded card uses a slightly elevated 2.5% bg tint so the open row reads as the focused one without pretending to be a card. Status colors no longer ride a 2px left border — overdue + high-pri override the existing `[ ]` title prefix to `[!] ` (red) / `[*] ` (amber) so status reads as a leading character on the title line, not as a chrome decoration.
+  - **Card actions.** Snooze/Edit/Skip lose their pill chrome — flat 1px hairline boxes, square corners, no hover bg fill. The Done primary button drops the accent fill + brand glow box-shadow + brightness-filter hover; becomes bordered `[ Done ]` text in accent color with a soft cyan text-shadow glow and a 0.08 opacity wash on hover. Skip-advance keeps amber but flattens the same way.
+  - **Energy chip.** Pill bg removed; becomes inline icon + bolts only.
+  - **ModalShell.** Sheet bg shifts to `var(--v2-bg)` (matches page) with a 1px hairline border instead of the surface elevation. Border-radius zeroed at all breakpoints, box-shadow zeroed (desktop drawer no longer floats with a shadow). Overlay scrim deepened from 0.45 to 0.70 so the modal reads as a takeover, not a card. Close X button squares off too.
+  - **FAB.** 48px circle → 36px square. Accent fill → transparent with thin accent border. Box-shadow + hover lift removed. Hover gets a 0.10 accent wash, active gets 0.18. Same flattening for both `+` (add) and target (what-now) variants. The FC card panel that expands from the FAB switches to flat-rect with accent border + cyan glow text-shadow.
+  - **Form submit primary.** "Save changes" / "Add task" fills replaced with bordered `[ verb ]` text — uses `::before` `[ ` and `::after` ` ]` brackets with the same accent color as the button text. No fill, no shadow, no transform on click.
+  - **Form inputs + textarea + title.** Border-radius 10px → 0. Border-color stays hairline; focus state still flips to accent.
+  - **EditTaskModal manage cluster.** Pill-shaped `Backlog` / `Projects` / `Make recurring` / `Delete` buttons → flat squared boxes. Delete border colors with overdue red. Confirm-yes button drops its red fill, becomes red-bordered transparent text.
+  - **Settings segmented control.** Rounded-pill cluster → joined-border tab strip. Adjacent buttons share a border (right-border collapsed except on the last child); active button gets accent border + accent text + glow text-shadow. No background fill on active.
+  - **Section labels.** Add a thin hairline `border-bottom` so the label reads as a listing header. Padding-bottom 4px so the rule sits close to the text but not flush.
+  - **ConfirmDialog + ChainReconcileModal.** Same flattening — bg matches page, border becomes hairline, radius zeroed, shadow removed, deeper overlay.
+  - **Toast.** Pill bg → bordered flat rect with accent border + cyan glow text-shadow.
+  - **Architecture.** New `src/v2/terminal/flatten.css` (~330 lines). Imported via `terminal/index.css` between `typography.css` and the existing structural override files. All selectors gated on `[data-theme^="terminal"]`. Light + dark are completely untouched. Deleting the file restores the modern chrome to terminal mode entirely.
+  - **Bundle.** CSS 217KB gzip 32.2KB (+~9KB from the new file's coverage). JS unchanged.
+  - Modified: `src/v2/terminal/index.css`, `wiki/Version-History.md`
+  - Added: `src/v2/terminal/flatten.css`
+
 - style(ui): terminal theme — typography scale-down [S]
   - **Why.** First in-browser look at the merged terminal aesthetic showed text feeling chunky — task titles dominating the column, modal headers eating half the screen. Monospace is denser per-character than proportional fonts at the same point size, but the v2 sizes were originally tuned for Syne + DM Sans. Swapping to JetBrains Mono at the same numeric sizes overshoots.
   - **Approach.** New `src/v2/terminal/typography.css` with size overrides under `[data-theme^="terminal"]`. Light + dark stay at the calm Wheneri-tuned sizes. Dedicated file (not inline per component) so "what does terminal change about text?" is one grep, and graduating the smaller scale to all themes (if that's where we land) is one block to delete or de-gate.


### PR DESCRIPTION
## Summary

PR A–I painted terminal text + ASCII flourishes on top of a fundamentally modern card-based UI — rounded card surfaces with borders, filled accent buttons, glowing FAB, drop-shadowed modals, pill-shaped action chrome. Reads as "modern app in monospace," not as a CLI tool. User feedback after first in-browser look: didn't go far enough. PR J flattens the chrome.

## What changed (all under `[data-theme^="terminal"]` — light + dark unchanged)

**TaskCard.** Surface bg + border + border-radius + box-shadow all dropped. Cards become flat rows on `var(--v2-bg)`, separated by a single top hairline (skipped on the first card). Hover gets a faint 2% bg tint instead of an accent border. Status colors no longer ride a 2px left border — overdue + high-pri override the existing `[ ]` title prefix to:
- Overdue: `[!] ` red
- High-pri: `[*] ` amber

Status reads as a leading character on the title line, not as chrome decoration.

**Card actions.** Snooze/Edit/Skip lose pill chrome — flat hairline boxes, square corners, no hover bg fill. Done primary loses accent fill + brand glow + brightness-filter; becomes bordered `[ Done ]` accent text with cyan text-shadow glow and 0.08 opacity wash on hover.

**Energy chip.** Pill bg removed; becomes inline icon + bolts only.

**ModalShell.** Sheet bg → page bg with 1px hairline border. Border-radius zeroed at all breakpoints. Box-shadow zeroed (desktop drawer no longer floats). Overlay scrim deepened 0.45 → 0.70 so the modal reads as a takeover, not a floating card. Close X squared off too.

**FAB.** 48px circle → 36px square. Accent fill → transparent with thin accent border. Box-shadow + hover lift removed. Same flattening for both `+` (add) and target (what-now) variants. The FC card panel that expands from the FAB switches to flat-rect with accent border + cyan text-shadow glow.

**Form submit primary.** "Save changes" / "Add task" → bordered `[ verb ]` text via `::before`/`::after` brackets in the same accent color. No fill, no shadow.

**Form inputs + textarea + title.** Border-radius 10px → 0. Focus still flips to accent.

**EditTaskModal manage cluster.** Pill-shaped Backlog/Projects/Make recurring/Delete → flat squared boxes. Delete borders red. Confirm-yes loses its red fill, becomes red-bordered transparent text.

**Settings segmented control.** Rounded-pill cluster → joined-border tab strip; adjacent buttons share borders, active button gets accent border + accent text + glow.

**Section labels.** Add a thin hairline `border-bottom` so the label reads as a listing header.

**ConfirmDialog + ChainReconcileModal.** Same flattening — bg matches page, border hairline, radius 0, shadow removed, overlay deepened.

**Toast.** Pill bg → bordered flat rect with accent border + cyan text-shadow glow.

## Architecture

New `src/v2/terminal/flatten.css` (~330 lines). Imported via `terminal/index.css` between `typography.css` and the existing structural override files. All selectors gated on `[data-theme^="terminal"]`. Light + dark are completely untouched. Deleting the file restores the modern chrome to terminal mode entirely.

## Bundle

CSS 217KB gzip 32.2KB (+~9KB). JS unchanged.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run check:terminal-titles` — OK
- [x] `npm run build` succeeds
- [ ] Term Dark home screen — cards read as flat rows with hairlines, not bordered surfaces
- [ ] Overdue task — `[!]` red leading character on title; no left border
- [ ] High-pri task — `[*]` amber leading character on title
- [ ] Tap a task to expand — Done button reads as bordered `[ Done ]` text in accent color, no fill
- [ ] FAB lower-right — flat 36px square with thin accent border, no glow circle
- [ ] Tap +, expand the inline add card — flat rectangle with accent border, no shadow
- [ ] Open any modal — page-bg fill with hairline border, square corners, no drop shadow
- [ ] Settings → theme picker — 4 options join into a tab strip, active button has accent border + glow text
- [ ] Term Light: same flattening, white canvas, blue accent
- [ ] Light + Dark: completely unchanged from before

https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_