### PR TITLE
release: v0.12.0 — activity prompts to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Open `http://localhost:3001` and add your API keys in Settings.
 - **Desktop UI** — kanban board with drag-and-drop, responsive modals, hover states
 - **Mobile-first PWA** — installable to home screen, swipe gestures (left for Edit/Done, right to delete)
 - **Themes** — Light, Dark, Terminal Dark (GitHub Dark), Terminal Light (GitHub Light). Terminal mode swaps the calm-modern aesthetic for a monospace power-user shell with ASCII flourishes, `> verb` modal headers, flat sigil+text controls, and density signals on every task card
+- **Routines + Habits + Suggestions** — recurring tasks with cadence (daily/weekly/monthly/quarterly/annually), an `auto_roll` flag for meds that can't double up, habit mode for target-frequency tracking (`2× / week`, behind-pace nudges), plus a weekly server scan that detects patterns in completed-task history and surfaces them as routine suggestions
 - **Custom labels**, due dates, high-priority escalation
 
 ### Notifications
@@ -43,6 +44,8 @@ Configurable notification types with ADHD-friendly defaults:
 | Nudges | General ADHD-friendly pokes | configurable (hours) |
 | Size-based | Reminders scaled by task size | configurable (hours) |
 | Pile-up warnings | Alerts when too many tasks accumulate | configurable (hours) |
+| Habit nudges | Behind-pace pokes for habit-mode routines (push only, never Pushover) | 24h per habit |
+| Routine suggestions | Weekly summary of pattern-detected routine candidates from history | weekly |
 
 All frequencies are set in hours (supports fractional values, e.g. `0.25` = 15 minutes). Quiet hours, notification history, and avoidance boost (confrontation/errand tasks get nagged more frequently) included.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "boomerang",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "boomerang",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "cors": "^2.8.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "boomerang",
   "private": true,
-  "version": "0.11.0",
+  "version": "0.12.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,16 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-16
 
+- release: v0.12.0 — activity prompts (auto-roll, habit mode, suggestions) to main [L]
+  - Bump version 0.11.0 → 0.12.0. Ship the full Activity-Prompts feature set from `dev` to `main`. Three user-facing features land together: routine `auto_roll` (medication-style — missed days roll the existing task forward instead of stacking), `spawn_mode: 'habit'` (target-frequency tracking with `+ Log it` button and behind-pace push nudges), and a weekly pattern-detection scan that surfaces routine suggestions from completed-task history. Plus a snooze-leak fix that stops the dispatcher from nudging on items the user explicitly silenced.
+  - **Schema deltas:** migrations 025 (`auto_roll`), 026 (`spawn_mode` + `target_count` + `target_period`), 027 (`pattern_suggestions` table). Existing rows unaffected — every new field defaults safely.
+  - **Notifications matrix gains two rows:** `habit_nudge` (push priority-0 only, never Pushover) and `routine_suggestion` (weekly; push + email default-on, pushover opt-in). Settings UI auto-renders both.
+  - **New surfaces:** v2 SuggestionsModal accessible via overflow ⋯ → Suggestions. v2 RoutinesModal gains Auto/Habit segmented picker + auto-roll toggle. Quokka gets `list_suggestions` / `dismiss_suggestion` / `snooze_suggestion` tools.
+  - **Durability:** `pattern_suggestions` is server-only, outside the `/api/data` bulk-PUT path — same posture as `notification_log` post-2026-05-08 wipe.
+  - **Docs:** README updated with Routines+Habits+Suggestions line and two new notification-table rows. Spec in `wiki/Activity-Prompts.md`; comprehensive test plan in `wiki/Activity-Prompts-Testing.md`.
+  - `npm audit` reports 0 vulnerabilities.
+  - Modified: `package.json`, `package-lock.json`, `README.md`, `wiki/Version-History.md`
+
 - fix(routines): priority toggle alignment in habit-mode form [XS]
   - **Why.** User: "Priority isn't aligned like the rest." In habit mode the End date / Priority row collapses to just Priority (End date is hidden) inside a 2-column grid (`v2-form-row`). With End date gone, Priority fills the left half-column with center-aligned bracketed text, making `[ normal ]` float at ~25% from the left — visually offset from every other field in the form which hugs the left edge.
   - **Fix.** Split the JSX: keep the End date + Priority row when `!isHabit`; render Priority as its own full-width `v2-form-section` when `isHabit` (same pattern as the Mode picker and the now-hidden Auto-roll section). Now `[ normal ]` aligns flush-left with the other section labels.


### PR DESCRIPTION
## Summary

Release commit for v0.12.0. Bumps `package.json` 0.11.0 → 0.12.0, adds Routines+Habits+Suggestions line to README, adds `habit_nudge` + `routine_suggestion` rows to the README notifications table, and stamps the milestone in Version-History.

This is the prep commit for the `dev → main` PR — needs to land on `dev` first so the dev→main merge carries it.

https://claude.ai/code/session_01NoYVqzgys5WDWLdALTsZrS

---
_Generated by [Claude Code](https://claude.ai/code/session_01NoYVqzgys5WDWLdALTsZrS)_