### PR TITLE
fix(ui): v2 EditTaskModal — restore field autosave (v1 parity) [S]

### DIFF
--- a/src/v2/components/EditTaskModal.jsx
+++ b/src/v2/components/EditTaskModal.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useMemo, useRef } from 'react'
 import { Sparkles, Trash2, FolderKanban, Archive, Plus, X as XIcon, Search, Paperclip, FileText, Sun, ChevronDown, ChevronRight, RotateCw } from 'lucide-react'
 import { loadLabels, ENERGY_TYPES, STATUS_META, uuid } from '../../store'
 import { useTaskForm } from '../../hooks/useTaskForm'
@@ -102,32 +102,78 @@ export default function EditTaskModal({ task, onSave, onClose, onDelete, onBackl
   const labels = loadLabels()
   const today = new Date().toISOString().split('T')[0]
 
-  // Auto-save title/notes/due/priority/size/energy/tags on blur/change is
-  // common in v1 EditTaskModal. v2 keeps the explicit Save button for now —
-  // less surprising for the new UI, easier to reason about. PR8 polish can
-  // add per-field autosave if it feels natural in use.
+  // v2 autosaves every field change with a 500ms debounce, mirroring v1
+  // behavior the user expects. The Save button is kept as an explicit
+  // flush-and-close affordance — useful when the modal is dismissed via
+  // route change or in case the autosave debounce hasn't fired yet.
+  //
+  // Payload is JSON-serialized + ref-compared so reference churn on
+  // array/object state (e.g. selectedTags) doesn't fire spurious saves.
+  // `last_touched` is omitted here — useTasks.updateTask stamps it.
+  const savePayload = useMemo(() => ({
+    title: form.title.trim(),
+    notes: form.notes,
+    tags: form.selectedTags,
+    due_date: form.dueDate || null,
+    size: form.size,
+    energy: form.energy,
+    energyLevel: form.energyLevel,
+    high_priority: form.highPriority,
+    low_priority: form.lowPriority,
+    size_inferred: !!form.size,
+    checklists,
+    attachments: form.attachments,
+    comments,
+    notion_page_id: form.notionResult?.id || null,
+    notion_url: form.notionResult?.url || null,
+    weather_hidden: weatherHidden,
+    gcal_duration: gcalDuration ? parseInt(gcalDuration, 10) : null,
+  }), [
+    form.title, form.notes, form.selectedTags, form.dueDate,
+    form.size, form.energy, form.energyLevel,
+    form.highPriority, form.lowPriority,
+    form.attachments, form.notionResult,
+    checklists, comments, weatherHidden, gcalDuration,
+  ])
+
+  const lastSavedJson = useRef(null)
+  const savePayloadRef = useRef(savePayload)
+  savePayloadRef.current = savePayload
+
+  useEffect(() => {
+    const json = JSON.stringify(savePayload)
+    // First render: capture the loaded-task baseline so we don't fire
+    // a redundant save immediately on open.
+    if (lastSavedJson.current === null) {
+      lastSavedJson.current = json
+      return
+    }
+    if (lastSavedJson.current === json) return
+    if (!savePayload.title) return // empty-title guard
+    const t = setTimeout(() => {
+      lastSavedJson.current = json
+      onSave(task.id, savePayload)
+    }, 500)
+    return () => clearTimeout(t)
+  }, [savePayload, onSave, task.id])
+
+  // Flush any pending edits on unmount. Without this, closing the modal
+  // (X button, route change) within the 500ms debounce window would
+  // strand the user's last few edits.
+  useEffect(() => {
+    return () => {
+      const json = JSON.stringify(savePayloadRef.current)
+      if (lastSavedJson.current === json) return
+      if (!savePayloadRef.current.title) return
+      onSave(task.id, savePayloadRef.current)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
   const handleSave = () => {
     if (!form.title.trim()) return
-    onSave(task.id, {
-      title: form.title.trim(),
-      notes: form.notes,
-      tags: form.selectedTags,
-      due_date: form.dueDate || null,
-      size: form.size,
-      energy: form.energy,
-      energyLevel: form.energyLevel,
-      high_priority: form.highPriority,
-      low_priority: form.lowPriority,
-      size_inferred: !!form.size,
-      checklists,
-      attachments: form.attachments,
-      comments,
-      notion_page_id: form.notionResult?.id || null,
-      notion_url: form.notionResult?.url || null,
-      weather_hidden: weatherHidden,
-      gcal_duration: gcalDuration ? parseInt(gcalDuration, 10) : null,
-      last_touched: new Date().toISOString(),
-    })
+    lastSavedJson.current = JSON.stringify(savePayload)
+    onSave(task.id, savePayload)
     onClose()
   }
 

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,13 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-11
 
+- fix(ui): v2 EditTaskModal — restore field autosave (v1 parity) [S]
+  - **Why.** User: "Everything else used to auto save before v2. This was a regression." Correct — v1 EditTaskModal autosaved every form change on blur/onChange. v2 shipped with an explicit `[ Save changes ]` button intentionally (per the source comment: "less surprising for the new UI, easier to reason about. PR8 polish can add per-field autosave if it feels natural in use"), but in practice the modal partially autosaved anyway: status changes and the manage actions (`> archive`, `> delete --confirm`, etc.) fired immediately, while form fields (title, notes, tags, due date, size, energy, priority, checklists, attachments, comments, weather-hidden, gcal-duration) only persisted on explicit Save. The mixed behavior trained the user to expect autosave for everything; checklist edits silently dropped when they closed the modal via X.
+  - **Fix.** Single `useMemo`-built `savePayload`, watched by a debounced (500ms) autosave effect. JSON-string ref-compare so reference churn on array/object state (e.g. `selectedTags`) doesn't fire spurious saves. Empty-title guard preserved. `last_touched` removed from the payload — `useTasks.updateTask` already stamps it.
+  - **Unmount flush.** A separate effect with empty deps fires on unmount: if the latest payload differs from the last-saved baseline, save synchronously before the modal goes away. Closing via X / route change within the 500ms window no longer strands edits.
+  - **Save button kept.** Still wired to `handleSave` — explicit flush-and-close affordance. Updates `lastSavedJson` ref so the autosave doesn't double-fire.
+  - Modified: `src/v2/components/EditTaskModal.jsx`, `wiki/Version-History.md`
+
 - release: v0.11.0 — terminal theme + v2 milestone to main [L]
   - **What's in this release.** First merge of `dev` → `main` since the v2 cutover. Bundles every PR from 2026-05-10 + 2026-05-11. Highlights:
     - **Terminal theme family** (PR A–H) — Light, Dark, Terminal Dark (GitHub Dark), Terminal Light (GitHub Light) palettes; ASCII flourishes, monospace stack, `> verb` modal headers, `// section` labels, bracket toggles, density signals on TaskCard.


### PR DESCRIPTION
## Why

User: "Everything else used to auto save before v2. This was a regression."

Correct. v1 EditTaskModal autosaved every form change. v2 shipped with an explicit `[ Save changes ]` button, but the modal partially autosaved anyway — status changes + manage actions (archive/delete/etc.) fired immediately while form fields didn't. The mixed behavior trained users to expect autosave for everything; checklist edits silently dropped when closing the modal via X.

## Fix

- **`useMemo` payload** of every persisted field (title, notes, tags, due date, size, energy, priority, checklists, attachments, comments, weather-hidden, gcal-duration). `last_touched` left to `useTasks.updateTask`.
- **500ms debounced autosave** with JSON-string ref-compare. Reference churn on array/object state (e.g. `selectedTags`) no longer fires spurious saves. Empty-title guard preserved.
- **Unmount flush**. Separate empty-deps effect fires on unmount; if the latest payload differs from the last saved baseline, synchronously save before the modal goes away. Closing via X / route change within the debounce window no longer strands edits.
- **Save button kept** — explicit flush-and-close. Updates `lastSavedJson` ref so the autosave doesn't double-fire.

## Test plan

- [ ] Open a task, add a checklist item, close modal via X → reopen → item present
- [ ] Open a task, edit notes, wait 1s without closing → check API logs for PATCH
- [ ] Open a task, edit title to empty → autosave does NOT fire (empty-title guard)
- [ ] Open a task, type in title, hit `[ Save changes ]` quickly → no duplicate PATCH
- [ ] Open a task with checklist, toggle item completed, close → reopen → toggle persisted
- [ ] Trello-linked task: edit checklist → confirm no external-sync race writeback

https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_