### PR TITLE
fix(ui): terminal — markdown import button row alignment

### DIFF
--- a/src/v2/terminal/init.css
+++ b/src/v2/terminal/init.css
@@ -1924,6 +1924,14 @@
   padding: 6px 0 !important;
   font: 500 13px/1.2 var(--v2-font-body) !important;
   text-transform: lowercase;
+  /* Base CSS sets `flex: 1` so the button expands to fill its row —
+   * centers the bracketed text awkwardly in the left half while the
+   * secondary `[ upload .md ]` sits separately to the right. Override
+   * to natural width + push the gap so both sit side-by-side from the
+   * row's start. */
+  flex: 0 0 auto !important;
+  min-width: 0;
+  margin-right: 18px;
 }
 
 :root[data-ui="v2"][data-theme^="terminal"] .v2-md-import-primary::before {

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,12 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-10
 
+- fix(ui): terminal — markdown import button row alignment [XS]
+  - **Why.** User: "Alignment on the buttons here is fucked." `[ preview tasks ]` and `[ upload .md ]` sat in a row but `[ preview tasks ]` was centered awkwardly in its half.
+  - **Root cause.** Base CSS on `.v2-md-import-primary` sets `flex: 1` so the button expands to fill remaining space. With chrome stripped in terminal mode, the bracketed text floats centered in an invisible-but-expanded button slot. Visual mismatch with `[ upload .md ]` (which uses `.v2-settings-btn`, natural width).
+  - **Fix.** Override `flex: 0 0 auto` + `margin-right: 18px` in terminal mode so the preview button takes natural width and the two buttons sit side-by-side from the row's start, with a comfortable gap between.
+  - Modified: `src/v2/terminal/init.css`, `wiki/Version-History.md`
+
 - style(ui): terminal — DoneList reopen + load-more buttons [XS]
   - **Why.** User: "Done list reopen are buttons. Import markdown preview is a button." The markdown preview button was already fixed in #123 — the user is seeing a cached PWA build. Done-list reopen + load-more genuinely weren't touched.
   - **`.v2-done-reopen`** (per-row "Reopen" button on each completed task): hairline-bordered pill → bracketed accent text `[ reopen ]`. Hover deepens the glow.


### PR DESCRIPTION
User: "Alignment on the buttons here is fucked."

`[ preview tasks ]` and `[ upload .md ]` shared a row but `[ preview tasks ]` floated centered in an invisible-but-expanded button slot — base CSS sets `flex: 1` on `.v2-md-import-primary`, which made the button take up half the row with the bracketed text centered inside.

Fix: override `flex: 0 0 auto` + `margin-right: 18px` in terminal mode. Preview takes natural width, both buttons sit side-by-side from the row's start with a comfortable gap.

https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_