### PR TITLE
style(ui): terminal — per-section sigils + sigil+text action buttons

### DIFF
--- a/src/v2/AppV2.jsx
+++ b/src/v2/AppV2.jsx
@@ -517,9 +517,9 @@ export default function AppV2() {
     }
   }, [addTask, updateTask, prefetchToast])
 
-  const renderSection = (label, list) => list.length > 0 && (
+  const renderSection = (label, list, sigil) => list.length > 0 && (
     <>
-      <SectionLabel count={list.length}>{label}</SectionLabel>
+      <SectionLabel count={list.length} sigil={sigil}>{label}</SectionLabel>
       {list.map(t => (
         <TaskCard
           key={t.id}
@@ -674,11 +674,11 @@ export default function AppV2() {
             {settingsForRings.show_week_strip && (
               <WeekStrip tasks={tasks} dailyTaskGoal={settingsForRings.daily_task_goal || 3} />
             )}
-            {renderSection('Doing', sortedDoing)}
-            {renderSection('Stale', sortedStale)}
-            {renderSection('Up next', sortedUpNext)}
-            {renderSection('Waiting', sortedWaiting)}
-            {renderSection('Snoozed', sortedSnoozed)}
+            {renderSection('Doing', sortedDoing, '→')}
+            {renderSection('Stale', sortedStale, '~')}
+            {renderSection('Up next', sortedUpNext, '+')}
+            {renderSection('Waiting', sortedWaiting, '…')}
+            {renderSection('Snoozed', sortedSnoozed, 'z')}
             {settingsForRings.show_goal_progress && (
               <GoalProgressBar tasksToday={dailyStats.tasksToday} goal={settingsForRings.daily_task_goal || 3} />
             )}

--- a/src/v2/components/SectionLabel.jsx
+++ b/src/v2/components/SectionLabel.jsx
@@ -1,9 +1,15 @@
 import './SectionLabel.css'
 
-export default function SectionLabel({ children, count }) {
+// `sigil` is the bullet glyph rendered before the label. Defaults to
+// `✦` so light/dark see a uniform sparkle. Per-section variants
+// (`→ doing`, `~ stale`, `+ up next`, `… waiting`, `z snoozed`) drive
+// the terminal-mode bullet via `data-sigil` — terminal CSS reads the
+// attribute via `attr()` so callers can pass a section-specific glyph
+// without it bleeding into the light/dark display (which keeps `✦`).
+export default function SectionLabel({ children, count, sigil = '✦' }) {
   return (
     <div className="v2-section-label">
-      <span className="v2-section-label-bullet" aria-hidden="true">✦</span>
+      <span className="v2-section-label-bullet" data-sigil={sigil} aria-hidden="true">✦</span>
       <span className="v2-section-label-text">{children}</span>
       {typeof count === 'number' && count > 0 && (
         <span className="v2-section-label-count">{count}</span>

--- a/src/v2/terminal/init.css
+++ b/src/v2/terminal/init.css
@@ -31,21 +31,24 @@
   color: var(--v2-text-meta);
 }
 
+/* Sigil + text, no brackets. Each action gets a meaningful glyph
+ * prefix that reads as a powerlevel10k segment. */
 :root[data-ui="v2"][data-theme^="terminal"] .v2-card-action[aria-label="Snooze"]::before {
-  content: "[snooze]";
+  content: "☾ snooze";
 }
 
 :root[data-ui="v2"][data-theme^="terminal"] .v2-card-action[aria-label="Edit"]::before {
-  content: "[edit]";
+  content: "✎ edit";
 }
 
 :root[data-ui="v2"][data-theme^="terminal"] .v2-card-action[aria-label*="Skip"]::before {
-  content: "[skip]";
+  content: "↷ skip";
   color: var(--v2-alert-high-pri);
 }
 
 /* Done — the primary. Icon hidden, the existing <span>Done</span>
- * stays visible and gets bracket prefixes from PR C. Lowercase it. */
+ * stays visible. Drop the bracket prefix/suffix from PR C, render a
+ * leading `✓ ` glyph instead. */
 :root[data-ui="v2"][data-theme^="terminal"] .v2-card-action-primary {
   text-transform: lowercase;
   color: var(--v2-accent) !important;
@@ -53,17 +56,14 @@
 }
 
 :root[data-ui="v2"][data-theme^="terminal"] .v2-card-action-primary::before {
-  content: "[";
+  content: "✓ ";
   margin-right: 0;
   color: var(--v2-accent);
   font-weight: 500;
 }
 
 :root[data-ui="v2"][data-theme^="terminal"] .v2-card-action-primary::after {
-  content: "]";
-  margin-left: 0;
-  color: var(--v2-accent);
-  font-weight: 500;
+  content: "";
 }
 
 /* Hover glow on text buttons */
@@ -172,7 +172,11 @@
 }
 
 :root[data-ui="v2"][data-theme^="terminal"] .v2-section-label-bullet::before {
-  content: "✦";
+  /* Read per-section sigil from the JSX-supplied data attribute. Falls
+   * back to `✦` for sections that don't pass one. Light/dark show the
+   * inline `✦` text content; terminal hides that and renders the
+   * data-sigil glyph here. */
+  content: attr(data-sigil);
   color: var(--v2-accent);
   text-shadow: var(--v2-glow);
   font-weight: 400;

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,25 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-10
 
+- style(ui): terminal theme — per-section sigils + sigil+text action buttons [S]
+  - **Why.** Locked-in design decisions from a four-question round: per-section sigils to differentiate sections at a glance (vs the uniform `✦`), and sigil+text action buttons to read as powerlevel10k segments (vs flat bracketed text). Energy chip stays top-right; status indicators stay leading-bracket — those were already right.
+  - **`SectionLabel.jsx` accepts a `sigil` prop.** Defaults to `✦` (light/dark see uniform sparkle, no behavior change). The bullet span renders `✦` as inline text AND carries `data-sigil={sigil}` as an attribute. Light/dark CSS shows the inline text. Terminal CSS reads `attr(data-sigil)` via `::before`. Cost: one prop, JSX stays minimal.
+  - **Per-section sigils on the home screen:**
+    - `→ doing` (active, in-progress)
+    - `~ stale` (squiggle, languishing)
+    - `+ up next` (queued)
+    - `… waiting` (pending external)
+    - `z snoozed` (sleep)
+    - Kanban columns keep uniform `✦` for now (different code path; a follow-up could differentiate those too)
+  - **Card action buttons → sigil + text, no brackets.** Lucide icons hidden via CSS. Each action gets a meaningful glyph prefix:
+    - `☾ snooze` (moon, rest)
+    - `✎ edit` (pencil)
+    - `↷ skip` (rotation arrow, advance chain)
+    - `✓ done` (check; primary; replaces the `[ ]` bracket wrap from PR C)
+  - The Done bracket wrap from PR C dropped — `::before` content goes from `[ ` to `✓ `, `::after` content empties out. Reads as `✓ done` in accent green/blue with the existing glow on hover.
+  - **Bundle.** CSS 226.0KB gzip 33.4KB (unchanged — content swaps, not additions). JS +0.06KB (the SectionLabel sigil prop + AppV2 renderSection signature change).
+  - Modified: `src/v2/components/SectionLabel.jsx`, `src/v2/AppV2.jsx`, `src/v2/terminal/init.css`, `wiki/Version-History.md`
+
 - style(ui): terminal theme — revert palette to GitHub Dark/Light + powerlevel10k energy segments [S]
   - **Why.** User: "Stick with GitHub light and dark color palettes. So you don't need to completely strip everything. Incorporate our add ons like energy and whatever into the init design. Think like powerlevel10k or similar." — and a follow-up: "We can have a terminal look without losing all of the features."
   - **Palette reverted.** terminal-dark back to canonical GitHub Dark blue (`#58A6FF` accent, `#0D1117` canvas, `#C9D1D9` text, cyan glow). terminal-light back to GitHub Light blue (`#0969DA`). The structural language (powerlevel10k segments, bracketed text, bare rows, lowercased section labels with `✦` prefix) carries the init feel; the palette stays canonical.


### PR DESCRIPTION
## Summary

Implements the locked-in answers from the four-question round:
1. **Per-section sigils** to differentiate the home-screen sections at a glance
2. **Sigil + text action buttons** instead of bracketed plain text

Energy chip stays top-right; status indicators stay leading-bracket — those were the user's "keep current" picks.

## What changed

**`SectionLabel.jsx` accepts a `sigil` prop.** Defaults to `✦` (light/dark see uniform sparkle, no behavior change). The bullet span renders `✦` as inline text AND carries `data-sigil={sigil}` as an attribute. Light/dark CSS shows the inline text. Terminal CSS reads `attr(data-sigil)` via `::before`. One prop, JSX stays minimal.

**Per-section sigils** on the home screen:

| Section | Sigil | Reason |
|---|---|---|
| Doing | `→` | active, in-progress |
| Stale | `~` | squiggle, languishing |
| Up next | `+` | queued |
| Waiting | `…` | pending external |
| Snoozed | `z` | sleep |

Kanban columns keep uniform `✦` for now (separate code path; could differentiate as a follow-up).

**Card action buttons → sigil + text, no brackets.** Lucide icons hidden via CSS:

| Action | Render |
|---|---|
| Snooze | `☾ snooze` |
| Edit | `✎ edit` |
| Skip | `↷ skip` (amber) |
| Done | `✓ done` (accent) |

The `[ Done ]` bracket wrap from PR C is dropped — `::before` content goes from `[ ` to `✓ `, `::after` empties out.

## Bundle

CSS 226.0KB gzip 33.4KB (unchanged — content swaps, not additions). JS +0.06KB (SectionLabel sigil prop + AppV2 renderSection signature change).

## Test plan

- [x] `npm run lint` clean
- [x] `npm run check:terminal-titles` — OK
- [x] `npm run build` succeeds
- [ ] Term Dark home — sections render `→ doing [6]`, `~ stale [1]`, `+ up next [2]`, `… waiting [3]`, `z snoozed [1]`
- [ ] Light/Dark home — all sections still show `✦` uniformly (no behavior change)
- [ ] Term Dark expanded card — actions render `✓ done   ☾ snooze   ✎ edit` (no brackets)
- [ ] Term Dark routine task expanded — `↷ skip` shows in amber when chain has follow_ups remaining

https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_