### PR TITLE
feat(ui): terminal — WeekStrip toggle moves to home-stats date [S]

### DIFF
--- a/src/v2/AppV2.jsx
+++ b/src/v2/AppV2.jsx
@@ -65,6 +65,10 @@ export default function AppV2() {
   const [showPackages, setShowPackages] = useState(false)
   const [showAdviser, setShowAdviser] = useState(false)
   const [showAnalytics, setShowAnalytics] = useState(false)
+  // Terminal-mode 7-day strip visibility. The calendar+date span in the
+  // home stats line acts as the toggle (default closed). The
+  // `week_strip_always_open` setting forces it visible regardless.
+  const [weekStripShown, setWeekStripShown] = useState(false)
   const [expandedTaskId, setExpandedTaskId] = useState(null)
   const [activeFilter, setActiveFilter] = useState('all')
   const [sortBy, setSortBy] = useState(() => loadSettings().sort_by || 'age')
@@ -681,26 +685,41 @@ export default function AppV2() {
               * single powerlevel10k-style segmented line. Only renders in
               * terminal mode; light/dark have the mini-rings in the app
               * header for the same job. */}
-            {isTerminal && (
-              <div className="v2-terminal-home-stats" aria-hidden="false">
-                <span className="v2-thx-date">
-                  📅 {new Date().toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' })}
-                </span>
-                <span className="v2-thx-sep">·</span>
-                <span className="v2-thx-streak">
-                  🔥 {streak} day{streak === 1 ? '' : 's'}
-                </span>
-                <span className="v2-thx-sep">·</span>
-                <span className="v2-thx-today">
-                  ✓ {dailyStats.tasksToday}/{settingsForRings.daily_task_goal || 3} today
-                </span>
-              </div>
-            )}
-            {(settingsForRings.show_week_strip || isTerminal) && (
+            {isTerminal && (() => {
+              const alwaysOpen = !!settingsForRings.week_strip_always_open
+              const open = alwaysOpen || weekStripShown
+              return (
+                <div className="v2-terminal-home-stats" aria-hidden="false">
+                  <button
+                    type="button"
+                    className={`v2-thx-date v2-thx-date-toggle${open ? ' v2-thx-date-open' : ''}`}
+                    onClick={() => !alwaysOpen && setWeekStripShown(v => !v)}
+                    aria-expanded={open}
+                    aria-controls="v2-week-strip-days"
+                    aria-label={open ? 'Hide 7-day strip' : 'Show 7-day strip'}
+                    disabled={alwaysOpen}
+                  >
+                    📅 {new Date().toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' })}
+                    {!alwaysOpen && (
+                      <span className="v2-thx-date-chev" aria-hidden="true">{open ? '▴' : '▾'}</span>
+                    )}
+                  </button>
+                  <span className="v2-thx-sep">·</span>
+                  <span className="v2-thx-streak">
+                    🔥 {streak} day{streak === 1 ? '' : 's'}
+                  </span>
+                  <span className="v2-thx-sep">·</span>
+                  <span className="v2-thx-today">
+                    ✓ {dailyStats.tasksToday}/{settingsForRings.daily_task_goal || 3} today
+                  </span>
+                </div>
+              )
+            })()}
+            {((isTerminal && (settingsForRings.week_strip_always_open || weekStripShown)) ||
+              (!isTerminal && settingsForRings.show_week_strip)) && (
               <WeekStrip
                 tasks={tasks}
                 dailyTaskGoal={settingsForRings.daily_task_goal || 3}
-                alwaysOpen={!!settingsForRings.week_strip_always_open}
               />
             )}
             {renderSection('Doing', sortedDoing, '→')}

--- a/src/v2/components/SettingsModal.jsx
+++ b/src/v2/components/SettingsModal.jsx
@@ -2008,8 +2008,8 @@ export default function SettingsModal({
 
             <div className="v2-settings-row">
               <div className="v2-settings-row-text">
-                <div className="v2-settings-row-label">Show 7-day strip</div>
-                <div className="v2-settings-row-hint">Calendar row above the task list with activity intensity per day. Renders as cards in light/dark, monospace block characters in terminal.</div>
+                <div className="v2-settings-row-label">Show 7-day strip (light/dark)</div>
+                <div className="v2-settings-row-hint">Calendar row above the task list with activity intensity per day. In terminal mode the strip is always available — tap the date in the home stats line to show/hide.</div>
               </div>
               <label className="v2-settings-toggle">
                 <input
@@ -2023,8 +2023,8 @@ export default function SettingsModal({
 
             <div className="v2-settings-row">
               <div className="v2-settings-row-text">
-                <div className="v2-settings-row-label">Keep day cells expanded</div>
-                <div className="v2-settings-row-hint">By default the day cells are hidden — tap the range label to show them. Enable this to keep them visible permanently.</div>
+                <div className="v2-settings-row-label">Keep 7-day strip always open</div>
+                <div className="v2-settings-row-hint">In terminal mode, force the strip visible permanently so you don't have to tap the date to expand it.</div>
               </div>
               <label className="v2-settings-toggle">
                 <input

--- a/src/v2/components/WeekStrip.css
+++ b/src/v2/components/WeekStrip.css
@@ -22,10 +22,6 @@
   padding: 0 4px;
 }
 
-.v2-week-strip-collapsed .v2-week-strip-head {
-  margin-bottom: 0;
-}
-
 .v2-week-strip-range {
   display: inline-flex;
   align-items: center;
@@ -33,35 +29,6 @@
   font: 500 12px/1 var(--v2-font-body);
   color: var(--v2-text-meta);
   letter-spacing: 0.02em;
-}
-
-.v2-week-strip-range-toggle {
-  border: none;
-  background: transparent;
-  padding: 4px 8px;
-  border-radius: var(--v2-radius-pill);
-  cursor: pointer;
-  color: var(--v2-text-meta);
-  transition: background var(--v2-dur-quick) var(--v2-ease-standard),
-              color var(--v2-dur-quick) var(--v2-ease-standard);
-}
-
-.v2-week-strip-range-toggle:hover {
-  color: var(--v2-text);
-  background: rgba(var(--v2-text-rgb), 0.04);
-}
-
-.v2-week-strip-range-today {
-  color: var(--v2-accent);
-  font-weight: 600;
-}
-
-.v2-week-strip-range-chev {
-  transition: transform var(--v2-dur-quick) var(--v2-ease-standard);
-}
-
-.v2-week-strip-range-chev-open {
-  transform: rotate(180deg);
 }
 
 .v2-week-strip-nav {
@@ -186,32 +153,6 @@
 :root[data-ui="v2"][data-theme^="terminal"] .v2-week-strip-range-label::before {
   content: "// ";
   color: var(--v2-text-faint);
-}
-
-:root[data-ui="v2"][data-theme^="terminal"] .v2-week-strip-range-toggle {
-  border-radius: 0;
-  padding: 4px 6px;
-}
-
-:root[data-ui="v2"][data-theme^="terminal"] .v2-week-strip-range-toggle:hover {
-  background: transparent;
-  color: var(--v2-accent);
-}
-
-:root[data-ui="v2"][data-theme^="terminal"] .v2-week-strip-range-chev {
-  display: none;
-}
-
-:root[data-ui="v2"][data-theme^="terminal"] .v2-week-strip-range-toggle::after {
-  content: " ▾";
-  font-family: var(--v2-font-body);
-  color: var(--v2-text-faint);
-  font-size: 10px;
-}
-
-:root[data-ui="v2"][data-theme^="terminal"] .v2-week-strip-range-toggle[aria-expanded="true"]::after {
-  content: " ▴";
-  color: var(--v2-accent);
 }
 
 :root[data-ui="v2"][data-theme^="terminal"] .v2-week-strip-row {

--- a/src/v2/components/WeekStrip.jsx
+++ b/src/v2/components/WeekStrip.jsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react'
-import { ChevronLeft, ChevronRight, ChevronDown } from 'lucide-react'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
 import './WeekStrip.css'
 
 // 7-day calendar strip rendered above the task list. Each day cell shows
@@ -8,13 +8,12 @@ import './WeekStrip.css'
 // were completed that day relative to `daily_task_goal`. Today's cell
 // also shows the exact `count/goal` inline.
 //
-// Opt-in via the `show_week_strip` setting (always-on in terminal mode).
-// The day cells are hidden by default — clicking the range label
-// expands/collapses them. The `alwaysOpen` prop (driven by the
-// `week_strip_always_open` setting) keeps them expanded permanently.
+// Visibility is owned by the parent (AppV2): the calendar date in the
+// home stats line is the show/hide toggle in terminal mode. This
+// component is "dumb display" — when mounted, it renders fully.
 //
-// Week navigation: < prev / next > arrows. Arrow clicks don't toggle
-// expansion; they shift the visible week regardless of state.
+// Week navigation: < prev / next > arrows. State managed locally —
+// defaults to the week containing today; arrows shift by ±7 days.
 
 const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
 
@@ -29,10 +28,8 @@ function startOfWeekSunday(date) {
   return d
 }
 
-export default function WeekStrip({ tasks, dailyTaskGoal, alwaysOpen = false }) {
+export default function WeekStrip({ tasks, dailyTaskGoal }) {
   const [weekOffset, setWeekOffset] = useState(0)
-  const [userExpanded, setUserExpanded] = useState(false)
-  const expanded = alwaysOpen || userExpanded
 
   const completionsByDate = useMemo(() => {
     const map = {}
@@ -85,11 +82,8 @@ export default function WeekStrip({ tasks, dailyTaskGoal, alwaysOpen = false }) 
     return `${firstMonth} ${first.getDate()}–${lastMonth} ${last.getDate()}`
   }, [days])
 
-  const today = days.find(d => d.isToday)
-  const canToggle = !alwaysOpen
-
   return (
-    <div className={`v2-week-strip${expanded ? ' v2-week-strip-expanded' : ' v2-week-strip-collapsed'}`}>
+    <div className="v2-week-strip">
       <div className="v2-week-strip-head">
         <button
           className="v2-week-strip-nav"
@@ -98,31 +92,9 @@ export default function WeekStrip({ tasks, dailyTaskGoal, alwaysOpen = false }) 
         >
           <ChevronLeft size={14} strokeWidth={2} />
         </button>
-        {canToggle ? (
-          <button
-            className="v2-week-strip-range v2-week-strip-range-toggle"
-            onClick={() => setUserExpanded(v => !v)}
-            aria-expanded={expanded}
-            aria-controls="v2-week-strip-days"
-          >
-            <span className="v2-week-strip-range-label">{rangeLabel}</span>
-            {today && (
-              <span className="v2-week-strip-range-today">· today {today.count}/{today.goal}</span>
-            )}
-            <ChevronDown
-              size={12}
-              strokeWidth={2}
-              className={`v2-week-strip-range-chev${expanded ? ' v2-week-strip-range-chev-open' : ''}`}
-            />
-          </button>
-        ) : (
-          <span className="v2-week-strip-range">
-            <span className="v2-week-strip-range-label">{rangeLabel}</span>
-            {today && (
-              <span className="v2-week-strip-range-today">· today {today.count}/{today.goal}</span>
-            )}
-          </span>
-        )}
+        <span className="v2-week-strip-range">
+          <span className="v2-week-strip-range-label">{rangeLabel}</span>
+        </span>
         <button
           className="v2-week-strip-nav"
           onClick={() => setWeekOffset(o => o + 1)}
@@ -131,29 +103,27 @@ export default function WeekStrip({ tasks, dailyTaskGoal, alwaysOpen = false }) 
           <ChevronRight size={14} strokeWidth={2} />
         </button>
       </div>
-      {expanded && (
-        <ol id="v2-week-strip-days" className="v2-week-strip-row">
-          {days.map(d => (
-            <li
-              key={d.key}
-              className={[
-                'v2-week-strip-day',
-                d.isToday ? 'v2-week-strip-day-today' : '',
-                d.isFuture ? 'v2-week-strip-day-future' : '',
-                `v2-week-strip-day-i${d.intensity}`,
-              ].filter(Boolean).join(' ')}
-              aria-label={`${d.label} ${d.dayNumber}: ${d.count} task${d.count === 1 ? '' : 's'} completed`}
-            >
-              <span className="v2-week-strip-label">{d.label}</span>
-              <span className="v2-week-strip-num">{d.dayNumber}</span>
-              {d.isToday && (
-                <span className="v2-week-strip-count">{d.count}/{d.goal}</span>
-              )}
-              <span className="v2-week-strip-bar" aria-hidden="true" />
-            </li>
-          ))}
-        </ol>
-      )}
+      <ol id="v2-week-strip-days" className="v2-week-strip-row">
+        {days.map(d => (
+          <li
+            key={d.key}
+            className={[
+              'v2-week-strip-day',
+              d.isToday ? 'v2-week-strip-day-today' : '',
+              d.isFuture ? 'v2-week-strip-day-future' : '',
+              `v2-week-strip-day-i${d.intensity}`,
+            ].filter(Boolean).join(' ')}
+            aria-label={`${d.label} ${d.dayNumber}: ${d.count} task${d.count === 1 ? '' : 's'} completed`}
+          >
+            <span className="v2-week-strip-label">{d.label}</span>
+            <span className="v2-week-strip-num">{d.dayNumber}</span>
+            {d.isToday && (
+              <span className="v2-week-strip-count">{d.count}/{d.goal}</span>
+            )}
+            <span className="v2-week-strip-bar" aria-hidden="true" />
+          </li>
+        ))}
+      </ol>
     </div>
   )
 }

--- a/src/v2/terminal/init.css
+++ b/src/v2/terminal/init.css
@@ -529,6 +529,52 @@
   color: var(--v2-text-meta);
 }
 
+/* The date is a button that toggles the WeekStrip below. Strip the
+ * button defaults so it reads as plain text + chevron. Hover/active
+ * states tint accent. When the `week_strip_always_open` setting is
+ * on, the toggle disables (still renders as plain text, no chevron). */
+.v2-thx-date-toggle {
+  border: none;
+  background: transparent;
+  padding: 0;
+  font: inherit;
+  color: var(--v2-text-meta);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  transition: color var(--v2-dur-quick) var(--v2-ease-standard),
+              text-shadow var(--v2-dur-quick) var(--v2-ease-standard);
+}
+
+.v2-thx-date-toggle:hover:not(:disabled),
+.v2-thx-date-toggle:focus-visible:not(:disabled) {
+  color: var(--v2-accent);
+  text-shadow: var(--v2-glow);
+  outline: none;
+}
+
+.v2-thx-date-toggle:disabled {
+  cursor: default;
+  opacity: 1;
+}
+
+.v2-thx-date-open {
+  color: var(--v2-accent);
+  text-shadow: var(--v2-glow);
+}
+
+.v2-thx-date-chev {
+  font-family: var(--v2-font-body);
+  font-size: 10px;
+  color: var(--v2-text-faint);
+  transition: color var(--v2-dur-quick) var(--v2-ease-standard);
+}
+
+.v2-thx-date-open .v2-thx-date-chev {
+  color: var(--v2-accent);
+}
+
 .v2-thx-streak {
   color: var(--v2-alert-high-pri);
   text-shadow: 0 0 6px rgba(255, 184, 77, 0.35);

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,14 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-11
 
+- feat(ui): terminal — WeekStrip toggle moves to home-stats calendar date [S]
+  - **Why.** User: "The weekstrip makes no sense anyway when the dates are hidden. Remove the today N and hide the '// Month dd-dd' with the dates below that are already hidden with the toggle. Make the calendar icon and the date next to it as the hide/show button." Right call — the WeekStrip had its own internal range-toggle while the home stats line above already showed today's count, so toggling the days alone left an orphan header. And the `today 3/3` in the header duplicated `✓ 3/3 today` in the stats line one row up.
+  - **Behavior.** Default in terminal mode: the home stats line shows `📅 Sun, May 10 ▾ · 🔥 1 day · ✓ 3/3 today`. The WeekStrip is entirely hidden. Tapping `📅 Sun, May 10 ▾` reveals the strip (header + day cells together); chevron flips to `▴` and the date+chevron tint accent. Tap again to hide.
+  - **WeekStrip simplified.** Dropped the internal `userExpanded` state, the range-label-as-button, the `today N/goal` summary, and the `alwaysOpen` prop. The component is now a "dumb display" — when mounted, it renders fully. Visibility is owned by AppV2.
+  - **Light/dark unchanged.** `show_week_strip` setting still gates the strip in light/dark mode (always-visible when opted in). The new click-to-toggle behavior is terminal-only. Setting label clarified: "Show 7-day strip (light/dark)".
+  - **`week_strip_always_open` preserved** — terminal users who want the strip permanently visible can flip it in Settings → General → Home screen. When on, the date-toggle button disables (no chevron) and the strip renders permanently.
+  - Modified: `src/v2/components/WeekStrip.jsx`, `src/v2/components/WeekStrip.css`, `src/v2/AppV2.jsx`, `src/v2/components/SettingsModal.jsx`, `src/v2/terminal/init.css`, `wiki/Version-History.md`
+
 - style(ui): terminal — flatten EditTaskModal "add" pills [XS]
   - **Why.** Screenshot showed `+ Add checklist`, `📎 attach files`, `🔍 notion`, `+ add comment` still rendering as dashed-border boxes in terminal mode. The dashed chrome was a holdover from an earlier pass that meant to drop borders but didn't go far enough — they read as boxes, not commands.
   - **Treatment.** All four classes (`.v2-edit-add-pill`, `.v2-edit-checklist-new`, `.v2-edit-connection-pill`) collapse to flat `+ verb noun` text. Border, radius, padding chrome all dropped. Inline SVG icons hidden — the `+ ` sigil via `::before` replaces them. Hover swaps text + sigil to accent + glow, same idiom as the `// manage` section rows. Disabled state fades to 0.4 opacity.


### PR DESCRIPTION
## Summary

Drop the duplicate `today N/goal` from the WeekStrip header and move the show/hide toggle to the calendar+date span in the home stats line. The WeekStrip now collapses fully (no orphan range label hanging out alone) and re-renders all-at-once when expanded.

## Default state

```
📅 Sun, May 10 ▾ · 🔥 1 day · ✓ 3/3 today
[ task list ]
```

## Tap calendar+date

```
📅 Sun, May 10 ▴ · 🔥 1 day · ✓ 3/3 today
< // May 10–16 >
[ S  M  T  W  T  F  S ]   ← 7 day cells with intensity fill
[ task list ]
```

## Visual

- Date+chevron is plain meta-color when collapsed. Accent + glow when open.
- Chevron ASCII `▾` / `▴` swaps on toggle.
- `week_strip_always_open` setting disables the toggle and forces visible.

## Light/Dark

Unchanged. `show_week_strip` setting still gates the strip in light/dark mode (always-visible when opted in). The toggle behavior is terminal-only.

## A11y

- Button has `aria-expanded`, `aria-controls="v2-week-strip-days"`, `aria-label`.
- Reading the stats line still announces today's progress; expanding adds the week pattern.

## Test plan

- [ ] Terminal-dark default: home stats shows date with `▾`, WeekStrip hidden
- [ ] Tap date → strip appears (header + days together), chevron flips to `▴`
- [ ] Tap again → both hide
- [ ] Settings → "Keep 7-day strip always open" on → strip permanent, chevron gone, button disabled
- [ ] Toggle off → toggle behavior restored
- [ ] Switch to light: home stats line absent, WeekStrip honors `show_week_strip` (always-on when enabled)
- [ ] Nav prev/next inside the expanded strip works regardless of toggle state

https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_