### PR TITLE
fix(ui): quokka — typing demo types each phrase once, sequentially

### DIFF
--- a/src/v2/components/AdviserModal.css
+++ b/src/v2/components/AdviserModal.css
@@ -116,19 +116,19 @@
   margin-bottom: 18px;
 }
 
-/* Typing-cursor demo line. Above the static suggestion buttons; cycles
- * through the same phrases character-by-character so the user sees
- * Quokka "demoing" what they could ask. Terminal mode adds a `>`
- * prompt prefix. */
+/* Typing-cursor demo block. Types each PROMPT_SUGGESTION sequentially
+ * (one line per phrase), accumulates them, holds the final state.
+ * Standard themes: faint bg + rounded corners (callout look). Terminal
+ * mode: bare left-hairline + `> ` prefix on each typed line. */
 .v2-adviser-empty-demo {
   width: 100%;
-  font: 400 13px/1.55 var(--v2-font-body);
+  font: 400 13px/1.5 var(--v2-font-body);
   color: var(--v2-text);
   margin-bottom: 14px;
-  min-height: 1.55em;
   padding: 10px 12px;
   background: rgba(var(--v2-text-rgb), 0.04);
   border-radius: 10px;
+  text-align: left;
 }
 
 :root[data-ui="v2"][data-theme^="terminal"] .v2-adviser-empty-demo {
@@ -136,13 +136,6 @@
   border-radius: 0;
   border-left: 2px solid var(--v2-hairline);
   padding: 6px 0 6px 10px;
-}
-
-:root[data-ui="v2"][data-theme^="terminal"] .v2-adviser-empty-demo::before {
-  content: "> ";
-  color: var(--v2-accent);
-  font-weight: 700;
-  text-shadow: var(--v2-glow);
 }
 
 .v2-adviser-suggestions {

--- a/src/v2/components/TypingPrompt.css
+++ b/src/v2/components/TypingPrompt.css
@@ -1,22 +1,23 @@
-/* Typing-cursor demo line. Used in Quokka's empty state above the
- * static suggestion buttons. Cycles through `PROMPT_SUGGESTIONS`,
- * character-by-character. Cursor blinks like a terminal prompt.
- *
- * The cursor renders in every theme (a blinking `_` reads as a hint
- * that this is a typing input). Terminal mode picks up the accent
- * automatically from the surrounding theme tokens. */
+/* Typing-prompt — types each phrase in sequence, builds up a list of
+ * completed lines, holds the final state. Used by Quokka's empty-state
+ * demo above the static suggestion buttons. */
 
 .v2-typing-prompt {
-  display: inline;
-  font-variant-ligatures: none;
-  letter-spacing: 0;
-  white-space: pre-wrap;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  width: 100%;
+}
+
+.v2-typing-prompt-line {
+  font: 400 13px/1.5 var(--v2-font-body);
+  color: var(--v2-text);
   word-break: break-word;
   overflow-wrap: break-word;
 }
 
-.v2-typing-prompt-text {
-  color: var(--v2-text);
+.v2-typing-prompt-line-complete {
+  color: var(--v2-text-meta);
 }
 
 .v2-typing-prompt-cursor {

--- a/src/v2/components/TypingPrompt.jsx
+++ b/src/v2/components/TypingPrompt.jsx
@@ -1,24 +1,26 @@
 import { useEffect, useRef, useState } from 'react'
 import './TypingPrompt.css'
 
-// Cycles through a list of phrases, typing each one character by
-// character, pausing while complete, then erasing and moving to the
-// next. Renders inline with a blinking cursor. Used by Quokka's empty
-// state to demo what the user could ask without overwhelming the
-// static suggestion list below it.
+// Types out each phrase in `phrases` sequentially, ONE TIME. As each
+// phrase finishes typing, it stays on screen and the next phrase types
+// below it. Once the last phrase finishes, the animation stops — the
+// final layout shows every phrase as a typed line, no looping.
 //
-// Respects `prefers-reduced-motion` — if reduced motion is preferred,
-// shows the longest phrase statically with no animation.
+// Used by Quokka's empty state to demo what the user could ask. The
+// static suggestion buttons below give the actual one-tap shortcut;
+// this is just the visual "Quokka can do these things" demo.
+//
+// `prefers-reduced-motion` short-circuits to rendering all phrases
+// statically with no typing animation.
 export default function TypingPrompt({
   phrases,
-  typeMs = 55,
-  eraseMs = 25,
-  holdMs = 1600,
-  pauseBetweenMs = 400,
+  typeMs = 45,
+  holdMs = 700,
 }) {
-  const [text, setText] = useState('')
-  const [phase, setPhase] = useState('typing')
-  const [phraseIdx, setPhraseIdx] = useState(0)
+  const [completed, setCompleted] = useState([])
+  const [currentIdx, setCurrentIdx] = useState(0)
+  const [currentText, setCurrentText] = useState('')
+  const [phase, setPhase] = useState('typing')   // typing | holding | done
   const reducedMotion = useRef(false)
 
   useEffect(() => {
@@ -29,37 +31,49 @@ export default function TypingPrompt({
   useEffect(() => {
     if (!Array.isArray(phrases) || phrases.length === 0) return
     if (reducedMotion.current) {
-      const longest = phrases.reduce((a, b) => (b.length > a.length ? b : a), '')
-      setText(longest)
+      setCompleted(phrases)
+      setPhase('done')
       return
     }
-    const phrase = phrases[phraseIdx % phrases.length]
+    if (phase === 'done') return
+    const phrase = phrases[currentIdx]
+    if (!phrase) { setPhase('done'); return }
     let timer
     if (phase === 'typing') {
-      if (text.length < phrase.length) {
-        timer = setTimeout(() => setText(phrase.slice(0, text.length + 1)), typeMs)
+      if (currentText.length < phrase.length) {
+        timer = setTimeout(() => setCurrentText(phrase.slice(0, currentText.length + 1)), typeMs)
       } else {
         timer = setTimeout(() => setPhase('holding'), holdMs)
       }
     } else if (phase === 'holding') {
-      timer = setTimeout(() => setPhase('erasing'), 0)
-    } else if (phase === 'erasing') {
-      if (text.length > 0) {
-        timer = setTimeout(() => setText(text.slice(0, -1)), eraseMs)
-      } else {
-        timer = setTimeout(() => {
-          setPhraseIdx(i => (i + 1) % phrases.length)
+      timer = setTimeout(() => {
+        setCompleted(prev => [...prev, phrase])
+        setCurrentText('')
+        const next = currentIdx + 1
+        if (next >= phrases.length) {
+          setPhase('done')
+        } else {
+          setCurrentIdx(next)
           setPhase('typing')
-        }, pauseBetweenMs)
-      }
+        }
+      }, 0)
     }
     return () => clearTimeout(timer)
-  }, [text, phase, phraseIdx, phrases, typeMs, eraseMs, holdMs, pauseBetweenMs])
+  }, [currentText, phase, currentIdx, phrases, typeMs, holdMs])
 
   return (
-    <span className="v2-typing-prompt" aria-hidden="true">
-      <span className="v2-typing-prompt-text">{text}</span>
-      <span className="v2-typing-prompt-cursor">_</span>
-    </span>
+    <div className="v2-typing-prompt" aria-hidden="true">
+      {completed.map((p, i) => (
+        <div key={i} className="v2-typing-prompt-line v2-typing-prompt-line-complete">
+          {p}
+        </div>
+      ))}
+      {phase !== 'done' && (
+        <div className="v2-typing-prompt-line v2-typing-prompt-line-active">
+          <span className="v2-typing-prompt-text">{currentText}</span>
+          <span className="v2-typing-prompt-cursor">_</span>
+        </div>
+      )}
+    </div>
   )
 }

--- a/src/v2/terminal/init.css
+++ b/src/v2/terminal/init.css
@@ -1746,5 +1746,19 @@
 
 :root[data-ui="v2"][data-theme^="terminal"] .v2-adviser-empty-demo {
   overflow: hidden;
-  text-overflow: ellipsis;
+}
+
+/* Per-line `> ` prefix on each typed phrase so it reads as a sequence
+ * of prompts being entered. Completed lines fade their prompt slightly
+ * so the in-progress one stands out — eye lands on the active cursor. */
+:root[data-ui="v2"][data-theme^="terminal"] .v2-typing-prompt-line::before {
+  content: "> ";
+  color: var(--v2-accent);
+  font-weight: 700;
+  text-shadow: var(--v2-glow);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-typing-prompt-line-complete::before {
+  color: var(--v2-text-meta);
+  text-shadow: none;
 }

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,15 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-10
 
+- fix(ui): quokka — typing demo types each phrase once, sequentially, no loop [XS]
+  - **Bug.** Typing-prompt was effectively looping the same phrase. User: "You should b typing each line sequentially once. Not the same one over and over."
+  - **Rewrite.** Each phrase types once, in order. As it finishes, it moves into a `completed[]` array (rendered as a static line) and the next phrase starts typing below it. After the last phrase, `phase` flips to `'done'` — no more animation, all phrases visible as a stack. The cursor sits on the active line during typing; completed lines fade to meta-text so the eye lands on the typing one.
+  - **State model** simplified: `{ completed: string[], currentIdx, currentText, phase: 'typing' | 'holding' | 'done' }`. No erase phase, no loop.
+  - **`prefers-reduced-motion`** sets `completed = phrases` immediately, no animation.
+  - **Terminal mode** adds a `> ` prefix per line via `.v2-typing-prompt-line::before`; completed-line prefix fades to meta.
+  - **NOTE:** PR #118 was a false-positive merge — pushed against a stale local branch ref so the diff was empty against base. This is the real ship.
+  - Modified: `src/v2/components/TypingPrompt.jsx`, `src/v2/components/TypingPrompt.css`, `src/v2/components/AdviserModal.css`, `src/v2/terminal/init.css`, `wiki/Version-History.md`
+
 - fix(ui): quokka — horizontal overflow + missed toolbar buttons [XS]
   - **Bug.** Quokka modal scrolling expanded the page horizontally — text in the empty state body, the typing-prompt line, and the suggestion buttons all extended past the visible viewport. Plus the "+ New chat" and "Chats" toolbar buttons still rendered as filled-blue / outlined-blue pills in terminal mode (audit miss — they use `.v2-adviser-tool-btn` not `.v2-adviser-btn`).
   - **Root cause #1 — `white-space: pre` on `.v2-typing-prompt`.** The longest suggestion phrase rendered as a non-wrapping single line, forced its parent wide, and cascaded the overflow up through the empty state into the modal body. **Fix:** changed to `white-space: pre-wrap; word-break: break-word; overflow-wrap: break-word`. Preserves the visible spaces in the typed phrase but wraps when needed.


### PR DESCRIPTION
## Bug

User: "You should b typing each line sequentially once. Not the same one over and over."

The typing-prompt was cycling — type a phrase, erase it, type the next, erase, repeat forever. User wanted each phrase to type ONCE and stay visible.

## Note on PR #118

PR #118 had this exact title but the merge had no diff. I pushed against a stale local branch ref (the branch I'd used for PR #117, which got auto-deleted from remote after rebase-merge). The "merge" succeeded with empty changes against base. **This PR is the real ship.**

## Rewrite

Each phrase types once, in order. As it finishes typing, it moves into a `completed[]` array (rendered as a static line) and the next phrase starts typing below it. After the last phrase, `phase` flips to `'done'` — no more animation, all phrases visible as a stack.

```
> I've rescheduled my exam — adjust related tasks
> Move my lawn-care tasks to next weekend (bad weather coming)
> What should I tackle right now?
> Clean up tasks that have been sitting over 30 days_
```

The cursor sits on the active line. Completed lines fade to meta-text. After all four finish, the cursor remains on the last line briefly then settles.

## State

`{ completed: string[], currentIdx, currentText, phase: 'typing' | 'holding' | 'done' }` — no erase, no loop.

`prefers-reduced-motion` sets `completed = phrases` immediately.

Terminal mode adds the `> ` prefix per line via `.v2-typing-prompt-line::before`; completed-line prefix fades to meta-text.

https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_