### PR TITLE
style(ui): terminal — `$` prompt prefix → `>` everywhere

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -771,7 +771,7 @@ These five primitives are the v2 task-surface language. Every subsequent v2 surf
 
 ### Terminal Theme Stress Test (2026-05-10)
 
-**Working hypothesis: terminal may become the default forever.** PR A–H shipped a four-palette family — Light, Dark, Terminal Dark (GitHub Dark), Terminal Light (GitHub Light) — with terminal-specific structural overrides (ASCII flourishes, monospace stack, bracket toggles, `$ verb` modal headers, `// manage` section, density signals on TaskCard). The user is now stress-testing whether terminal feels right as the daily driver. Light/dark stay maintained as defensive baseline.
+**Working hypothesis: terminal may become the default forever.** PR A–H shipped a four-palette family — Light, Dark, Terminal Dark (GitHub Dark), Terminal Light (GitHub Light) — with terminal-specific structural overrides (ASCII flourishes, monospace stack, bracket toggles, `> verb` modal headers, `// manage` section, density signals on TaskCard). The user is now stress-testing whether terminal feels right as the daily driver. Light/dark stay maintained as defensive baseline.
 
 **The convention while we stress-test:**
 
@@ -790,7 +790,7 @@ These five primitives are the v2 task-surface language. Every subsequent v2 surf
    - Picker collapses from 4 options to "Theme: Terminal Dark / Terminal Light"
    - `[data-theme^="terminal"]` selectors lose their guard (terminal IS v2)
    - Density signals graduate to always-on
-   - `useTerminalMode` hook + `terminalTitle`/`terminalCommand` props get unified — modal titles use the `$ verb` form unconditionally, no fallback
+   - `useTerminalMode` hook + `terminalTitle`/`terminalCommand` props get unified — modal titles use the `> verb` form unconditionally, no fallback
    - `src/v2/terminal/` directory contents merge into the regular component CSS
 
 7. **What "terminal didn't stick" means structurally:**

--- a/src/v2/AppV2.jsx
+++ b/src/v2/AppV2.jsx
@@ -752,54 +752,54 @@ export default function AppV2() {
 
       {/* More-menu sheet. Each row's icon is tinted to match v1's color hint
           system so users can recognize destinations at a glance. */}
-      <ModalShell open={showMenu} onClose={() => setShowMenu(false)} title="More" terminalTitle="$ menu" width="narrow">
+      <ModalShell open={showMenu} onClose={() => setShowMenu(false)} title="More" terminalTitle="> menu" width="narrow">
         <ul className="v2-more-menu">
           <li>
             <button className="v2-more-row" onClick={() => { setShowMenu(false); setShowSettings(true) }}>
               <SettingsIcon size={18} strokeWidth={1.75} className="v2-more-row-icon v2-more-row-icon-settings" />
-              <span className="v2-more-row-label" data-terminal-cmd="$ settings">Settings</span>
+              <span className="v2-more-row-label" data-terminal-cmd="> settings">Settings</span>
               <ChevronRight size={16} strokeWidth={1.75} className="v2-more-row-chev" />
             </button>
           </li>
           <li>
             <button className="v2-more-row" onClick={() => { setShowMenu(false); setShowProjects(true) }}>
               <FolderKanban size={18} strokeWidth={1.75} className="v2-more-row-icon v2-more-row-icon-projects" />
-              <span className="v2-more-row-label" data-terminal-cmd="$ projects">Projects</span>
+              <span className="v2-more-row-label" data-terminal-cmd="> projects">Projects</span>
               <ChevronRight size={16} strokeWidth={1.75} className="v2-more-row-chev" />
             </button>
           </li>
           <li>
             <button className="v2-more-row" onClick={() => { setShowMenu(false); setShowRoutines(true) }}>
               <RotateCw size={18} strokeWidth={1.75} className="v2-more-row-icon v2-more-row-icon-routines" />
-              <span className="v2-more-row-label" data-terminal-cmd="$ routines">Routines</span>
+              <span className="v2-more-row-label" data-terminal-cmd="> routines">Routines</span>
               <ChevronRight size={16} strokeWidth={1.75} className="v2-more-row-chev" />
             </button>
           </li>
           <li>
             <button className="v2-more-row" onClick={() => { setShowMenu(false); setShowDone(true) }}>
               <CheckCircle2 size={18} strokeWidth={1.75} className="v2-more-row-icon v2-more-row-icon-done" />
-              <span className="v2-more-row-label" data-terminal-cmd="$ done">Done</span>
+              <span className="v2-more-row-label" data-terminal-cmd="> done">Done</span>
               <ChevronRight size={16} strokeWidth={1.75} className="v2-more-row-chev" />
             </button>
           </li>
           <li>
             <button className="v2-more-row" onClick={() => { setShowMenu(false); setShowAnalytics(true) }}>
               <BarChart3 size={18} strokeWidth={1.75} className="v2-more-row-icon v2-more-row-icon-analytics" />
-              <span className="v2-more-row-label" data-terminal-cmd="$ stats">Analytics</span>
+              <span className="v2-more-row-label" data-terminal-cmd="> stats">Analytics</span>
               <ChevronRight size={16} strokeWidth={1.75} className="v2-more-row-chev" />
             </button>
           </li>
           <li>
             <button className="v2-more-row" onClick={() => { setShowMenu(false); setShowActivityLog(true) }}>
               <History size={18} strokeWidth={1.75} className="v2-more-row-icon v2-more-row-icon-activity" />
-              <span className="v2-more-row-label" data-terminal-cmd="$ log">Activity log</span>
+              <span className="v2-more-row-label" data-terminal-cmd="> log">Activity log</span>
               <ChevronRight size={16} strokeWidth={1.75} className="v2-more-row-chev" />
             </button>
           </li>
           <li>
             <button className="v2-more-row" onClick={() => { setShowMenu(false); setShowMarkdownImport(true) }}>
               <Upload size={18} strokeWidth={1.75} className="v2-more-row-icon" />
-              <span className="v2-more-row-label" data-terminal-cmd="$ import --markdown">Import from markdown</span>
+              <span className="v2-more-row-label" data-terminal-cmd="> import --markdown">Import from markdown</span>
               <ChevronRight size={16} strokeWidth={1.75} className="v2-more-row-chev" />
             </button>
           </li>
@@ -814,7 +814,7 @@ export default function AppV2() {
         }}
       />
 
