### PR TITLE
feat(ui): quokka — typing-prompt demo above example suggestions

### DIFF
--- a/src/v2/components/AdviserModal.css
+++ b/src/v2/components/AdviserModal.css
@@ -116,6 +116,35 @@
   margin-bottom: 18px;
 }
 
+/* Typing-cursor demo line. Above the static suggestion buttons; cycles
+ * through the same phrases character-by-character so the user sees
+ * Quokka "demoing" what they could ask. Terminal mode adds a `>`
+ * prompt prefix. */
+.v2-adviser-empty-demo {
+  width: 100%;
+  font: 400 13px/1.55 var(--v2-font-body);
+  color: var(--v2-text);
+  margin-bottom: 14px;
+  min-height: 1.55em;
+  padding: 10px 12px;
+  background: rgba(var(--v2-text-rgb), 0.04);
+  border-radius: 10px;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-adviser-empty-demo {
+  background: transparent;
+  border-radius: 0;
+  border-left: 2px solid var(--v2-hairline);
+  padding: 6px 0 6px 10px;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-adviser-empty-demo::before {
+  content: "> ";
+  color: var(--v2-accent);
+  font-weight: 700;
+  text-shadow: var(--v2-glow);
+}
+
 .v2-adviser-suggestions {
   display: flex;
   flex-direction: column;

--- a/src/v2/components/AdviserModal.jsx
+++ b/src/v2/components/AdviserModal.jsx
@@ -6,6 +6,7 @@ import {
 import { renderMarkdown } from '../../utils/renderMarkdown'
 import ModalShell from './ModalShell'
 import EmptyState from './EmptyState'
+import TypingPrompt from './TypingPrompt'
 import './AdviserModal.css'
 
 const PROMPT_SUGGESTIONS = [
@@ -259,6 +260,9 @@ export default function AdviserModal({ open, adviser, onClose, onAfterCommit }) 
                 <div className="v2-adviser-empty-title">G'day from Quokka</div>
                 <div className="v2-adviser-empty-body">
                   I can make changes across tasks, routines, calendar, Notion, Trello, Gmail, packages, weather, and settings. Every action is previewed before it runs.
+                </div>
+                <div className="v2-adviser-empty-demo" aria-hidden="true">
+                  <TypingPrompt phrases={PROMPT_SUGGESTIONS} />
                 </div>
                 <div className="v2-adviser-suggestions">
                   {PROMPT_SUGGESTIONS.map((s, i) => (

--- a/src/v2/components/TypingPrompt.css
+++ b/src/v2/components/TypingPrompt.css
@@ -1,0 +1,37 @@
+/* Typing-cursor demo line. Used in Quokka's empty state above the
+ * static suggestion buttons. Cycles through `PROMPT_SUGGESTIONS`,
+ * character-by-character. Cursor blinks like a terminal prompt.
+ *
+ * The cursor renders in every theme (a blinking `_` reads as a hint
+ * that this is a typing input). Terminal mode picks up the accent
+ * automatically from the surrounding theme tokens. */
+
+.v2-typing-prompt {
+  display: inline-block;
+  font-variant-ligatures: none;
+  letter-spacing: 0;
+  white-space: pre;
+}
+
+.v2-typing-prompt-text {
+  color: var(--v2-text);
+}
+
+.v2-typing-prompt-cursor {
+  color: var(--v2-accent);
+  font-weight: 700;
+  margin-left: 1px;
+  animation: v2-typing-prompt-blink 1.1s steps(2) infinite;
+}
+
+@keyframes v2-typing-prompt-blink {
+  0%, 49%   { opacity: 1; }
+  50%, 100% { opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .v2-typing-prompt-cursor {
+    animation: none;
+    opacity: 0.6;
+  }
+}

--- a/src/v2/components/TypingPrompt.jsx
+++ b/src/v2/components/TypingPrompt.jsx
@@ -1,0 +1,65 @@
+import { useEffect, useRef, useState } from 'react'
+import './TypingPrompt.css'
+
+// Cycles through a list of phrases, typing each one character by
+// character, pausing while complete, then erasing and moving to the
+// next. Renders inline with a blinking cursor. Used by Quokka's empty
+// state to demo what the user could ask without overwhelming the
+// static suggestion list below it.
+//
+// Respects `prefers-reduced-motion` — if reduced motion is preferred,
+// shows the longest phrase statically with no animation.
+export default function TypingPrompt({
+  phrases,
+  typeMs = 55,
+  eraseMs = 25,
+  holdMs = 1600,
+  pauseBetweenMs = 400,
+}) {
+  const [text, setText] = useState('')
+  const [phase, setPhase] = useState('typing')
+  const [phraseIdx, setPhraseIdx] = useState(0)
+  const reducedMotion = useRef(false)
+
+  useEffect(() => {
+    const mq = window.matchMedia?.('(prefers-reduced-motion: reduce)')
+    reducedMotion.current = mq?.matches || false
+  }, [])
+
+  useEffect(() => {
+    if (!Array.isArray(phrases) || phrases.length === 0) return
+    if (reducedMotion.current) {
+      const longest = phrases.reduce((a, b) => (b.length > a.length ? b : a), '')
+      setText(longest)
+      return
+    }
+    const phrase = phrases[phraseIdx % phrases.length]
+    let timer
+    if (phase === 'typing') {
+      if (text.length < phrase.length) {
+        timer = setTimeout(() => setText(phrase.slice(0, text.length + 1)), typeMs)
+      } else {
+        timer = setTimeout(() => setPhase('holding'), holdMs)
+      }
+    } else if (phase === 'holding') {
+      timer = setTimeout(() => setPhase('erasing'), 0)
+    } else if (phase === 'erasing') {
+      if (text.length > 0) {
+        timer = setTimeout(() => setText(text.slice(0, -1)), eraseMs)
+      } else {
+        timer = setTimeout(() => {
+          setPhraseIdx(i => (i + 1) % phrases.length)
+          setPhase('typing')
+        }, pauseBetweenMs)
+      }
+    }
+    return () => clearTimeout(timer)
+  }, [text, phase, phraseIdx, phrases, typeMs, eraseMs, holdMs, pauseBetweenMs])
+
+  return (
+    <span className="v2-typing-prompt" aria-hidden="true">
+      <span className="v2-typing-prompt-text">{text}</span>
+      <span className="v2-typing-prompt-cursor">_</span>
+    </span>
+  )
+}

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,14 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-10
 
+- feat(ui): quokka — typing-prompt demo above example suggestions [XS]
+  - **Why.** User: "Can you do typing text? I'd love to see that added to the examples in quokka." Adds a CLI-demo feel to Quokka's empty state — Quokka literally types out what you could ask, cycling through `PROMPT_SUGGESTIONS`.
+  - **New `TypingPrompt` component.** Character-by-character typing with a blinking cursor (`_`). Cycles through provided phrases: type → hold (~1.6s) → erase → next phrase. Configurable `typeMs` / `eraseMs` / `holdMs` / `pauseBetweenMs` props. `prefers-reduced-motion` short-circuits to a static render of the longest phrase, no animation.
+  - **Wiring.** Rendered inside AdviserModal's empty state, between the intro body text and the static suggestion buttons below. Standard themes give it a faint background tint + rounded corners (callout look). Terminal mode swaps to a left-hairline + `> ` prompt prefix in accent green-blue with glow, so it reads as a live CLI demo.
+  - **Static buttons still ship.** The typing line is a demo; the four clickable suggestion buttons under it still give users a one-tap shortcut to populate the input.
+  - Modified: `src/v2/components/AdviserModal.jsx`, `src/v2/components/AdviserModal.css`, `wiki/Version-History.md`
+  - Added: `src/v2/components/TypingPrompt.jsx`, `src/v2/components/TypingPrompt.css`
+
 - style(ui): terminal — audit-pass cleanup (settings tabs, Kanban sigils, WeatherBadge, hover glow) [S]
   - **Why.** User: "go through and look for any inconsistencies in the terminal layouts. Check everything so as to minimize what I need to tell you to go fix." Five issues found and fixed; two genuine design forks asked and confirmed as "keep both" (action vocab: sigil+text on cards vs bracketed on modal CTAs; picker idiom: underline toolbar pills vs bracket settings segments).
   - **Settings tabs** (`.v2-settings-tab` — General/AI/Labels/Integrations/etc.) had no terminal override beyond font-size; still rendered as bordered pills. Now flat text-tabs with bottom-border accent underline-on-active, matching the toolbar pill idiom (both are "navigate between sub-views" tabs).


### PR DESCRIPTION
## Summary

User: "Can you do typing text? I'd love to see that added to the examples in quokka."

Adds a CLI-demo feel to Quokka's empty state. Quokka literally types out what you could ask, cycling through `PROMPT_SUGGESTIONS` character by character.

## Behavior

| Phase | Duration |
|---|---|
| Type | 55ms per character |
| Hold (complete phrase) | 1600ms |
| Erase | 25ms per character |
| Pause before next | 400ms |

Blinking cursor (`_`) at the end. `prefers-reduced-motion` short-circuits to a static render of the longest phrase, no animation.

## Visual

**Standard themes:** faint bg tint + rounded corners (callout look)

**Terminal mode:** left-hairline border + `> ` prompt prefix in accent + glow — reads as a live CLI demo

Static suggestion buttons still ship below the typing line. The demo is a flourish; the buttons are the actual one-tap shortcut.

## Files

- `src/v2/components/TypingPrompt.jsx` (new) — the typing component
- `src/v2/components/TypingPrompt.css` (new) — cursor blink animation
- `src/v2/components/AdviserModal.jsx` — wire into empty state
- `src/v2/components/AdviserModal.css` — `.v2-adviser-empty-demo` styles for both themes

https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_