### PR TITLE
style(ui): terminal — toolbar buffer + checkbox-style status idiom

### DIFF
--- a/src/v2/terminal/init.css
+++ b/src/v2/terminal/init.css
@@ -247,10 +247,13 @@
   text-shadow: var(--v2-glow);
 }
 
-/* === Filter pills: tighten further to true tabs ==================== */
+/* === Filter pills: tighten further to true tabs ====================
+ * Restore horizontal padding so the first tab doesn't sit flush
+ * against the viewport edge (16px gives the scroll-strip room to
+ * breathe + matches the page's body inset). */
 
 :root[data-ui="v2"][data-theme^="terminal"] .v2-toolbar {
-  padding: 8px 0;
+  padding: 8px 16px;
   gap: 0;
 }
 
@@ -591,6 +594,75 @@
   border: 1px dashed var(--v2-hairline) !important;
   border-radius: 0 !important;
   padding: 10px !important;
+}
+
+/* === EditTaskModal status row: [•] checkbox idiom ================
+ * The status segmented control (`not started / doing / waiting / done`)
+ * renders as filled buttons in light/dark — out of place in terminal.
+ * Strip the chrome and render each option as a checkbox row:
+ *   [•] doing         (active — accent dot)
+ *   [ ] not started   (inactive — empty bracket)
+ *   [ ] waiting
+ *   [ ] done
+ * Mutually exclusive single-pick, so `[•]` (radio dot) instead of `[x]`.
+ * Visually arranges as a vertical column of bracketed text rows. */
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-edit-status-row {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  align-items: stretch;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-edit-status-row .v2-form-seg {
+  background: transparent !important;
+  color: var(--v2-text-meta) !important;
+  border: none !important;
+  border-radius: 0 !important;
+  padding: 6px 8px !important;
+  text-align: left !important;
+  text-transform: lowercase !important;
+  font: 500 13px/1.2 var(--v2-font-body) !important;
+  display: flex !important;
+  align-items: center !important;
+  gap: 8px !important;
+  height: auto !important;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-edit-status-row .v2-form-seg::before {
+  content: "[ ]";
+  color: var(--v2-text-faint);
+  font-weight: 500;
+  letter-spacing: 0;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-edit-status-row .v2-form-seg-active {
+  color: var(--v2-accent) !important;
+  text-shadow: var(--v2-glow);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-edit-status-row .v2-form-seg-active::before {
+  content: "[•]";
+  color: var(--v2-accent);
+  font-weight: 700;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-edit-status-row .v2-form-seg:hover:not(.v2-form-seg-active) {
+  color: var(--v2-text) !important;
+  background: transparent !important;
+}
+
+/* The `✓ Done` row at the bottom keeps its own visual weight — a status
+ * change that ends the task. Render as a bracketed accent text row but
+ * keep the leading checkmark idiom from the JSX. */
+:root[data-ui="v2"][data-theme^="terminal"] .v2-edit-status-done {
+  color: var(--v2-energy-errand) !important;
+  text-shadow: 0 0 6px rgba(126, 231, 135, 0.35);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-edit-status-done::before {
+  content: "[ ]";
+  color: var(--v2-text-faint);
 }
 
 /* === EditTaskModal form labels: // comment style ================= */

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,17 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-10
 
+- style(ui): terminal — toolbar buffer + checkbox-style status idiom [XS]
+  - **Why.** Two specific feedback items: (1) the filter pill scroll-strip at the top of the home was sitting flush against the viewport edge — needed left/right padding to breathe; (2) the EditTaskModal status row (`not started / doing / waiting / done`) still rendered as filled segmented buttons even in terminal mode, which "made zero sense" against the rest of the bare-text aesthetic.
+  - **Toolbar padding.** `padding: 8px 0` from the earlier flatten was too aggressive — restored to `padding: 8px 16px`. The first tab no longer sits flush; the scroll-strip has room to breathe.
+  - **Status row → `[ ]` / `[•]` checkbox column.** In terminal mode, the segmented buttons strip all chrome, become a vertical column of bracketed text rows:
+    - `[•] doing` (active — accent radio dot + glow)
+    - `[ ] not started` (inactive — empty bracket, faint)
+    - `[ ] waiting`
+    - `[ ] done` (kept as its own row from the JSX; green errand-color since it's the completion state)
+  - Mutually exclusive single-pick uses `[•]` (radio dot) rather than `[x]` (checkbox). Hover lifts inactive rows from meta to text color.
+  - Modified: `src/v2/terminal/init.css`, `wiki/Version-History.md`
+
 - feat(ui): terminal — init treatment for modals + theme picker reorg + global Analytics→stats [M]
   - **Why.** "Now put that same treatment on the edit menus, routines, and packages. Also globally replace analytics with stats in the terminal themes." Plus a follow-up: theme picker should be `Standard / Terminal` family with a `Light / Dark` mode underneath, not a flat 4-option strip.
   - **More menu rows** (`AppV2.jsx` + `init.css`). Each row label gets a `data-terminal-cmd` attribute (`$ settings`, `$ projects`, `$ routines`, `$ done`, `$ stats`, `$ log`, `$ import --markdown`). Terminal CSS hides the visible label text (`font-size: 0`) and renders the `$ verb` form via `attr(data-terminal-cmd)` on `::before`. Same pattern as PR F's manage-cluster labels. Hover lights the row's command text in accent + glow. Card chrome on the row dropped — flat with hairline separator below.


### PR DESCRIPTION
## Summary

Two specific feedback items:

1. **Filter pill scroll-strip flush against viewport edge** — `all` was sitting at the screen edge with no left buffer. Restored toolbar horizontal padding (`8px 0` → `8px 16px`). Earlier flatten was too aggressive.

2. **EditTaskModal status row "made zero sense"** — segmented filled buttons still rendered out-of-place against the rest of the bare-text aesthetic. Replaced with `[ ]` / `[•]` checkbox-column idiom:

```
[•] doing            (active — accent radio dot + glow)
[ ] not started      (inactive — empty bracket, faint)
[ ] waiting
[ ] done             (errand-green; kept as its own row from the JSX)
```

Mutually exclusive single-pick → `[•]` radio dot rather than `[x]` checkbox. Hover lifts inactive rows from meta to text color.

CSS-only, terminal-only. Light + dark untouched.

## Bundle

CSS 232.7KB gzip 34.0KB (+~1KB).

https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_