### PR TITLE
fix(ui): ship-prep batch — Quokka send button + autofocus + docs

### DIFF
--- a/src/v2/components/AdviserModal.jsx
+++ b/src/v2/components/AdviserModal.jsx
@@ -177,7 +177,10 @@ export default function AdviserModal({ open, adviser, onClose, onAfterCommit }) 
     if (scrollRef.current) scrollRef.current.scrollTop = scrollRef.current.scrollHeight
   }, [messages, status])
 
-  useEffect(() => { if (open && !showHistory) inputRef.current?.focus() }, [open, activeId, showHistory])
+  // Don't auto-focus the input on modal open — on iOS PWA the keyboard
+  // pops immediately and covers half the empty-state typing demo +
+  // suggestion buttons before the user can read them. Focus moves into
+  // the input naturally when the user taps it or picks a suggestion.
 
   // Auto-grow textarea up to a sensible max.
   useEffect(() => {

--- a/src/v2/terminal/init.css
+++ b/src/v2/terminal/init.css
@@ -1069,23 +1069,39 @@
   text-shadow: var(--v2-glow);
 }
 
-/* AdviserModal — send + tool buttons */
+/* AdviserModal — send button. The JSX renders a `<Send>` lucide SVG
+ * as the only child (no text). Hide the SVG and render `[ send ]` text
+ * via ::before so terminal mode reads as `[ send ]` instead of an
+ * airplane icon flanked by brackets. */
 :root[data-ui="v2"][data-theme^="terminal"] .v2-adviser-send {
   background: transparent !important;
   border: none !important;
   border-radius: 0 !important;
+  width: auto !important;
+  height: auto !important;
+  padding: 4px 0 !important;
   color: var(--v2-accent) !important;
   text-transform: lowercase;
   text-shadow: var(--v2-glow);
+  font: 500 13px/1 var(--v2-font-body);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-adviser-send svg {
+  display: none !important;
 }
 
 :root[data-ui="v2"][data-theme^="terminal"] .v2-adviser-send::before {
-  content: "[ ";
+  content: "[ send ]";
   color: var(--v2-accent);
+  font-weight: 500;
 }
+
 :root[data-ui="v2"][data-theme^="terminal"] .v2-adviser-send::after {
-  content: " ]";
-  color: var(--v2-accent);
+  content: "";
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-adviser-send:disabled {
+  opacity: 0.4;
 }
 
 :root[data-ui="v2"][data-theme^="terminal"] .v2-adviser-send:hover:not(:disabled) {

--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -33,9 +33,15 @@ Browser (React PWA)
 - `useTerminalMode()` hook in `src/v2/hooks/useTerminalMode.js` — MutationObserver on `data-theme`, returns true when prefix matches `terminal-`
 - `terminalTitle` prop on `ModalShell` + `ConfirmDialog` — overrides the regular `title` when terminal mode is active
 - `terminalCommand` prop on `EmptyState` — short-circuits the icon+title+body tree to a `// comment` line
-- `data-terminal-cmd` attr on `.v2-edit-action-label` spans — visible label swaps via CSS `attr()` to its CLI form (`$ archive`, `$ delete --confirm`, etc.)
+- `data-terminal-cmd` attr on `.v2-edit-action-label` spans + `.v2-more-row-label` + others — visible label swaps via CSS `attr()` to its CLI form (`> archive`, `> delete --confirm`, etc.)
+- `DateField` (`src/v2/components/DateField.jsx`) — bracketed text trigger that opens the native date picker via `input.showPicker()`. Renders `[ due date ]` empty / `[ YYYY-MM-DD ]` filled, plus an inline `× clear` button. Same component shape in all themes; terminal mode flattens the trigger to bare bracketed text via CSS.
+- `TypingSuggestions` (`src/v2/components/TypingSuggestions.jsx`) — Quokka empty-state suggestion list where each row types itself in sequentially. Pending/active/complete states render the same element with different visual treatments; completed rows are real clickable buttons.
 
-Convention smoke test: `scripts/check-terminal-titles.js` (wired into the pre-push hook) asserts every `<ModalShell>` JSX call site carries `terminalTitle`. Run via `npm run check:terminal-titles`. See CLAUDE.md → "Terminal Theme Stress Test" for the policy on what's terminal-only vs theme-agnostic going forward.
+Convention smoke tests (both wired into the pre-push hook):
+- `npm run check:terminal-titles` — asserts every `<ModalShell>` JSX call site carries `terminalTitle`
+- `npm run check:terminal-buttons` — asserts every button-shaped v2 class (matching `.v2-*-{btn|pill|toggle|seg|chip|tab|option|action|row|cta|trigger}`) has a terminal-mode rule somewhere under `[data-theme^="terminal"]`. Layout-only containers are exempt-listed at the top of the script.
+
+See CLAUDE.md → "Terminal Theme Stress Test" for the policy on what's terminal-only vs theme-agnostic going forward.
 
 ## Data Flow
 

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,13 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-10
 
+- fix(ui): ship-prep batch — Quokka send button + autofocus + docs [XS]
+  - **Why.** User feedback: "Quokka seems fixed. The paper airplane should probably be adjusted to p10k or true word only send button. There is also a bug in PWA where it drops me immediately into the text box and the keyboard covers up half the stuff." Plus the heads-up that `DateField` + `TypingSuggestions` weren't yet in `wiki/Architecture.md`.
+  - **Send button** (`.v2-adviser-send`) — was rendering an airplane SVG flanked by `[` `]` brackets in terminal mode (the JSX child is `<Send>` lucide; my bracket-wrap `::before`/`::after` rules wrapped the SVG). Hidden the SVG in terminal mode via `display: none` and replaced with `[ send ]` text via `::before` content. Matches the bracketed-CTA convention used by `.v2-form-submit`, `.v2-confirm-btn-primary`, etc.
+  - **Autofocus bug** — `useEffect(() => { if (open && !showHistory) inputRef.current?.focus() }, ...)` was firing the keyboard immediately on modal open, covering half the empty-state typing demo + suggestion buttons on iOS PWA. Removed. Focus moves into the input naturally when the user taps it or picks a suggestion (the existing `inputRef.current?.focus()` inside the `onSelect` callback still works).
+  - **wiki/Architecture.md** — `DateField` and `TypingSuggestions` added to the v2 component family list with notes on what they do + their terminal-mode treatment. Also bumped the convention-smoke-test mention to reference both `check:terminal-titles` AND `check:terminal-buttons`.
+  - Modified: `src/v2/components/AdviserModal.jsx`, `src/v2/terminal/init.css`, `wiki/Architecture.md`, `wiki/Version-History.md`
+
 - fix(sync): terminal theme persistence — REAL fix (AppV2's hydrate also clobbered local) [XS]
   - **Bug.** PR #109 added a theme-preservation guard inside `useServerSync.js`, but the persistence bug came back. User: "The terminal setting isn't sticking still."
   - **Why #109 was incomplete.** `AppV2.jsx`'s `hydrateFromServer` callback ALSO wrote `saveSettings(data.settings)` directly — and it ran BEFORE the protected save in useServerSync. So the order on every hydrate was: (1) onHydrate clobbers local theme with server's stale value; (2) useServerSync reads localStorage to get "the local theme" — which is now the stale server value just written; (3) "preserves" it — i.e. writes it back as a no-op. Net effect: local pick gets overwritten.


### PR DESCRIPTION
Ship-prep batch. Three small fixes in one PR.

## 1. Quokka send button — airplane → `[ send ]`

User: "The paper airplane should probably be adjusted to p10k or true word only send button."

The button rendered as `[ <airplane SVG> ]` in terminal mode — my earlier bracket-wrap `::before`/`::after` rules wrapped the lucide SVG child instead of replacing it. Hidden the SVG in terminal mode + put `[ send ]` text in the `::before` content. Matches the bracketed-CTA convention used everywhere else (`[ Save ]`, `[ apply ]`, `[ go ]`, `[ delete --confirm ]`).

## 2. PWA autofocus bug

User: "There is also a bug in PWA where it drops me immediately into the text box and the keyboard covers up half the stuff."

`useEffect(() => { if (open && !showHistory) inputRef.current?.focus() }, ...)` was firing the keyboard the instant the modal opened. On iOS PWA the keyboard covers ~half the screen — hiding the typing demo, suggestion buttons, and intro text before the user could read them.

Removed the auto-focus. Focus still moves into the input naturally when the user taps it OR picks a suggestion (the `setInput(s); inputRef.current?.focus()` in the `onSelect` callback still works — picking a suggestion fills the input AND brings up the keyboard, which is the right moment for it).

## 3. Docs (Architecture.md)

`DateField` and `TypingSuggestions` weren't in `wiki/Architecture.md`'s v2 component list. Added both with one-line summaries.

Also bumped the convention-smoke-test mention to include `check:terminal-buttons` alongside `check:terminal-titles` (the second one was added in PR #107 but the wiki only mentioned the first).

https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_