### PR TITLE
fix(ui): quokka — horizontal overflow + missed toolbar buttons

### DIFF
--- a/src/v2/components/TypingPrompt.css
+++ b/src/v2/components/TypingPrompt.css
@@ -7,10 +7,12 @@
  * automatically from the surrounding theme tokens. */
 
 .v2-typing-prompt {
-  display: inline-block;
+  display: inline;
   font-variant-ligatures: none;
   letter-spacing: 0;
-  white-space: pre;
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow-wrap: break-word;
 }
 
 .v2-typing-prompt-text {

--- a/src/v2/terminal/init.css
+++ b/src/v2/terminal/init.css
@@ -1671,3 +1671,80 @@
 /* The `✓ done` card action stays green (errand-green) — the completion
  * state has its own color identity distinct from accent. Same for the
  * checkbox tap-active `[✓]` and the `.v2-confirm-btn-danger` red glow. */
+
+/* === Adviser toolbar buttons (Chats / New chat) ====================
+ * The audit missed these — they use `.v2-adviser-tool-btn` (not
+ * `.v2-adviser-btn`) and the primary variant adds accent fill. Strip
+ * chrome to match the rest of the terminal idiom. */
+:root[data-ui="v2"][data-theme^="terminal"] .v2-adviser-tool-btn {
+  background: transparent !important;
+  border: none !important;
+  border-radius: 0 !important;
+  color: var(--v2-text-meta) !important;
+  text-transform: lowercase;
+  padding: 6px 8px !important;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-adviser-tool-btn:hover {
+  background: transparent !important;
+  color: var(--v2-accent) !important;
+  text-shadow: var(--v2-glow);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-adviser-tool-btn-primary {
+  color: var(--v2-accent) !important;
+  text-shadow: var(--v2-glow);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-adviser-tool-btn-primary:hover {
+  color: var(--v2-accent) !important;
+  filter: none;
+  text-shadow: 0 0 12px rgba(88, 166, 255, 0.65);
+}
+
+/* === Adviser suggestion buttons: ensure wrap, drop chrome ========= */
+:root[data-ui="v2"][data-theme^="terminal"] .v2-adviser-suggestion {
+  background: transparent !important;
+  border: none !important;
+  border-bottom: 1px dashed var(--v2-hairline) !important;
+  border-radius: 0 !important;
+  padding: 10px 8px !important;
+  color: var(--v2-text-meta) !important;
+  white-space: normal;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  width: 100%;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-adviser-suggestion:hover {
+  background: transparent !important;
+  border-color: var(--v2-accent) !important;
+  color: var(--v2-accent) !important;
+  text-shadow: var(--v2-glow);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-adviser-suggestion::before {
+  content: "> ";
+  color: var(--v2-text-faint);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-adviser-suggestion:hover::before {
+  color: var(--v2-accent);
+}
+
+/* === Adviser empty state: prevent horizontal overflow ============= */
+:root[data-ui="v2"][data-theme^="terminal"] .v2-adviser-empty {
+  max-width: 100%;
+  padding: 24px 4px 16px;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-adviser-empty-body,
+:root[data-ui="v2"][data-theme^="terminal"] .v2-adviser-empty-title {
+  word-break: break-word;
+  overflow-wrap: break-word;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-adviser-empty-demo {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,14 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-10
 
+- fix(ui): quokka — horizontal overflow + missed toolbar buttons [XS]
+  - **Bug.** Quokka modal scrolling expanded the page horizontally — text in the empty state body, the typing-prompt line, and the suggestion buttons all extended past the visible viewport. Plus the "+ New chat" and "Chats" toolbar buttons still rendered as filled-blue / outlined-blue pills in terminal mode (audit miss — they use `.v2-adviser-tool-btn` not `.v2-adviser-btn`).
+  - **Root cause #1 — `white-space: pre` on `.v2-typing-prompt`.** The longest suggestion phrase rendered as a non-wrapping single line, forced its parent wide, and cascaded the overflow up through the empty state into the modal body. **Fix:** changed to `white-space: pre-wrap; word-break: break-word; overflow-wrap: break-word`. Preserves the visible spaces in the typed phrase but wraps when needed.
+  - **Root cause #2 — audit miss on toolbar buttons.** `.v2-adviser-tool-btn` only had a font-size override in terminal mode. The base CSS still rendered borders/fills. Added explicit chrome strip: bare lowercase text, `-primary` variant gets accent color + glow.
+  - **Suggestion buttons** also flattened in terminal mode: dashed bottom hairline, `> ` prefix on each row, full-width with `word-break: break-word` so long prompts wrap.
+  - **Empty state** got safety constraints: `max-width: 100%`, `padding: 24px 4px 16px` (less horizontal), and `overflow: hidden; text-overflow: ellipsis` on the demo line as a fallback.
+  - Modified: `src/v2/components/TypingPrompt.css`, `src/v2/terminal/init.css`, `wiki/Version-History.md`
+
 - feat(ui): quokka — typing-prompt demo above example suggestions [XS]
   - **Why.** User: "Can you do typing text? I'd love to see that added to the examples in quokka." Adds a CLI-demo feel to Quokka's empty state — Quokka literally types out what you could ask, cycling through `PROMPT_SUGGESTIONS`.
   - **New `TypingPrompt` component.** Character-by-character typing with a blinking cursor (`_`). Cycles through provided phrases: type → hold (~1.6s) → erase → next phrase. Configurable `typeMs` / `eraseMs` / `holdMs` / `pauseBetweenMs` props. `prefers-reduced-motion` short-circuits to a static render of the longest phrase, no animation.


### PR DESCRIPTION
## Bug

User: "Scrolling expands the screen in some fucked up way."

Quokka modal in terminal mode horizontally overflows — the empty state body text, typing-prompt line, and suggestion buttons all extend past the visible viewport. Plus the "+ New chat" and "Chats" toolbar buttons still rendered as filled-blue / outlined-blue pills (audit missed them).

## Root causes

### #1 — `white-space: pre` on `.v2-typing-prompt`

The longest suggestion phrase ("Clean up tasks that have been sitting over 30 days") rendered as a non-wrapping single line in monospace 13px. That's ~400px wide, wider than a mobile viewport. The typing-prompt forced its parent (`.v2-adviser-empty-demo`) wide, which cascaded up to `.v2-adviser-empty`, then the modal body, then the modal itself. Horizontal scrollbar.

**Fix:** `white-space: pre-wrap; word-break: break-word; overflow-wrap: break-word`. Preserves the visible spaces in the typed phrase but wraps when it needs to.

### #2 — Audit miss on toolbar buttons

`.v2-adviser-tool-btn` and `.v2-adviser-tool-btn-primary` are different classes from `.v2-adviser-btn`. Yesterday's audit covered `.v2-adviser-btn` and `.v2-adviser-history-btn` but missed these two. The base CSS still drew borders and the `-primary` variant added accent fill.

**Fix:** explicit chrome strip — bare lowercase text, `-primary` variant gets accent color + glow.

### #3 — Suggestion buttons not wrapping

`.v2-adviser-suggestion` in terminal mode now: dashed bottom hairline, `> ` prefix per row, `white-space: normal; word-break: break-word; width: 100%` so long prompts wrap.

### #4 — Empty state safety

`max-width: 100%` (overrides the 420px in base CSS that exceeded mobile viewports), `padding: 24px 4px 16px` (less horizontal), and `overflow: hidden; text-overflow: ellipsis` on the demo line as a fallback if anything still tries to expand.

## Verify

- [x] `npm run lint` clean
- [x] `npm run check:terminal-titles` OK
- [x] `npm run check:terminal-buttons` OK (58 covered)
- [x] `npm run build` succeeds

https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_