### PR TITLE
feat(ui): WeekStrip days collapse by default, click range to toggle [S]

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -54,6 +54,10 @@ export const DEFAULT_SETTINGS = {
   // fill; this is the single source of truth for daily-goal progress
   // (GoalProgressBar was removed 2026-05-11).
   show_week_strip: false,
+  // When true, the day cells stay expanded all the time. When false
+  // (default), the strip renders collapsed — just the range label +
+  // today's count — and tapping the range expands the days.
+  week_strip_always_open: false,
   vacation_mode: false,
   vacation_started: null,
   trello_api_key: '',

--- a/src/v2/AppV2.jsx
+++ b/src/v2/AppV2.jsx
@@ -697,7 +697,11 @@ export default function AppV2() {
               </div>
             )}
             {(settingsForRings.show_week_strip || isTerminal) && (
-              <WeekStrip tasks={tasks} dailyTaskGoal={settingsForRings.daily_task_goal || 3} />
+              <WeekStrip
+                tasks={tasks}
+                dailyTaskGoal={settingsForRings.daily_task_goal || 3}
+                alwaysOpen={!!settingsForRings.week_strip_always_open}
+              />
             )}
             {renderSection('Doing', sortedDoing, '→')}
             {renderSection('Stale', sortedStale, '~')}