-      <ModalShell open={showHelp} onClose={() => setShowHelp(false)} title="Keyboard shortcuts" terminalTitle="$ help --keys" width="narrow">
+      <ModalShell open={showHelp} onClose={() => setShowHelp(false)} title="Keyboard shortcuts" terminalTitle="> help --keys" width="narrow">
         <ul className="v2-shortcut-list">
           {[
             { keys: ['n'], desc: 'New task' },

--- a/src/v2/components/ActivityLog.jsx
+++ b/src/v2/components/ActivityLog.jsx
@@ -63,7 +63,7 @@ export default function ActivityLog({ open, onRestore, onClose }) {
   }
 
   return (
-    <ModalShell open={open} onClose={onClose} title="Activity log" terminalTitle="$ log" width="wide">
+    <ModalShell open={open} onClose={onClose} title="Activity log" terminalTitle="> log" width="wide">
       <div className="v2-activity-toolbar">
         <div className="v2-activity-filters">
           <button

--- a/src/v2/components/AddTaskModal.jsx
+++ b/src/v2/components/AddTaskModal.jsx
@@ -44,7 +44,7 @@ export default function AddTaskModal({ open, onAdd, onClose }) {
   const priorityLabel = priorityState === 'high' ? '! High' : priorityState === 'low' ? '↓ Low' : 'Normal'
 
   return (
-    <ModalShell open={open} onClose={onClose} title="New task" terminalTitle="$ task --new" width="narrow">
+    <ModalShell open={open} onClose={onClose} title="New task" terminalTitle="> task --new" width="narrow">
       <input
         ref={titleRef}
         className="v2-form-input v2-form-title"

--- a/src/v2/components/AdviserModal.jsx
+++ b/src/v2/components/AdviserModal.jsx
@@ -220,7 +220,7 @@ export default function AdviserModal({ open, adviser, onClose, onAfterCommit }) 
   }
 
   return (
-    <ModalShell open={open} onClose={onClose} title="Quokka" terminalTitle="$ quokka" width="wide">
+    <ModalShell open={open} onClose={onClose} title="Quokka" terminalTitle="> quokka" width="wide">
       <div className="v2-adviser-toolbar">
         <button
           className="v2-adviser-tool-btn"

--- a/src/v2/components/AnalyticsModal.jsx
+++ b/src/v2/components/AnalyticsModal.jsx
@@ -141,7 +141,7 @@ export default function AnalyticsModal({ open, onClose }) {
   }, [history, metric])
 
   return (
-    <ModalShell open={open} onClose={onClose} title="Analytics" terminalTitle="$ stats" width="wide">
+    <ModalShell open={open} onClose={onClose} title="Analytics" terminalTitle="> stats" width="wide">
       {/* Range + metric controls */}
       <div className="v2-analytics-toolbar">
         <div className="v2-analytics-range">

--- a/src/v2/components/DoneList.jsx
+++ b/src/v2/components/DoneList.jsx
@@ -95,7 +95,7 @@ export default function DoneList({ open, onClose, onUncomplete }) {
   )
 
   return (
-    <ModalShell open={open} onClose={onClose} title="Done" terminalTitle="$ done --list" width="wide">
+    <ModalShell open={open} onClose={onClose} title="Done" terminalTitle="> done --list" width="wide">
       {loading && <div className="v2-done-loading">Loading…</div>}
 
       {!loading && doneTasks.length === 0 && (

--- a/src/v2/components/EditTaskModal.jsx
+++ b/src/v2/components/EditTaskModal.jsx
@@ -207,7 +207,7 @@ export default function EditTaskModal({ task, onSave, onClose, onDelete, onBackl
   }, [confirmDelete])
 
   return (
-    <ModalShell open={!!task} onClose={onClose} title="Edit task" terminalTitle="$ task --edit" width="narrow">
+    <ModalShell open={!!task} onClose={onClose} title="Edit task" terminalTitle="> task --edit" width="narrow">
       <input
         className="v2-form-input v2-form-title"
         placeholder="What needs doing?"
@@ -848,14 +848,14 @@ export default function EditTaskModal({ task, onSave, onClose, onDelete, onBackl
             onClick={() => { onBacklog(task.id, true); onClose() }}
             title="Move to backlog"
           >
-            <Archive size={14} strokeWidth={1.75} /> <span className="v2-edit-action-label" data-terminal-cmd="$ archive">Backlog</span>
+            <Archive size={14} strokeWidth={1.75} /> <span className="v2-edit-action-label" data-terminal-cmd="> archive">Backlog</span>
           </button>
           <button
             className="v2-edit-action"
             onClick={() => { onProject(task.id, true); onClose() }}
             title="Move to projects"
           >
-            <FolderKanban size={14} strokeWidth={1.75} /> <span className="v2-edit-action-label" data-terminal-cmd="$ move-to-projects">Projects</span>
+            <FolderKanban size={14} strokeWidth={1.75} /> <span className="v2-edit-action-label" data-terminal-cmd="> move-to-projects">Projects</span>
           </button>
           {!task.routine_id && !makeRecurring && (
             <button
@@ -863,7 +863,7 @@ export default function EditTaskModal({ task, onSave, onClose, onDelete, onBackl
               onClick={() => setMakeRecurring(true)}
               title="Convert this task into a recurring routine"
             >
-              <RotateCw size={14} strokeWidth={1.75} /> <span className="v2-edit-action-label" data-terminal-cmd="$ make-recurring">Make recurring</span>
+              <RotateCw size={14} strokeWidth={1.75} /> <span className="v2-edit-action-label" data-terminal-cmd="> make-recurring">Make recurring</span>
             </button>
           )}
           {!confirmDelete ? (
@@ -872,7 +872,7 @@ export default function EditTaskModal({ task, onSave, onClose, onDelete, onBackl
               onClick={() => setConfirmDelete(true)}
               title="Delete task"
             >
-              <Trash2 size={14} strokeWidth={1.75} /> <span className="v2-edit-action-label" data-terminal-cmd="$ delete --confirm">Delete</span>
+              <Trash2 size={14} strokeWidth={1.75} /> <span className="v2-edit-action-label" data-terminal-cmd="> delete --confirm">Delete</span>
             </button>
           ) : (
             <div className="v2-edit-confirm-delete">

--- a/src/v2/components/Header.jsx
+++ b/src/v2/components/Header.jsx
@@ -136,7 +136,7 @@ export default function Header({
               onClick={() => { setPopoverOpen(false); onOpenAnalytics?.() }}
             >
               <MiniRings rings={miniRingsData} />
-              <span data-terminal-cmd="open $ stats">Open Analytics</span>
+              <span data-terminal-cmd="open > stats">Open Analytics</span>
             </button>
           )}
           {(todayCount > 0 || hasDone) && (

--- a/src/v2/components/MarkdownImportModal.jsx
+++ b/src/v2/components/MarkdownImportModal.jsx
@@ -59,7 +59,7 @@ export default function MarkdownImportModal({ open, onImport, onClose }) {
   }
 
   return (
-    <ModalShell open={open} onClose={handleClose} title="Import from Markdown" terminalTitle="$ import --markdown" width="wide">
+    <ModalShell open={open} onClose={handleClose} title="Import from Markdown" terminalTitle="> import --markdown" width="wide">
       {!parsed ? (
         <div className="v2-md-import">
           <div className="v2-md-import-hint">

--- a/src/v2/components/PackagesModal.jsx
+++ b/src/v2/components/PackagesModal.jsx
@@ -194,7 +194,7 @@ export default function PackagesModal({
   }
 
   return (
-    <ModalShell open={open} onClose={onClose} title="Packages" terminalTitle="$ packages" width="wide">
+    <ModalShell open={open} onClose={onClose} title="Packages" terminalTitle="> packages" width="wide">
       <div className="v2-packages-toolbar">
         <button
           className="v2-package-toolbar-btn"

--- a/src/v2/components/ProjectsView.jsx
+++ b/src/v2/components/ProjectsView.jsx
@@ -15,7 +15,7 @@ export default function ProjectsView({ open, tasks, onClose, onComplete, onEdit,
       open={open}
       onClose={onClose}
       title="Projects"
-      terminalTitle="$ projects"
+      terminalTitle="> projects"
       subtitle={projectTasks.length > 0
         ? `${projectTasks.length} project${projectTasks.length !== 1 ? 's' : ''} · no notifications, take your time`
         : undefined}

--- a/src/v2/components/ReframeModal.jsx
+++ b/src/v2/components/ReframeModal.jsx
@@ -33,7 +33,7 @@ export default function ReframeModal({ task, onReframe, onClose }) {
       open={!!task}
       onClose={onClose}
       title="This one keeps coming back"
-      terminalTitle="$ reframe"
+      terminalTitle="> reframe"
       subtitle={`"${task.title}" has been snoozed ${task.snooze_count} times. What's actually in the way?`}
     >
       {!results ? (

--- a/src/v2/components/SettingsModal.jsx
+++ b/src/v2/components/SettingsModal.jsx
@@ -1842,7 +1842,7 @@ export default function SettingsModal({
   }
 
   return (
-    <ModalShell open={open} onClose={onClose} title="Settings" terminalTitle="$ settings" width="wide">
+    <ModalShell open={open} onClose={onClose} title="Settings" terminalTitle="> settings" width="wide">
       <div className="v2-settings-tabs">
         {TABS.map(tab => (
           <button

--- a/src/v2/components/SnoozeModal.jsx
+++ b/src/v2/components/SnoozeModal.jsx
@@ -54,7 +54,7 @@ export default function SnoozeModal({ task, onSnooze, onClose }) {
       open={!!task}
       onClose={onClose}
       title={task.title}
-      terminalTitle="$ snooze"
+      terminalTitle="> snooze"
       subtitle="When should this come back?"
     >
       {filteredOptions.length === 0 && !showCustom ? (

--- a/src/v2/components/WhatNowModal.jsx
+++ b/src/v2/components/WhatNowModal.jsx
@@ -92,7 +92,7 @@ export default function WhatNowModal({ open, tasks, onClose, onComplete }) {
   }[step]
 
   return (
-    <ModalShell open={open} onClose={handleClose} title="What now?" terminalTitle="$ what-now" subtitle={stepTitle} width="narrow">
+    <ModalShell open={open} onClose={handleClose} title="What now?" terminalTitle="> what-now" subtitle={stepTitle} width="narrow">
       {step === 1 && (
         <ul className="v2-whatnow-options">
           {TIME_OPTIONS.map(opt => (

--- a/src/v2/terminal/wordmark.css
+++ b/src/v2/terminal/wordmark.css
@@ -21,7 +21,7 @@
 }
 
 :root[data-ui="v2"][data-theme^="terminal"] .v2-header-wordmark::before {
-  content: "$ ";
+  content: "> ";
   color: var(--v2-text-meta);
   font-weight: 500;
   margin-right: 2px;

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,17 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-10
 
+- style(ui): terminal — `$` prompt prefix → `>` everywhere [XS]
+  - **Why.** User: "Replace the terminal $ with >". `$` reads as shell-prompt; `>` reads as more universal CLI-prompt (matches our `→` section sigils + the chevron-y feel of the rest of the language).
+  - **Bulk replace across all terminal-mode prompt strings:**
+    - `terminalTitle` props on 15 modal call sites: `$ task --new` → `> task --new`, `$ snooze` → `> snooze`, `$ settings` → `> settings`, `$ stats` → `> stats`, etc.
+    - `data-terminal-cmd` attributes on the More menu + EditTaskModal manage cluster: `$ archive` → `> archive`, `$ delete --confirm` → `> delete --confirm`, etc.
+    - Header popover: `open $ stats` → `open > stats`
+    - Wordmark CSS: `content: "$ "` → `content: "> "` (so the `$ boomerang_` brand wordmark becomes `> boomerang_`)
+    - CLAUDE.md convention doc updated to reference `> verb` as the canonical form
+  - **No JSX shape change**, just literal text. Light + dark themes don't see any of these — they remain the modal's regular `title` prop value.
+  - Modified: `src/v2/AppV2.jsx`, `src/v2/components/AddTaskModal.jsx`, `src/v2/components/EditTaskModal.jsx`, `src/v2/components/SnoozeModal.jsx`, `src/v2/components/ReframeModal.jsx`, `src/v2/components/WhatNowModal.jsx`, `src/v2/components/SettingsModal.jsx`, `src/v2/components/PackagesModal.jsx`, `src/v2/components/AnalyticsModal.jsx`, `src/v2/components/ProjectsView.jsx`, `src/v2/components/DoneList.jsx`, `src/v2/components/ActivityLog.jsx`, `src/v2/components/AdviserModal.jsx`, `src/v2/components/MarkdownImportModal.jsx`, `src/v2/components/Header.jsx`, `src/v2/terminal/wordmark.css`, `CLAUDE.md`, `wiki/Version-History.md`
+
 - style(ui): terminal — settings segments → bare brackets + double completion-fade duration [XS]
   - **Why.** Settings → General Theme picker (Standard/Terminal + Light/Dark rows) still rendered as bordered button boxes despite the bare-bracket idiom used everywhere else. And user feedback on the completion fade: "Could stand to have the card and check stay a little longer. What if you double that."
   - **Settings segments.** `.v2-settings-segment-btn` overrides in flatten.css rewritten to match the `.v2-form-seg` style:


### PR DESCRIPTION
## Summary

User: "Replace the terminal $ with >".

Bulk replace across every terminal-mode prompt prefix. No JSX shape change — just literal text. Light + dark themes don't see any of these (they use the modal's regular `title` prop, not `terminalTitle`).

## What changed

**Wordmark.** `$ boomerang_` → `> boomerang_` via CSS (`content: "$ "` → `content: "> "` in `wordmark.css`).

**Modal titles** (15 call sites): `$ task --new` → `> task --new`, `$ snooze` → `> snooze`, `$ settings` → `> settings`, `$ stats` → `> stats`, `$ what-now` → `> what-now`, `$ packages` → `> packages`, `$ projects` → `> projects`, `$ done --list` → `> done --list`, `$ log` → `> log`, `$ routines` / `> routine --new` / `> routine --edit`, `$ quokka` → `> quokka`, `$ import --markdown` → `> import --markdown`, `$ menu` → `> menu`, `$ help --keys` → `> help --keys`, `$ reframe` → `> reframe`.

**Manage cluster** in EditTaskModal: `$ archive` / `$ move-to-projects` / `$ make-recurring` / `$ delete --confirm` → `> ...`.

**More menu** in AppV2: `$ settings` / `$ projects` / `$ routines` / `$ done` / `$ stats` / `$ log` / `$ import --markdown` → `> ...`.

**Header popover:** `open $ stats` → `open > stats`.

**CLAUDE.md** convention doc updated to reference `> verb` as the canonical form.

https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_