### PR TITLE
style(ui): terminal — checkbox idiom inline, not stacked

### DIFF
--- a/src/v2/terminal/init.css
+++ b/src/v2/terminal/init.css
@@ -596,73 +596,70 @@
   padding: 10px !important;
 }
 
-/* === EditTaskModal status row: [•] checkbox idiom ================
- * The status segmented control (`not started / doing / waiting / done`)
- * renders as filled buttons in light/dark — out of place in terminal.
- * Strip the chrome and render each option as a checkbox row:
- *   [•] doing         (active — accent dot)
- *   [ ] not started   (inactive — empty bracket)
- *   [ ] waiting
- *   [ ] done
- * Mutually exclusive single-pick, so `[•]` (radio dot) instead of `[x]`.
- * Visually arranges as a vertical column of bracketed text rows. */
+/* === Form segmented controls → inline `[ ]` / `[•]` checkboxes ====
+ * Every segmented control in v2 (status, priority, size, energy type,
+ * energy drain) uses `.v2-form-segmented` + `.v2-form-seg`. Filled-
+ * button chrome reads as out-of-place in terminal mode; replace with
+ * inline checkbox notation while keeping the horizontal layout (don't
+ * stack vertically — that wastes too much space).
+ *
+ *   `[•] doing  [ ] not started  [ ] waiting  [ ] done`
+ *
+ * Mutually exclusive single-pick uses `[•]` radio dot rather than `[x]`
+ * checkbox. Wraps to multiple lines if the row doesn't fit. */
 
