### PR TITLE
style(ui): terminal — revert palette to GitHub + powerlevel10k energy segments

### DIFF
--- a/src/v2/terminal/index.css
+++ b/src/v2/terminal/index.css
@@ -22,3 +22,4 @@
 @import './sections.css';
 @import './cards.css';
 @import './controls.css';
+@import './init.css';

--- a/src/v2/terminal/init.css
+++ b/src/v2/terminal/init.css
@@ -1,0 +1,279 @@
+/* Terminal — init.habits aesthetic pass.
+ *
+ * After PR #95's deeper flatten, the user's call: "go full init."
+ * This file pushes the rest of the way:
+ *
+ *   - Card action icons (Snooze / Edit / Skip / Done) replaced with
+ *     bracketed text buttons via CSS attribute selectors. SVGs hidden;
+ *     `[snooze]` `[edit]` `[done]` `[skip]` rendered in monospace.
+ *   - Energy chip hidden entirely. Init habits don't carry per-row
+ *     energy badges — the title speaks for itself.
+ *   - Section labels lowercased, smaller, count badge dimmed.
+ *   - Wordmark tightened — smaller font, less prominent.
+ *   - Kanban columns + their headers go bare-text on the dark canvas.
+ *
+ * !important is used liberally where component CSS / inline styles
+ * would otherwise win. Per the stress-test convention, JSX stays
+ * untouched; CSS does the work.
+ */
+
+/* === Card actions: text buttons instead of icon buttons ============= */
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-action svg {
+  display: none !important;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-action {
+  font: 500 13px/1 var(--v2-font-body);
+  letter-spacing: 0;
+  text-transform: lowercase;
+  padding: 4px 6px;
+  color: var(--v2-text-meta);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-action[aria-label="Snooze"]::before {
+  content: "[snooze]";
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-action[aria-label="Edit"]::before {
+  content: "[edit]";
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-action[aria-label*="Skip"]::before {
+  content: "[skip]";
+  color: var(--v2-alert-high-pri);
+}
+
+/* Done — the primary. Icon hidden, the existing <span>Done</span>
+ * stays visible and gets bracket prefixes from PR C. Lowercase it. */
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-action-primary {
+  text-transform: lowercase;
+  color: var(--v2-accent) !important;
+  text-shadow: var(--v2-glow);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-action-primary::before {
+  content: "[";
+  margin-right: 0;
+  color: var(--v2-accent);
+  font-weight: 500;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-action-primary::after {
+  content: "]";
+  margin-left: 0;
+  color: var(--v2-accent);
+  font-weight: 500;
+}
+
+/* Hover glow on text buttons */
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-action:hover {
+  color: var(--v2-text);
+  text-shadow: 0 0 6px rgba(194, 209, 197, 0.45);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-action-primary:hover {
+  color: var(--v2-accent) !important;
+  text-shadow: 0 0 12px rgba(126, 231, 135, 0.65);
+}
+
+/* === Energy chip: hide completely ================================== */
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-energy {
+  display: none !important;
+}
+
+/* === Section labels: lowercase + smaller + dimmed count ============ */
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-section-label {
+  text-transform: lowercase !important;
+  letter-spacing: 0 !important;
+  font: 500 13px/1 var(--v2-font-body);
+  color: var(--v2-accent);
+  padding: 18px 0 4px;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-section-label-bullet::before {
+  content: "✦";
+  color: var(--v2-accent);
+  text-shadow: var(--v2-glow);
+  font-weight: 400;
+  margin-right: 6px;
+  font-size: 12px;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-section-label-count {
+  color: var(--v2-text-faint) !important;
+  font-weight: 400;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-section-label-count::before,
+:root[data-ui="v2"][data-theme^="terminal"] .v2-section-label-count::after {
+  color: var(--v2-text-faint);
+}
+
+/* === Wordmark: tighten ============================================== */
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-header-wordmark {
+  font-size: 13px;
+  letter-spacing: 0;
+  font-weight: 500;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-header-wordmark::before {
+  color: var(--v2-text-meta);
+  font-weight: 400;
+}
+
+/* The wordmark `boomerang` letters themselves should be plain accent —
+ * no brand-y wave bounce in terminal mode. (PR D already mutes the
+ * letter animation during sync states; we extend that to idle too.) */
+:root[data-ui="v2"][data-theme^="terminal"] .v2-header-wordmark-letter {
+  color: var(--v2-accent);
+  font-weight: 500;
+  text-shadow: var(--v2-glow);
+}
+
+/* === Header icons: smaller, bare ==================================== */
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-header-icon-btn,
+:root[data-ui="v2"][data-theme^="terminal"] .v2-header-icon {
+  background: transparent !important;
+  border: none !important;
+  color: var(--v2-text-meta) !important;
+  padding: 6px;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-header-icon-btn:hover {
+  color: var(--v2-accent) !important;
+  text-shadow: var(--v2-glow);
+}
+
+/* === Filter pills: tighten further to true tabs ==================== */
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-toolbar {
+  padding: 8px 0;
+  gap: 0;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-toolbar-pills {
+  gap: 0;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-toolbar-pill {
+  font: 500 12px/1 var(--v2-font-body) !important;
+  text-transform: lowercase;
+  padding: 8px 4px !important;
+  margin: 0 10px 0 0 !important;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-toolbar-pill:first-child {
+  margin-left: 0 !important;
+}
+
+/* === Kanban (desktop) — make column headers + cards init-flavored == */
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-kanban-col {
+  background: transparent !important;
+  border: none !important;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-kanban-col-head {
+  border-bottom: none !important;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-kanban-col-title {
+  text-transform: lowercase !important;
+  letter-spacing: 0 !important;
+  font: 500 13px/1 var(--v2-font-body) !important;
+  color: var(--v2-accent) !important;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-kanban-col-title::before {
+  content: "✦ ";
+  color: var(--v2-accent);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-kanban-col-count {
+  color: var(--v2-text-faint) !important;
+  background: transparent !important;
+  font-weight: 400 !important;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-kanban-col-count::before {
+  content: "[";
+}
+:root[data-ui="v2"][data-theme^="terminal"] .v2-kanban-col-count::after {
+  content: "]";
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-kanban-add-btn {
+  border-radius: 0 !important;
+  background: transparent !important;
+  border: none !important;
+  color: var(--v2-accent) !important;
+  text-transform: lowercase;
+  padding: 8px 4px !important;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-kanban-add-btn:hover {
+  background: transparent !important;
+  text-shadow: var(--v2-glow);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-kanban-add-btn::before {
+  content: "[+] ";
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-kanban-add-input {
+  background: transparent !important;
+  border: none !important;
+  border-bottom: 1px solid var(--v2-hairline) !important;
+  border-radius: 0 !important;
+  color: var(--v2-text);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-kanban-add-input:focus {
+  border-bottom-color: var(--v2-accent) !important;
+  outline: none;
+}
+
+/* === Card title: drop the `[ ] ` prefix when status indicator
+ *      already provides one ([!] / [*]) so we don't double-up. */
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-overdue .v2-card-title::before,
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-high-pri .v2-card-title::before {
+  /* keep the override from flatten.css — already correct */
+}
+
+/* === Card title spacing: fix tap target leakage ==================== */
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-main {
+  padding: 12px 8px;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-content {
+  padding: 0;
+}
+
+/* === Notes preview: use indented text style (matches init's
+ *      `// description` indent under each habit) ==================== */
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-notes-preview {
+  padding-left: 24px;
+  font-size: 11px;
+  margin-top: 4px;
+}
+
+/* === Floating capture: position closer to the corner =============== */
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-floating-capture {
+  right: 12px;
+  bottom: max(12px, env(safe-area-inset-bottom, 0px));
+  gap: 14px;
+}
+
+/* === Subtle: section-label first-of-kind has less top padding ===== */
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-list > .v2-section-label:first-child {
+  padding-top: 6px;
+}

--- a/src/v2/terminal/init.css
+++ b/src/v2/terminal/init.css
@@ -77,11 +77,89 @@
   text-shadow: 0 0 12px rgba(126, 231, 135, 0.65);
 }
 
-/* === Energy chip: hide completely ================================== */
+/* === Energy chip: powerlevel10k segment ============================
+ *
+ * Init.habits hides per-row energy info. We don't — energy type +
+ * level is a real signal we want to keep visible. Render it as a
+ * powerlevel10k-style colored segment instead of a pill: emoji prefix
+ * (per type) + `⚡`-character bolts (per level) in the energy color.
+ *
+ * Lucide icon hidden via CSS. Emoji rendered via [title^="..."]
+ * attribute selector since `task.energy` doesn't surface to the DOM.
+ * Bolt SVGs replaced with `⚡` text via [title*="level N"].
+ *
+ * Each energy type gets its own color from the palette tokens — applied
+ * to the whole chip via attribute selector so the prefix + bolts read
+ * as one segment in the type's color. */
 
 :root[data-ui="v2"][data-theme^="terminal"] .v2-card-energy {
+  background: transparent !important;
+  padding: 0 !important;
+  border-radius: 0 !important;
+  font: 500 12px/1 var(--v2-font-body);
+  letter-spacing: 0;
+  gap: 2px !important;
+}
+
+/* Hide the lucide icon — emoji prefix replaces it */
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-energy > svg {
   display: none !important;
 }
+
+/* Emoji prefix per energy type. ENERGY_TYPES labels are capitalized
+ * (Desk, People, Errand, Creative, Physical) so [title^="X"] matches
+ * `title="Desk · level 2"` etc. */
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-energy[title^="Desk"]::before {
+  content: "💻 ";
+  color: var(--v2-energy-desk);
+}
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-energy[title^="People"]::before {
+  content: "👥 ";
+  color: var(--v2-energy-people);
+}
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-energy[title^="Errand"]::before {
+  content: "🏃 ";
+  color: var(--v2-energy-errand);
+}
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-energy[title^="Creative"]::before {
+  content: "🎨 ";
+  color: var(--v2-energy-creative);
+}
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-energy[title^="Physical"]::before {
+  content: "💪 ";
+  color: var(--v2-energy-physical);
+}
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-energy[title^="Confrontation"]::before {
+  content: "⚡ ";
+  color: var(--v2-energy-confrontation);
+}
+
+/* Color the entire segment (prefix + bolts) per energy type so it reads
+ * as one colored powerlevel10k cell. */
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-energy[title^="Desk"] { color: var(--v2-energy-desk); }
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-energy[title^="People"] { color: var(--v2-energy-people); }
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-energy[title^="Errand"] { color: var(--v2-energy-errand); }
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-energy[title^="Creative"] { color: var(--v2-energy-creative); }
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-energy[title^="Physical"] { color: var(--v2-energy-physical); }
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-energy[title^="Confrontation"] { color: var(--v2-energy-confrontation); }
+
+/* Hide the bolt SVGs — replace with `⚡` text per level via the
+ * energy-bolts container's ::after. The container's parent has the
+ * title; use combinator to read level from the title. */
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-energy-bolts > svg {
+  display: none !important;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-energy-bolts {
+  font-size: 11px;
+  line-height: 1;
+}
+
+/* Level → bolt-text glyphs. Use the parent .v2-card-energy's title to
+ * pick the right count. */
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-energy[title*="level 1"] .v2-card-energy-bolts::after { content: "⚡"; }
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-energy[title*="level 2"] .v2-card-energy-bolts::after { content: "⚡⚡"; }
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-energy[title*="level 3"] .v2-card-energy-bolts::after { content: "⚡⚡⚡"; }
 
 /* === Section labels: lowercase + smaller + dimmed count ============ */
 

--- a/src/v2/terminal/palette-dark.css
+++ b/src/v2/terminal/palette-dark.css
@@ -1,57 +1,55 @@
-/* Terminal — GitHub Dark palette.
- * Classic dev-tool dark theme: deep code-editor navy, blue-grey text,
- * cyan accent, GitHub Dark's signature green/red/amber alarm colors.
+/* Terminal — Dark palette (init.habits flavor).
  *
- * Background hex values are pulled from GitHub's Primer design system
- * (https://primer.style/foundations/color/dark) so the look reads as
- * "code editor in dark mode" to anyone who's spent time on github.com.
+ * Was originally GitHub Dark blue; user wants the look to read as
+ * init.habits as much as possible. Init's palette is green-on-near-
+ * black, with a subtle green tint to the dark canvas. Accent is bright
+ * terminal green (`#7ee787`-ish), not GitHub Dark's link blue.
  *
- * Layout, spacing, and component contracts stay identical to light/dark
- * v2; only the palette and font stack swap. */
+ * Keeping the variable names + structural contract identical to
+ * before — only the hex values move. Light + dark themes are
+ * untouched (different palette files).
+ */
 
 :root[data-ui="v2"][data-theme="terminal-dark"] {
-  /* Type — full monospace stack. JetBrains Mono / SF Mono / Cascadia
-   * preferred where available; fall back to system mono. */
+  /* Type — full monospace stack. */
   --v2-font-display: 'JetBrains Mono', 'SF Mono', 'Cascadia Code', 'Fira Code', ui-monospace, monospace;
   --v2-font-body: 'JetBrains Mono', 'SF Mono', 'Cascadia Code', 'Fira Code', ui-monospace, monospace;
 
-  /* Surfaces — GitHub Dark canvas + surface. The cards and bg differ by
-   * a few percent lightness so cards still read as elevated. Terminal
-   * UIs lean flat, not Material-shadowy. */
-  --v2-bg: #0D1117;
-  --v2-surface: #161B22;
-  --v2-text: #C9D1D9;
-  --v2-text-rgb: 201, 209, 217;
-  --v2-text-meta: rgba(201, 209, 217, 0.55);
-  --v2-text-faint: rgba(201, 209, 217, 0.32);
-  --v2-hairline: rgba(240, 246, 252, 0.10);
+  /* Surfaces — near-black with a slight green tint, the way init's
+   * canvas reads. Surface barely lifts from bg (terminal UIs lean
+   * flat; cards-as-elevation isn't the language). */
+  --v2-bg: #0B1110;
+  --v2-surface: #11171A;
+  --v2-text: #C2D1C5;
+  --v2-text-rgb: 194, 209, 197;
+  --v2-text-meta: rgba(194, 209, 197, 0.55);
+  --v2-text-faint: rgba(194, 209, 197, 0.32);
+  --v2-hairline: rgba(126, 231, 135, 0.10);
 
-  /* Accent — GitHub Dark's signature blue. Reads as "this is a link or
-   * an active control" anywhere on github.com; same affordance here. */
-  --v2-accent: #58A6FF;
+  /* Accent — bright terminal green. Same role as the old cyan/blue
+   * but matches init's signature. */
+  --v2-accent: #7EE787;
 
-  /* Status — GitHub Dark alarm colors, semantically aligned with
-   * light/dark (overdue=red, high-pri=amber). */
-  --v2-alert-overdue: #F85149;
-  --v2-alert-high-pri: #D29922;
+  /* Status — keep red + amber so overdue/high-pri stay readable. */
+  --v2-alert-overdue: #FF7B72;
+  --v2-alert-high-pri: #FFB347;
 
-  /* Energy types — slightly desaturated to fit the palette and not
-   * compete with the cyan/blue accent. */
+  /* Energy types — recolored for the green palette. Most desaturated
+   * vs the GitHub Dark variant. */
   --v2-energy-desk: #79C0FF;
-  --v2-energy-people: #FF9DC0;
+  --v2-energy-people: #FFA8D8;
   --v2-energy-errand: #7EE787;
-  --v2-energy-confrontation: #FF7B72;
-  --v2-energy-creative: #D2A8FF;
-  --v2-energy-physical: #FFA657;
+  --v2-energy-confrontation: #FF8C7A;
+  --v2-energy-creative: #C9A8FF;
+  --v2-energy-physical: #FFC07A;
 
-  /* Soft glow — components opt in via this token. Used sparingly on the
-   * wordmark, primary buttons, the sync indicator. The blur is small
-   * enough not to soften legibility. */
-  --v2-glow: 0 0 8px rgba(88, 166, 255, 0.45);
+  /* Soft green glow — sparingly used (wordmark cursor, primary
+   * action text, active filter underline). */
+  --v2-glow: 0 0 8px rgba(126, 231, 135, 0.45);
 
-  /* Slightly softer radii so the look feels "boxy terminal" not
-   * "iOS pill" while still staying tap-friendly. */
-  --v2-radius-pill: 6px;
-  --v2-radius-card: 4px;
-  --v2-radius-modal: 6px;
+  /* Boxy — keep terminal-y radii (nothing rounder than 4px). */
+  --v2-radius-pill: 0;
+  --v2-radius-card: 0;
+  --v2-radius-modal: 0;
 }
+

--- a/src/v2/terminal/palette-dark.css
+++ b/src/v2/terminal/palette-dark.css
@@ -1,53 +1,51 @@
-/* Terminal — Dark palette (init.habits flavor).
+/* Terminal — GitHub Dark palette.
  *
- * Was originally GitHub Dark blue; user wants the look to read as
- * init.habits as much as possible. Init's palette is green-on-near-
- * black, with a subtle green tint to the dark canvas. Accent is bright
- * terminal green (`#7ee787`-ish), not GitHub Dark's link blue.
+ * Canonical Primer (https://primer.style/foundations/color/dark) values.
+ * After a brief detour to init's green-on-dark, the user's call is to
+ * stick with GitHub palettes — the structural language (powerlevel10k
+ * segments + bracketed text + bare rows) does the init heavy lifting,
+ * the palette just provides a clean dev-tool dark canvas.
  *
- * Keeping the variable names + structural contract identical to
- * before — only the hex values move. Light + dark themes are
- * untouched (different palette files).
+ * Light + dark themes (separate files) untouched.
  */
 
 :root[data-ui="v2"][data-theme="terminal-dark"] {
-  /* Type — full monospace stack. */
   --v2-font-display: 'JetBrains Mono', 'SF Mono', 'Cascadia Code', 'Fira Code', ui-monospace, monospace;
   --v2-font-body: 'JetBrains Mono', 'SF Mono', 'Cascadia Code', 'Fira Code', ui-monospace, monospace;
 
-  /* Surfaces — near-black with a slight green tint, the way init's
-   * canvas reads. Surface barely lifts from bg (terminal UIs lean
-   * flat; cards-as-elevation isn't the language). */
-  --v2-bg: #0B1110;
-  --v2-surface: #11171A;
-  --v2-text: #C2D1C5;
-  --v2-text-rgb: 194, 209, 197;
-  --v2-text-meta: rgba(194, 209, 197, 0.55);
-  --v2-text-faint: rgba(194, 209, 197, 0.32);
-  --v2-hairline: rgba(126, 231, 135, 0.10);
+  /* Surfaces — GitHub Dark canvas + raised surface. Cards-as-elevation
+   * is suppressed structurally elsewhere; the surface var stays for
+   * popovers/modals that benefit from a tiny lift. */
+  --v2-bg: #0D1117;
+  --v2-surface: #161B22;
+  --v2-text: #C9D1D9;
+  --v2-text-rgb: 201, 209, 217;
+  --v2-text-meta: rgba(201, 209, 217, 0.55);
+  --v2-text-faint: rgba(201, 209, 217, 0.32);
+  --v2-hairline: rgba(240, 246, 252, 0.10);
 
-  /* Accent — bright terminal green. Same role as the old cyan/blue
-   * but matches init's signature. */
-  --v2-accent: #7EE787;
+  /* Accent — GitHub's link blue. Reads as "this is interactive" the
+   * way it does on github.com. */
+  --v2-accent: #58A6FF;
 
-  /* Status — keep red + amber so overdue/high-pri stay readable. */
-  --v2-alert-overdue: #FF7B72;
-  --v2-alert-high-pri: #FFB347;
+  /* Status — GitHub Dark red + amber. */
+  --v2-alert-overdue: #F85149;
+  --v2-alert-high-pri: #D29922;
 
-  /* Energy types — recolored for the green palette. Most desaturated
-   * vs the GitHub Dark variant. */
+  /* Energy types — powerlevel10k-style colored segments. Each type gets
+   * a distinct color that pops against the dark canvas without competing
+   * with the blue accent. */
   --v2-energy-desk: #79C0FF;
-  --v2-energy-people: #FFA8D8;
+  --v2-energy-people: #FF9DC0;
   --v2-energy-errand: #7EE787;
-  --v2-energy-confrontation: #FF8C7A;
-  --v2-energy-creative: #C9A8FF;
-  --v2-energy-physical: #FFC07A;
+  --v2-energy-confrontation: #FF7B72;
+  --v2-energy-creative: #D2A8FF;
+  --v2-energy-physical: #FFA657;
 
-  /* Soft green glow — sparingly used (wordmark cursor, primary
-   * action text, active filter underline). */
-  --v2-glow: 0 0 8px rgba(126, 231, 135, 0.45);
+  /* Cyan glow on the wordmark cursor, sparingly elsewhere. */
+  --v2-glow: 0 0 8px rgba(88, 166, 255, 0.45);
 
-  /* Boxy — keep terminal-y radii (nothing rounder than 4px). */
+  /* Boxy: zero radius across the board. */
   --v2-radius-pill: 0;
   --v2-radius-card: 0;
   --v2-radius-modal: 0;

--- a/src/v2/terminal/palette-light.css
+++ b/src/v2/terminal/palette-light.css
@@ -25,16 +25,15 @@
   --v2-text-faint: rgba(31, 35, 40, 0.40);
   --v2-hairline: rgba(31, 35, 40, 0.14);
 
-  /* Accent — GitHub Light's deep link blue (#0969da). This replaces
-   * the orange of regular Light v2. */
-  --v2-accent: #0969DA;
+  /* Accent — terminal green (init flavor) on a light canvas. Reads as
+   * a unified family with terminal-dark; same role as the dark variant. */
+  --v2-accent: #1F8E3A;
 
-  /* Status — GitHub Light alarm colors (red #cf222e, amber #9a6700)
-   * matched against a white background. */
+  /* Status — alarm colors matched against a white background. */
   --v2-alert-overdue: #CF222E;
   --v2-alert-high-pri: #9A6700;
 
-  /* Energy types — desaturated to GitHub Light's character. */
+  /* Energy types — kept GitHub Light flavors (work fine on white). */
   --v2-energy-desk: #0969DA;
   --v2-energy-people: #BF3989;
   --v2-energy-errand: #1A7F37;

--- a/src/v2/terminal/palette-light.css
+++ b/src/v2/terminal/palette-light.css
@@ -25,15 +25,15 @@
   --v2-text-faint: rgba(31, 35, 40, 0.40);
   --v2-hairline: rgba(31, 35, 40, 0.14);
 
-  /* Accent — terminal green (init flavor) on a light canvas. Reads as
-   * a unified family with terminal-dark; same role as the dark variant. */
-  --v2-accent: #1F8E3A;
+  /* Accent — GitHub Light's deep link blue. Returned to canon after a
+   * brief green detour; structural language carries the init feel. */
+  --v2-accent: #0969DA;
 
-  /* Status — alarm colors matched against a white background. */
+  /* Status — GitHub Light alarm colors against a white canvas. */
   --v2-alert-overdue: #CF222E;
   --v2-alert-high-pri: #9A6700;
 
-  /* Energy types — kept GitHub Light flavors (work fine on white). */
+  /* Energy types — GitHub Light segment colors. */
   --v2-energy-desk: #0969DA;
   --v2-energy-people: #BF3989;
   --v2-energy-errand: #1A7F37;

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,28 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-10
 
+- style(ui): terminal theme — full init aesthetic pass [M]
+  - **Why.** User: "Done fucking around. Go full init aesthetic. Fuck the duplication and deviation comments from earlier." Stress test is over — the call is to commit. PR pushes the rest of the way to look like init.habits.
+  - **Palette swap.** GitHub Dark blue accent → terminal green (`#7EE787`). Canvas darkened with a subtle green tint (`#0D1117` → `#0B1110`); text shifts cool gray → light green-gray (`#C9D1D9` → `#C2D1C5`). Hairlines pick up the green. Glow shadow shifts cyan → green. terminal-light gets matching green accent (`#0969DA` → `#1F8E3A`). Radii zeroed across the board (`pill: 6px → 0`, `card: 4px → 0`, `modal: 6px → 0`).
+  - **Card action buttons → text buttons.** Lucide icons hidden via CSS. CSS attribute selectors render bracketed text buttons:
+    - `aria-label="Snooze"` → `[snooze]`
+    - `aria-label="Edit"` → `[edit]`
+    - `aria-label*="Skip"` → `[skip]` (amber)
+    - `aria-label="Mark done"` → `[ done ]` (existing PR C bracket prefix retained, lowercased + green)
+  - Hover shifts color to bright accent + glow text-shadow.
+  - **Energy chip hidden.** Init habits don't carry per-row energy badges; the title speaks for itself. `display: none` via `!important`.
+  - **Section labels: lowercase + smaller + sparkle prefix.** `> DOING [6]` → `✦ doing [6]`. The chevron `>` from PR B's section bullet replaced with `✦` (init's section sparkle). Text lowercased, font dropped to 13px, count badge dimmed to faint.
+  - **Wordmark tightened.** `$ boomerang_` text drops 2px more (15 → 13). Letters use accent green with glow. `$` prefix stays meta-color.
+  - **Header icons** lose any background/border, become bare 16px lucide icons in meta-text color, hover to accent + glow.
+  - **Filter pills further tightened.** Smaller font (12px), lowercase, gap dropped between tabs.
+  - **Kanban (desktop) gets the same treatment.** Column headers lowercase + sparkle prefix + accent. Count badges bracketed. "Add task" inline button becomes `[+] add task` text. Inline add input becomes a bottom-bordered transparent field.
+  - **Notes preview indented** to match init's `// description` indent under each habit (24px left padding, 11px font).
+  - **Floating capture position** tightened (right: 16px → 12px) so the bare `+` glyph hugs the corner.
+  - **Architecture.** New `src/v2/terminal/init.css` (~220 lines). Imported last in `terminal/index.css` so its rules override anything from earlier files. All under `[data-theme^="terminal"]`. `!important` used liberally where component CSS / inline styles would otherwise win — JSX stays untouched per the stress-test convention but the convention's "be conservative" guideline is loosened: user's call is explicit.
+  - **Bundle.** CSS 223.9KB gzip 33.1KB (+~5KB). JS unchanged.
+  - Modified: `src/v2/terminal/palette-dark.css`, `src/v2/terminal/palette-light.css`, `src/v2/terminal/index.css`, `wiki/Version-History.md`
+  - Added: `src/v2/terminal/init.css`
+
 - style(ui): terminal theme — deeper flatten (no row borders, bare buttons, text-tab filters) [S]
   - **Why.** First flatten pass (PR earlier today) kept hairline row separators on cards, kept thin borders on action buttons, kept the FAB as a small bordered square. Side-by-side with init.habits, all of that still reads as "modern app chrome" — init has zero borders on individual rows, zero borders on action buttons (just bracketed `[add]` text), zero borders on filter chips (just text-tabs with underline-on-active).
   - **TaskCard rows.** Top hairline `border-top` removed. Hover background tint removed. Expanded-state background tint removed. Cards become bare text on the page bg, separated by line-height alone. Status `[!]`/`[*]` glyph leading characters from the previous PR continue to do the work for overdue/high-pri.

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,19 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-10
 
+- style(ui): terminal theme — revert palette to GitHub Dark/Light + powerlevel10k energy segments [S]
+  - **Why.** User: "Stick with GitHub light and dark color palettes. So you don't need to completely strip everything. Incorporate our add ons like energy and whatever into the init design. Think like powerlevel10k or similar." — and a follow-up: "We can have a terminal look without losing all of the features."
+  - **Palette reverted.** terminal-dark back to canonical GitHub Dark blue (`#58A6FF` accent, `#0D1117` canvas, `#C9D1D9` text, cyan glow). terminal-light back to GitHub Light blue (`#0969DA`). The structural language (powerlevel10k segments, bracketed text, bare rows, lowercased section labels with `✦` prefix) carries the init feel; the palette stays canonical.
+  - **Energy chip restored as powerlevel10k segment.** Init.habits hides per-row energy info, but for Boomerang energy is real signal. Render it as a colored segment instead of a pill: emoji prefix per type + `⚡`-character bolts per level, in the energy-type color, on transparent. Lucide icon + Zap SVGs hidden via CSS. Emoji + bolt-text rendered via attribute selectors (`[title^="Desk"]`, `[title*="level 2"]`, etc.) since `task.energy`/`task.energyLevel` don't surface to the DOM. Per-type color applied to the whole segment so the prefix + bolts read as one cell:
+    - 💻 desk → `var(--v2-energy-desk)`
+    - 👥 people → `var(--v2-energy-people)`
+    - 🏃 errand → `var(--v2-energy-errand)`
+    - 🎨 creative → `var(--v2-energy-creative)`
+    - 💪 physical → `var(--v2-energy-physical)`
+    - ⚡ confrontation → `var(--v2-energy-confrontation)`
+  - **Convention reaffirmed.** Don't strip features to chase the aesthetic. When something doesn't fit init's exact look, find the powerlevel10k-style monospace re-render (sigil + colored text segment) instead of `display: none`. Same pattern can apply to any other surface where the init reflex says "remove" but the feature is actually useful.
+  - Modified: `src/v2/terminal/palette-dark.css`, `src/v2/terminal/palette-light.css`, `src/v2/terminal/init.css`, `wiki/Version-History.md`
+
 - style(ui): terminal theme — full init aesthetic pass [M]
   - **Why.** User: "Done fucking around. Go full init aesthetic. Fuck the duplication and deviation comments from earlier." Stress test is over — the call is to commit. PR pushes the rest of the way to look like init.habits.
   - **Palette swap.** GitHub Dark blue accent → terminal green (`#7EE787`). Canvas darkened with a subtle green tint (`#0D1117` → `#0B1110`); text shifts cool gray → light green-gray (`#C9D1D9` → `#C2D1C5`). Hairlines pick up the green. Glow shadow shifts cyan → green. terminal-light gets matching green accent (`#0969DA` → `#1F8E3A`). Radii zeroed across the board (`pill: 6px → 0`, `card: 4px → 0`, `modal: 6px → 0`).


### PR DESCRIPTION
## Summary

Two corrections to PR #96:

1. **Stick with GitHub palettes.** The init green-on-dark detour was wrong. Palette reverts to canonical GitHub Dark blue (`#58A6FF`) and GitHub Light blue (`#0969DA`). Structural language (sparkle section labels, bracketed text buttons, bare rows, p10k segments) carries the init feel — the palette stays canonical.

2. **Bring back features as monospace re-renders, don't strip them.** Init.habits hides per-row energy info but for Boomerang energy is real signal. Render it as a powerlevel10k-style colored segment instead of removing it.

## Energy chip → p10k segment

| Type | Render | Color |
|---|---|---|
| Desk | `💻 ⚡⚡` | desk blue |
| People | `👥 ⚡` | people pink |
| Errand | `🏃 ⚡⚡⚡` | errand green |
| Creative | `🎨 ⚡` | creative purple |
| Physical | `💪 ⚡⚡` | physical orange |
| Confrontation | `⚡ ⚡⚡⚡` | confrontation coral |

CSS-only:
- Hide the lucide icon + Zap SVGs
- `[title^="Desk"]::before { content: "💻 "; color: var(--v2-energy-desk); }` per type
- `[title*="level 2"] .v2-card-energy-bolts::after { content: "⚡⚡"; }` per level
- Color the whole segment in the energy token so prefix + bolts read as one cell

The `title` attribute (e.g. `"Desk · level 2"`) was already on the JSX for tooltip; we use it for selector targeting without touching the component.

## Convention reaffirmed

Don't strip features to chase the aesthetic. When something doesn't fit init's exact look, find the powerlevel10k re-render (sigil + colored text segment) instead of `display: none`. Same pattern can apply to other surfaces if needed.

## Bundle

CSS 226KB gzip 33.4KB (+~2KB).

## Test plan

- [x] `npm run lint` clean
- [x] `npm run check:terminal-titles` — OK
- [x] `npm run build` succeeds
- [ ] Term Dark — accent everywhere is GitHub Dark blue (`#58A6FF`), not green
- [ ] Term Light — accent is GitHub Light blue (`#0969DA`)
- [ ] Cards show energy segment on the right (e.g. `💻 ⚡⚡` in desk-blue)
- [ ] Each energy type renders with its emoji + matching color
- [ ] Bolt count matches energy level (1/2/3 ⚡ characters)
- [ ] Tasks without energy data don't render the segment (the JSX guards on `energyType && EnergyIcon`)

https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_