### PR TITLE
style+fix: terminal stats ◎ + WhatNow → Compass [XS]

### DIFF
--- a/src/v2/components/FloatingCapture.jsx
+++ b/src/v2/components/FloatingCapture.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { Plus, Target } from 'lucide-react'
+import { Plus, Compass } from 'lucide-react'
 import './FloatingCapture.css'
 
 // Right-edge speed-dial. Two circles stacked at the lower-right of the
@@ -138,7 +138,7 @@ export default function FloatingCapture({ onAddTask, onOpenWhatNow }) {
               onClick={() => setMode('idle')}
               aria-label="Close"
             >
-              <Target size={20} strokeWidth={2} />
+              <Compass size={20} strokeWidth={2} />
             </button>
           </div>
         ) : (
@@ -148,7 +148,7 @@ export default function FloatingCapture({ onAddTask, onOpenWhatNow }) {
             onClick={() => setMode('whatnow')}
             aria-label="What can I do right now?"
           >
-            <Target size={20} strokeWidth={2} />
+            <Compass size={20} strokeWidth={2} />
           </button>
         )}
       </div>

--- a/src/v2/terminal/sections.css
+++ b/src/v2/terminal/sections.css
@@ -67,3 +67,24 @@
   color: var(--v2-text-faint);
   margin-left: 2px;
 }
+
+/* Brand popover stats row — drop the colored ring SVG, render `[◎]` as
+ * a flat ASCII bullseye matching the rest of the terminal idiom. The
+ * `.v2-header-popover-rings` button still routes to Analytics. */
+:root[data-ui="v2"][data-theme^="terminal"] .v2-header-popover-rings .mini-rings svg {
+  display: none;
+}
+:root[data-ui="v2"][data-theme^="terminal"] .v2-header-popover-rings .mini-rings {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  font-family: var(--v2-font-body);
+  font-size: 16px;
+  color: var(--v2-accent);
+  text-shadow: var(--v2-glow);
+}
+:root[data-ui="v2"][data-theme^="terminal"] .v2-header-popover-rings .mini-rings::before {
+  content: "◎";
+}

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,12 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-11
 
+- style+fix: terminal stats `◎` + WhatNow icon swapped to Compass [XS]
+  - **Bug.** Brand popover's stats row still rendered the colored MiniRings SVG in terminal mode — the only ring of color in an otherwise monochrome popover. User flagged it as "hasn't migrated to the new look."
+  - **Fix.** Terminal CSS hides the SVG and renders `◎` (bullseye glyph) in accent color + glow via `::before` on `.mini-rings`. Rings concept preserved (per user request "I want to keep the rings concept for stats"), look matches the rest of the terminal idiom.
+  - **Identity collision.** The WhatNow FAB at the lower-right used `Target` (concentric rings), the same visual identity as Stats. User: "Come up with a new icon for what's next that's not a +." Replaced `Target` → `Compass` in `FloatingCapture.jsx` (both render slots: the idle button and the open-card anchor). Compass reads as "find direction / pick a path forward" — semantically right for "what should I do now?" without overlapping with stats or with the `+` add affordance. `WhatNowModal`'s internal "Anything" capacity button keeps `Target` — semantically distinct (open-ended, no constraint).
+  - Modified: `src/v2/components/FloatingCapture.jsx`, `src/v2/terminal/sections.css`, `wiki/Version-History.md`
+
 - fix+style: EditTaskModal CTA → "Close" + restore section-count alignment [XS]
   - **CTA rename.** With autosave back (#134) and the AutosaveIndicator showing "✓ Saved" feedback (#136), the `[ Save changes ]` button no longer commits anything new — it just closes the modal. Relabeled to `Close` so the affordance reads honestly. RoutinesModal kept as-is (still explicit-save; no autosave there).
   - **Count regression.** Collapsible sections (#138) introduced `.v2-section-label-toggle .v2-section-label-count { margin-left: 0 }` to make room for the chevron — that stranded the count flush-left next to the section text instead of pushed right. The chevron also had `margin-left: auto`, which became redundant. Fix: drop the count override, drop the chevron's auto, give it an 8px gap. Count returns to the right; chevron sits beside it.


### PR DESCRIPTION
## What

- Stats row in brand popover: render `◎` in terminal mode instead of colored MiniRings SVG. Rings concept preserved per user request.
- WhatNow FAB: `Target` → `Compass` to break visual identity collision with stats. WhatNowModal's "Anything" capacity button keeps Target.

## Test plan

- [ ] Merge triggers `:latest` rebuild → Portainer deploy
- [ ] Open brand popover in terminal → stats row shows `◎` accent+glow, no SVG
- [ ] FAB bottom-right shows compass instead of target

https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_