### PR TITLE
fix(ui): terminal — checkbox [✓] persists with row fade-out on complete

### DIFF
--- a/src/v2/components/TaskCard.jsx
+++ b/src/v2/components/TaskCard.jsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useRef, useState } from 'react'
+import { memo, useCallback, useEffect, useRef, useState } from 'react'
 import { Check, Pencil, Moon, Monitor, Users, MapPin, Palette, Dumbbell, Zap, SkipForward } from 'lucide-react'
 import {
   isStale, isSnoozed, isOverdue,
@@ -19,6 +19,21 @@ const SWIPE_VERT_CANCEL = 12     // px of vertical movement that cancels the swi
 
 function TaskCard({ task, expanded, onToggleExpand, onComplete, onEdit, onSnooze, onSkipAdvance, weatherByDate, selected, routineStreaks }) {
   const isTerminal = useTerminalMode()
+  // Track a brief "completing" window so the checkbox can stay `[✓]` and
+  // the row can fade out while still visible — without this the card
+  // unmounts on the next render after onComplete and the user never sees
+  // the checkmark land. ~350ms feels confirmatory without dragging.
+  const [completing, setCompleting] = useState(false)
+  const completeTimer = useRef(null)
+  const completeWithFade = useCallback((taskId) => {
+    if (completing) return
+    setCompleting(true)
+    completeTimer.current = setTimeout(() => onComplete(taskId), 350)
+  }, [completing, onComplete])
+
+  useEffect(() => () => {
+    if (completeTimer.current) clearTimeout(completeTimer.current)
+  }, [])
   const overdue = isOverdue(task)
   const stale = isStale(task)
   const snoozed = isSnoozed(task)
@@ -150,6 +165,7 @@ function TaskCard({ task, expanded, onToggleExpand, onComplete, onEdit, onSnooze
         task.low_priority ? 'v2-card-faded' : '',
         expanded ? 'v2-card-expanded-state' : '',
         selected ? 'v2-card-selected' : '',
+        completing ? 'v2-card-completing' : '',
       ].filter(Boolean).join(' ')}
       style={{
         transform: swipeX !== 0 ? `translateX(${swipeX}px)` : undefined,
@@ -172,12 +188,12 @@ function TaskCard({ task, expanded, onToggleExpand, onComplete, onEdit, onSnooze
               tabIndex={0}
               className="v2-card-checkbox"
               aria-label={`Mark "${task.title}" done`}
-              onClick={(e) => { e.stopPropagation(); onComplete(task.id) }}
+              onClick={(e) => { e.stopPropagation(); completeWithFade(task.id) }}
               onKeyDown={(e) => {
                 if (e.key === 'Enter' || e.key === ' ') {
                   e.preventDefault()
                   e.stopPropagation()
-                  onComplete(task.id)
+                  completeWithFade(task.id)
                 }
               }}
             />

--- a/src/v2/terminal/init.css
+++ b/src/v2/terminal/init.css
@@ -413,10 +413,45 @@
   text-shadow: 0 0 6px rgba(88, 166, 255, 0.5);
 }
 
+/* Mid-tap (:active) — instant feedback while finger is down. */
 :root[data-ui="v2"][data-theme^="terminal"] .v2-card-checkbox:active::before {
   content: "[✓]";
   color: var(--v2-energy-errand);
   text-shadow: 0 0 8px rgba(126, 231, 135, 0.55);
+}
+
+/* Completing state — locked in by TaskCard when the user taps. The
+ * class stays on for ~350ms (matched to the card's fade-out below)
+ * so the `[✓]` mark persists the entire time the row is on screen.
+ * Without this, `:active` would only render the check while the finger
+ * was down — too brief to register before the card unmounts. */
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-completing .v2-card-checkbox::before {
+  content: "[✓]" !important;
+  color: var(--v2-energy-errand) !important;
+  text-shadow: 0 0 10px rgba(126, 231, 135, 0.7) !important;
+  font-weight: 700;
+}
+
+/* The whole row fades + slides slightly while the user reads the
+ * completion. After 350ms the parent removes the task from the active
+ * list and the card unmounts. Light/dark themes don't get this — their
+ * Done button-driven completion just removes the row immediately. */
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-completing {
+  animation: v2-card-completing-out 350ms var(--v2-ease-standard) forwards;
+  pointer-events: none;
+}
+
+@keyframes v2-card-completing-out {
+  0%   { opacity: 1; transform: translateX(0); }
+  25%  { opacity: 1; transform: translateX(0); }
+  100% { opacity: 0; transform: translateX(8px); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :root[data-ui="v2"][data-theme^="terminal"] .v2-card-completing {
+    animation: none;
+    opacity: 0.5;
+  }
 }
 
 /* === Drop the `✓ done` button in the expanded action row ===========

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,18 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-10
 
+- fix(ui): terminal — checkbox `[✓]` persists with row fade-out on complete [XS]
+  - **Bug.** When the user tapped `[ ]` to complete a task, the `[✓]` only rendered during `:active` (finger held down). The moment they lifted their finger, React processed `onComplete`, the parent filtered the task out of the active list, the card unmounted — and the user never saw a confirmation. The check felt non-existent.
+  - **Fix.** Add a local `completing` state to TaskCard. On checkbox tap: `setCompleting(true)` immediately, then `setTimeout(onComplete, 350)`. While completing:
+    - The card root gets `v2-card-completing` class → CSS animates a 350ms opacity-out + slight rightward slide
+    - The checkbox `::before` flips to `[✓]` (errand-green + glow) via a class-based rule that wins over the default `[ ]`
+    - `pointer-events: none` while fading so accidental double-taps can't re-fire
+    - 350ms timer hits → `onComplete(task.id)` fires → task removed from active list → card unmounts cleanly
+  - **Cleanup.** `useEffect` clears the timer if the card unmounts for some other reason (parent removes the task, navigation, etc.) so the callback can't fire on a stale instance.
+  - **Light/dark unchanged.** Their Done button + swipe-to-Done paths still remove the row immediately. The fade is terminal-only — it's specifically the answer to "the checkbox tap feels invisible because the checkmark doesn't stay long enough."
+  - **Reduced motion.** `prefers-reduced-motion` reduces the animation to a flat `opacity: 0.5` while fading.
+  - Modified: `src/v2/components/TaskCard.jsx`, `src/v2/terminal/init.css`, `wiki/Version-History.md`
+
 - style(ui): terminal — urgency moves from checkbox glyph to title color [XS]
   - **Why.** User: "Why are you dropping the urgency? Shit is that what those were? I thought they were done check boxes." The leading `[!]` (overdue) and `[*]` (high-pri) glyphs on the checkbox were misreading as alternate checkbox states rather than urgency markers — especially now that the checkbox is a real tappable button. Suggested fix: title color for urgency.
   - **What changed.** The `.v2-card-overdue .v2-card-checkbox::before` and `.v2-card-high-pri .v2-card-checkbox::before` overrides removed. Checkbox now reads `[ ]` always (or `[✓]` on tap-active). Urgency signal moves to the title text:


### PR DESCRIPTION
## Bug

User: "Check in box doesn't stay in the box long enough to recognize it is there. It should stay on the card as long as the card is still visible in the UI."

When the user tapped `[ ]` to complete, the `[✓]` only rendered during `:active` (finger held). The instant the finger lifted, `onComplete` ran → parent filtered the task out → card unmounted — and the user never saw the checkmark land. Felt invisible.

## Fix

Local `completing` state in TaskCard. On tap:

```js
setCompleting(true)              // immediate state flip
completeTimer.current = setTimeout(() => onComplete(taskId), 350)
```

While completing:
- `.v2-card-completing` class on the card root → CSS animates a 350ms opacity-out + slight rightward slide
- `.v2-card-completing .v2-card-checkbox::before` → flips to `[✓]` errand-green + glow (wins over the default `[ ]` rule via `!important`)
- `pointer-events: none` while fading so double-taps can't re-fire
- 350ms timer fires → `onComplete(task.id)` → task removed from active list → card unmounts cleanly

`useEffect` cleanup clears the timer if the card unmounts for some other reason (parent removes the task, modal closes, etc.) so the callback can't fire on a stale instance.

`prefers-reduced-motion` reduces the animation to a flat `opacity: 0.5` while waiting for the timer.

## Light/dark unchanged

Their Done button and swipe-to-Done paths still remove the row immediately — no fade. The fade is specifically the answer to "the checkbox tap feels invisible because the checkmark doesn't stay long enough" — terminal-only.

https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_