### PR TITLE
refactor(ui): move markdown import to Settings → Data [XS]

### DIFF
--- a/src/v2/AppV2.jsx
+++ b/src/v2/AppV2.jsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { ListChecks, Settings as SettingsIcon, FolderKanban, BarChart3, History, ChevronRight, CheckCircle2, RotateCw, Upload } from 'lucide-react'
+import { ListChecks, Settings as SettingsIcon, FolderKanban, BarChart3, History, ChevronRight, CheckCircle2, RotateCw } from 'lucide-react'
 import Header from './components/Header'
 import ModalShell from './components/ModalShell'
 import EmptyState from './components/EmptyState'
@@ -801,13 +801,6 @@ export default function AppV2() {
               <ChevronRight size={16} strokeWidth={1.75} className="v2-more-row-chev" />
             </button>
           </li>
-          <li>
-            <button className="v2-more-row" onClick={() => { setShowMenu(false); setShowMarkdownImport(true) }}>
-              <Upload size={18} strokeWidth={1.75} className="v2-more-row-icon" />
-              <span className="v2-more-row-label" data-terminal-cmd="> import --markdown">Import from markdown</span>
-              <ChevronRight size={16} strokeWidth={1.75} className="v2-more-row-chev" />
-            </button>
-          </li>
         </ul>
       </ModalShell>
 
@@ -854,6 +847,7 @@ export default function AppV2() {
         onClearCompleted={() => { clearCompleted(); setShowSettings(false); flushSync() }}
         onClearAll={() => { clearAll(); setShowSettings(false); flushSync() }}
         onShowActivityLog={() => setShowActivityLog(true)}
+        onShowMarkdownImport={() => setShowMarkdownImport(true)}
         onTrelloSync={syncTrello}
         trelloSyncing={trelloSyncing}
         onNotionSync={syncNotion}

--- a/src/v2/components/SettingsModal.jsx
+++ b/src/v2/components/SettingsModal.jsx
@@ -1727,7 +1727,7 @@ function ServerLogsPanel() {
 }
 
 export default function SettingsModal({
-  open, onClose, onFlush, onClearCompleted, onClearAll, onShowActivityLog,
+  open, onClose, onFlush, onClearCompleted, onClearAll, onShowActivityLog, onShowMarkdownImport,
   onTrelloSync, trelloSyncing, onNotionSync, notionSyncing, onGCalSync, gcalSyncing,
 }) {
   const [activeTab, setActiveTab] = useState('General')
@@ -2132,6 +2132,18 @@ export default function SettingsModal({
                 disabled={!onShowActivityLog}
               >
                 <FileText size={13} strokeWidth={1.75} /> Open activity log
+              </button>
+            </div>
+
+            <div className="v2-settings-block">
+              <div className="v2-form-label">Markdown import</div>
+              <div className="v2-settings-row-hint">Paste a markdown list or checklist and have it parsed into tasks. Rarely used; lives here so it doesn't crowd the main menu.</div>
+              <button
+                className="v2-settings-btn"
+                onClick={() => { onClose?.(); onShowMarkdownImport?.() }}
+                disabled={!onShowMarkdownImport}
+              >
+                <Upload size={13} strokeWidth={1.75} /> Import from markdown
               </button>
             </div>
 

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -4,6 +4,18 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ---
 
+## 2026-05-11
+
+- refactor(ui): move markdown import from overflow menu to Settings → Data [XS]
+  - **Why.** User: "Let's move import markdown to the data tab. I'm not positive it's going to live long. But I have it built for now. It's a rarely used function." Crowding the top-level overflow menu with a feature that may be deprecated isn't worth the slot.
+  - **Settings → Data.** New "Markdown import" block sits between Activity and Danger zone. Bracketed `[ import from markdown ]` button (terminal idiom inherited from `.v2-settings-btn` class) opens the existing `MarkdownImportModal` after closing Settings.
+  - **Wiring.** `SettingsModal` gains an `onShowMarkdownImport` prop, mirroring the existing `onShowActivityLog` pattern. `AppV2` passes `() => setShowMarkdownImport(true)`.
+  - **Overflow menu.** "Import from markdown" row removed from the `…` menu. `Upload` lucide icon dropped from `AppV2.jsx` import list (no longer used there).
+  - **No behavior change** beyond placement — the modal itself is untouched.
+  - Modified: `src/v2/components/SettingsModal.jsx`, `src/v2/AppV2.jsx`, `wiki/Version-History.md`, `wiki/Architecture.md`
+
+---
+
 ## 2026-05-10
 
 - fix(ui): terminal — markdown import button row alignment [XS]


### PR DESCRIPTION
## Summary

- Markdown import moves out of the top-level `…` overflow menu into a Settings → Data block (between Activity and Danger zone).
- User: "Let's move import markdown to the data tab. I'm not positive it's going to live long. But I have it built for now. It's a rarely used function."
- `SettingsModal` gains `onShowMarkdownImport` prop, mirroring the existing `onShowActivityLog` pattern. `AppV2` passes `() => setShowMarkdownImport(true)`.
- `Upload` lucide icon dropped from `AppV2.jsx` import list (no longer used there).

No behavior change beyond placement — the modal itself is untouched.

## Test plan

- [ ] Open Settings → Data → "Markdown import" block visible.
- [ ] Click `[ import from markdown ]` → Settings closes, MarkdownImportModal opens.
- [ ] Paste a markdown checklist → preview → import → tasks appear.
- [ ] Open the overflow `…` menu → no "Import from markdown" row.
- [ ] `npm run lint` clean, `npm run check:terminal-titles` + `check:terminal-buttons` green.

https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_