### PR TITLE
sync(dev): notification-history date fix + v2 push subscribe fix from main

### DIFF
--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -103,9 +103,9 @@ function NotificationHistory() {
               </span>
             </span>
             <span className="notif-history-time">
-              {new Date(entry.timestamp).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}
+              {new Date(entry.sent_at).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}
               {' '}
-              {new Date(entry.timestamp).toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' })}
+              {new Date(entry.sent_at).toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' })}
             </span>
           </div>
           <div className="notif-history-title">{entry.title}</div>

--- a/src/v2/components/SettingsModal.jsx
+++ b/src/v2/components/SettingsModal.jsx
@@ -6,6 +6,7 @@ import {
   LABEL_COLORS, uuid,
 } from '../../store'
 import { restoreFromBackup } from '../../api'
+import { usePushSubscription } from '../../hooks/usePushSubscription'
 import ModalShell from './ModalShell'
 import EmptyState from './EmptyState'
 import AutosaveIndicator from './AutosaveIndicator'
@@ -1205,6 +1206,13 @@ function NotificationsPanel({ settings, update }) {
     { key: 'pushover_notifications_enabled', label: 'Pushover', hint: 'iOS-friendly transport via the Pushover app. Credentials in v1 → Integrations.' },
   ]
 
+  // Web push needs a per-device subscribe step (browser permission +
+  // pushManager.subscribe). The master toggle alone only flips the server-side
+  // boolean — without this, no iOS permission prompt fires and the server
+  // never gets an endpoint to push to.
+  const pushSub = usePushSubscription()
+  const [subscribeError, setSubscribeError] = useState(null)
+
   const Toggle = ({ checked, onChange, disabled }) => (
     <label className={`v2-settings-toggle${disabled ? ' v2-settings-toggle-disabled' : ''}`}>
       <input type="checkbox" checked={!!checked} onChange={onChange} disabled={disabled} />
@@ -1280,6 +1288,56 @@ function NotificationsPanel({ settings, update }) {
             />
           </div>
         ))}
+
+        {/* Per-device subscribe — only relevant when Web push is enabled. */}
+        {settings.push_notifications_enabled === true && pushSub.supported && (
+          <div className="v2-settings-row" style={{ alignItems: 'flex-start', flexDirection: 'column', gap: 8 }}>
+            <div className="v2-settings-row-text">
+              <div className="v2-settings-row-label">This device</div>
+              <div className="v2-settings-row-hint">
+                {pushSub.subscribed
+                  ? 'Subscribed. Push notifications will deliver to this browser.'
+                  : 'Not subscribed. Grant notification permission to receive web push on this device.'}
+              </div>
+            </div>
+            {!pushSub.subscribed && (
+              <button
+                className="v2-settings-btn"
+                disabled={pushSub.loading}
+                onClick={async () => {
+                  setSubscribeError(null)
+                  const result = await pushSub.subscribe()
+                  if (!result.success) setSubscribeError(result.error)
+                }}
+              >
+                {pushSub.loading ? 'Enabling…' : 'Enable on this device'}
+              </button>
+            )}
+            {pushSub.subscribed && (
+              <button
+                className="v2-settings-btn"
+                disabled={pushSub.loading}
+                onClick={async () => {
+                  setSubscribeError(null)
+                  const result = await pushSub.unsubscribe()
+                  if (!result.success) setSubscribeError(result.error)
+                }}
+              >
+                {pushSub.loading ? 'Disabling…' : 'Disable on this device'}
+              </button>
+            )}
+            {subscribeError && (
+              <div className="v2-settings-row-hint" style={{ color: 'var(--v2-danger, #c83a3a)' }}>
+                {subscribeError}
+              </div>
+            )}
+          </div>
+        )}
+        {settings.push_notifications_enabled === true && !pushSub.supported && (
+          <div className="v2-settings-row-hint" style={{ marginTop: 8 }}>
+            Web push isn't supported in this browser. On iOS, add Boomerang to the Home Screen and open from there.
+          </div>
+        )}
       </div>
 
       {/* Per-type × per-channel — card-per-type layout works at any width */}

--- a/src/v2/components/SettingsModal.jsx
+++ b/src/v2/components/SettingsModal.jsx
@@ -1527,7 +1527,7 @@ function NotificationsPanel({ settings, update }) {
                     <div className="v2-notif-history-meta">
                       <span className="v2-notif-history-channel">{entry.channel || 'unknown'}</span>
                       <span className="v2-notif-history-type">{entry.type}</span>
-                      <span className="v2-notif-history-time">{new Date(entry.timestamp).toLocaleString(undefined, { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' })}</span>
+                      <span className="v2-notif-history-time">{new Date(entry.sent_at).toLocaleString(undefined, { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' })}</span>
                     </div>
                     {entry.title && <div className="v2-notif-history-title">{entry.title}</div>}
                     {entry.body && <div className="v2-notif-history-body">{entry.body}</div>}

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,12 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-17
 
+- fix(settings): notification history showed "Invalid Date" on every row [XS]
+  - **Bug.** Notification history list rendered every timestamp as "INVALID DATE" in both v1 and v2 Settings.
+  - **Cause.** Server's `GET /api/notifications/log` returns rows with `sent_at` (matching the SQLite column name), but both `Settings.jsx` and v2 `SettingsModal.jsx` read `entry.timestamp` — a field that doesn't exist on the response. `new Date(undefined)` → Invalid Date.
+  - **Fix.** Read `entry.sent_at` in both components. No server-side change.
+  - Modified: `src/components/Settings.jsx`, `src/v2/components/SettingsModal.jsx`, `wiki/Version-History.md`
+
 - fix(ui): tighten PWA manifest for iOS install recognition [XS]
   - **Why.** Diagnosing Pushover-on-iOS deep-link UX. Tapping a notification opens Safari (per Pushover settings), but Safari was not showing the "Open in Boomerang" affordance that hands a URL off to an installed PWA. iOS Safari's PWA install-matching logic is opaque, but `id` (stable identity anchor) and explicit `scope` are documented prerequisites for reliable association across manifest updates. Current manifest had neither.
   - **Fix.** Add `id: '/'`, explicit `scope: '/'`, and `handle_links: 'preferred'` to the VitePWA manifest. `id` anchors PWA identity so iOS doesn't treat post-update manifests as a different app. Explicit `scope` removes ambiguity vs. the implicit start_url-derived default. `handle_links` is a Chrome-respected hint that doesn't hurt Safari.

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,12 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-17
 
+- fix(notifications): v2 Settings never wired up web-push subscribe flow [S]
+  - **Bug.** Toggling "Web push" ON in v2 Settings → Notifications never triggered an iOS notification permission prompt, never registered a device subscription, and never caused Boomerang to appear in iOS Settings → Notifications. Web push couldn't actually deliver.
+  - **Cause.** v2's `NotificationsPanel` only flipped the server-side `push_notifications_enabled` boolean. It never imported `usePushSubscription`, never called `Notification.requestPermission()`, never called `pushManager.subscribe()`, never POSTed an endpoint to the server. v1 has the correct flow (the "Enable on this device" button at `Settings.jsx:2625`) but v2 has been the default since the 2026-05-03 cutover, so anyone who newly enabled web push in v2 silently got no delivery. Server-side `subscription_count` could still read >0 because of stale subscriptions from before the cutover, hiding the bug from the diagnostic endpoint.
+  - **Fix.** Wire `usePushSubscription` into v2 `NotificationsPanel`. When `push_notifications_enabled === true` and the device isn't yet subscribed, render an "Enable on this device" button that runs the full subscribe handshake (permission prompt → pushManager.subscribe → POST endpoint). When subscribed, render a "Disable on this device" button. Surface any subscribe error inline.
+  - Modified: `src/v2/components/SettingsModal.jsx`, `wiki/Version-History.md`
+
 - fix(settings): notification history showed "Invalid Date" on every row [XS]
   - **Bug.** Notification history list rendered every timestamp as "INVALID DATE" in both v1 and v2 Settings.
   - **Cause.** Server's `GET /api/notifications/log` returns rows with `sent_at` (matching the SQLite column name), but both `Settings.jsx` and v2 `SettingsModal.jsx` read `entry.timestamp` — a field that doesn't exist on the response. `new Date(undefined)` → Invalid Date.


### PR DESCRIPTION
Brings dev up to date with two hotfixes that landed directly on main:

- `4822e13` — fix(settings): notification history showed Invalid Date on every row [XS]
- `9cdd254` — fix(notifications): v2 Settings never wired web-push subscribe flow [S]

User explicitly approved "fix in dev and prod" for the web-push subscribe fix, and the date fix is a pure bug fix with no behavioral risk. No new commits — this PR is just the sync to keep dev from drifting behind main.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NoYVqzgys5WDWLdALTsZrS)_