### PR TITLE
feat(ui): terminal — clickable [ ] checkbox + drop duplicate done affordances

### DIFF
--- a/src/v2/components/TaskCard.jsx
+++ b/src/v2/components/TaskCard.jsx
@@ -5,6 +5,7 @@ import {
   formatSnoozeLabel, formatDueDate, daysOld, ENERGY_TYPES,
 } from '../../store'
 import WeatherBadge from './WeatherBadge'
+import { useTerminalMode } from '../hooks/useTerminalMode'
 import './TaskCard.css'
 
 const ENERGY_ICONS = { Monitor, Users, MapPin, Palette, Dumbbell }
@@ -17,6 +18,7 @@ const SWIPE_OPEN_OFFSET = -160   // resting position when actions are revealed; 
 const SWIPE_VERT_CANCEL = 12     // px of vertical movement that cancels the swipe
 
 function TaskCard({ task, expanded, onToggleExpand, onComplete, onEdit, onSnooze, onSkipAdvance, weatherByDate, selected, routineStreaks }) {
+  const isTerminal = useTerminalMode()
   const overdue = isOverdue(task)
   const stale = isStale(task)
   const snoozed = isSnoozed(task)
@@ -69,11 +71,16 @@ function TaskCard({ task, expanded, onToggleExpand, onComplete, onEdit, onSnooze
   }, [])
 
   const handleTouchStart = useCallback((e) => {
+    // Terminal mode replaces the swipe-action gesture with a tappable
+    // `[ ]` checkbox + expanded action row. Bail early to keep the
+    // gesture from stealing taps that should expand or check off.
+    if (isTerminal) return
     const t = e.touches[0]
     touchStart.current = { x: t.clientX, y: t.clientY, startX: swipeX }
-  }, [swipeX])
+  }, [swipeX, isTerminal])
 
   const handleTouchMove = useCallback((e) => {
+    if (isTerminal) return
     if (!touchStart.current) return
     const t = e.touches[0]
     const dx = t.clientX - touchStart.current.x
@@ -90,7 +97,7 @@ function TaskCard({ task, expanded, onToggleExpand, onComplete, onEdit, onSnooze
       // close it but never go past 0.
       setSwipeX(Math.max(-160, Math.min(0, next)))
     }
-  }, [swiping])
+  }, [swiping, isTerminal])
 
   const handleTouchEnd = useCallback(() => {
     if (!touchStart.current) { setSwiping(false); return }
@@ -155,6 +162,25 @@ function TaskCard({ task, expanded, onToggleExpand, onComplete, onEdit, onSnooze
       <button type="button" className="v2-card-main" onClick={onMainClick}>
         <div className="v2-card-content">
           <div className="v2-card-title">
+            {/* Clickable checkbox — visible in terminal mode only, hidden in
+              * light/dark via CSS. Renders `[ ]` / `[!]` / `[*]` per the
+              * task's overdue/high-pri state via ::before; tap toggles done.
+              * Uses span+role=button so it can nest inside .v2-card-main
+              * (which is already a <button>). */}
+            <span
+              role="button"
+              tabIndex={0}
+              className="v2-card-checkbox"
+              aria-label={`Mark "${task.title}" done`}
+              onClick={(e) => { e.stopPropagation(); onComplete(task.id) }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault()
+                  e.stopPropagation()
+                  onComplete(task.id)
+                }
+              }}
+            />
             {task.title}
             {totalItems > 0 && (
               <span className="v2-card-checklist-inline" aria-label={`${checkedItems} of ${totalItems} checklist items done`}>

--- a/src/v2/terminal/cards.css
+++ b/src/v2/terminal/cards.css
@@ -9,12 +9,14 @@
  *     glow falls back to `none` in terminal-light)
  */
 
-:root[data-ui="v2"][data-theme^="terminal"] .v2-card-title::before {
-  content: "[ ] ";
-  color: var(--v2-text-meta);
-  font-weight: 500;
-  letter-spacing: 0;
-}
+/* The `[ ]` / `[!]` / `[*]` title prefix is rendered by the
+ * `.v2-card-checkbox` <span role="button"> element (see TaskCard.jsx)
+ * so the user can tap it to complete the task. Title text itself no
+ * longer carries a ::before; checkbox CSS lives in flatten.css /
+ * init.css next to the rest of the checkbox styling.
+ *
+ * Left intentionally empty — the structural prefix moved to a real
+ * interactive element. */
 
 :root[data-ui="v2"][data-theme^="terminal"] .v2-card-action-primary {
   box-shadow: var(--v2-glow);

--- a/src/v2/terminal/flatten.css
+++ b/src/v2/terminal/flatten.css
@@ -65,17 +65,11 @@
   border-left: none;
 }
 
-:root[data-ui="v2"][data-theme^="terminal"] .v2-card-overdue .v2-card-title::before {
-  content: "[!] ";
-  color: var(--v2-alert-overdue);
-  font-weight: 700;
-}
-
-:root[data-ui="v2"][data-theme^="terminal"] .v2-card-high-pri .v2-card-title::before {
-  content: "[*] ";
-  color: var(--v2-alert-high-pri);
-  font-weight: 700;
-}
+/* Status: `[!]` and `[*]` glyphs are now rendered by the `.v2-card-
+ * checkbox` ::before (see Clickable checkbox block at end of this
+ * file). The colored title-prefix rules below were the old behavior
+ * before the checkbox became interactive — kept empty here so the
+ * cascade resolves correctly. */
 
 /* Energy chip → inline icon + bolts, no pill bg */
 :root[data-ui="v2"][data-theme^="terminal"] .v2-card-energy {

--- a/src/v2/terminal/init.css
+++ b/src/v2/terminal/init.css
@@ -339,11 +339,85 @@
   outline: none;
 }
 
-/* === Card title: drop the `[ ] ` prefix when status indicator
- *      already provides one ([!] / [*]) so we don't double-up. */
-:root[data-ui="v2"][data-theme^="terminal"] .v2-card-overdue .v2-card-title::before,
-:root[data-ui="v2"][data-theme^="terminal"] .v2-card-high-pri .v2-card-title::before {
-  /* keep the override from flatten.css — already correct */
+/* === Clickable checkbox =============================================
+ *
+ * Tappable `[ ]` / `[!]` / `[*]` element before the title. JSX renders
+ * a `<span role="button" className="v2-card-checkbox">`. CSS hides it
+ * in light/dark (the existing card chrome carries the done affordance
+ * there) and renders the bracketed glyph via ::before in terminal mode.
+ *
+ * On click → onComplete(task.id). The :active state flips to `[✓]`
+ * green for a moment so the user sees the toggle land before the task
+ * disappears from the list. Click bubbling is stopped in JSX so taps
+ * here don't also expand the card. */
+
+.v2-card-checkbox {
+  display: none;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-checkbox {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: none;
+  padding: 0;
+  margin-right: 8px;
+  cursor: pointer;
+  font: 500 14px/1.35 var(--v2-font-body);
+  vertical-align: baseline;
+  color: var(--v2-text-meta);
+  /* Generous tap target without bloating visual size — extends the
+   * hit zone with negative-margin padding. */
+  min-width: 32px;
+  min-height: 32px;
+  margin-left: -4px;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-checkbox::before {
+  content: "[ ]";
+  color: var(--v2-text-meta);
+  font-weight: 500;
+  letter-spacing: 0;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-overdue .v2-card-checkbox::before {
+  content: "[!]";
+  color: var(--v2-alert-overdue);
+  font-weight: 700;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-high-pri .v2-card-checkbox::before {
+  content: "[*]";
+  color: var(--v2-alert-high-pri);
+  font-weight: 700;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-checkbox:hover::before {
+  color: var(--v2-accent);
+  text-shadow: 0 0 6px rgba(88, 166, 255, 0.5);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-checkbox:active::before {
+  content: "[✓]";
+  color: var(--v2-energy-errand);
+  text-shadow: 0 0 8px rgba(126, 231, 135, 0.55);
+}
+
+/* === Drop the `✓ done` button in the expanded action row ===========
+ * The clickable checkbox at the top of the card handles done now.
+ * Keeping a second affordance in expand is duplication. */
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-action-primary {
+  display: none !important;
+}
+
+/* === Hide the swipe-left action panel ==============================
+ * Terminal mode replaces swipe-to-Done/Edit with the visible checkbox
+ * + expand-actions pattern. The swipe gesture itself is short-
+ * circuited in JSX (handleTouchStart bails on isTerminal), but we
+ * also hide the visual panel in case any stale state lingers. */
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-swipe-actions {
+  display: none !important;
 }
 
 /* === Card title spacing: fix tap target leakage ==================== */

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,15 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-10
 
+- feat(ui): terminal — clickable `[ ]` checkbox + drop duplicate done affordances [S]
+  - **Why.** User: "I should be able to click on the empty check box squares on the tasks page and have them be marked as done. I know that is duplicative of the done slider and done button. Wondering if it actually mitigates the need for those. Thoughts? Edit and done on click AND slide already feel a little duplicative." Locked-in answer after a 2-question round: tap `[ ]` toggles done; drop `✓ done` from expanded actions; drop swipe-left gestures entirely. Terminal mode only.
+  - **JSX.** Added a `<span role="button" className="v2-card-checkbox">` before the title text in TaskCard. Click handler stops propagation (so taps don't also expand the card) and calls `onComplete(task.id)`. Keyboard accessible via Enter/Space. Used `<span role="button">` rather than `<button>` because TaskCard's outer `.v2-card-main` is already a `<button>` and HTML doesn't allow nested buttons. Light/dark mode hides the element via `display: none`.
+  - **CSS.** The existing `[ ]` / `[!]` / `[*]` glyphs that previously rendered on `.v2-card-title::before` moved to `.v2-card-checkbox::before` (so the user is tapping a real DOM element, not a pseudo-element). Hover lifts the bracket to accent + glow. Active state flips to `[✓]` errand-green so the tap lands visibly before the task disappears from the list. `.v2-card-action-primary` (the `✓ done` button in expand) is `display: none` in terminal — duplicate of the checkbox. `.v2-card-swipe-actions` panel hidden too.
+  - **Gesture.** `handleTouchStart` and `handleTouchMove` short-circuit when `useTerminalMode()` is true so the swipe gesture itself never engages. Light/dark themes keep swipe.
+  - **Expand actions in terminal now show:** `☾ snooze` + `✎ edit` (+ `↷ skip` for chain tasks). Done is no longer here — the checkbox at the top is the canonical way.
+  - **Tap target.** Checkbox has `min-width: 32px` and `min-height: 32px` with negative `margin-left: -4px` to extend the hit zone slightly past the visual `[ ]` width without changing layout.
+  - Modified: `src/v2/components/TaskCard.jsx`, `src/v2/terminal/cards.css`, `src/v2/terminal/flatten.css`, `src/v2/terminal/init.css`, `wiki/Version-History.md`
+
 - fix(sync): preserve local theme on server hydration [XS]
   - **Bug.** Terminal mode preference didn't persist on refresh. User picks Terminal in Settings → Theme; refresh; back to the previous theme.
   - **Root cause.** `useServerSync.js` hydration path called `saveSettings(data.settings)` unconditionally on every SSE-triggered server fetch. If a refresh landed within the ~300ms debounce window between a local theme pick and the server flush — OR if the server was briefly unreachable when the flush fired — the hydration would overwrite the just-saved local theme with stale server data. The preference appeared to revert.


### PR DESCRIPTION
## Summary

User: "I should be able to click on the empty check box squares on the tasks page and have them be marked as done. I know that is duplicative of the done slider and done button. Wondering if it actually mitigates the need for those. Thoughts? Edit and done on click AND slide already feel a little duplicative."

Locked-in answers after a 2-question round:
1. Tap `[ ]` toggles done
2. Drop `✓ done` from expanded actions
3. Drop swipe-left gestures entirely
4. Terminal mode only — light/dark keep their existing affordances

## What changed

### JSX (`TaskCard.jsx`)

Added a `<span role="button" className="v2-card-checkbox">` before the title text. Click handler stops propagation (so taps don't also expand the card) and calls `onComplete(task.id)`. Keyboard accessible via Enter/Space.

Used `<span role="button">` rather than a real `<button>` because the outer `.v2-card-main` is already a `<button>` and HTML doesn't allow nested buttons.

### CSS (`terminal/cards.css`, `terminal/flatten.css`, `terminal/init.css`)

The `[ ]` / `[!]` / `[*]` glyphs that previously rendered on `.v2-card-title::before` moved to `.v2-card-checkbox::before`. The user is now tapping a real DOM element, not a pseudo-element.

- Default: `[ ]` faint meta-text
- Overdue: `[!]` red
- High-pri: `[*]` amber
- Hover: lifts to accent + cyan glow
- Active (mid-tap): `[✓]` errand-green — lands visibly before the task disappears

Light/dark hide the element via `display: none` — those themes keep their current card chrome + Done button + swipes.

### Duplicate affordances removed in terminal

- `.v2-card-action-primary` (the `✓ done` button in expand) → `display: none`
- `.v2-card-swipe-actions` panel → `display: none`
- `handleTouchStart` / `handleTouchMove` short-circuit when `useTerminalMode()` is true, so the swipe gesture itself never engages

Expanded action row in terminal now shows only `☾ snooze` + `✎ edit` (plus `↷ skip` for chain tasks). Done is canonical-only via the checkbox.

### Tap target

Checkbox has `min-width: 32px` and `min-height: 32px` with `margin-left: -4px` so the hit zone extends slightly past the visual `[ ]` width without changing layout.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run check:terminal-titles` — OK
- [x] `npm run check:terminal-buttons` — OK
- [x] `npm run build` succeeds
- [ ] Terminal: tap `[ ]` on a task → task completes, row disappears
- [ ] Terminal: tap title text → row expands (not completed)
- [ ] Terminal: expanded card shows snooze + edit only (no done button)
- [ ] Terminal: swipe-left on a row does nothing
- [ ] Terminal: tap-and-hold the `[ ]` shows `[✓]` green active state
- [ ] Terminal: overdue task shows `[!]` red; high-pri shows `[*]` amber
- [ ] Light/dark: cards render unchanged — checkbox hidden, swipe + done button + expand all work as before

https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_