--- a/src/v2/components/SettingsModal.jsx
+++ b/src/v2/components/SettingsModal.jsx
@@ -2023,6 +2023,21 @@ export default function SettingsModal({
 
             <div className="v2-settings-row">
               <div className="v2-settings-row-text">
+                <div className="v2-settings-row-label">Keep day cells expanded</div>
+                <div className="v2-settings-row-hint">By default the day cells are hidden — tap the range label to show them. Enable this to keep them visible permanently.</div>
+              </div>
+              <label className="v2-settings-toggle">
+                <input
+                  type="checkbox"
+                  checked={!!settings.week_strip_always_open}
+                  onChange={e => update('week_strip_always_open', e.target.checked)}
+                />
+                <span className="v2-settings-toggle-track"><span className="v2-settings-toggle-thumb" /></span>
+              </label>
+            </div>
+
+            <div className="v2-settings-row">
+              <div className="v2-settings-row-text">
                 <label className="v2-settings-row-label" htmlFor="v2-daily-goal">Daily task goal</label>
                 <div className="v2-settings-row-hint">Used by the progress bar + activity intensity on the 7-day strip.</div>
               </div>

--- a/src/v2/components/WeekStrip.css
+++ b/src/v2/components/WeekStrip.css
@@ -22,10 +22,46 @@
   padding: 0 4px;
 }
 
+.v2-week-strip-collapsed .v2-week-strip-head {
+  margin-bottom: 0;
+}
+
 .v2-week-strip-range {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
   font: 500 12px/1 var(--v2-font-body);
   color: var(--v2-text-meta);
   letter-spacing: 0.02em;
+}
+
+.v2-week-strip-range-toggle {
+  border: none;
+  background: transparent;
+  padding: 4px 8px;
+  border-radius: var(--v2-radius-pill);
+  cursor: pointer;
+  color: var(--v2-text-meta);
+  transition: background var(--v2-dur-quick) var(--v2-ease-standard),
+              color var(--v2-dur-quick) var(--v2-ease-standard);
+}
+
+.v2-week-strip-range-toggle:hover {
+  color: var(--v2-text);
+  background: rgba(var(--v2-text-rgb), 0.04);
+}
+
+.v2-week-strip-range-today {
+  color: var(--v2-accent);
+  font-weight: 600;
+}
+
+.v2-week-strip-range-chev {
+  transition: transform var(--v2-dur-quick) var(--v2-ease-standard);
+}
+
+.v2-week-strip-range-chev-open {
+  transform: rotate(180deg);
 }
 
 .v2-week-strip-nav {
@@ -147,9 +183,35 @@
   padding: 0;
 }
 
-:root[data-ui="v2"][data-theme^="terminal"] .v2-week-strip-range::before {
+:root[data-ui="v2"][data-theme^="terminal"] .v2-week-strip-range-label::before {
   content: "// ";
   color: var(--v2-text-faint);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-week-strip-range-toggle {
+  border-radius: 0;
+  padding: 4px 6px;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-week-strip-range-toggle:hover {
+  background: transparent;
+  color: var(--v2-accent);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-week-strip-range-chev {
+  display: none;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-week-strip-range-toggle::after {
+  content: " ▾";
+  font-family: var(--v2-font-body);
+  color: var(--v2-text-faint);
+  font-size: 10px;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-week-strip-range-toggle[aria-expanded="true"]::after {
+  content: " ▴";
+  color: var(--v2-accent);
 }
 
 :root[data-ui="v2"][data-theme^="terminal"] .v2-week-strip-row {

--- a/src/v2/components/WeekStrip.jsx
+++ b/src/v2/components/WeekStrip.jsx
@@ -1,22 +1,20 @@
 import { useMemo, useState } from 'react'
-import { ChevronLeft, ChevronRight } from 'lucide-react'
+import { ChevronLeft, ChevronRight, ChevronDown } from 'lucide-react'
 import './WeekStrip.css'
 
 // 7-day calendar strip rendered above the task list. Each day cell shows
 // day-of-week label + date number + an activity-intensity indicator
 // (dot in light/dark, block in terminal mode) reflecting how many tasks
-// were completed that day relative to `daily_task_goal`.
+// were completed that day relative to `daily_task_goal`. Today's cell
+// also shows the exact `count/goal` inline.
 //
-// Opt-in via the `show_week_strip` setting. Theme-aware visuals: rounded
-// card cells in light/dark; bare monospace strip with `*` today marker
-// + block-character intensity in terminal mode (CSS-only difference).
+// Opt-in via the `show_week_strip` setting (always-on in terminal mode).
+// The day cells are hidden by default — clicking the range label
+// expands/collapses them. The `alwaysOpen` prop (driven by the
+// `week_strip_always_open` setting) keeps them expanded permanently.
 //
-// Tap a day = no-op for v1. Hook reserved for future "filter list to
-// that day" or "jump to that day" interactions.
-//
-// Week navigation: < prev / next > arrows on the edges. State managed
-// locally — defaults to the week containing today; arrow clicks shift
-// the offset by ±7 days.
+// Week navigation: < prev / next > arrows. Arrow clicks don't toggle
+// expansion; they shift the visible week regardless of state.
 
 const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
 
@@ -31,11 +29,11 @@ function startOfWeekSunday(date) {
   return d
 }
 
-export default function WeekStrip({ tasks, dailyTaskGoal }) {
+export default function WeekStrip({ tasks, dailyTaskGoal, alwaysOpen = false }) {
   const [weekOffset, setWeekOffset] = useState(0)
+  const [userExpanded, setUserExpanded] = useState(false)
+  const expanded = alwaysOpen || userExpanded
 
-  // Pre-bucket task completions by ISO date. Cheap; runs on every tasks
-  // change, but the list is bounded and the bucket is just a count.
   const completionsByDate = useMemo(() => {
     const map = {}
     for (const t of tasks) {
@@ -57,7 +55,6 @@ export default function WeekStrip({ tasks, dailyTaskGoal }) {
       const key = ymd(d)
       const count = completionsByDate[key] || 0
       const goal = dailyTaskGoal > 0 ? dailyTaskGoal : 3
-      // Intensity: 0 = no completions, 1 = some, 2 = met goal, 3 = exceeded
       let intensity = 0
       if (count > 0 && count < goal) intensity = 1
       else if (count >= goal && count < goal * 2) intensity = 2
@@ -77,7 +74,6 @@ export default function WeekStrip({ tasks, dailyTaskGoal }) {
     return out
   }, [completionsByDate, weekOffset, dailyTaskGoal])
 
-  // Range label — "May 4–10" or "Apr 27–May 3" if straddling a month.
   const rangeLabel = useMemo(() => {
     const first = days[0].date
     const last = days[6].date
@@ -89,8 +85,11 @@ export default function WeekStrip({ tasks, dailyTaskGoal }) {
     return `${firstMonth} ${first.getDate()}–${lastMonth} ${last.getDate()}`
   }, [days])
 
+  const today = days.find(d => d.isToday)
+  const canToggle = !alwaysOpen
+
   return (
-    <div className="v2-week-strip">
+    <div className={`v2-week-strip${expanded ? ' v2-week-strip-expanded' : ' v2-week-strip-collapsed'}`}>
       <div className="v2-week-strip-head">
         <button
           className="v2-week-strip-nav"
@@ -99,7 +98,31 @@ export default function WeekStrip({ tasks, dailyTaskGoal }) {
         >
           <ChevronLeft size={14} strokeWidth={2} />
         </button>
-        <span className="v2-week-strip-range">{rangeLabel}</span>
+        {canToggle ? (
+          <button
+            className="v2-week-strip-range v2-week-strip-range-toggle"
+            onClick={() => setUserExpanded(v => !v)}
+            aria-expanded={expanded}
+            aria-controls="v2-week-strip-days"
+          >
+            <span className="v2-week-strip-range-label">{rangeLabel}</span>
+            {today && (
+              <span className="v2-week-strip-range-today">· today {today.count}/{today.goal}</span>
+            )}
+            <ChevronDown
+              size={12}
+              strokeWidth={2}
+              className={`v2-week-strip-range-chev${expanded ? ' v2-week-strip-range-chev-open' : ''}`}
+            />
+          </button>
+        ) : (
+          <span className="v2-week-strip-range">
+            <span className="v2-week-strip-range-label">{rangeLabel}</span>
+            {today && (
+              <span className="v2-week-strip-range-today">· today {today.count}/{today.goal}</span>
+            )}
+          </span>
+        )}
         <button
           className="v2-week-strip-nav"
           onClick={() => setWeekOffset(o => o + 1)}
@@ -108,27 +131,29 @@ export default function WeekStrip({ tasks, dailyTaskGoal }) {
           <ChevronRight size={14} strokeWidth={2} />
         </button>
       </div>
-      <ol className="v2-week-strip-row">
-        {days.map(d => (
-          <li
-            key={d.key}
-            className={[
-              'v2-week-strip-day',
-              d.isToday ? 'v2-week-strip-day-today' : '',
-              d.isFuture ? 'v2-week-strip-day-future' : '',
-              `v2-week-strip-day-i${d.intensity}`,
-            ].filter(Boolean).join(' ')}
-            aria-label={`${d.label} ${d.dayNumber}: ${d.count} task${d.count === 1 ? '' : 's'} completed`}
-          >
-            <span className="v2-week-strip-label">{d.label}</span>
-            <span className="v2-week-strip-num">{d.dayNumber}</span>
-            {d.isToday && (
-              <span className="v2-week-strip-count">{d.count}/{d.goal}</span>
-            )}
-            <span className="v2-week-strip-bar" aria-hidden="true" />
-          </li>
-        ))}
-      </ol>
+      {expanded && (
+        <ol id="v2-week-strip-days" className="v2-week-strip-row">
+          {days.map(d => (
+            <li
+              key={d.key}
+              className={[
+                'v2-week-strip-day',
+                d.isToday ? 'v2-week-strip-day-today' : '',
+                d.isFuture ? 'v2-week-strip-day-future' : '',
+                `v2-week-strip-day-i${d.intensity}`,
+              ].filter(Boolean).join(' ')}
+              aria-label={`${d.label} ${d.dayNumber}: ${d.count} task${d.count === 1 ? '' : 's'} completed`}
+            >
+              <span className="v2-week-strip-label">{d.label}</span>
+              <span className="v2-week-strip-num">{d.dayNumber}</span>
+              {d.isToday && (
+                <span className="v2-week-strip-count">{d.count}/{d.goal}</span>
+              )}
+              <span className="v2-week-strip-bar" aria-hidden="true" />
+            </li>
+          ))}
+        </ol>
+      )}
     </div>
   )
 }

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,15 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-11
 
+- feat(ui): WeekStrip days collapse by default, click range to toggle [S]
+  - **Why.** User: "I want to be able to click on the calendar on the main page and have it hide/show the days under the weekly summary. It should be hidden by default and can [be] enabled permanently in settings." The strip was always-open, taking 60+px of vertical space on every load even when the user just wants the task list.
+  - **Behavior.** WeekStrip default state is collapsed — only the header row renders, showing `< May 4-10 · today 3/5 ▾ >`. Clicking the range label toggles the day grid below. Nav arrows still shift the visible week; they don't fold/unfold.
+  - **`week_strip_always_open` setting.** New Settings → General → Home screen toggle ("Keep day cells expanded"). When on, days stay rendered permanently and the range label loses its toggle affordance (chevron hidden, no hover bg). When off (default), the toggle works.
+  - **Collapsed-header summary.** When collapsed, the header gains `· today N/goal` right after the range so users still see today's progress without expanding. Hidden when there's no today cell in the visible week (i.e., user navigated to a past/future week).
+  - **Visual.** Light/dark: range becomes a hover-tinted pill, chevron rotates 180° when expanded. Terminal: range stays flat, chevron swaps to `▾` (collapsed) / `▴` (expanded) ASCII via `::after` on the toggle, accent color when expanded. Today summary renders accent color in both themes.
+  - **A11y.** Toggle button has `aria-expanded` + `aria-controls` pointing at the day list. Days list gets `id="v2-week-strip-days"`. Reading the collapsed header conveys today's progress aloud.
+  - Modified: `src/v2/components/WeekStrip.jsx`, `src/v2/components/WeekStrip.css`, `src/v2/AppV2.jsx`, `src/v2/components/SettingsModal.jsx`, `src/store.js`, `wiki/Version-History.md`
+
 - refactor(ui): drop GoalProgressBar, fold count into WeekStrip's today cell [S]
   - **Why.** User: "Let's move the completion bar up to the top. I thought we were using the shaded boxes for that." Right — WeekStrip's intensity fill on each day cell already encodes `count vs goal` (0/some/met/2×met). GoalProgressBar duplicated the signal underneath, so the home screen had two indicators for the same number. Recommended dropping the bar and folding the exact `N/goal` count into today's cell; user approved.
   - **WeekStrip.** Today's cell gets a new `.v2-week-strip-count` line between the date number and the intensity bar, rendered only when `isToday`. Light/dark: 11px medium meta-color, accent on today. Terminal: 11px monospace accent. The intensity fill still does the at-a-glance week scan; the count gives the exact number for today without breaking the 7-cell grid rhythm.


### PR DESCRIPTION
## Summary

- Day cells hidden by default — `< May 4-10 · today 3/5 ▾ >` is all that renders. Tap the range label to expand.
- New `week_strip_always_open` setting (Settings → General → Home screen → "Keep day cells expanded") keeps cells visible permanently.
- Collapsed header includes today's `count/goal` inline so the daily progress signal isn't lost when days are hidden.

## Visual

- **Light/Dark:** range becomes a pill button with hover tint, chevron rotates 180° on expand.
- **Terminal:** flat range with ASCII `▾` / `▴` caret swap, accent color when expanded.
- Nav arrows still shift the week regardless of expand state.

## A11y

- Toggle button: `aria-expanded` + `aria-controls="v2-week-strip-days"`.
- Collapsed header speaks today's progress without expansion.

## Test plan

- [ ] Open home: WeekStrip renders collapsed by default, showing range + today's count + chevron
- [ ] Click range: day cells appear, chevron flips
- [ ] Click again: collapse
- [ ] Settings → General → "Keep day cells expanded" on: cells visible permanently, range loses toggle chrome
- [ ] Toggle off: cells hide again, click works
- [ ] Toggle terminal-dark / terminal-light: header restyles cleanly; ASCII caret swaps correctly
- [ ] Navigate to prev/next week: today's `count/goal` summary disappears when today isn't in view

https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_