### PR TITLE
fix(terminal): three small RoutinesModal bugs

### DIFF
--- a/src/v2/terminal/init.css
+++ b/src/v2/terminal/init.css
@@ -1674,6 +1674,12 @@
   text-shadow: var(--v2-glow);
 }
 
+/* Hide the JSX Plus icon — the terminal-mode "[ + " prefix already
+ * provides the visual marker, so the SVG would render as a second plus. */
+:root[data-ui="v2"][data-theme^="terminal"] .v2-routine-new-btn > svg {
+  display: none !important;
+}
+
 :root[data-ui="v2"][data-theme^="terminal"] .v2-routine-new-btn::before {
   content: "[ + ";
   color: var(--v2-accent);
@@ -1697,6 +1703,7 @@
   color: var(--v2-text) !important;
   height: auto !important;
   min-height: 32px !important;
+  text-align: left !important;
 }
 
 :root[data-ui="v2"][data-theme^="terminal"] .v2-form-pri-toggle::before {
@@ -1733,6 +1740,7 @@
   height: auto !important;
   min-height: 32px !important;
   text-transform: lowercase;
+  text-align: left !important;
 }
 
 :root[data-ui="v2"][data-theme^="terminal"] .v2-form-toggle::before {

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,12 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-16
 
+- fix(terminal): three small RoutinesModal bugs [XS]
+  - **Double plus on "new routine" button.** Terminal CSS renders `[ + ` as a `::before` prefix; the JSX also rendered a Lucide `<Plus>` SVG icon, so terminal users saw `[ + + new routine ]`. Hide the SVG when in terminal mode via `.v2-routine-new-btn > svg { display: none }`. Light/dark themes still get the proper icon.
+  - **Priority `[ normal ]` center-aligned.** Both modes: button text was inheriting browser-default `text-align: center`, so the bracketed text floated mid-row in habit mode (full-width section) and mid-column in auto mode (half-width grid cell). Added `text-align: left` to `.v2-form-pri-toggle` under the terminal selector.
+  - **Auto-roll `[ on ]` / `[ off ]` center-aligned.** Same cause; same fix on `.v2-form-toggle`.
+  - Modified: `src/v2/terminal/init.css`, `wiki/Version-History.md`
+
 - fix(terminal): auto-roll toggle no longer renders as a chromed button [XS]
   - **Why.** Production sighting on v1.6.0 — the auto-roll On/Off toggle in the RoutinesModal form rendered with rounded-rectangle button chrome in terminal mode, breaking the no-button-chrome idiom that every other control follows. The `.v2-form-toggle` class had base styling but no terminal-mode override; the check-terminal-buttons script had it listed under EXEMPT with a misleading "sub-element" comment, which silenced the guard.
   - **Fix.** Terminal-mode rules added to `src/v2/terminal/init.css`: transparent background, no border, bracket prefix/suffix (`[ on ]` / `[ off ]`) matching `.v2-form-pri-toggle`. Off renders muted, On renders accent + glow.


### PR DESCRIPTION
## Summary

Three small terminal-mode bugs surfaced in the RoutinesModal on `dev-61a2953`:

1. **`[ + + new routine ]`** — terminal CSS adds `[ + ` as a `::before` prefix, but the JSX also renders a Lucide `<Plus>` SVG. Result: two plus signs. Fix: hide the SVG in terminal mode only; light/dark themes still get the proper icon.

2. **Priority `[ normal ]` center-aligned** in both habit mode (full-width section) and auto/cadence mode (half-width grid cell). Browser default `text-align: center` on `<button>` floats the bracketed text mid-row instead of hugging the left like every other label. Fix: `text-align: left` on `.v2-form-pri-toggle` under the terminal selector.

3. **Auto-roll `[ on ]` / `[ off ]` center-aligned** — same cause, same fix on `.v2-form-toggle`.

## Test plan

- [x] Smoke test green
- [ ] Manual: open Routines → New routine in terminal-dark
  - Button reads `[ + new routine ]` (single plus)
  - Priority `[ normal ]` hugs the left edge of its column (auto mode) or the modal (habit mode)
  - Auto-roll `[ off ]` / `[ on ]` hugs the left edge

https://claude.ai/code/session_01NoYVqzgys5WDWLdALTsZrS

---
_Generated by [Claude Code](https://claude.ai/code/session_01NoYVqzgys5WDWLdALTsZrS)_