### PR TITLE
style(ui): terminal — flatten EditTaskModal add pills [XS]

### DIFF
--- a/src/v2/terminal/init.css
+++ b/src/v2/terminal/init.css
@@ -1322,23 +1322,61 @@
   padding: 6px 0 !important;
 }
 
-/* --- Edit modal subviews ----------------------------------------- */
+/* --- Edit modal subviews -----------------------------------------
+ * "Add checklist / attach files / link Notion / add comment" pills:
+ * drop the dashed-border chrome entirely. Each renders as flat
+ * `+ verb noun` text with the SVG icon hidden — uniform with the
+ * `// manage` section's sigil-prefixed rows. The `.v2-edit-add-pill`
+ * text already starts with the verb ("Add checklist", "Attach files",
+ * "Notion", "Add comment"); we just prefix `+ ` and lowercase via CSS. */
 :root[data-ui="v2"][data-theme^="terminal"] .v2-edit-add-pill,
+:root[data-ui="v2"][data-theme^="terminal"] .v2-edit-checklist-new,
 :root[data-ui="v2"][data-theme^="terminal"] .v2-edit-connection-pill {
   background: transparent !important;
-  border: 1px dashed var(--v2-hairline) !important;
+  border: none !important;
   border-radius: 0 !important;
   color: var(--v2-text-meta) !important;
   text-transform: lowercase;
-  padding: 6px 10px !important;
+  padding: 4px 0 !important;
+  display: inline-flex;
+  align-items: center;
+  gap: 0;
+  font: 500 13px/1 var(--v2-font-body) !important;
+  height: auto !important;
 }
 
-:root[data-ui="v2"][data-theme^="terminal"] .v2-edit-add-pill:hover,
-:root[data-ui="v2"][data-theme^="terminal"] .v2-edit-connection-pill:hover {
+:root[data-ui="v2"][data-theme^="terminal"] .v2-edit-add-pill > svg,
+:root[data-ui="v2"][data-theme^="terminal"] .v2-edit-checklist-new > svg,
+:root[data-ui="v2"][data-theme^="terminal"] .v2-edit-connection-pill > svg {
+  display: none !important;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-edit-add-pill::before,
+:root[data-ui="v2"][data-theme^="terminal"] .v2-edit-checklist-new::before,
+:root[data-ui="v2"][data-theme^="terminal"] .v2-edit-connection-pill::before {
+  content: "+ ";
+  color: var(--v2-text-faint);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-edit-add-pill:hover:not(:disabled),
+:root[data-ui="v2"][data-theme^="terminal"] .v2-edit-checklist-new:hover:not(:disabled),
+:root[data-ui="v2"][data-theme^="terminal"] .v2-edit-connection-pill:hover:not(:disabled) {
   background: transparent !important;
-  border-color: var(--v2-accent) !important;
   color: var(--v2-accent) !important;
   text-shadow: var(--v2-glow);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-edit-add-pill:hover:not(:disabled)::before,
+:root[data-ui="v2"][data-theme^="terminal"] .v2-edit-checklist-new:hover:not(:disabled)::before,
+:root[data-ui="v2"][data-theme^="terminal"] .v2-edit-connection-pill:hover:not(:disabled)::before {
+  color: var(--v2-accent);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-edit-add-pill:disabled,
+:root[data-ui="v2"][data-theme^="terminal"] .v2-edit-checklist-new:disabled,
+:root[data-ui="v2"][data-theme^="terminal"] .v2-edit-connection-pill:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
 }
 
 :root[data-ui="v2"][data-theme^="terminal"] .v2-edit-checklist-toggle,

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,13 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-11
 
+- style(ui): terminal — flatten EditTaskModal "add" pills [XS]
+  - **Why.** Screenshot showed `+ Add checklist`, `📎 attach files`, `🔍 notion`, `+ add comment` still rendering as dashed-border boxes in terminal mode. The dashed chrome was a holdover from an earlier pass that meant to drop borders but didn't go far enough — they read as boxes, not commands.
+  - **Treatment.** All four classes (`.v2-edit-add-pill`, `.v2-edit-checklist-new`, `.v2-edit-connection-pill`) collapse to flat `+ verb noun` text. Border, radius, padding chrome all dropped. Inline SVG icons hidden — the `+ ` sigil via `::before` replaces them. Hover swaps text + sigil to accent + glow, same idiom as the `// manage` section rows. Disabled state fades to 0.4 opacity.
+  - **Notion search.** Stays as `+ notion` — uniform `+` sigil reads as "add this thing to the task" across all four. The button's actual behavior (search/link/create) is intact; just visually it joins the family.
+  - **Light/dark unchanged.** Base CSS dashed-border treatment kept — this is terminal-only.
+  - Modified: `src/v2/terminal/init.css`, `wiki/Version-History.md`
+
 - feat(ui): WeekStrip days collapse by default, click range to toggle [S]
   - **Why.** User: "I want to be able to click on the calendar on the main page and have it hide/show the days under the weekly summary. It should be hidden by default and can [be] enabled permanently in settings." The strip was always-open, taking 60+px of vertical space on every load even when the user just wants the task list.
   - **Behavior.** WeekStrip default state is collapsed — only the header row renders, showing `< May 4-10 · today 3/5 ▾ >`. Clicking the range label toggles the day grid below. Nav arrows still shift the visible week; they don't fold/unfold.


### PR DESCRIPTION
## Summary

Four EditTaskModal "add" buttons still rendered as dashed-border boxes in terminal mode. Flattened them to flat `+ verb noun` text matching the `// manage` section's sigil-row idiom.

## Changes

- `.v2-edit-add-pill`, `.v2-edit-checklist-new`, `.v2-edit-connection-pill` lose border + padding chrome in terminal.
- Inline SVG icons hidden; `+ ` sigil prepended via `::before`.
- Hover: accent color + glow on both text and sigil.
- Disabled: 40% opacity (e.g., Notion search needs a title).
- Light/Dark: unchanged.

## Final renders (terminal)

```
+ add checklist
+ attach files
+ notion
+ add comment
```

When attachments exist, the Attach files button swaps to `.v2-form-ai-pill` → renders `[ attach files ]` next to `[ extract text ]` — that's intentional (pair-action strip) and already styled.

## Test plan

- [ ] Open EditTaskModal in terminal-dark on a task with no checklist/notes/files/comments → see four flat `+ verb noun` rows
- [ ] Hover each → text + sigil go accent with glow
- [ ] Click `+ notion` with empty title → button disabled, 40% opacity
- [ ] Add an attachment → button class swaps to `[ attach files ]` (existing AI-pill treatment)
- [ ] Switch to light/dark → dashed-border treatment preserved

https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_