### PR TITLE
style(ui): terminal — audit-pass cleanup (settings tabs, Kanban sigils, WeatherBadge, hover glow)

### DIFF
--- a/src/v2/components/KanbanBoard.jsx
+++ b/src/v2/components/KanbanBoard.jsx
@@ -42,7 +42,7 @@ function AddCardInline({ onAdd, status }) {
 }
 
 function KanbanColumn({
-  title, tasks, defaultStatus, onAddTask,
+  title, sigil, tasks, defaultStatus, onAddTask,
   dragOverColumn, onDragOver, onDrop, onDragStart, draggingId,
   expandedTaskId, onToggleExpand, onComplete, onEdit, onSnooze, onSkipAdvance, weatherByDate,
   selectedTaskId, routineStreaks,
@@ -58,7 +58,7 @@ function KanbanColumn({
       onDrop={acceptsDrop ? (e) => { e.preventDefault(); onDrop(defaultStatus) } : undefined}
     >
       <div className="v2-kanban-col-head">
-        <span className="v2-kanban-col-title">{title}</span>
+        <span className="v2-kanban-col-title" data-sigil={sigil || '✦'}>{title}</span>
         {tasks.length > 0 && <span className="v2-kanban-col-count">{tasks.length}</span>}
       </div>
       <div className="v2-kanban-col-body">
@@ -145,12 +145,12 @@ export default function KanbanBoard({
 
   return (
     <div className="v2-kanban">
-      <KanbanColumn title="Doing" tasks={doing} defaultStatus="doing" onAddTask={onAddTask} {...dragCallbacks} {...cardCallbacks} />
-      <KanbanColumn title="Up next" tasks={upNext} defaultStatus="not_started" onAddTask={onAddTask} {...dragCallbacks} {...cardCallbacks} />
-      <KanbanColumn title="Waiting" tasks={waiting} defaultStatus="waiting" onAddTask={onAddTask} {...dragCallbacks} {...cardCallbacks} />
-      <KanbanColumn title="Snoozed" tasks={snoozedTasks} {...dragCallbacks} {...cardCallbacks} />
-      <KanbanColumn title="Backlog" tasks={backlogTasks} defaultStatus="backlog" {...dragCallbacks} {...cardCallbacks} />
-      <KanbanColumn title="Projects" tasks={projectTasks} defaultStatus="project" {...dragCallbacks} {...cardCallbacks} />
+      <KanbanColumn title="Doing" sigil="→" tasks={doing} defaultStatus="doing" onAddTask={onAddTask} {...dragCallbacks} {...cardCallbacks} />
+      <KanbanColumn title="Up next" sigil="+" tasks={upNext} defaultStatus="not_started" onAddTask={onAddTask} {...dragCallbacks} {...cardCallbacks} />
+      <KanbanColumn title="Waiting" sigil="…" tasks={waiting} defaultStatus="waiting" onAddTask={onAddTask} {...dragCallbacks} {...cardCallbacks} />
+      <KanbanColumn title="Snoozed" sigil="z" tasks={snoozedTasks} {...dragCallbacks} {...cardCallbacks} />
+      <KanbanColumn title="Backlog" sigil="≈" tasks={backlogTasks} defaultStatus="backlog" {...dragCallbacks} {...cardCallbacks} />
+      <KanbanColumn title="Projects" sigil="§" tasks={projectTasks} defaultStatus="project" {...dragCallbacks} {...cardCallbacks} />
     </div>
   )
 }

--- a/src/v2/terminal/init.css
+++ b/src/v2/terminal/init.css
@@ -291,7 +291,11 @@
 }
 
 :root[data-ui="v2"][data-theme^="terminal"] .v2-kanban-col-title::before {
-  content: "✦ ";
+  /* Per-column sigil from JSX data-sigil attribute. Matches mobile
+   * section sigils so desktop + mobile speak the same vocabulary:
+   *   → doing   + up next   … waiting   z snoozed   ≈ backlog   § projects
+   * Falls back to `✦` if no sigil supplied. */
+  content: attr(data-sigil) " ";
   color: var(--v2-accent);
 }
 
@@ -1570,3 +1574,100 @@
 :root[data-ui="v2"][data-theme^="terminal"] .v2-form-pri-toggle:hover::after {
   color: var(--v2-accent);
 }
+
+/* === Audit-pass cleanup: Settings tabs + WeatherBadge ============== */
+
+/* Settings tabs (General / AI / Labels / Integrations / etc.) — match
+ * the toolbar pill underline-tab idiom. They're "navigate between sub-
+ * views" tabs, same UX role as the toolbar filter pills, so they should
+ * read identically. */
+:root[data-ui="v2"][data-theme^="terminal"] .v2-settings-tab {
+  background: transparent !important;
+  border: none !important;
+  border-bottom: 2px solid transparent !important;
+  border-radius: 0 !important;
+  padding: 6px 4px !important;
+  margin: 0 10px 0 0 !important;
+  color: var(--v2-text-meta) !important;
+  text-transform: lowercase !important;
+  font-weight: 500;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-settings-tab:hover {
+  background: transparent !important;
+  color: var(--v2-text) !important;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-settings-tab-active {
+  background: transparent !important;
+  color: var(--v2-accent) !important;
+  border-bottom-color: var(--v2-accent) !important;
+  text-shadow: var(--v2-glow);
+}
+
+/* WeatherBadge — give it monospace + meta-text color to match the rest
+ * of the card meta line. The emoji icon stays at native size; the temp
+ * picks up the meta text color so it doesn't read brighter than the
+ * surrounding date/stale meta. */
+:root[data-ui="v2"][data-theme^="terminal"] .v2-weather-badge {
+  font: 400 11px/1.4 var(--v2-font-body);
+  color: var(--v2-text-meta);
+  letter-spacing: 0;
+  gap: 2px;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-weather-icon {
+  font-size: 12px;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-weather-temp {
+  color: var(--v2-text-meta);
+}
+
+/* === Hover-glow normalization =====================================
+ *
+ * Standardize on `var(--v2-glow)` for accent-colored interactive
+ * elements. Hardcoded rgba glows are kept ONLY where the color is
+ * NOT the accent (errand-green for done; alert-overdue red for danger;
+ * high-pri amber for warning). All other accent-colored hovers use the
+ * shared `--v2-glow` token. */
+:root[data-ui="v2"][data-theme^="terminal"] .v2-card-checkbox:hover::before {
+  text-shadow: var(--v2-glow);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-submit:hover:not(:disabled) {
+  text-shadow: var(--v2-glow);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-adviser-send:hover:not(:disabled) {
+  text-shadow: var(--v2-glow);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-package-toolbar-btn:hover:not(:disabled) {
+  text-shadow: var(--v2-glow);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-edit-research-go:hover:not(:disabled),
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-ai-pill:hover:not(:disabled) {
+  text-shadow: var(--v2-glow);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-routine-new-btn:hover {
+  text-shadow: var(--v2-glow);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-activity-action:hover {
+  text-shadow: var(--v2-glow);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-package-action:hover:not(:disabled) {
+  text-shadow: var(--v2-glow);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-settings-btn:hover:not(:disabled) {
+  text-shadow: var(--v2-glow);
+}
+
+/* The `✓ done` card action stays green (errand-green) — the completion
+ * state has its own color identity distinct from accent. Same for the
+ * checkbox tap-active `[✓]` and the `.v2-confirm-btn-danger` red glow. */

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,18 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-10
 
+- style(ui): terminal — audit-pass cleanup (settings tabs, Kanban sigils, WeatherBadge, hover glow) [S]
+  - **Why.** User: "go through and look for any inconsistencies in the terminal layouts. Check everything so as to minimize what I need to tell you to go fix." Five issues found and fixed; two genuine design forks asked and confirmed as "keep both" (action vocab: sigil+text on cards vs bracketed on modal CTAs; picker idiom: underline toolbar pills vs bracket settings segments).
+  - **Settings tabs** (`.v2-settings-tab` — General/AI/Labels/Integrations/etc.) had no terminal override beyond font-size; still rendered as bordered pills. Now flat text-tabs with bottom-border accent underline-on-active, matching the toolbar pill idiom (both are "navigate between sub-views" tabs).
+  - **Kanban column sigils** were uniform `✦` while mobile sections used per-section sigils. Threaded a `sigil` prop through `KanbanColumn` JSX + new `data-sigil` attribute on `.v2-kanban-col-title`. Terminal CSS reads it via `attr()` so desktop matches mobile:
+    - `→ doing`, `+ up next`, `… waiting`, `z snoozed`, `≈ backlog`, `§ projects`
+  - **WeatherBadge** (`🌧 64°` on task meta) had no terminal treatment — picked up default font + color. Added explicit `var(--v2-font-body)` monospace + meta-text color so it blends into the rest of the card meta line.
+  - **Hover glow normalization** — most accent-colored interactive elements used hardcoded rgba glows of varying intensity (6px 0.45, 8px 0.55, 12px 0.65, 14px 0.7). Standardized on `var(--v2-glow)` everywhere the color is accent. Errand-green (`✓ done` action, `[✓]` tap-active), overdue-red (`[ delete ]`), and high-pri-amber (`↷ skip`) keep their non-accent hardcoded glows intentionally — they signal a color identity distinct from "primary interactive."
+  - **Two design forks confirmed as "keep both" (no action):**
+    - Action vocab: card actions stay sigil+text (`☾ snooze`, `✎ edit`, `✓ done`); modal CTAs stay bracketed (`[ Save ]`, `[ apply ]`, `[ send ]`). Reads as "row-level vs commit-level."
+    - Picker idiom: toolbar filter pills stay underline-tab style; settings family/mode segments stay bracket-radio style. Reads as "navigate between views vs pick one value."
+  - Modified: `src/v2/components/KanbanBoard.jsx`, `src/v2/terminal/init.css`, `wiki/Version-History.md`
+
 - style(ui): terminal — `$` prompt prefix → `>` everywhere [XS]
   - **Why.** User: "Replace the terminal $ with >". `$` reads as shell-prompt; `>` reads as more universal CLI-prompt (matches our `→` section sigils + the chevron-y feel of the rest of the language).
   - **Bulk replace across all terminal-mode prompt strings:**


### PR DESCRIPTION
## Summary

User: "go through and look for any inconsistencies in the terminal layouts. Check everything so as to minimize what I need to tell you to go fix."

Five issues found and fixed. Two genuine design forks asked + confirmed as "keep both" (no action needed).

## Fixes

### Settings tabs were still pills
`.v2-settings-tab` (General/AI/Labels/Integrations/etc.) had **no terminal override** beyond font-size. Still rendered as bordered rounded pills while every other "pick one" surface in the modal was bracket-flat. Now matches the toolbar pill idiom — text-tabs with bottom-border accent underline-on-active.

### Kanban column sigils didn't match mobile
- Before: uniform `✦` on every column
- After: `→ doing`, `+ up next`, `… waiting`, `z snoozed`, `≈ backlog`, `§ projects`

Threaded a `sigil` prop through `KanbanColumn` JSX + `data-sigil` attribute on `.v2-kanban-col-title`. Terminal CSS reads via `attr()`. Desktop now speaks the same vocabulary as mobile.

### WeatherBadge had zero terminal treatment
The `🌧 64°` on task meta inherited default styling. Added explicit `var(--v2-font-body)` monospace + meta-text color so it blends into the card meta line cleanly.

### Hover glow intensity normalized
Most accent-colored interactive elements used hardcoded rgba glows of varying intensity (6px 0.45, 8px 0.55, 12px 0.65, 14px 0.7…). Standardized on `var(--v2-glow)` for everything accent-colored. Non-accent glows kept intentionally:
- Errand-green for `✓ done` action + `[✓]` tap-active (completion color)
- Overdue-red for `[ delete ]` (danger color)
- High-pri-amber for `↷ skip` (warning color)

### Both terminal-check scripts pass

```
OK — every <ModalShell> call site has a terminalTitle prop.
OK — every button-shaped v2 class has a terminal-mode rule (58 classes checked).
```

## Forks confirmed as "keep both" (no change)

- **Action vocab:** card actions stay sigil+text (`☾ snooze`, `✎ edit`, `✓ done`); modal CTAs stay bracketed (`[ Save ]`, `[ apply ]`, `[ send ]`). Reads as "row-level vs commit-level."
- **Picker idiom:** toolbar filter pills stay underline-tab style; Settings family/mode segments stay bracket-radio style. Reads as "navigate between views vs pick one value."

https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_