### PR TITLE
release: v0.11.0 — version bump + doc sweep for main [L]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -769,9 +769,9 @@ These five primitives are the v2 task-surface language. Every subsequent v2 surf
 
 **End state.** After all 8 PRs ship and a 1-2 week opt-in period validates v2, flip the default to `'v2'`, leave v1 reachable via `?ui=v1` for one release, then delete `src/AppV1.jsx` + `src/components/` and rename `src/v2/components/` → `src/components/`.
 
-### Terminal Theme Stress Test (2026-05-10)
+### Terminal Theme Stress Test (2026-05-10, shipped to main 2026-05-11)
 
-**Working hypothesis: terminal may become the default forever.** PR A–H shipped a four-palette family — Light, Dark, Terminal Dark (GitHub Dark), Terminal Light (GitHub Light) — with terminal-specific structural overrides (ASCII flourishes, monospace stack, bracket toggles, `> verb` modal headers, `// manage` section, density signals on TaskCard). The user is now stress-testing whether terminal feels right as the daily driver. Light/dark stay maintained as defensive baseline.
+**Working hypothesis: terminal may become the default forever.** PR A–H shipped a four-palette family — Light, Dark, Terminal Dark (GitHub Dark), Terminal Light (GitHub Light) — with terminal-specific structural overrides (ASCII flourishes, monospace stack, bracket toggles, `> verb` modal headers, `// manage` section, density signals on TaskCard, no-button-chrome on settings controls, WeekStrip toggle from home stats date). The user shipped v0.11.0 to `main` on 2026-05-11 with terminal as their daily driver; the 30-day decision criterion (terminal-forever vs. didn't-stick) starts clocking from there. Light/dark stay maintained as defensive baseline.
 
 **The convention while we stress-test:**
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ Open `http://localhost:3001` and add your API keys in Settings.
 - **Real-time sync** — cross-client sync via Server-Sent Events (SSE)
 - **Desktop UI** — kanban board with drag-and-drop, responsive modals, hover states
 - **Mobile-first PWA** — installable to home screen, swipe gestures (left for Edit/Done, right to delete)
-- **Dark mode**, custom labels, due dates, high-priority escalation
+- **Themes** — Light, Dark, Terminal Dark (GitHub Dark), Terminal Light (GitHub Light). Terminal mode swaps the calm-modern aesthetic for a monospace power-user shell with ASCII flourishes, `> verb` modal headers, flat sigil+text controls, and density signals on every task card
+- **Custom labels**, due dates, high-priority escalation
 
 ### Notifications
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "boomerang",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "boomerang",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "cors": "^2.8.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "boomerang",
   "private": true,
-  "version": "0.10.0",
+  "version": "0.11.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/wiki/Features.md
+++ b/wiki/Features.md
@@ -12,12 +12,14 @@ Four palettes, picked in Settings → General → Theme:
 |---|---|
 | **Light** | Wheneri-style — warm orange accent, soft pastels, rounded pills, generous whitespace |
 | **Dark** | Same layout language, dark canvas |
-| **Terminal Dark** | GitHub Dark code-editor aesthetic — monospace stack, cyan-blue accent on `#0D1117` canvas, `$ boomerang_` blinking-cursor wordmark, ASCII flourishes (`[ ]` task prefix, `[ Done ]` bracket buttons, `> SECTION [3]` chevron labels), `[off] [on]` bracket toggles in Settings, density signals on TaskCard (`[3/5]` checklist counter, `🔥N` routine streak, one-line notes preview) |
+| **Terminal Dark** | GitHub Dark code-editor aesthetic — monospace stack, cyan-blue accent on `#0D1117` canvas, `> boomerang_` blinking-cursor wordmark, ASCII flourishes (`[ ]` clickable checkboxes on task rows, `[ Save changes ]` bracket buttons, `> section [3]` sigil-prefixed labels), no-button-chrome philosophy (every settings control flat sigil+text or bracket-radio idiom), density signals on TaskCard (`[3/5]` checklist counter, `🔥N` routine streak, one-line notes preview) |
 | **Terminal Light** | Same monospace aesthetic on a white canvas with GitHub Light colors (deep-link blue `#0969DA`, `#1F2328` text). Same density signals, same ASCII structure |
 
-Modal headers in terminal mode read as commands: `$ task --new`, `$ snooze`, `$ what-now`, `$ settings`, `$ quokka`, `$ delete --confirm`. Empty states render as `// comment` lines. Light + Dark stay calm and unchanged.
+Modal headers in terminal mode read as commands: `> task --new`, `> snooze`, `> what-now`, `> settings`, `> quokka`, `> delete --confirm`. Empty states render as `// comment` lines. Light + Dark stay calm and unchanged.
 
-**Home-screen surfaces (opt-in, theme-aware):** Settings → General → Home screen offers two toggles. The 7-day calendar strip renders above the task list with activity-intensity dots/blocks per day; the goal progress bar sits below the list and tracks `tasksToday / daily_task_goal`. Both render as cards in light/dark, bare monospace strip + block characters in terminal mode.
+**Home stats line (terminal):** Above the task list, a single segmented line shows `📅 Sun, May 10 ▾ · 🔥 N days · ✓ N/goal today`. Tap the calendar date to show/hide the 7-day strip below — the strip is collapsed by default. The `🔥 streak` is the global day-streak; the `✓ today` tracks `tasksToday / daily_task_goal`.
+
+**7-day strip:** Shows activity intensity per day (▁▃█ in terminal, soft dots in light/dark) with today's exact `count/goal` inline. Hidden by default in terminal mode — tap the date in the home stats line to reveal. Light/dark users opt-in via Settings → General → Home screen. `week_strip_always_open` setting keeps it permanently visible.
 
 ## Task Management
 

--- a/wiki/V2-State.md
+++ b/wiki/V2-State.md
@@ -1,6 +1,6 @@
 # V2 — Current State and Future Work
 
-The v2 redesign was built between 2026-05-03 and 2026-05-09. This doc captures
+The v2 redesign was built between 2026-05-03 and 2026-05-11. This doc captures
 where v2 stands today, what's shipped, what's still pending, and how to pick
 up the work in a future session.
 
@@ -8,10 +8,12 @@ up the work in a future session.
 
 ## TL;DR
 
+- **v0.11.0 milestone shipped to `main` 2026-05-11.** v2 is the default; terminal-dark / terminal-light palettes joined Light / Dark in the picker; WeekStrip + EditTaskModal + update modal all flattened to the terminal idiom; every "add" pill collapsed to `+ verb noun` text; markdown import moved to Settings → Data; GoalProgressBar removed (folded into WeekStrip).
 - **v2 is the default UI** since `b1f2e76` (PR6 cutover, 2026-05-03). `?ui=v1` reverts.
-- **Every v1 surface has a v2 implementation.** All 8 Settings tabs, all task-flow modals, KanbanBoard on desktop, swipe gestures on mobile, weather badges, Trello status push, routine cadence advancing on complete, multi-list checklists. As of 2026-05-09, all six v2-polish ship-blockers + all seven medium-priority items have landed (skip-this-cycle, sort+filter pills, search, Pushover credentials, Anthropic key, manual sync triggers, channel test buttons, notification history, EditTaskModal Comments/Research/Attachments/Extract-Text, weather geocode, Notion link/create on tasks, Trello/GCal/Gmail picker UIs, Notion DB sync config). Visual bugs from screenshots all fixed. Polish + lower-priority items still pending; final-mile cherry-picks + dev → main merge prep are next.
-- **Dev-merge workflow is locked in.** Direct push to `refs/heads/dev` still 403s on the local proxy (status as of 2026-05-09). The MCP-PR-and-rebase-merge loop documented in CLAUDE.md is the canonical way work lands on `dev` — fully automated end-to-end with no GitHub-UI clicks.
-- **Dark-mode QA was deferred** at the user's request until light-mode sizes/positions/colors are dialed.
+- **Every v1 surface has a v2 implementation.** All 8 Settings tabs, all task-flow modals, KanbanBoard on desktop, swipe gestures on mobile, weather badges, Trello status push, routine cadence advancing on complete, multi-list checklists. As of 2026-05-09, all six v2-polish ship-blockers + all seven medium-priority items have landed.
+- **Terminal theme is the active aesthetic.** GitHub Dark + GitHub Light sub-palettes. Per CLAUDE.md "Terminal Theme Stress Test", structural decision-criteria (30-day daily use → deprecate Light/Dark) still apply; ship-to-main is a strong signal but not the formal trigger.
+- **Dev-merge workflow is locked in.** Direct push to `refs/heads/dev` still 403s on the local proxy (status as of 2026-05-11). The MCP-PR-and-rebase-merge loop documented in CLAUDE.md is the canonical way work lands on `dev`.
+- **Dark-mode QA was deferred** at the user's request until light-mode sizes/positions/colors are dialed. Less critical now that terminal is the daily driver.
 
 ---
 

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,24 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-11
 
+- release: v0.11.0 — terminal theme + v2 milestone to main [L]
+  - **What's in this release.** First merge of `dev` → `main` since the v2 cutover. Bundles every PR from 2026-05-10 + 2026-05-11. Highlights:
+    - **Terminal theme family** (PR A–H) — Light, Dark, Terminal Dark (GitHub Dark), Terminal Light (GitHub Light) palettes; ASCII flourishes, monospace stack, `> verb` modal headers, `// section` labels, bracket toggles, density signals on TaskCard.
+    - **No-button-chrome philosophy** in terminal — every settings control, every notification card, every modal CTA, every "add" pill flattened to sigil+text or bracket-radio idiom. Update-available modal included.
+    - **Home stats line** (`📅 Sun, May 10 ▾ · 🔥 N days · ✓ N/goal today`) where the calendar date is the WeekStrip show/hide toggle.
+    - **WeekStrip** lost its internal range-toggle + `today N/goal` summary (folded into home stats line). GoalProgressBar removed entirely — today's count lives in WeekStrip's today cell.
+    - **EditTaskModal "add" pills** (`+ add checklist`, `+ attach files`, `+ notion`, `+ add comment`) — dashed borders dropped, flat `+ verb noun` idiom matching the `// manage` section.
+    - **Markdown import** moved from overflow menu to Settings → Data.
+    - Click-to-complete `[ ]` checkboxes on task cards (terminal); urgency as title text color; 700ms `[✓]` confirmation pulse.
+    - Sequential typing demo on Quokka empty state; `[ object Object ]` bug fixed.
+    - Theme persistence rewrite — local theme survives server hydration.
+    - DateField component — `[ due date ]` opens native picker, renders `[ YYYY-MM-DD ]` filled.
+    - Smoke tests for terminal-title + terminal-button coverage in pre-push hook.
+  - **Audit.** `npm audit` reports 0 vulnerabilities.
+  - **Decision criterion clock starts now.** Per CLAUDE.md → "Terminal Theme Stress Test", 30 days of daily terminal use → consider Light/Dark deprecation. All four palettes stay live + equal in the picker until that date.
+  - Bumped: `package.json` 0.10.0 → 0.11.0, `package-lock.json` to match
+  - Modified: `wiki/V2-State.md` (status flip), `wiki/Features.md` (`>` prefix, home stats line, WeekStrip behavior), `CLAUDE.md` (terminal section header)
+
 - style(ui): terminal — flatten update-available modal [XS]
   - **Why.** User: "The reload module still has a button." The version-mismatch modal (`v2-update-overlay` / `v2-update-modal`) still rendered with rounded-modal chrome + a filled accent reload pill in terminal mode.
   - **Modal.** Drop the border-radius + drop-shadow chrome. Add a hairline border + soft accent glow ring. Match the terminal flat-card idiom used elsewhere.


### PR DESCRIPTION
## Summary

Ship-prep batch for v0.11.0 → dev → main:

- **`npm audit`**: 0 vulnerabilities.
- **Version bump**: `package.json` + `package-lock.json` 0.10.0 → 0.11.0.
- **Doc sweep**:
  - `wiki/V2-State.md` — TL;DR flipped to "v0.11.0 milestone shipped to `main`". Date range extended to 2026-05-11.
  - `wiki/Features.md` — `> verb` modal-header convention (was stale `$ verb`); home stats line + WeekStrip date-toggle behavior documented; GoalProgressBar reference removed.
  - `CLAUDE.md` — Terminal Theme Stress Test header notes ship-to-main on 2026-05-11; 30-day decision criterion clock starts now.
  - `README.md` — themes bullet expanded to mention Light/Dark/Terminal Dark/Terminal Light.
  - `wiki/Version-History.md` — v0.11.0 milestone entry summarizing what's in this release.

## After merge to dev

Cut a separate dev → main PR for the actual production release. Per CLAUDE.md workflow: try `git push origin main` first; fall back to PR-and-merge if proxy 403s.

## Test plan

- [ ] CI green
- [ ] `:dev` Docker image picks up version label
- [ ] Browser hard-refresh on dev shows "v0.11.0" wherever version is displayed

https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_