### PR TITLE
fix(ui): tighten PWA manifest for iOS install recognition

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -38,13 +38,16 @@ export default defineConfig({
         navigateFallbackDenylist: [/^\/api/],
       },
       manifest: {
+        id: '/',
         name: 'Boomerang',
         short_name: 'Boomerang',
         description: 'Tasks that always come back',
         theme_color: '#0B0B0F',
         background_color: '#0B0B0F',
         display: 'standalone',
+        scope: '/',
         start_url: '/',
+        handle_links: 'preferred',
         icons: [
           {
             src: '/icon-192.png',

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -4,6 +4,17 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ---
 
+## 2026-05-17
+
+- fix(ui): tighten PWA manifest for iOS install recognition [XS]
+  - **Why.** Diagnosing Pushover-on-iOS deep-link UX. Tapping a notification opens Safari (per Pushover settings), but Safari was not showing the "Open in Boomerang" affordance that hands a URL off to an installed PWA. iOS Safari's PWA install-matching logic is opaque, but `id` (stable identity anchor) and explicit `scope` are documented prerequisites for reliable association across manifest updates. Current manifest had neither.
+  - **Fix.** Add `id: '/'`, explicit `scope: '/'`, and `handle_links: 'preferred'` to the VitePWA manifest. `id` anchors PWA identity so iOS doesn't treat post-update manifests as a different app. Explicit `scope` removes ambiguity vs. the implicit start_url-derived default. `handle_links` is a Chrome-respected hint that doesn't hurt Safari.
+  - **iOS users must delete + re-add the Home Screen icon** for changes to take effect — iOS caches the manifest at install time. Manifest changes have zero effect on already-installed PWAs.
+  - **What this does NOT solve.** iOS does not deep-link from third-party apps directly to PWAs — that's a platform limitation. Best case after this change is "Pushover → Safari → tap 'Open in Boomerang' banner → PWA" (one extra tap). If the banner still doesn't appear after re-install, we've hit the iOS ceiling and the options narrow to (a) live with manual app-switch after Pushover, or (b) Capacitor wrap.
+  - Modified: `vite.config.js`, `wiki/Version-History.md`
+
+---
+
 ## 2026-05-16
 
 - fix(terminal): three small RoutinesModal bugs [XS]


### PR DESCRIPTION
## Why

Diagnosing Pushover-on-iOS deep-link UX. Tapping a notification opens Safari (per Pushover's "Web browser: Safari" setting), but Safari is not showing the "Open in Boomerang" affordance that hands a URL off to an installed PWA. iOS Safari's PWA install-matching logic is opaque, but `id` (stable identity anchor) and explicit `scope` are documented prerequisites for reliable association across manifest updates. Current manifest had neither.

## Change

Three new fields on the VitePWA manifest config in `vite.config.js`:

- `id: '/'` — anchors PWA identity so iOS does not treat post-update manifests as a different app
- `scope: '/'` — explicit, removes ambiguity vs. the implicit start_url-derived default
- `handle_links: 'preferred'` — Chrome-respected hint, harmless on Safari

## Important — manual step required on iOS

Manifest changes do NOT auto-propagate to installed PWAs on iOS. After this merges and `:dev` deploys:

1. Delete the Boomerang Home Screen icon
2. Open the site in Safari
3. Re-add to Home Screen
4. Fire a test Pushover notification with a URL
5. Look for the "Open in Boomerang" banner at the top of Safari

## What this does NOT solve

iOS does not deep-link from third-party apps directly to PWAs — platform limitation. Best case after this change is "Pushover → Safari → tap banner → PWA" (one extra tap). If the banner still does not appear after re-install, the iOS ceiling has been hit and the options narrow to (a) live with manual app-switch after Pushover, or (b) Capacitor wrap.

## Checks

- `npm audit`: 0 vulnerabilities
- Pre-push smoke test passed (lint warnings only, no errors; build + server boot + health check OK)
- Terminal-title + terminal-button convention checks passed

---
_Generated by [Claude Code](https://claude.ai/code/session_01NoYVqzgys5WDWLdALTsZrS)_