### PR TITLE
fix(sync): terminal theme persistence — real fix (AppV2 hydrate also clobbered local)

### DIFF
--- a/src/v2/AppV2.jsx
+++ b/src/v2/AppV2.jsx
@@ -148,11 +148,16 @@ export default function AppV2() {
 
   // Server hydration + cross-client sync. Mirror v1's hydrateFromServer so
   // settings + labels stay in localStorage when other clients update them.
+  //
+  // Note on theme: `useServerSync` owns the localStorage write for settings
+  // and has a theme-preservation guard (theme is device-local; a stale
+  // server snapshot shouldn't overwrite a fresh local pick). Don't call
+  // `saveSettings(data.settings)` here — it'd bypass that guard. We only
+  // mirror downstream React state that depends on server-side settings.
   const hydrateFromServer = useCallback((data) => {
     if (data.tasks) hydrateTasks(data.tasks)
     if (data.routines) hydrateRoutines(data.routines)
     if (data.settings) {
-      saveSettings(data.settings)
       if (data.settings.sort_by) setSortBy(data.settings.sort_by)
     }
     if (data.labels) {

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,12 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-10
 
+- fix(sync): terminal theme persistence — REAL fix (AppV2's hydrate also clobbered local) [XS]
+  - **Bug.** PR #109 added a theme-preservation guard inside `useServerSync.js`, but the persistence bug came back. User: "The terminal setting isn't sticking still."
+  - **Why #109 was incomplete.** `AppV2.jsx`'s `hydrateFromServer` callback ALSO wrote `saveSettings(data.settings)` directly — and it ran BEFORE the protected save in useServerSync. So the order on every hydrate was: (1) onHydrate clobbers local theme with server's stale value; (2) useServerSync reads localStorage to get "the local theme" — which is now the stale server value just written; (3) "preserves" it — i.e. writes it back as a no-op. Net effect: local pick gets overwritten.
+  - **Fix.** Drop the `saveSettings(data.settings)` call from `hydrateFromServer`. useServerSync owns the localStorage write for settings (with the theme-preservation guard from #109). The hydrate callback now only mirrors downstream React state — `setSortBy(data.settings.sort_by)` — and lets useServerSync handle persistence.
+  - Modified: `src/v2/AppV2.jsx`, `wiki/Version-History.md`
+
 - fix(ui): quokka — typing demo types each phrase once, sequentially, no loop [XS]
   - **Bug.** Typing-prompt was effectively looping the same phrase. User: "You should b typing each line sequentially once. Not the same one over and over."
   - **Rewrite.** Each phrase types once, in order. As it finishes, it moves into a `completed[]` array (rendered as a static line) and the next phrase starts typing below it. After the last phrase, `phase` flips to `'done'` — no more animation, all phrases visible as a stack. The cursor sits on the active line during typing; completed lines fade to meta-text so the eye lands on the typing one.


### PR DESCRIPTION
## Bug

User: "The terminal setting isn't sticking still." (Same bug as PR #109, returned.)

## Why PR #109 was incomplete

PR #109 added a theme-preservation guard to `useServerSync.js`'s settings write. But it missed that `AppV2.jsx`'s `hydrateFromServer` callback ALSO writes `saveSettings(data.settings)` directly — and that one runs BEFORE the protected save.

Order on every hydrate:

1. `useServerSync` calls `onHydrate(data)` — which is `hydrateFromServer` in AppV2
2. `hydrateFromServer` calls `saveSettings(data.settings)` → **local theme clobbered with server's stale value**
3. `useServerSync` then calls its own protected `saveSettings(merged)` — reads `loadSettings().theme` to get "local theme," but localStorage now holds the stale server value just written in step 2
4. Writes that back as a no-op

Net: user's local theme pick gets overwritten on every hydrate.

## Fix

Drop the `saveSettings(data.settings)` call from `hydrateFromServer`. `useServerSync` owns the localStorage write for settings (with the theme-preservation guard from #109). The hydrate callback now only mirrors downstream React state (the `setSortBy(data.settings.sort_by)` line, which has to live in AppV2 because it's React state outside of localStorage).

https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_