### PR TITLE
fix(sync): preserve local theme on server hydration

### DIFF
--- a/src/hooks/useServerSync.js
+++ b/src/hooks/useServerSync.js
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
-import { saveTasks, saveRoutines, saveSettings, saveLabels, uuid } from '../store'
+import { saveTasks, saveRoutines, saveSettings, saveLabels, loadSettings, uuid } from '../store'
 import { serverCreateTask, serverUpdateTask, serverDeleteTask,
   serverCreateRoutine, serverUpdateRoutine, serverDeleteRoutine } from '../api'
 
@@ -303,7 +303,18 @@ export function useServerSync(tasks, routines, onHydrate, onVersionMismatch) {
           onHydrate(data)
           if (data.tasks) saveTasks(data.tasks)
           if (data.routines) saveRoutines(data.routines)
-          if (data.settings) saveSettings(data.settings)
+          if (data.settings) {
+            // Preserve local theme. Theme is device-local (laptop vs phone vs
+            // tablet have different ergonomics; user might prefer terminal on
+            // one device and light on another). Without this guard, a
+            // hydration that lands within ~300ms of a theme pick can overwrite
+            // the just-saved local theme with stale server data and the
+            // preference appears to revert on refresh.
+            const localTheme = (loadSettings() || {}).theme
+            const merged = { ...data.settings }
+            if (localTheme) merged.theme = localTheme
+            saveSettings(merged)
+          }
           if (data.labels) saveLabels(data.labels)
           prevTasks.current = data.tasks || []
           prevRoutines.current = data.routines || []

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,13 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-10
 
+- fix(sync): preserve local theme on server hydration [XS]
+  - **Bug.** Terminal mode preference didn't persist on refresh. User picks Terminal in Settings → Theme; refresh; back to the previous theme.
+  - **Root cause.** `useServerSync.js` hydration path called `saveSettings(data.settings)` unconditionally on every SSE-triggered server fetch. If a refresh landed within the ~300ms debounce window between a local theme pick and the server flush — OR if the server was briefly unreachable when the flush fired — the hydration would overwrite the just-saved local theme with stale server data. The preference appeared to revert.
+  - **Fix.** Theme is now device-local: hydrate preserves whatever local theme value was set before the hydrate ran. The reasoning: different devices have different ergonomics (laptop vs phone vs tablet) and the user might genuinely want terminal on one device and light on another. First-install case (no local theme yet) still adopts the server's theme — only an explicitly-set local theme blocks server overwrite.
+  - Other settings (notification preferences, integration tokens, etc.) still sync through the bulk path. Theme is the only key the hydrate now ignores from the server.
+  - Modified: `src/hooks/useServerSync.js`, `wiki/Version-History.md`
+
 - fix(ui): edit modal — done status didn't show active state [XS]
   - **Bug.** In EditTaskModal's status row, the `✓ Done` button never showed as "selected" even when the task's current status was `done`. The user reported it as "done checkmark doesn't show up when checked; selected vs not may be inverted."
   - **Root cause.** `STATUS_OPTIONS` only contains `['not_started', 'doing', 'waiting']`, and the JSX threads the active class via `currentStatus === s ? ' v2-form-seg-active' : ''` only on the map. The `✓ Done` button is rendered outside the map as a separate "mark complete" affordance and hardcodes `className="v2-form-seg v2-edit-status-done"` with no active-state branch. Result: when `status === 'done'`, none of the four options showed the `[•]` radio dot — nothing read as currently selected.


### PR DESCRIPTION
## Bug

Terminal mode preference didn't persist on refresh. User picks Terminal in Settings → Theme, refreshes the page, and the theme reverts to whatever was there before.

## Root cause

`useServerSync.js` hydration path called `saveSettings(data.settings)` unconditionally on every SSE-triggered server fetch:

```js
if (data.settings) saveSettings(data.settings)
```

Race window: the SettingsModal calls `update('theme', value)` which writes to localStorage immediately AND fires a `flushSync` after a 300ms debounce. If a refresh lands during that 300ms — OR if the server was briefly unreachable when the flush fired — the hydration's `saveSettings(data.settings)` overwrites the just-saved local theme with stale server data.

The visual manifestation: local picks terminal → 300ms hasn't passed → user refreshes → pre-paint correctly reads `'terminal-dark'` from localStorage and applies it → SSE hydrate runs → reads stale `'dark'` from server → writes it back to localStorage → **next** refresh shows dark.

## Fix

Theme is now device-local. Hydrate merges server settings but **preserves the local theme** if one is explicitly set:

```js
if (data.settings) {
  const localTheme = (loadSettings() || {}).theme
  const merged = { ...data.settings }
  if (localTheme) merged.theme = localTheme
  saveSettings(merged)
}
```

First-install case (no local theme yet) still adopts the server's theme. Only an explicitly-set local theme blocks server overwrite.

## Reasoning

Different devices have different ergonomics — a user might genuinely want terminal on one device and light/dark on another. Theme is the only key the hydrate now ignores from the server. Notification preferences, integration tokens, daily goals, etc. all still sync through the bulk path.

https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_