### PR TITLE
fix(terminal): auto-roll toggle no longer renders as a chromed button

### DIFF
--- a/scripts/check-terminal-buttons.js
+++ b/scripts/check-terminal-buttons.js
@@ -39,7 +39,6 @@ const EXEMPT = new Set([
   'v2-edit-routine-row',   // covered explicitly
   'v2-edit-status-row',    // covered by .v2-form-seg child rule
   'v2-form-pri-action',    // sub-element of priority toggle
-  'v2-form-toggle',        // sub-element
   'v2-card-meta-row',      // pure layout
   'v2-card-row',           // alias for swipe-wrap
   'v2-card-swipe-wrap',    // wrapper

--- a/src/v2/terminal/init.css
+++ b/src/v2/terminal/init.css
@@ -1720,6 +1720,49 @@
   color: var(--v2-accent);
 }
 
+/* Generic on/off toggle (auto-roll, future binary flags). Same bracket
+ * treatment as .v2-form-pri-toggle so it doesn't look like a chrome'd
+ * button in terminal mode. Off = muted, On = accent + glow. */
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-toggle {
+  background: transparent !important;
+  border: none !important;
+  border-radius: 0 !important;
+  padding: 4px 0 !important;
+  font: 500 13px/1.2 var(--v2-font-body) !important;
+  color: var(--v2-text) !important;
+  height: auto !important;
+  min-height: 32px !important;
+  text-transform: lowercase;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-toggle::before {
+  content: "[ ";
+  color: var(--v2-text-faint);
+}
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-toggle::after {
+  content: " ]";
+  color: var(--v2-text-faint);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-toggle-on {
+  color: var(--v2-accent) !important;
+  text-shadow: var(--v2-glow);
+}
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-toggle-off {
+  color: var(--v2-text-meta) !important;
+  background: transparent !important;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-toggle:hover {
+  background: transparent !important;
+  color: var(--v2-accent) !important;
+  text-shadow: var(--v2-glow);
+}
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-toggle:hover::before,
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-toggle:hover::after {
+  color: var(--v2-accent);
+}
+
 /* === Audit-pass cleanup: Settings tabs + WeatherBadge ============== */
 
 /* Settings tabs (General / AI / Labels / Integrations / etc.) — match

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,12 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-16
 
+- fix(terminal): auto-roll toggle no longer renders as a chromed button [XS]
+  - **Why.** Production sighting on v1.6.0 — the auto-roll On/Off toggle in the RoutinesModal form rendered with rounded-rectangle button chrome in terminal mode, breaking the no-button-chrome idiom that every other control follows. The `.v2-form-toggle` class had base styling but no terminal-mode override; the check-terminal-buttons script had it listed under EXEMPT with a misleading "sub-element" comment, which silenced the guard.
+  - **Fix.** Terminal-mode rules added to `src/v2/terminal/init.css`: transparent background, no border, bracket prefix/suffix (`[ on ]` / `[ off ]`) matching `.v2-form-pri-toggle`. Off renders muted, On renders accent + glow.
+  - Removed `v2-form-toggle` from `check-terminal-buttons.js` EXEMPT so the guard will catch future regressions on this class. Confirmed `OK — 64 classes checked`.
+  - Modified: `src/v2/terminal/init.css`, `scripts/check-terminal-buttons.js`, `wiki/Version-History.md`
+
 - release: v0.12.0 — activity prompts (auto-roll, habit mode, suggestions) to main [L]
   - Bump version 0.11.0 → 0.12.0. Ship the full Activity-Prompts feature set from `dev` to `main`. Three user-facing features land together: routine `auto_roll` (medication-style — missed days roll the existing task forward instead of stacking), `spawn_mode: 'habit'` (target-frequency tracking with `+ Log it` button and behind-pace push nudges), and a weekly pattern-detection scan that surfaces routine suggestions from completed-task history. Plus a snooze-leak fix that stops the dispatcher from nudging on items the user explicitly silenced.
   - **Schema deltas:** migrations 025 (`auto_roll`), 026 (`spawn_mode` + `target_count` + `target_period`), 027 (`pattern_suggestions` table). Existing rows unaffected — every new field defaults safely.


### PR DESCRIPTION
## Summary

Prod sighting on v1.6.0: the auto-roll On/Off toggle in the RoutinesModal form rendered with rounded-rectangle button chrome in terminal mode, breaking the no-button-chrome idiom every other control follows.

**Root cause:** `.v2-form-toggle` had base styling but no terminal-mode override. The `check-terminal-buttons` script listed it under `EXEMPT` with a misleading "sub-element" comment, which silenced the guard.

**Fix:** Terminal-mode rules added to `src/v2/terminal/init.css` — transparent bg, no border, bracket prefix/suffix (`[ on ]` / `[ off ]`) matching `.v2-form-pri-toggle`. Off renders muted, On renders accent + glow.

Removed `v2-form-toggle` from `EXEMPT` so the guard catches future regressions on this class. Confirmed `OK — 64 classes checked`.

## Test plan

- [x] Smoke test green
- [x] `check-terminal-buttons` passes
- [ ] Manual: open Routines → New routine in terminal-dark → confirm auto-roll renders as `[ off ]` / `[ on ]` with no chrome
- [ ] Manual: verify light/dark themes unaffected

https://claude.ai/code/session_01NoYVqzgys5WDWLdALTsZrS

---
_Generated by [Claude Code](https://claude.ai/code/session_01NoYVqzgys5WDWLdALTsZrS)_