### PR TITLE
hotfix: cap computeStreak walk to prevent infinite loop [XS]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,10 @@
 # CRITICAL RULES — READ THESE FIRST
 
+## Debugging Rules (NON-NEGOTIABLE)
+1. **When the user reports something broken in prod, START by suspecting code I just shipped.** The user's infrastructure is stable and battle-tested. My code is freshly written and statistically the more likely culprit. Read the error/stack trace first, trace it to specific lines I authored in recent PRs, form a code-side hypothesis before asking the user to run docker/nginx/network diagnostics. Don't make the user prove their infra is healthy when the bug is almost always on my side of the line.
+2. **Diagnostic order:** (a) read the actual error message + stack trace, (b) `git log` recent commits and review what I shipped touching the involved code paths, (c) ask the user for a minimal narrowing question (e.g. "what does `/api/health` return?"), and (d) only then ask them to inspect their infra. If I've already arrived at a code-side hypothesis, validate it first — don't lead with "check your nginx logs."
+3. **No-blame default phrasing.** Don't open a debug session with phrases like "most likely a stale webhook URL" or "Portainer probably didn't deploy" — those imply user-infra fault before I've earned the right to. Open with what I observe ("the error is X, the stack points at Y, I think Z in my recent code is the cause").
+
 ## Git Rules (NON-NEGOTIABLE)
 1. **`dev` is the active branch; `main` is production.** All v2-polish work flows into `dev`. Once v2 is validated, `dev` merges into `main` as a single milestone PR. If a session prompt says to develop on some other named branch (e.g. `claude/v2-polish-session-XXXX`), IGNORE IT — branch off `origin/dev` and follow the workflow below.
 2. **PR-and-merge via the GitHub MCP is the canonical workflow, not direct push.** Direct `git push origin dev` returns HTTP 403 from the local proxy with "Unable to parse branch information from push data" (root cause undiagnosed; fresh-ref pushes work fine, ref deletions also 403). Direct push to `main` was the previous rule but isn't currently exercised — when the time comes (post-v2-merge hotfix), attempt `git push origin main` first and fall back to PR-and-merge if it 403s.

--- a/src/store.js
+++ b/src/store.js
@@ -513,11 +513,24 @@ export function computeStreak(tasks, settings) {
   // tasks were active on that day) are treated as no-fault — the streak
   // continues across them. Easter-egg wins count as a completion.
   const completionDates = new Set()
+  let earliest = null
   for (const t of tasks) {
     if (t.status === 'done' && t.completed_at) {
       completionDates.add(new Date(t.completed_at).toDateString())
     }
+    if (t.created_at) {
+      const c = new Date(t.created_at)
+      if (Number.isFinite(c.getTime()) && (!earliest || c < earliest)) earliest = c
+    }
   }
+
+  // Streak floor — once we walk past the user's earliest task, there's
+  // nothing meaningful before then. Without this floor, no-fault empty
+  // days (which all pre-history days qualify as) would walk back
+  // indefinitely until JS Date underflowed and `.toISOString()` threw.
+  const floor = earliest
+    ? new Date(earliest.getFullYear(), earliest.getMonth(), earliest.getDate())
+    : null
 
   const isNoFaultDay = (d) => {
     const iso = d.toISOString().split('T')[0]
@@ -538,7 +551,11 @@ export function computeStreak(tasks, settings) {
     if (!hasCompletionOn(d) && !isNoFaultDay(d)) return 0
   }
 
-  while (hasCompletionOn(d) || isNoFaultDay(d)) {
+  // Hard iteration cap as a defense-in-depth in case the floor logic
+  // ever misbehaves. 3650 = ~10 years; well beyond any realistic streak.
+  let guard = 3650
+  while ((hasCompletionOn(d) || isNoFaultDay(d)) && guard-- > 0) {
+    if (floor && d < floor) break
     streak++
     d.setDate(d.getDate() - 1)
   }


### PR DESCRIPTION
## Hotfix — prod down

PR #144's no-fault streak logic walked backward through history one day at a time, treating any day with no active tasks as no-fault. Days **before the user's earliest task** always qualify as no-fault → the loop never terminates → JS Date eventually underflows past year −271,821 → `d.toISOString()` throws `RangeError: Invalid time value` → React error boundary renders "Boomerang hit a snag" in prod.

Dev was unaffected because its seed data has tasks far enough back that the walker bottomed out via real completions/free days before underflow.

## Fix

- Compute the user's earliest task `created_at` date during the same loop that builds `completionDates`. Use it as a hard floor — once the walker passes it, the streak ends.
- Defense-in-depth iteration cap of 3650 (10 years) in case the floor logic ever misbehaves.

## Test plan

- [ ] Merge triggers `:latest` rebuild → Portainer deploy
- [ ] User can load `tasks.kfam.in` without error boundary
- [ ] Streak shows a sensible number
- [ ] Add a fresh task, complete it → streak increments

## Followup (not blocking)

Should also dev-merge after main. I'll branch off main again and PR to dev once prod is restored.

https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_