### PR TITLE
feat(ui): terminal — DateField + form polish (energy/auto/research/priority as labels)

### DIFF
--- a/src/v2/components/AddTaskModal.jsx
+++ b/src/v2/components/AddTaskModal.jsx
@@ -3,6 +3,7 @@ import { Sparkles } from 'lucide-react'
 import { loadLabels, getDefaultDueDate, ENERGY_TYPES } from '../../store'
 import { useTaskForm } from '../../hooks/useTaskForm'
 import ModalShell from './ModalShell'
+import DateField from './DateField'
 import './AddTaskModal.css'
 
 const ENERGY_LEVEL_LABELS = [
@@ -89,13 +90,7 @@ export default function AddTaskModal({ open, onAdd, onClose }) {
       <div className="v2-form-row">
         <div className="v2-form-field">
           <label className="v2-form-label">Due</label>
-          <input
-            className="v2-form-input"
-            type="date"
-            value={form.dueDate}
-            min={today}
-            onChange={e => form.setDueDate(e.target.value)}
-          />
+          <DateField value={form.dueDate} onChange={form.setDueDate} min={today} />
         </div>
         <div className="v2-form-field">
           <label className="v2-form-label">Priority</label>

--- a/src/v2/components/DateField.css
+++ b/src/v2/components/DateField.css
@@ -1,0 +1,116 @@
+/* DateField — bracketed text trigger that opens the native date picker.
+ *
+ * Light/dark: looks like a regular form input (bordered rect with the
+ * date or "due date" placeholder text inside). Terminal: collapses to
+ * bare bracketed text. Clear button is plain accent-colored text.
+ *
+ * Hidden input is positioned off-screen but still focusable for the
+ * picker. We call .showPicker() on tap to open the native calendar
+ * without ever rendering the input visually. */
+
+.v2-form-date-field {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.v2-form-date-hidden-input {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  pointer-events: none;
+  border: 0;
+  padding: 0;
+}
+
+/* Light/dark: regular input-styled trigger */
+.v2-form-date-trigger {
+  flex: 1 1 auto;
+  min-height: 44px;
+  padding: 12px 14px;
+  border-radius: 10px;
+  border: 1px solid var(--v2-hairline);
+  background: var(--v2-bg);
+  color: var(--v2-text);
+  font: 400 14px/1.4 var(--v2-font-body);
+  text-align: left;
+  cursor: pointer;
+  transition: border-color var(--v2-dur-quick) var(--v2-ease-standard);
+}
+
+.v2-form-date-trigger:hover {
+  border-color: var(--v2-text-meta);
+}
+
+.v2-form-date-trigger:not(.v2-form-date-trigger-filled) {
+  color: var(--v2-text-meta);
+}
+
+.v2-form-date-clear {
+  background: transparent;
+  border: none;
+  color: var(--v2-text-meta);
+  font: 500 12px/1 var(--v2-font-body);
+  cursor: pointer;
+  padding: 4px 6px;
+  text-transform: lowercase;
+}
+
+.v2-form-date-clear:hover {
+  color: var(--v2-alert-overdue);
+}
+
+/* === Terminal mode ================================================= */
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-date-field {
+  gap: 10px;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-date-trigger {
+  background: transparent !important;
+  border: none !important;
+  border-radius: 0 !important;
+  color: var(--v2-text-meta) !important;
+  padding: 4px 0 !important;
+  min-height: 32px !important;
+  font: 500 13px/1 var(--v2-font-body);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-date-trigger::before {
+  content: "[ ";
+  color: var(--v2-text-faint);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-date-trigger::after {
+  content: " ]";
+  color: var(--v2-text-faint);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-date-trigger-filled {
+  color: var(--v2-accent) !important;
+  text-shadow: var(--v2-glow);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-date-trigger-filled::before,
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-date-trigger-filled::after {
+  color: var(--v2-accent);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-date-trigger:hover {
+  color: var(--v2-text) !important;
+  text-shadow: 0 0 6px rgba(194, 209, 197, 0.3);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-date-clear {
+  color: var(--v2-text-faint) !important;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-date-clear:hover {
+  color: var(--v2-alert-overdue) !important;
+  text-shadow: 0 0 6px rgba(248, 81, 73, 0.4);
+}

--- a/src/v2/components/DateField.jsx
+++ b/src/v2/components/DateField.jsx
@@ -1,0 +1,59 @@
+import { useRef } from 'react'
+import './DateField.css'
+
+// Date picker field that renders as a bracketed text trigger and opens
+// the native calendar picker on tap. Empty: `[ due date ]`. Filled:
+// `[ YYYY-MM-DD ] × clear`. Same UX in every theme — terminal-flat
+// monospace gets it for free since the trigger is just text + the
+// clear button is bracketed text.
+//
+// We hide the actual <input type="date"> off-screen and call
+// `.showPicker()` on tap. Falls back to focus+click if the browser
+// doesn't support showPicker (older Safari, etc.). Modern browsers
+// (iOS 16.4+, Chrome 99+, Firefox 101+) all support it.
+export default function DateField({ value, onChange, min }) {
+  const inputRef = useRef(null)
+
+  const open = () => {
+    const el = inputRef.current
+    if (!el) return
+    if (typeof el.showPicker === 'function') {
+      try { el.showPicker(); return } catch { /* fall through */ }
+    }
+    el.focus()
+    el.click()
+  }
+
+  return (
+    <div className="v2-form-date-field">
+      <button
+        type="button"
+        className={`v2-form-date-trigger${value ? ' v2-form-date-trigger-filled' : ''}`}
+        onClick={open}
+      >
+        {value ? value : 'due date'}
+      </button>
+      {value && (
+        <button
+          type="button"
+          className="v2-form-date-clear"
+          onClick={() => onChange('')}
+          title="Clear due date"
+          aria-label="Clear due date"
+        >
+          × clear
+        </button>
+      )}
+      <input
+        ref={inputRef}
+        type="date"
+        className="v2-form-date-hidden-input"
+        value={value || ''}
+        min={min || undefined}
+        onChange={e => onChange(e.target.value)}
+        tabIndex={-1}
+        aria-hidden="true"
+      />
+    </div>
+  )
+}

--- a/src/v2/components/EditTaskModal.jsx
+++ b/src/v2/components/EditTaskModal.jsx
@@ -5,6 +5,7 @@ import { useTaskForm } from '../../hooks/useTaskForm'
 import { researchTask } from '../../api'
 import WeatherSection, { resolveWeatherVisibility } from '../../components/WeatherSection'
 import ModalShell from './ModalShell'
+import DateField from './DateField'
 import './AddTaskModal.css' // shared form-control styles
 import './EditTaskModal.css'
 
@@ -373,13 +374,7 @@ export default function EditTaskModal({ task, onSave, onClose, onDelete, onBackl
       <div className="v2-form-row">
         <div className="v2-form-field">
           <label className="v2-form-label">Due</label>
-          <input
-            className="v2-form-input"
-            type="date"
-            value={form.dueDate}
-            min={today}
-            onChange={e => form.setDueDate(e.target.value)}
-          />
+          <DateField value={form.dueDate} onChange={form.setDueDate} min={today} />
         </div>
         <div className="v2-form-field">
           <label className="v2-form-label">Priority</label>

--- a/src/v2/terminal/init.css
+++ b/src/v2/terminal/init.css
@@ -388,11 +388,13 @@
   display: flex;
   flex-wrap: wrap;
   align-items: center;
+  justify-content: center;
   gap: 6px 8px;
   padding: 12px 0 10px;
   font: 500 12px/1 var(--v2-font-body);
   color: var(--v2-text-meta);
   letter-spacing: 0;
+  text-align: center;
 }
 
 .v2-thx-date {
@@ -980,23 +982,135 @@
   color: var(--v2-accent);
 }
 
-/* Research button + comment input button + similar inline action buttons
- * inside EditTaskModal's content blocks. They use various class names
- * but share the v1 inline pill shape. */
-:root[data-ui="v2"][data-theme^="terminal"] .v2-edit-research-btn,
-:root[data-ui="v2"][data-theme^="terminal"] .v2-edit-research-row button {
+/* AI / Auto / Polish / Research pills — bracketed accent text. The
+ * sparkle icon stays as a visual cue, the chrome drops. */
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-ai-pill,
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-ai-pill-inline {
+  background: transparent !important;
+  border: none !important;
+  border-radius: 0 !important;
+  padding: 4px 0 !important;
+  color: var(--v2-accent) !important;
+  font: 500 12px/1 var(--v2-font-body) !important;
+  text-transform: lowercase;
+  text-shadow: var(--v2-glow);
+  height: auto !important;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-ai-pill::before {
+  content: "[ ";
+  color: var(--v2-accent);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-ai-pill::after {
+  content: " ]";
+  color: var(--v2-accent);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-ai-pill:hover:not(:disabled) {
+  background: transparent !important;
+  filter: none;
+  text-shadow: 0 0 12px rgba(88, 166, 255, 0.65);
+}
+
+/* Energy type pills — same bracketed treatment as the labels grid.
+ * Inline `style={{ borderColor, color }}` from the JSX leaks the
+ * energy-type color through, which is what we want — the active pill
+ * gets its energy color rather than the generic accent. */
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-energy-grid {
+  flex-wrap: wrap;
+  gap: 4px 12px;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-energy-pill {
+  background: transparent !important;
+  border: none !important;
+  border-radius: 0 !important;
+  padding: 4px 0 !important;
+  height: auto !important;
+  flex: 0 0 auto !important;
+  color: var(--v2-text-meta) !important;
+  font: 500 13px/1.2 var(--v2-font-body) !important;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-energy-pill::before {
+  content: "[ ";
+  color: var(--v2-text-faint);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-energy-pill::after {
+  content: " ]";
+  color: var(--v2-text-faint);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-energy-pill:hover {
+  background: transparent !important;
+  color: var(--v2-text) !important;
+}
+
+/* Active energy pill — keep the inline color (energy-type) but drop the
+ * border. The text + brackets already pick up the inline color via
+ * cascade since JSX sets `style={{ color: et.color }}`. */
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-energy-pill-active {
+  background: transparent !important;
+  border-width: 0 !important;
+  text-shadow: 0 0 8px currentColor;
+}
+
+/* The Research toggle button is also `.v2-form-ai-pill` so it gets the
+ * treatment above. Inline research-row "Go" button keeps its accent
+ * bracket treatment. */
+:root[data-ui="v2"][data-theme^="terminal"] .v2-edit-research-go {
   background: transparent !important;
   border: none !important;
   border-radius: 0 !important;
   color: var(--v2-accent) !important;
   text-transform: lowercase;
+  text-shadow: var(--v2-glow);
 }
 
-:root[data-ui="v2"][data-theme^="terminal"] .v2-edit-research-btn::before {
+:root[data-ui="v2"][data-theme^="terminal"] .v2-edit-research-go::before {
   content: "[ ";
   color: var(--v2-accent);
 }
-:root[data-ui="v2"][data-theme^="terminal"] .v2-edit-research-btn::after {
+:root[data-ui="v2"][data-theme^="terminal"] .v2-edit-research-go::after {
   content: " ]";
+  color: var(--v2-accent);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-edit-research-go:hover:not(:disabled) {
+  filter: none;
+  text-shadow: 0 0 12px rgba(88, 166, 255, 0.65);
+}
+
+/* Priority toggle — refine the previous pass. Show the priority text
+ * wrapped in brackets so it reads as a label, not a button. */
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-pri-toggle {
+  border-bottom: none !important;
+  padding: 4px 0 !important;
+  font: 500 13px/1.2 var(--v2-font-body) !important;
+  color: var(--v2-text) !important;
+  height: auto !important;
+  min-height: 32px !important;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-pri-toggle::before {
+  content: "[ ";
+  color: var(--v2-text-faint);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-pri-toggle::after {
+  content: " ]";
+  color: var(--v2-text-faint);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-pri-toggle:hover {
+  background: transparent !important;
+  color: var(--v2-accent) !important;
+  text-shadow: var(--v2-glow);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-pri-toggle:hover::before,
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-pri-toggle:hover::after {
   color: var(--v2-accent);
 }

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,19 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-10
 
+- feat(ui): terminal — DateField + form polish (energy/auto/research/priority as labels) [S]
+  - **Why.** User feedback: "Center up the calendar row at the top. Energy type should look like labels. Same with auto, research and priority. I think date should just be the word [due date] and have it open a calendar picker. Once picked, Date format should be YYYY-MM-DD. Give me an option to clear the due date."
+  - **`DateField` (new component).** Replaces the bare `<input type="date">` in AddTaskModal + EditTaskModal. Renders as a `[ due date ]` placeholder when empty, `[ YYYY-MM-DD ]` when filled, with an inline `× clear` button (only visible when filled). Tap the trigger → calls `.showPicker()` on a hidden off-screen `<input type="date">`; falls back to focus+click for older browsers. Modern support is iOS 16.4+ / Chrome 99+ / Firefox 101+, which covers what Boomerang targets. Same UX in light/dark (looks like a regular input rect with the placeholder/value text inside) and terminal (collapses to bare bracketed text).
+  - **Energy type, Auto, Research, Priority → bracketed labels.** Earlier passes only stripped some of these. This pass generalizes:
+    - `.v2-form-energy-pill` → `[ desk ]` / `[ people ]` / `[ errand ]` / etc. — active state keeps the inline energy-type color (so the segment legend on the form matches the chip color on the card row)
+    - `.v2-form-ai-pill` (Auto, Polish, Research toggle) → `[ auto ]` / `[ polish ]` / `[ research ]` accent text + glow
+    - `.v2-edit-research-go` (the inline "Go" inside the research input row) → `[ go ]` accent
+    - `.v2-form-pri-toggle` → `[ normal ]` / `[ ↑ high ]` / `[ ↓ low ]` bracket text; hover lifts to accent + glow
+  - **Center home-stats line.** `.v2-terminal-home-stats` was left-aligned by the default `flex` flow. Added `justify-content: center` + `text-align: center` so the date · streak · today line sits centered above the calendar.
+  - **Bundle.** CSS 244.0KB gzip 35.0KB (+~3KB for energy/ai-pill/priority/date-field overrides). JS 810.5KB gzip 224.4KB (+~1KB for the new DateField component).
+  - Modified: `src/v2/components/AddTaskModal.jsx`, `src/v2/components/EditTaskModal.jsx`, `src/v2/terminal/init.css`, `wiki/Version-History.md`
+  - Added: `src/v2/components/DateField.jsx`, `src/v2/components/DateField.css`
+
 - fix(adviser): render assistant markdown as React nodes, not HTML [XS]
   - **Bug.** Quokka assistant messages were rendering as the literal string `[object Object]` whenever the message content was non-empty. Reproduced consistently on multi-step plan responses (the screenshot the user reported was a "Combine the two UPS drop off tasks" plan where the assistant text bubble between the tool calls and the planned changes showed `[object Object]`).
   - **Root cause.** `AdviserModal.jsx` used `dangerouslySetInnerHTML={{ __html: renderMarkdown(message.content) }}`, but `renderMarkdown()` (in `src/utils/renderMarkdown.js`) returns **React nodes**, not an HTML string. Assigning a React element to `innerHTML` calls the element's `toString()` which produces `[object Object]`.


### PR DESCRIPTION
## Summary

Four feedback items addressed in one push:

1. **Center the calendar row at top** — home-stats line was left-aligned
2. **Energy type → bracketed labels** — same idiom as the labels grid below
3. **Auto / Research / Priority → labels** — same treatment
4. **Date input → `[ due date ]` text trigger + native picker + clear button + YYYY-MM-DD format**

## What changed

### `DateField` (new component)

Replaces the raw `<input type="date">` in AddTaskModal + EditTaskModal. Renders:
- Empty: `[ due date ]` (bracketed placeholder, meta color)
- Filled: `[ 2026-05-15 ]` accent + glow + inline `× clear` button

Tap → `.showPicker()` on a hidden off-screen `<input type="date">`. Falls back to focus+click for older browsers. Modern support: iOS 16.4+ / Chrome 99+ / Firefox 101+.

Same UX in every theme — light/dark renders the trigger as a regular input rect; terminal collapses to bare bracketed text for free.

### Form pill → label sweep

| Class | Before | After (terminal) |
|---|---|---|
| `.v2-form-energy-pill` | bordered chrome | `[ desk ] [ people ] [ errand ]` — active keeps inline energy color |
| `.v2-form-ai-pill` (Auto / Polish / Research toggle) | filled accent pill | `[ auto ]` / `[ polish ]` / `[ research ]` accent + glow |
| `.v2-edit-research-go` (inline Go button) | filled accent | `[ go ]` accent |
| `.v2-form-pri-toggle` | bottom-bordered text pill | `[ normal ]` / `[ ↑ high ]` / `[ ↓ low ]` hover-lifts to accent |

### Centered home-stats

`.v2-terminal-home-stats` was using default flex layout. Added `justify-content: center` + `text-align: center` so the `📅 Sun, May 10  ·  🔥 0 days  ·  ✓ 0/3 today` line sits centered above the calendar.

## Bundle

CSS 244.0KB gzip 35.0KB (+~3KB). JS 810.5KB gzip 224.4KB (+~1KB).

https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_