### PR TITLE
feat(ui): v2 AutosaveIndicator — EditTaskModal + SettingsModal [S]

### DIFF
--- a/src/v2/components/AutosaveIndicator.css
+++ b/src/v2/components/AutosaveIndicator.css
@@ -1,0 +1,54 @@
+/* Top-of-modal autosave pill. Caller positions it (typically in
+ * ModalShell's header slot, mirroring v1's `.autosave-pill-floating`
+ * spot near the close X). Default: pill chrome in light/dark, bracketed
+ * comment-text in terminal mode. */
+
+.v2-autosave-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 10px;
+  border-radius: var(--v2-radius-pill);
+  background: rgba(var(--v2-text-rgb), 0.06);
+  color: var(--v2-text-meta);
+  font: 500 11px/1 var(--v2-font-body);
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+  transition: background var(--v2-dur-quick) var(--v2-ease-standard),
+              color var(--v2-dur-quick) var(--v2-ease-standard);
+}
+
+.v2-autosave-pill-saved {
+  background: rgba(82, 201, 127, 0.15);
+  color: #52C97F;
+}
+
+/* === Terminal mode override =====================================
+ * No pill chrome. Render as `// autosave` / `// ✓ saved` — same
+ * comment idiom used everywhere else in terminal mode. Accent + glow
+ * on the saved flash. */
+:root[data-ui="v2"][data-theme^="terminal"] .v2-autosave-pill {
+  background: transparent;
+  padding: 0;
+  border-radius: 0;
+  color: var(--v2-text-faint);
+  font-family: var(--v2-font-body);
+  font-size: 11px;
+  font-weight: 400;
+  letter-spacing: 0;
+  text-transform: lowercase;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-autosave-pill::before {
+  content: "// ";
+  color: var(--v2-text-faint);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-autosave-pill-saved {
+  background: transparent;
+  color: var(--v2-accent);
+  text-shadow: var(--v2-glow);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-autosave-pill-saved::before {
+  color: var(--v2-accent);
+}

--- a/src/v2/components/AutosaveIndicator.jsx
+++ b/src/v2/components/AutosaveIndicator.jsx
@@ -1,0 +1,20 @@
+import './AutosaveIndicator.css'
+
+// Top-of-modal pill that reassures the user that field-level changes
+// are being persisted automatically. Two states:
+//
+//   idle  → "Autosave" — quiet meta-color text
+//   saved → "✓ Saved"  — flashes accent (light/dark) or terminal-accent
+//                       for ~2s after each successful autosave
+//
+// Theme-aware via CSS gated on [data-theme^="terminal"].
+//
+// Caller drives the `saved` boolean via a setTimeout-cleared local flag,
+// e.g. flip true when the autosave effect fires, back to false 2s later.
+export default function AutosaveIndicator({ saved = false }) {
+  return (
+    <span className={`v2-autosave-pill${saved ? ' v2-autosave-pill-saved' : ''}`} aria-live="polite">
+      {saved ? '✓ Saved' : 'Autosave'}
+    </span>
+  )
+}

--- a/src/v2/components/EditTaskModal.jsx
+++ b/src/v2/components/EditTaskModal.jsx
@@ -5,6 +5,7 @@ import { useTaskForm } from '../../hooks/useTaskForm'
 import { researchTask } from '../../api'
 import WeatherSection, { resolveWeatherVisibility } from '../../components/WeatherSection'
 import ModalShell from './ModalShell'
+import AutosaveIndicator from './AutosaveIndicator'
 import DateField from './DateField'
 import './AddTaskModal.css' // shared form-control styles
 import './EditTaskModal.css'
@@ -139,6 +140,10 @@ export default function EditTaskModal({ task, onSave, onClose, onDelete, onBackl
   const lastSavedJson = useRef(null)
   const savePayloadRef = useRef(savePayload)
   savePayloadRef.current = savePayload
+  // Drives the "✓ Saved" flash in the AutosaveIndicator. Flips true
+  // when an autosave fires, back to false after 2s.
+  const [justSaved, setJustSaved] = useState(false)
+  const justSavedTimer = useRef(null)
 
   useEffect(() => {
     const json = JSON.stringify(savePayload)
@@ -153,9 +158,17 @@ export default function EditTaskModal({ task, onSave, onClose, onDelete, onBackl
     const t = setTimeout(() => {
       lastSavedJson.current = json
       onSave(task.id, savePayload)
+      setJustSaved(true)
+      if (justSavedTimer.current) clearTimeout(justSavedTimer.current)
+      justSavedTimer.current = setTimeout(() => setJustSaved(false), 2000)
     }, 500)
     return () => clearTimeout(t)
   }, [savePayload, onSave, task.id])
+
+  // Clean up the saved-flash timer on unmount.
+  useEffect(() => () => {
+    if (justSavedTimer.current) clearTimeout(justSavedTimer.current)
+  }, [])
 
   // Flush any pending edits on unmount. Without this, closing the modal
   // (X button, route change) within the 500ms debounce window would
@@ -253,7 +266,14 @@ export default function EditTaskModal({ task, onSave, onClose, onDelete, onBackl
   }, [confirmDelete])
 
   return (
-    <ModalShell open={!!task} onClose={onClose} title="Edit task" terminalTitle="> task --edit" width="narrow">
+    <ModalShell
+      open={!!task}
+      onClose={onClose}
+      title="Edit task"
+      terminalTitle="> task --edit"
+      width="narrow"
+      headerSlot={<AutosaveIndicator saved={justSaved} />}
+    >
       <input
         className="v2-form-input v2-form-title"
         placeholder="What needs doing?"

--- a/src/v2/components/ModalShell.css
+++ b/src/v2/components/ModalShell.css
@@ -52,6 +52,23 @@
   background: var(--v2-hairline);
 }
 
+/* Slot for status pills/indicators (e.g. AutosaveIndicator) — sits at
+ * the same top-row as the close X, offset to its left. Caller controls
+ * what gets rendered; this just provides positioning. */
+.v2-modal-header-slot {
+  position: absolute;
+  top: 24px;
+  right: 64px;
+  z-index: 1;
+  display: inline-flex;
+  align-items: center;
+  pointer-events: none;
+}
+
+.v2-modal-header-slot > * {
+  pointer-events: auto;
+}
+
 .v2-modal-header {
   padding: 40px 24px 20px;
   border-bottom: 1px solid var(--v2-hairline);

--- a/src/v2/components/ModalShell.jsx
+++ b/src/v2/components/ModalShell.jsx
@@ -3,7 +3,7 @@ import { X } from 'lucide-react'
 import { useTerminalMode } from '../hooks/useTerminalMode'
 import './ModalShell.css'
 
-export default function ModalShell({ open, onClose, title, terminalTitle, subtitle, children, width = 'narrow' }) {
+export default function ModalShell({ open, onClose, title, terminalTitle, subtitle, headerSlot, children, width = 'narrow' }) {
   const terminal = useTerminalMode()
   useEffect(() => {
     if (!open) return
@@ -25,6 +25,7 @@ export default function ModalShell({ open, onClose, title, terminalTitle, subtit
         <button className="v2-modal-close" onClick={onClose} aria-label="Close">
           <X size={18} strokeWidth={1.75} />
         </button>
+        {headerSlot && <div className="v2-modal-header-slot">{headerSlot}</div>}
         <header className="v2-modal-header">
           <h1 className="v2-modal-title">{terminal && terminalTitle ? terminalTitle : title}</h1>
           {subtitle && <p className="v2-modal-subtitle">{subtitle}</p>}

--- a/src/v2/components/SettingsModal.jsx
+++ b/src/v2/components/SettingsModal.jsx
@@ -8,6 +8,7 @@ import {
 import { restoreFromBackup } from '../../api'
 import ModalShell from './ModalShell'
 import EmptyState from './EmptyState'
+import AutosaveIndicator from './AutosaveIndicator'
 import './SettingsModal.css'
 
 // Labels tab — extracted so SettingsModal stays readable.
@@ -1736,11 +1737,20 @@ export default function SettingsModal({
   const flushDebounceRef = useRef(null)
   const dataImportRef = useRef(null)
   const ciFileRef = useRef(null)
+  // Mirror the EditTaskModal autosave-flash pattern. Flips true when
+  // the debounced flush fires; back to false after 2s.
+  const [justSaved, setJustSaved] = useState(false)
+  const justSavedTimer = useRef(null)
 
   // Reload settings whenever the modal reopens — server may have updated them.
   useEffect(() => {
     if (open) setSettings(loadSettings())
   }, [open])
+
+  // Cleanup the saved-flash timer on unmount.
+  useEffect(() => () => {
+    if (justSavedTimer.current) clearTimeout(justSavedTimer.current)
+  }, [])
 
   const update = useCallback((key, value) => {
     setSettings(prev => {
@@ -1750,7 +1760,12 @@ export default function SettingsModal({
     })
     if (onFlush) {
       if (flushDebounceRef.current) clearTimeout(flushDebounceRef.current)
-      flushDebounceRef.current = setTimeout(() => { onFlush() }, 300)
+      flushDebounceRef.current = setTimeout(() => {
+        onFlush()
+        setJustSaved(true)
+        if (justSavedTimer.current) clearTimeout(justSavedTimer.current)
+        justSavedTimer.current = setTimeout(() => setJustSaved(false), 2000)
+      }, 300)
     }
   }, [onFlush])
 
@@ -1842,7 +1857,14 @@ export default function SettingsModal({
   }
 
   return (
-    <ModalShell open={open} onClose={onClose} title="Settings" terminalTitle="> settings" width="wide">
+    <ModalShell
+      open={open}
+      onClose={onClose}
+      title="Settings"
+      terminalTitle="> settings"
+      width="wide"
+      headerSlot={<AutosaveIndicator saved={justSaved} />}
+    >
       <div className="v2-settings-tabs">
         {TABS.map(tab => (
           <button

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,16 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-11
 
+- feat(ui): v2 AutosaveIndicator — pill at top of EditTaskModal [S]
+  - **Why.** User: "I used to have a save indicator at the top of the places I would edit in v1. For each theme that should come back to show that auto save happened." v1 had `.autosave-pill` near the close X showing "Auto Save" idle / "✓ Saved" 2s flash. v2 shipped without it; with autosave back from PR #134 the user has no feedback that saves are actually firing.
+  - **`AutosaveIndicator` component.** Single `saved` boolean prop. Idle state reads "Autosave"; flash state reads "✓ Saved" for 2s.
+  - **Light/dark.** Pill chrome: rounded, soft `rgba(text, 0.06)` bg, meta-color text. Saved flash uses the green success color (`#52C97F` on 15% bg) matching v1's `.autosave-pill-saved` palette.
+  - **Terminal.** Drops pill chrome entirely. Renders as `// autosave` / `// ✓ saved` — same comment idiom used throughout terminal mode. Saved flash uses `--v2-accent` + glow.
+  - **`ModalShell` `headerSlot` prop.** New optional render-prop slot positioned at the same top-row as the close X (offset 64px to its left to avoid overlap). Mirrors v1's `.autosave-pill-floating` placement.
+  - **EditTaskModal wiring.** Local `justSaved` flag flips true inside the autosave effect's setTimeout (right after `onSave` fires), back to false after 2s. Separate cleanup useEffect clears the timer on unmount to avoid set-state-on-unmounted warnings.
+  - Modified: `src/v2/components/ModalShell.jsx`, `src/v2/components/ModalShell.css`, `src/v2/components/EditTaskModal.jsx`, `wiki/Version-History.md`
+  - Added: `src/v2/components/AutosaveIndicator.jsx`, `src/v2/components/AutosaveIndicator.css`
+
 - fix(ui): v2 EditTaskModal — restore field autosave (v1 parity) [S]
   - **Why.** User: "Everything else used to auto save before v2. This was a regression." Correct — v1 EditTaskModal autosaved every form change on blur/onChange. v2 shipped with an explicit `[ Save changes ]` button intentionally (per the source comment: "less surprising for the new UI, easier to reason about. PR8 polish can add per-field autosave if it feels natural in use"), but in practice the modal partially autosaved anyway: status changes and the manage actions (`> archive`, `> delete --confirm`, etc.) fired immediately, while form fields (title, notes, tags, due date, size, energy, priority, checklists, attachments, comments, weather-hidden, gcal-duration) only persisted on explicit Save. The mixed behavior trained the user to expect autosave for everything; checklist edits silently dropped when they closed the modal via X.
   - **Fix.** Single `useMemo`-built `savePayload`, watched by a debounced (500ms) autosave effect. JSON-string ref-compare so reference churn on array/object state (e.g. `selectedTags`) doesn't fire spurious saves. Empty-title guard preserved. `last_touched` removed from the payload — `useTasks.updateTask` already stamps it.

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,14 +6,15 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-11
 
-- feat(ui): v2 AutosaveIndicator — pill at top of EditTaskModal [S]
-  - **Why.** User: "I used to have a save indicator at the top of the places I would edit in v1. For each theme that should come back to show that auto save happened." v1 had `.autosave-pill` near the close X showing "Auto Save" idle / "✓ Saved" 2s flash. v2 shipped without it; with autosave back from PR #134 the user has no feedback that saves are actually firing.
+- feat(ui): v2 AutosaveIndicator — restored everywhere v1 had it [S]
+  - **Why.** User: "I used to have a save indicator at the top of the places I would edit in v1. For each theme that should come back." Then: "I want it everywhere it was in v1." v1 had the `.autosave-pill` at the top of `EditTaskModal` (driven by local `justSaved`) and `Settings.jsx` (driven by `syncStatus`). Both restored.
   - **`AutosaveIndicator` component.** Single `saved` boolean prop. Idle state reads "Autosave"; flash state reads "✓ Saved" for 2s.
   - **Light/dark.** Pill chrome: rounded, soft `rgba(text, 0.06)` bg, meta-color text. Saved flash uses the green success color (`#52C97F` on 15% bg) matching v1's `.autosave-pill-saved` palette.
   - **Terminal.** Drops pill chrome entirely. Renders as `// autosave` / `// ✓ saved` — same comment idiom used throughout terminal mode. Saved flash uses `--v2-accent` + glow.
   - **`ModalShell` `headerSlot` prop.** New optional render-prop slot positioned at the same top-row as the close X (offset 64px to its left to avoid overlap). Mirrors v1's `.autosave-pill-floating` placement.
-  - **EditTaskModal wiring.** Local `justSaved` flag flips true inside the autosave effect's setTimeout (right after `onSave` fires), back to false after 2s. Separate cleanup useEffect clears the timer on unmount to avoid set-state-on-unmounted warnings.
-  - Modified: `src/v2/components/ModalShell.jsx`, `src/v2/components/ModalShell.css`, `src/v2/components/EditTaskModal.jsx`, `wiki/Version-History.md`
+  - **EditTaskModal wiring.** `justSaved` flag flips true inside the autosave effect's setTimeout (right after `onSave` fires), back to false after 2s. Cleanup useEffect clears the timer on unmount.
+  - **SettingsModal wiring.** Same `justSaved` flag, flipped inside the existing 300ms `flushDebounceRef` debounce after `onFlush()` runs. Every settings change → debounced save → 2s flash. Cleanup mirrored.
+  - Modified: `src/v2/components/ModalShell.jsx`, `src/v2/components/ModalShell.css`, `src/v2/components/EditTaskModal.jsx`, `src/v2/components/SettingsModal.jsx`, `wiki/Version-History.md`
   - Added: `src/v2/components/AutosaveIndicator.jsx`, `src/v2/components/AutosaveIndicator.css`
 
 - fix(ui): v2 EditTaskModal — restore field autosave (v1 parity) [S]


### PR DESCRIPTION
## What

Restores the v1 autosave indicator in v2. v1 had `.autosave-pill` in `EditTaskModal` + `Settings.jsx`; both restored.

- New `AutosaveIndicator` component, theme-aware (`// autosave` / `// ✓ saved` in terminal; pill chrome + green flash in light/dark)
- New `ModalShell` `headerSlot` prop for positioning
- EditTaskModal flashes after autosave's 500ms debounce fires
- SettingsModal flashes after the existing 300ms flush debounce

Pairs with the autosave-restore hotfix shipped earlier today — gives the user visible feedback that the field-level saves are actually firing.

## Test plan

- [ ] Merge triggers `:latest` Docker rebuild → Portainer deploy
- [ ] EditTaskModal: type in title → 500ms later pill flashes "✓ Saved"
- [ ] Settings: toggle any switch → 300ms later flash fires
- [ ] Cycle all 4 themes; flash + idle styles look right in each

https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_