### PR TITLE
fix(ui): edit modal — done status didn't show active state

### DIFF
--- a/src/v2/components/EditTaskModal.jsx
+++ b/src/v2/components/EditTaskModal.jsx
@@ -228,7 +228,7 @@ export default function EditTaskModal({ task, onSave, onClose, onDelete, onBackl
             </button>
           ))}
           <button
-            className="v2-form-seg v2-edit-status-done"
+            className={`v2-form-seg v2-edit-status-done${currentStatus === 'done' ? ' v2-form-seg-active' : ''}`}
             onClick={() => handleStatusChange('done')}
             title="Mark complete"
           >

--- a/src/v2/terminal/init.css
+++ b/src/v2/terminal/init.css
@@ -664,6 +664,22 @@
   text-shadow: 0 0 6px rgba(126, 231, 135, 0.35);
 }
 
+/* When the task IS done, the done button gets `.v2-form-seg-active`
+ * (added in JSX) — the generic seg-active rule turns the [•] dot and
+ * text accent-blue. Override here so done's selected state stays in
+ * the errand-green family (matches the green-on-not-done resting
+ * color but brightens the dot + adds a stronger glow). */
+:root[data-ui="v2"][data-theme^="terminal"] .v2-edit-status-done.v2-form-seg-active {
+  color: var(--v2-energy-errand) !important;
+  text-shadow: 0 0 10px rgba(126, 231, 135, 0.6);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-edit-status-done.v2-form-seg-active::before {
+  content: "[•]";
+  color: var(--v2-energy-errand);
+  font-weight: 700;
+}
+
 /* === EditTaskModal form labels: // comment style ================= */
 
 :root[data-ui="v2"][data-theme^="terminal"] .v2-form-label {

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,12 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-10
 
+- fix(ui): edit modal — done status didn't show active state [XS]
+  - **Bug.** In EditTaskModal's status row, the `✓ Done` button never showed as "selected" even when the task's current status was `done`. The user reported it as "done checkmark doesn't show up when checked; selected vs not may be inverted."
+  - **Root cause.** `STATUS_OPTIONS` only contains `['not_started', 'doing', 'waiting']`, and the JSX threads the active class via `currentStatus === s ? ' v2-form-seg-active' : ''` only on the map. The `✓ Done` button is rendered outside the map as a separate "mark complete" affordance and hardcodes `className="v2-form-seg v2-edit-status-done"` with no active-state branch. Result: when `status === 'done'`, none of the four options showed the `[•]` radio dot — nothing read as currently selected.
+  - **Fix.** Add `${currentStatus === 'done' ? ' v2-form-seg-active' : ''}` to the done button's className. Terminal CSS gains an override so the `v2-edit-status-done.v2-form-seg-active` state stays in the errand-green family (`[•]` dot + stronger green glow) rather than flipping to the generic accent-blue from `.v2-form-seg-active`.
+  - Modified: `src/v2/components/EditTaskModal.jsx`, `src/v2/terminal/init.css`, `wiki/Version-History.md`
+
 - chore(ui): terminal — root-cause + sweep 32 missed button classes + add coverage guard [S]
   - **Why.** User asked why energy/auto/research/priority got missed in earlier "comprehensive button strip" passes and to proactively scan for others. Root cause analysis below; sweep covers everything found; new smoke test prevents it happening again.
   - **Root cause.** When earlier passes "generalized" the button strip, they only targeted **shared** classes (`.v2-form-seg`, `.v2-card-action`, `.v2-form-input`). v2 has several **custom-class** button shapes that exist as their own class because they needed unique sizing/icon rules: `.v2-form-energy-pill` (flex sharing), `.v2-form-ai-pill` (sparkle icon variant), `.v2-form-pri-toggle` (cycling state), `.v2-analytics-range-btn`, `.v2-adviser-history-btn`, `.v2-package-action`, etc. The generic rules never matched them. Plus I never opened AnalyticsModal, full ReframeModal, the Labels CRUD modal, or notification settings rows during this session — so their entire button surfaces never got swept.


### PR DESCRIPTION
## Bug

In EditTaskModal's status row, the `✓ Done` button never showed as "selected" even when the task's current status was `done`. User: "done checkmark doesn't show up when checked; selected vs not may be inverted."

## Root cause

`STATUS_OPTIONS = ['not_started', 'doing', 'waiting']`. The JSX threads `.v2-form-seg-active` only on the `.map()`:

```jsx
{STATUS_OPTIONS.map(s => (
  <button className={`v2-form-seg${currentStatus === s ? ' v2-form-seg-active' : ''}`} ...>
))}
```

The `✓ Done` button is rendered **outside** the map as a separate "mark complete" affordance and hardcodes `className="v2-form-seg v2-edit-status-done"` with no active branch. Result: when `status === 'done'`, none of the four options showed the `[•]` radio dot — nothing read as currently selected.

## Fix

Add the active-state branch to the done button's className:

```jsx
className={`v2-form-seg v2-edit-status-done${currentStatus === 'done' ? ' v2-form-seg-active' : ''}`}
```

Terminal CSS gains an override so `.v2-edit-status-done.v2-form-seg-active` stays in the errand-green family (`[•]` dot + stronger green glow) rather than flipping to the generic accent-blue from `.v2-form-seg-active`.

Net effect:
- `[ ] ✓ done` (green text, faint bracket) when task is not done
- `[•] ✓ done` (green dot + green text + strong green glow) when task is done

CSS-only fix beyond the one-line JSX className change. Light + dark unaffected.

https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_