### PR TITLE
style(ui): terminal — DoneList reopen + load-more buttons

### DIFF
--- a/src/v2/terminal/init.css
+++ b/src/v2/terminal/init.css
@@ -1940,3 +1940,65 @@
   filter: none;
   text-shadow: 0 0 12px rgba(88, 166, 255, 0.65);
 }
+
+/* === Done list buttons ============================================
+ * `.v2-done-reopen` (per-row Reopen button) and `.v2-done-load-more`
+ * (bottom "Load more" pagination) were missed in earlier sweeps —
+ * still rendered as hairline-bordered rounded pills. Flatten to
+ * bracketed accent text matching the other CTA convention. */
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-done-reopen {
+  background: transparent !important;
+  border: none !important;
+  border-radius: 0 !important;
+  height: auto !important;
+  padding: 4px 0 !important;
+  color: var(--v2-accent) !important;
+  text-transform: lowercase;
+  font: 500 12px/1 var(--v2-font-body) !important;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-done-reopen::before {
+  content: "[ ";
+  color: var(--v2-accent);
+}
+:root[data-ui="v2"][data-theme^="terminal"] .v2-done-reopen::after {
+  content: " ]";
+  color: var(--v2-accent);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-done-reopen:hover {
+  background: transparent !important;
+  color: var(--v2-accent) !important;
+  text-shadow: var(--v2-glow);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-done-load-more {
+  background: transparent !important;
+  border: none !important;
+  border-radius: 0 !important;
+  color: var(--v2-text-meta) !important;
+  text-transform: lowercase;
+  padding: 8px 0 !important;
+  font: 500 13px/1 var(--v2-font-body) !important;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-done-load-more::before {
+  content: "[ ";
+  color: var(--v2-text-faint);
+}
+:root[data-ui="v2"][data-theme^="terminal"] .v2-done-load-more::after {
+  content: " ]";
+  color: var(--v2-text-faint);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-done-load-more:hover {
+  background: transparent !important;
+  color: var(--v2-accent) !important;
+  text-shadow: var(--v2-glow);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-done-load-more:hover::before,
+:root[data-ui="v2"][data-theme^="terminal"] .v2-done-load-more:hover::after {
+  color: var(--v2-accent);
+}

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,12 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-10
 
+- style(ui): terminal — DoneList reopen + load-more buttons [XS]
+  - **Why.** User: "Done list reopen are buttons. Import markdown preview is a button." The markdown preview button was already fixed in #123 — the user is seeing a cached PWA build. Done-list reopen + load-more genuinely weren't touched.
+  - **`.v2-done-reopen`** (per-row "Reopen" button on each completed task): hairline-bordered pill → bracketed accent text `[ reopen ]`. Hover deepens the glow.
+  - **`.v2-done-load-more`** (bottom "Load more" pagination): same treatment, meta-text inactive, accent on hover.
+  - Modified: `src/v2/terminal/init.css`, `wiki/Version-History.md`
+
 - style(ui): terminal — notif cards + logs view + analytics brackets + markdown CTA [XS]
   - **Why.** Four screenshots in quick succession (per the new batching rule):
     1. Notif cards rendered each frequency type as a bordered card with surface-bg fill — "these don't fit with the aesthetic"


### PR DESCRIPTION
Two reports from this batch:

1. **"Done list reopen are buttons"** — genuine miss. `.v2-done-reopen` and `.v2-done-load-more` were never swept. Flattened to bracketed accent text.

2. **"Import markdown preview is a button"** — was already fixed in #123 (verified `.v2-md-import-primary` rule is present in `init.css` on dev: lines 1917+). User is most likely seeing a cached PWA build; a hard-refresh or close+reopen of the PWA picks up the new image.

## Changes

- `.v2-done-reopen` → `[ reopen ]` (accent, glow on hover)
- `.v2-done-load-more` → `[ load more ]` (meta inactive, accent on hover)

CSS-only, terminal-only.

https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_