### PR TITLE
feat: Easter-egg triggers — build row + Quokka phrase [S]

### DIFF
--- a/src/v2/AppV2.jsx
+++ b/src/v2/AppV2.jsx
@@ -25,6 +25,7 @@ import WeekStrip from './components/WeekStrip'
 import Toast from './components/Toast'
 import FloatingCapture from './components/FloatingCapture'
 import ConfirmDialog from './components/ConfirmDialog'
+import TicTacToe from './components/TicTacToe'
 import { useTasks } from '../hooks/useTasks'
 import { useRoutines, enhanceSpawnedTasks } from '../hooks/useRoutines'
 import { useNotifications } from '../hooks/useNotifications'
@@ -85,9 +86,11 @@ export default function AppV2() {
   const isTerminal = useTerminalMode()
   const weather = useWeather()
 
-  // Per-section collapsed state on the home task list. Initialized from
-  // settings, written back on every toggle so it persists across reloads
-  // (and syncs across devices via the standard /api/data round-trip).
+  // Hidden tic-tac-toe Easter egg. Triggered by either: 7-tap the Build
+  // row in Settings → Logs (Android-build-number metaphor) OR say "want
+  // to play a game" / "wanna play a game" to Quokka.
+  const [tttOpen, setTttOpen] = useState(false)
+  const openEasterEgg = useCallback(() => setTttOpen(true), [])
   const [collapsedSections, setCollapsedSections] = useState(() => loadSettings().collapsed_sections || {})
   const toggleSection = useCallback((name) => {
     setCollapsedSections(prev => {
@@ -773,7 +776,6 @@ export default function AppV2() {
         <EditTaskModal
           task={editTarget}
           onSave={updateTask}
-          onFlush={flushSync}
           onClose={() => setEditTarget(null)}
           onDelete={(id) => { handleDelete(id); setEditTarget(null) }}
           onBacklog={handleBacklog}
@@ -892,6 +894,7 @@ export default function AppV2() {
         onClearAll={() => { clearAll(); setShowSettings(false); flushSync() }}
         onShowActivityLog={() => setShowActivityLog(true)}
         onShowMarkdownImport={() => setShowMarkdownImport(true)}
+        onOpenEasterEgg={openEasterEgg}
         onTrelloSync={syncTrello}
         trelloSyncing={trelloSyncing}
         onNotionSync={syncNotion}
@@ -960,6 +963,13 @@ export default function AppV2() {
         open={showAdviser}
         adviser={adviserState}
         onClose={() => setShowAdviser(false)}
+        onOpenEasterEgg={openEasterEgg}
+      />
+
+      <TicTacToe
+        open={tttOpen}
+        onClose={() => setTttOpen(false)}
+        onPointEarned={flushSync}
       />
 
       <AnalyticsModal

--- a/src/v2/components/AdviserModal.jsx
+++ b/src/v2/components/AdviserModal.jsx
@@ -161,7 +161,13 @@ function ChatList({ chats, activeId, onSwitch, onDelete, onStar, onUnstar, onNew
   )
 }
 
-export default function AdviserModal({ open, adviser, onClose, onAfterCommit }) {
+// Easter-egg trigger phrase — matched against user input before the
+// message hits the AI. WarGames reference. Tight regex so it only fires
+// on intent ("want to play a game", "wanna play a game") and not on
+// passing mentions of games.
+const EASTER_EGG_PHRASE = /\b(?:want to|wanna|let'?s|shall we) play (?:a |an )?game\b/i
+
+export default function AdviserModal({ open, adviser, onClose, onAfterCommit, onOpenEasterEgg }) {
   const {
     messages, status, lastError,
     send, commit, abort,
@@ -202,6 +208,14 @@ export default function AdviserModal({ open, adviser, onClose, onAfterCommit }) 
   const handleSubmit = (e) => {
     e.preventDefault()
     if (!canSend) return
+    // Easter-egg short-circuit: intercept the trigger phrase before it
+    // hits the AI. No chat entry recorded — the game appears, and on
+    // close the user is back in the modal with input cleared.
+    if (onOpenEasterEgg && EASTER_EGG_PHRASE.test(input)) {
+      onOpenEasterEgg()
+      setInput('')
+      return
+    }
     send(input)
     setInput('')
   }

--- a/src/v2/components/EditTaskModal.jsx
+++ b/src/v2/components/EditTaskModal.jsx
@@ -7,7 +7,6 @@ import WeatherSection, { resolveWeatherVisibility } from '../../components/Weath
 import ModalShell from './ModalShell'
 import AutosaveIndicator from './AutosaveIndicator'
 import DateField from './DateField'
-import TicTacToe from './TicTacToe'
 import './AddTaskModal.css' // shared form-control styles
 import './EditTaskModal.css'
 
@@ -26,7 +25,7 @@ const STATUS_OPTIONS = ['not_started', 'doing', 'waiting']
 
 const CADENCE_OPTIONS = ['daily', 'weekly', 'monthly', 'quarterly', 'annually', 'custom']
 
-export default function EditTaskModal({ task, onSave, onFlush, onClose, onDelete, onBacklog, onProject, onStatusChange, onConvertToRoutine, weather }) {
+export default function EditTaskModal({ task, onSave, onClose, onDelete, onBacklog, onProject, onStatusChange, onConvertToRoutine, weather }) {
   const form = useTaskForm({
     title: task.title,
     notes: task.notes || '',
@@ -86,22 +85,6 @@ export default function EditTaskModal({ task, onSave, onFlush, onClose, onDelete
 
   const [currentStatus, setCurrentStatus] = useState(task.status === 'open' ? 'not_started' : task.status)
   const [confirmDelete, setConfirmDelete] = useState(false)
-  // Easter egg trigger — Android-build-number metaphor. 7 taps on the
-  // modal title within a rolling 2s window opens the hidden tic-tac-toe
-  // game. Undocumented in user-facing copy; discoverable by power users.
-  const [tttOpen, setTttOpen] = useState(false)
-  const titleTapsRef = useRef({ count: 0, last: 0 })
-  const handleTitleTap = () => {
-    const now = Date.now()
-    const taps = titleTapsRef.current
-    if (now - taps.last > 2000) taps.count = 0
-    taps.count += 1
-    taps.last = now
-    if (taps.count >= 7) {
-      taps.count = 0
-      setTttOpen(true)
-    }
-  }
   const [makeRecurring, setMakeRecurring] = useState(false)
   const [cadence, setCadence] = useState('weekly')
   const [customDays, setCustomDays] = useState(14)
@@ -290,7 +273,6 @@ export default function EditTaskModal({ task, onSave, onFlush, onClose, onDelete
       terminalTitle="> task --edit"
       width="narrow"
       headerSlot={<AutosaveIndicator saved={justSaved} />}
-      onTitleTap={handleTitleTap}
     >
       <input
         className="v2-form-input v2-form-title"
@@ -986,7 +968,6 @@ export default function EditTaskModal({ task, onSave, onFlush, onClose, onDelete
       >
         Close
       </button>
-      <TicTacToe open={tttOpen} onClose={() => setTttOpen(false)} onPointEarned={onFlush} />
     </ModalShell>
   )
 }

--- a/src/v2/components/ModalShell.jsx
+++ b/src/v2/components/ModalShell.jsx
@@ -3,7 +3,7 @@ import { X } from 'lucide-react'
 import { useTerminalMode } from '../hooks/useTerminalMode'
 import './ModalShell.css'
 
-export default function ModalShell({ open, onClose, title, terminalTitle, subtitle, headerSlot, onTitleTap, children, width = 'narrow' }) {
+export default function ModalShell({ open, onClose, title, terminalTitle, subtitle, headerSlot, children, width = 'narrow' }) {
   const terminal = useTerminalMode()
   useEffect(() => {
     if (!open) return
@@ -27,7 +27,7 @@ export default function ModalShell({ open, onClose, title, terminalTitle, subtit
         </button>
         {headerSlot && <div className="v2-modal-header-slot">{headerSlot}</div>}
         <header className="v2-modal-header">
-          <h1 className="v2-modal-title" onClick={onTitleTap}>{terminal && terminalTitle ? terminalTitle : title}</h1>
+          <h1 className="v2-modal-title">{terminal && terminalTitle ? terminalTitle : title}</h1>
           {subtitle && <p className="v2-modal-subtitle">{subtitle}</p>}
         </header>
         <div className="v2-modal-body">

--- a/src/v2/components/SettingsModal.jsx
+++ b/src/v2/components/SettingsModal.jsx
@@ -1729,6 +1729,7 @@ function ServerLogsPanel() {
 
 export default function SettingsModal({
   open, onClose, onFlush, onClearCompleted, onClearAll, onShowActivityLog, onShowMarkdownImport,
+  onOpenEasterEgg,
   onTrelloSync, trelloSyncing, onNotionSync, notionSyncing, onGCalSync, gcalSyncing,
 }) {
   const [activeTab, setActiveTab] = useState('General')
@@ -1741,6 +1742,22 @@ export default function SettingsModal({
   // the debounced flush fires; back to false after 2s.
   const [justSaved, setJustSaved] = useState(false)
   const justSavedTimer = useRef(null)
+  // Easter egg trigger — 7 taps on the Build row within a rolling 2s
+  // window opens the hidden tic-tac-toe game. Android-build-number
+  // metaphor. Undocumented in user-facing copy.
+  const buildTapsRef = useRef({ count: 0, last: 0 })
+  const handleBuildTap = () => {
+    if (!onOpenEasterEgg) return
+    const now = Date.now()
+    const taps = buildTapsRef.current
+    if (now - taps.last > 2000) taps.count = 0
+    taps.count += 1
+    taps.last = now
+    if (taps.count >= 7) {
+      taps.count = 0
+      onOpenEasterEgg()
+    }
+  }
 
   // Reload settings whenever the modal reopens — server may have updated them.
   useEffect(() => {
@@ -2079,7 +2096,12 @@ export default function SettingsModal({
                 <div className="v2-settings-row-label">Build</div>
                 <div className="v2-settings-row-hint">Static identifier of the running build.</div>
               </div>
-              <code className="v2-settings-build">{__APP_VERSION__}</code>
+              <code
+                className="v2-settings-build"
+                onClick={handleBuildTap}
+                role="button"
+                tabIndex={-1}
+              >{__APP_VERSION__}</code>
             </div>
           </div>
         )}

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -4,6 +4,18 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ---
 
+## 2026-05-12
+
+- feat: relocate Easter-egg triggers (build row + Quokka phrase) [S]
+  - **Why.** User: "Let's actually put it on the build number so I don't accidentally edit something. Also I want to trigger it with quokka if I say 'Want to play a game'." Original 7-tap location (EditTaskModal title) was too easy to fat-finger while editing real tasks.
+  - **TicTacToe lifted to AppV2.** Top-level state + render. Any modal can call `openEasterEgg()` to launch it. Removed from EditTaskModal entirely (title-tap counter, state, render, import).
+  - **Build row trigger.** Settings → Logs → Build code (`__APP_VERSION__`) gets a 7-tap counter inside a rolling 2s window. Same Android-build-number metaphor, just on the version display where accidental triggering doesn't matter.
+  - **Quokka phrase intercept.** AdviserModal's `handleSubmit` checks user input against `/\b(?:want to|wanna|let'?s|shall we) play (?:a |an )?game\b/i` before sending to the AI. Match → fire `onOpenEasterEgg`, clear input, skip the network call. No chat entry recorded; on game close, user is back in Quokka with a clean input. WarGames reference baked into the regex variants.
+  - **ModalShell `onTitleTap` prop removed** — no callers now that EditTaskModal doesn't use it.
+  - Modified: `src/v2/AppV2.jsx`, `src/v2/components/EditTaskModal.jsx`, `src/v2/components/ModalShell.jsx`, `src/v2/components/SettingsModal.jsx`, `src/v2/components/AdviserModal.jsx`, `wiki/Version-History.md`
+
+---
+
 ## 2026-05-11
 
 - feat: no-fault streak + hidden tic-tac-toe Easter egg [M]


### PR DESCRIPTION
## What

Relocate Easter-egg triggers off the EditTaskModal title (too easy to fat-finger while editing) onto safer surfaces:

1. **Settings → Logs → Build code** — tap the version 7× in <2s
2. **Quokka** — say "want to play a game" / "wanna play a game" / "let's play a game" / "shall we play a game"

TicTacToe lifted to AppV2 top-level so either trigger can fire it. EditTaskModal no longer has any Easter-egg logic.

## Test plan

- [ ] Merge triggers `:latest` rebuild → Portainer deploy
- [ ] Settings → Logs → 7× tap version code → game appears
- [ ] Quokka → "want to play a game" → game appears, no chat entry
- [ ] EditTaskModal title taps → nothing

https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpST92ro1NtX7UC1QBqr6h)_