### PR TITLE
feat(ui): terminal — home stats line + auto-enable WeekStrip + restore brand mark

### DIFF
--- a/src/v2/AppV2.jsx
+++ b/src/v2/AppV2.jsx
@@ -42,6 +42,7 @@ import { useTrelloSync } from '../hooks/useTrelloSync'
 import { useNotionSync } from '../hooks/useNotionSync'
 import { useGCalSync } from '../hooks/useGCalSync'
 import { useKeyboardShortcuts } from '../hooks/useKeyboardShortcuts'
+import { useTerminalMode } from './hooks/useTerminalMode'
 import { inferSize, trelloUpdateCard, serverSkipAdvanceTask } from '../api'
 import { loadLabels, loadSettings, saveSettings, saveLabels, sortTasks, computeDailyStats, computeStreak, computeRoutineStreak, logActivity } from '../store'
 import './AppV2.css'
@@ -78,6 +79,7 @@ export default function AppV2() {
   // same thread. Server session TTL still governs the staged-plan life.
   const adviserState = useAdviser()
   const isDesktop = useIsDesktop()
+  const isTerminal = useTerminalMode()
   const weather = useWeather()
 
   // Mark the document so v2-namespaced tokens activate. Also apply the saved
@@ -671,7 +673,26 @@ export default function AppV2() {
           />
         ) : (
           <div className="v2-list">
-            {settingsForRings.show_week_strip && (
+            {/* Terminal home header: date + streak + today's progress as a
+              * single powerlevel10k-style segmented line. Only renders in
+              * terminal mode; light/dark have the mini-rings in the app
+              * header for the same job. */}
+            {isTerminal && (
+              <div className="v2-terminal-home-stats" aria-hidden="false">
+                <span className="v2-thx-date">
+                  📅 {new Date().toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' })}
+                </span>
+                <span className="v2-thx-sep">·</span>
+                <span className="v2-thx-streak">
+                  🔥 {streak} day{streak === 1 ? '' : 's'}
+                </span>
+                <span className="v2-thx-sep">·</span>
+                <span className="v2-thx-today">
+                  ✓ {dailyStats.tasksToday}/{settingsForRings.daily_task_goal || 3} today
+                </span>
+              </div>
+            )}
+            {(settingsForRings.show_week_strip || isTerminal) && (
               <WeekStrip tasks={tasks} dailyTaskGoal={settingsForRings.daily_task_goal || 3} />
             )}
             {renderSection('Doing', sortedDoing, '→')}
@@ -679,7 +700,7 @@ export default function AppV2() {
             {renderSection('Up next', sortedUpNext, '+')}
             {renderSection('Waiting', sortedWaiting, '…')}
             {renderSection('Snoozed', sortedSnoozed, 'z')}
-            {settingsForRings.show_goal_progress && (
+            {(settingsForRings.show_goal_progress || isTerminal) && (
               <GoalProgressBar tasksToday={dailyStats.tasksToday} goal={settingsForRings.daily_task_goal || 3} />
             )}
           </div>

--- a/src/v2/terminal/init.css
+++ b/src/v2/terminal/init.css
@@ -194,12 +194,10 @@
   color: var(--v2-text-faint);
 }
 
-/* === Brand logo: hide in terminal mode ============================
- * The orange `v` SVG is a brand mark and reads as a misfit on a CLI
- * aesthetic. Hide it; the `$ boomerang` prompt is identity enough. */
-:root[data-ui="v2"][data-theme^="terminal"] .v2-header-brand > svg {
-  display: none !important;
-}
+/* === Brand logo: kept ==============================================
+ * The orange `v` SVG was briefly hidden ("modern brand on a CLI aesthetic"
+ * misfit), but the user's call is to keep it as a deliberate idiosyncrasy.
+ * One drop of brand color next to the `$ boomerang_` prompt. */
 
 /* === Section dividers: hairline between groups ====================
  * Whitespace alone wasn't doing enough visual work to separate
@@ -370,6 +368,46 @@
   right: 12px;
   bottom: max(12px, env(safe-area-inset-bottom, 0px));
   gap: 14px;
+}
+
+/* === Terminal home stats line ======================================
+ * Powerlevel10k-style segmented status line at the top of the task
+ * list, only in terminal mode. Renders date + streak + today's
+ * progress as colored cells:
+ *   📅 Sun, May 10  ·  🔥 14 days  ·  ✓ 3/5 today
+ *
+ * Each segment in a meaningful color: date in muted text, streak in
+ * the high-pri amber (the fire color), today in the success green
+ * (errand-green). Separators in faint text.
+ */
+
+.v2-terminal-home-stats {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px 8px;
+  padding: 12px 0 10px;
+  font: 500 12px/1 var(--v2-font-body);
+  color: var(--v2-text-meta);
+  letter-spacing: 0;
+}
+
+.v2-thx-date {
+  color: var(--v2-text-meta);
+}
+
+.v2-thx-streak {
+  color: var(--v2-alert-high-pri);
+  text-shadow: 0 0 6px rgba(255, 184, 77, 0.35);
+}
+
+.v2-thx-today {
+  color: var(--v2-energy-errand);
+  text-shadow: 0 0 6px rgba(126, 231, 135, 0.35);
+}
+
+.v2-thx-sep {
+  color: var(--v2-text-faint);
 }
 
 /* === Subtle: section-label first-of-kind has less top padding ===== */

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,15 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-10
 
+- feat(ui): terminal — home stats line (date · streak · today) + auto-enable WeekStrip + restore brand mark [S]
+  - **Why.** User's focus shifted to the main section: bring init's calendar + date-progress + fire-streak signals up there. PR-H opt-in surfaces (WeekStrip + GoalProgressBar) get auto-enabled in terminal mode so users don't have to toggle them. New segmented status line at the top renders date + streak + today's progress as three powerlevel10k cells.
+  - **`📅 Sun, May 10  ·  🔥 14 days  ·  ✓ 3/5 today`.** New `.v2-terminal-home-stats` div rendered above the WeekStrip (only in terminal mode). Each cell has a meaningful color: date in muted text, streak in high-pri amber (the fire color, with soft amber glow), today in errand-green (success, with soft green glow). Separators in faint text. Streak comes from existing `computeStreak(tasks, settings)`; today comes from `dailyStats.tasksToday` / `daily_task_goal`. Pluralization handled (`1 day`, `N days`).
+  - **WeekStrip + GoalProgressBar auto-enable in terminal mode.** Previously gated behind `settings.show_week_strip` / `settings.show_goal_progress` (default off). Now `(setting || isTerminal)` flips the gate — terminal mode always renders both. Light/dark users still opt-in via Settings → General → Home screen.
+  - **`useTerminalMode` hook imported in AppV2.** Already existed for `terminalTitle` / `terminalCommand`; now drives the auto-enable + the new stats line.
+  - **Brand `v` logo restored.** Earlier same day it was hidden ("modern brand on CLI aesthetic" misfit), but user's call: keep as a deliberate idiosyncrasy. One drop of brand color next to the prompt is fine.
+  - **Bundle.** CSS 226.7KB gzip 33.5KB (+~0.4KB stats-line CSS). JS 808.2KB gzip 223.8KB (+~0.6KB stats-line JSX + useTerminalMode hook).
+  - Modified: `src/v2/AppV2.jsx`, `src/v2/terminal/init.css`, `wiki/Version-History.md`
+
 - style(ui): terminal theme — hide brand logo + add section dividers [XS]
   - **Why.** Side-by-side check vs init showed two remaining misfits: the orange `v` brand SVG sitting next to the `$ boomerang` prompt (modern brand mark on a CLI aesthetic — wrong vibe) and section spacing relying on whitespace alone, which wasn't doing enough visual work to separate groups (init uses a thin rule above each section).
   - **Brand logo hidden.** `.v2-header-brand > svg { display: none }` in terminal mode. The `$ boomerang_` text prompt is identity enough; the visual payload of the SVG conflicts with the bare-text feel everywhere else.


### PR DESCRIPTION
## Summary

Focus on the main section per user direction. Bring init's calendar + date-progress + fire-streak signals up there. Also revert PR #99's logo-hide — user kept the brand mark as a deliberate idiosyncrasy.

## What changed

**New home stats line** (terminal-only, above WeekStrip):

`📅 Sun, May 10  ·  🔥 14 days  ·  ✓ 3/5 today`

Each cell is a powerlevel10k-style segment with a meaningful color:
- Date — muted text
- Streak — high-pri amber (fire color) + soft amber glow
- Today — errand-green (success) + soft green glow

Streak from existing `computeStreak()`; today from `dailyStats.tasksToday` / `daily_task_goal`. Pluralization handled (`1 day` / `N days`).

**WeekStrip + GoalProgressBar auto-enable in terminal mode.** Previously opt-in via `show_week_strip` / `show_goal_progress` settings (default off). Now `(setting || isTerminal)` flips the gate — terminal mode always renders both. Light/dark users still opt-in via Settings → General → Home screen.

**Brand `v` logo restored.** Earlier same day (PR #99) it was hidden as "modern brand on CLI aesthetic." User's call: keep as a deliberate idiosyncrasy — one drop of brand color next to the prompt is fine.

## Bundle

CSS 226.7KB gzip 33.5KB (+~0.4KB). JS 808.2KB gzip 223.8KB (+~0.6KB).

https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_