### PR TITLE
style(ui): terminal — flatten update-available modal [XS]

### DIFF
--- a/src/v2/AppV2.css
+++ b/src/v2/AppV2.css
@@ -313,3 +313,71 @@
   transition: filter var(--v2-dur-quick) var(--v2-ease-standard);
 }
 .v2-update-reload:hover { filter: brightness(1.08); }
+
+/* === Terminal-mode override ====================================== */
+:root[data-ui="v2"][data-theme^="terminal"] .v2-update-modal {
+  background: var(--v2-bg);
+  border: 1px solid var(--v2-hairline);
+  border-radius: 0;
+  box-shadow: 0 0 24px rgba(88, 166, 255, 0.18);
+  padding: 24px 20px 20px;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-update-title {
+  font: 500 15px/1.2 var(--v2-font-body);
+  color: var(--v2-text);
+  text-transform: lowercase;
+  letter-spacing: 0;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-update-title::before {
+  content: "// ";
+  color: var(--v2-text-faint);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-update-version {
+  font: 500 13px/1 var(--v2-font-body);
+  color: var(--v2-accent);
+  text-shadow: var(--v2-glow);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-update-sub {
+  font: 400 12px/1.4 var(--v2-font-body);
+  color: var(--v2-text-meta);
+  text-transform: lowercase;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-update-sub::before {
+  content: "// ";
+  color: var(--v2-text-faint);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-update-reload {
+  width: auto;
+  height: auto;
+  background: transparent;
+  border: none;
+  border-radius: 0;
+  color: var(--v2-accent);
+  font: 500 14px/1 var(--v2-font-body);
+  text-transform: lowercase;
+  padding: 8px 0;
+  margin-top: 4px;
+  text-shadow: var(--v2-glow);
+  filter: none;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-update-reload::before {
+  content: "[ ";
+  color: var(--v2-accent);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-update-reload::after {
+  content: " ]";
+  color: var(--v2-accent);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-update-reload:hover {
+  filter: none;
+  text-shadow: 0 0 12px rgba(88, 166, 255, 0.65);
+}

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,15 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-11
 
+- style(ui): terminal — flatten update-available modal [XS]
+  - **Why.** User: "The reload module still has a button." The version-mismatch modal (`v2-update-overlay` / `v2-update-modal`) still rendered with rounded-modal chrome + a filled accent reload pill in terminal mode.
+  - **Modal.** Drop the border-radius + drop-shadow chrome. Add a hairline border + soft accent glow ring. Match the terminal flat-card idiom used elsewhere.
+  - **Title.** "Update available" → `// update available` in monospace meta.
+  - **Sub copy.** "Refreshing automatically…" → `// refreshing automatically…` matching the comment idiom.
+  - **Version.** Rendered in monospace accent with glow.
+  - **Reload button.** `Reload now` → `[ reload now ]` — flat bracketed accent text, no fill, no pill radius. Matches every other terminal CTA (`[ Save changes ]`, `[ Done ]`, etc).
+  - Modified: `src/v2/AppV2.css`, `wiki/Version-History.md`
+
 - feat(ui): terminal — WeekStrip toggle moves to home-stats calendar date [S]
   - **Why.** User: "The weekstrip makes no sense anyway when the dates are hidden. Remove the today N and hide the '// Month dd-dd' with the dates below that are already hidden with the toggle. Make the calendar icon and the date next to it as the hide/show button." Right call — the WeekStrip had its own internal range-toggle while the home stats line above already showed today's count, so toggling the days alone left an orphan header. And the `today 3/3` in the header duplicated `✓ 3/3 today` in the stats line one row up.
   - **Behavior.** Default in terminal mode: the home stats line shows `📅 Sun, May 10 ▾ · 🔥 1 day · ✓ 3/3 today`. The WeekStrip is entirely hidden. Tapping `📅 Sun, May 10 ▾` reveals the strip (header + day cells together); chevron flips to `▴` and the date+chevron tint accent. Tap again to hide.


### PR DESCRIPTION
## Summary

Version-mismatch overlay (`.v2-update-modal`) still had modern card chrome + a filled-accent reload pill in terminal mode. Flattened to match the rest of the terminal idiom.

## Final render (terminal)

```
// update available
v0.10.1
// refreshing automatically…
[ reload now ]
```

- Modal: hairline border + soft accent glow, no border-radius, no shadow
- Title + sub: `// ` comment prefix in monospace meta
- Version: monospace accent with glow
- Reload button: `[ reload now ]` bracketed text, no fill

Light/Dark unchanged.

## Test plan

- [ ] Trigger a version mismatch (or temporarily set `updateVersion` to test value)
- [ ] Terminal-dark + terminal-light: modal renders flat with bracketed CTA
- [ ] Click `[ reload now ]`: page reloads
- [ ] Switch to light: original chrome preserved

https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_