### PR TITLE
style(ui): terminal — hide brand logo + add section dividers

### DIFF
--- a/src/v2/terminal/init.css
+++ b/src/v2/terminal/init.css
@@ -194,6 +194,24 @@
   color: var(--v2-text-faint);
 }
 
+/* === Brand logo: hide in terminal mode ============================
+ * The orange `v` SVG is a brand mark and reads as a misfit on a CLI
+ * aesthetic. Hide it; the `$ boomerang` prompt is identity enough. */
+:root[data-ui="v2"][data-theme^="terminal"] .v2-header-brand > svg {
+  display: none !important;
+}
+
+/* === Section dividers: hairline between groups ====================
+ * Whitespace alone wasn't doing enough visual work to separate
+ * sections; init uses a thin rule above each group. Apply to any
+ * section label preceded by a card (i.e., not the first section). */
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-swipe-wrap + .v2-section-label,
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card + .v2-section-label {
+  border-top: 1px solid var(--v2-hairline);
+  margin-top: 14px;
+  padding-top: 16px;
+}
+
 /* === Wordmark: tighten ============================================== */
 
 :root[data-ui="v2"][data-theme^="terminal"] .v2-header-wordmark {

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,12 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-10
 
+- style(ui): terminal theme — hide brand logo + add section dividers [XS]
+  - **Why.** Side-by-side check vs init showed two remaining misfits: the orange `v` brand SVG sitting next to the `$ boomerang` prompt (modern brand mark on a CLI aesthetic — wrong vibe) and section spacing relying on whitespace alone, which wasn't doing enough visual work to separate groups (init uses a thin rule above each section).
+  - **Brand logo hidden.** `.v2-header-brand > svg { display: none }` in terminal mode. The `$ boomerang_` text prompt is identity enough; the visual payload of the SVG conflicts with the bare-text feel everywhere else.
+  - **Section hairlines.** Any `.v2-section-label` preceded by a `.v2-card` or `.v2-card-swipe-wrap` gets `border-top: 1px solid hairline` + extra top padding. The first section in a list (which has no preceding card) doesn't get the rule, so the page top stays clean.
+  - Modified: `src/v2/terminal/init.css`, `wiki/Version-History.md`
+
 - style(ui): terminal theme — per-section sigils + sigil+text action buttons [S]
   - **Why.** Locked-in design decisions from a four-question round: per-section sigils to differentiate sections at a glance (vs the uniform `✦`), and sigil+text action buttons to read as powerlevel10k segments (vs flat bracketed text). Energy chip stays top-right; status indicators stay leading-bracket — those were already right.
   - **`SectionLabel.jsx` accepts a `sigil` prop.** Defaults to `✦` (light/dark see uniform sparkle, no behavior change). The bullet span renders `✦` as inline text AND carries `data-sigil={sigil}` as an attribute. Light/dark CSS shows the inline text. Terminal CSS reads `attr(data-sigil)` via `::before`. Cost: one prop, JSX stays minimal.


### PR DESCRIPTION
## Summary

Two misfits noticed in side-by-side vs init:

1. **Orange `v` brand SVG** sitting next to `$ boomerang` — modern brand mark on a CLI aesthetic, wrong vibe.
2. **Section spacing was whitespace-only** — init uses a thin rule above each group; whitespace alone wasn't doing enough visual work.

## Changes

- `.v2-header-brand > svg { display: none }` in terminal mode. The `$ boomerang_` prompt is identity enough.
- Any `.v2-section-label` preceded by a `.v2-card` or `.v2-card-swipe-wrap` gets `border-top: 1px solid hairline` + extra top padding. First section (no preceding card) stays flush.

CSS-only, terminal-only. Light + dark untouched.

https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_