### PR TITLE
style(ui): terminal — settings segments to bare brackets + double completion fade

### DIFF
--- a/src/v2/components/TaskCard.jsx
+++ b/src/v2/components/TaskCard.jsx
@@ -28,7 +28,10 @@ function TaskCard({ task, expanded, onToggleExpand, onComplete, onEdit, onSnooze
   const completeWithFade = useCallback((taskId) => {
     if (completing) return
     setCompleting(true)
-    completeTimer.current = setTimeout(() => onComplete(taskId), 350)
+    // 700ms — long enough for the `[✓]` checkmark to register before the
+    // card unmounts. Bumped from 350ms after user feedback that it was
+    // too brief. Matches the CSS keyframe duration.
+    completeTimer.current = setTimeout(() => onComplete(taskId), 700)
   }, [completing, onComplete])
 
   useEffect(() => () => {

--- a/src/v2/terminal/flatten.css
+++ b/src/v2/terminal/flatten.css
@@ -436,35 +436,57 @@
 
 /* === Settings segmented control — joined-border tab strip ========= */
 
+/* Settings segmented controls (Theme: Standard/Terminal, Mode: Light/Dark,
+ * any other family/mode pickers). Match the bare bracket idiom used by
+ * `.v2-form-seg` everywhere else — `[•] standard  [ ] terminal` — so
+ * the picker reads as text radios, not bordered buttons. */
 :root[data-ui="v2"][data-theme^="terminal"] .v2-settings-segment {
   border-radius: 0;
   border: none;
   padding: 0;
-  gap: 0;
+  gap: 16px;
+  display: flex;
+  flex-wrap: wrap;
 }
 
 :root[data-ui="v2"][data-theme^="terminal"] .v2-settings-segment-btn {
-  border-radius: 0;
-  border: 1px solid var(--v2-hairline);
-  border-right-width: 0;
-  background: transparent;
+  border-radius: 0 !important;
+  border: none !important;
+  background: transparent !important;
+  padding: 4px 0 !important;
+  height: auto !important;
+  min-width: 0 !important;
+  color: var(--v2-text-meta) !important;
+  text-transform: lowercase !important;
+  font: 500 13px/1.2 var(--v2-font-body) !important;
+  display: inline-flex !important;
+  align-items: center !important;
+  gap: 6px !important;
 }
 
-:root[data-ui="v2"][data-theme^="terminal"] .v2-settings-segment-btn:last-child {
-  border-right-width: 1px;
+:root[data-ui="v2"][data-theme^="terminal"] .v2-settings-segment-btn::before {
+  content: "[ ]";
+  color: var(--v2-text-faint);
+  font-weight: 500;
+  letter-spacing: 0;
 }
 
 :root[data-ui="v2"][data-theme^="terminal"] .v2-settings-segment-btn:hover:not(.v2-settings-segment-btn-active) {
-  background: rgba(var(--v2-text-rgb), 0.05);
+  background: transparent !important;
+  color: var(--v2-text) !important;
 }
 
 :root[data-ui="v2"][data-theme^="terminal"] .v2-settings-segment-btn-active {
-  background: transparent;
-  color: var(--v2-accent);
-  border-color: var(--v2-accent);
-  position: relative;
-  z-index: 1;
+  background: transparent !important;
+  color: var(--v2-accent) !important;
+  border: none !important;
   text-shadow: var(--v2-glow);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-settings-segment-btn-active::before {
+  content: "[•]";
+  color: var(--v2-accent);
+  font-weight: 700;
 }
 
 /* === Settings rows + numeric inputs ================================ */

--- a/src/v2/terminal/init.css
+++ b/src/v2/terminal/init.css
@@ -437,13 +437,13 @@
  * list and the card unmounts. Light/dark themes don't get this — their
  * Done button-driven completion just removes the row immediately. */
 :root[data-ui="v2"][data-theme^="terminal"] .v2-card-completing {
-  animation: v2-card-completing-out 350ms var(--v2-ease-standard) forwards;
+  animation: v2-card-completing-out 700ms var(--v2-ease-standard) forwards;
   pointer-events: none;
 }
 
 @keyframes v2-card-completing-out {
   0%   { opacity: 1; transform: translateX(0); }
-  25%  { opacity: 1; transform: translateX(0); }
+  60%  { opacity: 1; transform: translateX(0); }
   100% { opacity: 0; transform: translateX(8px); }
 }
 

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,17 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-10
 
+- style(ui): terminal — settings segments → bare brackets + double completion-fade duration [XS]
+  - **Why.** Settings → General Theme picker (Standard/Terminal + Light/Dark rows) still rendered as bordered button boxes despite the bare-bracket idiom used everywhere else. And user feedback on the completion fade: "Could stand to have the card and check stay a little longer. What if you double that."
+  - **Settings segments.** `.v2-settings-segment-btn` overrides in flatten.css rewritten to match the `.v2-form-seg` style:
+    - Inactive: `[ ] standard` (faint bracket + meta text)
+    - Active: `[•] standard` (accent bracket + accent text + glow)
+    - No background, no border, lowercase, monospace
+    - 16px gap between options (horizontal flex-wrap)
+    Reads identical to status/energy/size/etc. pickers now.
+  - **Completion fade 350ms → 700ms.** TaskCard's `completeTimer` setTimeout bumped to 700ms; CSS keyframe `v2-card-completing-out` matched. The `[✓]` checkmark now holds at full opacity for the first 60% of the window (~420ms) before the slide+fade kicks in. Total time on screen for user confirmation: roughly twice as long. Reduced-motion path unchanged.
+  - Modified: `src/v2/components/TaskCard.jsx`, `src/v2/terminal/flatten.css`, `src/v2/terminal/init.css`, `wiki/Version-History.md`
+
 - fix(ui): terminal — checkbox `[✓]` persists with row fade-out on complete [XS]
   - **Bug.** When the user tapped `[ ]` to complete a task, the `[✓]` only rendered during `:active` (finger held down). The moment they lifted their finger, React processed `onComplete`, the parent filtered the task out of the active list, the card unmounted — and the user never saw a confirmation. The check felt non-existent.
   - **Fix.** Add a local `completing` state to TaskCard. On checkbox tap: `setCompleting(true)` immediately, then `setTimeout(onComplete, 350)`. While completing:


### PR DESCRIPTION
## Two fixes

### 1. Settings theme picker → bare brackets

User: "Still buttons." The Settings → General Theme picker rows (Standard/Terminal + Light/Dark) rendered as bordered button boxes even though every other segmented selector (status, energy, size, etc.) is bare bracketed text in terminal mode.

`.v2-settings-segment-btn` rewritten to match `.v2-form-seg`:
- Inactive: `[ ] standard` (faint bracket + meta text)
- Active: `[•] standard` (accent bracket + accent text + glow)
- No background, no border, lowercase monospace
- 16px gap between options, horizontal flex-wrap

### 2. Completion fade 350ms → 700ms

User: "Could stand to have the card and check stay a little longer. What if you double that."

Both the JSX `setTimeout` in `TaskCard.completeWithFade` and the CSS keyframe `v2-card-completing-out` bumped from 350ms to 700ms. The `[✓]` now holds at full opacity for the first 60% of the window (~420ms) before the slide+fade starts. Total confirmation time on screen roughly doubled.

## Files

- `src/v2/components/TaskCard.jsx` — `setTimeout(..., 700)`
- `src/v2/terminal/flatten.css` — `.v2-settings-segment-btn` rewrite
- `src/v2/terminal/init.css` — keyframe duration + 60% hold

CSS-only on the settings side, one-number change on the timing side. Light/dark unchanged.

https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_