-:root[data-ui="v2"][data-theme^="terminal"] .v2-edit-status-row {
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-segmented {
   display: flex;
-  flex-direction: column;
-  gap: 4px;
-  align-items: stretch;
+  flex-wrap: wrap;
+  gap: 4px 14px;
+  align-items: center;
 }
 
-:root[data-ui="v2"][data-theme^="terminal"] .v2-edit-status-row .v2-form-seg {
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-seg {
   background: transparent !important;
   color: var(--v2-text-meta) !important;
   border: none !important;
   border-radius: 0 !important;
-  padding: 6px 8px !important;
-  text-align: left !important;
-  text-transform: lowercase !important;
-  font: 500 13px/1.2 var(--v2-font-body) !important;
-  display: flex !important;
-  align-items: center !important;
-  gap: 8px !important;
+  padding: 4px 0 !important;
   height: auto !important;
+  min-width: 0 !important;
+  font: 500 13px/1.2 var(--v2-font-body) !important;
+  text-transform: lowercase !important;
+  display: inline-flex !important;
+  align-items: center !important;
+  gap: 6px !important;
+  flex: 0 0 auto !important;
 }
 
-:root[data-ui="v2"][data-theme^="terminal"] .v2-edit-status-row .v2-form-seg::before {
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-seg::before {
   content: "[ ]";
   color: var(--v2-text-faint);
   font-weight: 500;
   letter-spacing: 0;
 }
 
-:root[data-ui="v2"][data-theme^="terminal"] .v2-edit-status-row .v2-form-seg-active {
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-seg-active {
   color: var(--v2-accent) !important;
   text-shadow: var(--v2-glow);
 }
 
-:root[data-ui="v2"][data-theme^="terminal"] .v2-edit-status-row .v2-form-seg-active::before {
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-seg-active::before {
   content: "[•]";
   color: var(--v2-accent);
   font-weight: 700;
 }
 
-:root[data-ui="v2"][data-theme^="terminal"] .v2-edit-status-row .v2-form-seg:hover:not(.v2-form-seg-active) {
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-seg:hover:not(.v2-form-seg-active) {
   color: var(--v2-text) !important;
   background: transparent !important;
 }
 
-/* The `✓ Done` row at the bottom keeps its own visual weight — a status
- * change that ends the task. Render as a bracketed accent text row but
- * keep the leading checkmark idiom from the JSX. */
+/* The `✓ Done` button in EditTaskModal status keeps its errand-green
+ * so it still reads as the completion action. JSX renders it as the
+ * last child of the segmented container; CSS just colors the row. */
 :root[data-ui="v2"][data-theme^="terminal"] .v2-edit-status-done {
   color: var(--v2-energy-errand) !important;
   text-shadow: 0 0 6px rgba(126, 231, 135, 0.35);
-}
-
-:root[data-ui="v2"][data-theme^="terminal"] .v2-edit-status-done::before {
-  content: "[ ]";
-  color: var(--v2-text-faint);
 }
 
 /* === EditTaskModal form labels: // comment style ================= */

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,17 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-10
 
+- style(ui): terminal — checkbox idiom inline, not stacked [XS]
+  - **Why.** Last PR replaced the status segmented control's filled buttons with `[•] doing` checkbox notation but stacked the options vertically. User: "Buttons don't make sense in terminal but we need to not just stack everything vertically when we eliminate them." The fix: keep horizontal layout, just swap chrome for inline `[ ]` / `[•]` per option.
+  - **Generalized to ALL segmented controls.** Previous rule only targeted `.v2-edit-status-row .v2-form-seg`; new rule targets every `.v2-form-seg` instance. So status, priority (Normal/High/Low), size (XS/S/M/L/XL/Auto), energy type (desk/people/errand/creative/physical), energy drain (low/medium/high) all get the same inline checkbox treatment in terminal mode.
+  - **Layout: `flex-wrap: wrap` keeps horizontal flow.** Options sit on one line at desktop widths, wrap to additional lines on narrow phones. `gap: 4px 14px` (row × column) gives breathing room without ballooning vertically.
+  - **Per-option text:**
+    - Inactive: `[ ] xs` in faint bracket + meta text
+    - Active: `[•] xs` in accent + cyan glow
+    - Hover: text color lifts from meta to text on inactive options
+  - The `✓ Done` row in EditTaskModal status keeps errand-green so it still reads as the completion action.
+  - Modified: `src/v2/terminal/init.css`, `wiki/Version-History.md`
+
 - style(ui): terminal — toolbar buffer + checkbox-style status idiom [XS]
   - **Why.** Two specific feedback items: (1) the filter pill scroll-strip at the top of the home was sitting flush against the viewport edge — needed left/right padding to breathe; (2) the EditTaskModal status row (`not started / doing / waiting / done`) still rendered as filled segmented buttons even in terminal mode, which "made zero sense" against the rest of the bare-text aesthetic.
   - **Toolbar padding.** `padding: 8px 0` from the earlier flatten was too aggressive — restored to `padding: 8px 16px`. The first tab no longer sits flush; the scroll-strip has room to breathe.


### PR DESCRIPTION
## Summary

Last PR stacked status options vertically when swapping the buttons for `[•]` checkbox notation. User: "Buttons don't make sense in terminal but we need to not just stack everything vertically when we eliminate them."

Fix: keep horizontal flow with `flex-wrap`, just swap the chrome.

## What changed

**Generalized to every `.v2-form-seg` instance** — previous rule only caught the EditTaskModal status row. Now applies to all segmented controls in terminal mode:

- Status (`not started / doing / waiting / done`)
- Priority (`normal / high / low`)
- Size (`xs / s / m / l / xl / auto`)
- Energy type (`desk / people / errand / creative / physical`)
- Energy drain (`low / medium / high`)

**Layout:** `flex-wrap: wrap` keeps horizontal flow. `gap: 4px 14px` (row × column) gives breathing room without ballooning vertically. Options sit on one line at desktop widths, wrap to additional lines on narrow phones.

**Per-option text:**
- Inactive: `[ ] xs` (faint bracket + meta text)
- Active: `[•] xs` (accent + cyan glow)
- Hover: meta → text on inactive

The `✓ Done` row in EditTaskModal status keeps errand-green as the completion action.

CSS-only, terminal-only.

https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_