### PR TITLE
sync(dev): digest config + test error message fix from main

### DIFF
--- a/pushoverNotifications.js
+++ b/pushoverNotifications.js
@@ -691,7 +691,16 @@ export async function sendDigestNow() {
     skipped.push({ channel: 'push', reason: 'disabled' })
   }
 
-  return { success: fired.length > 0, fired, skipped, subject: digest.subject }
+  if (fired.length === 0) {
+    const reasons = skipped.map(s => `${s.channel}: ${s.reason}`).join('; ')
+    return {
+      success: false,
+      fired,
+      skipped,
+      error: `No digest channel delivered. Enable at least one of push_digest, email_digest, or pushover_digest in Settings → Notifications → Daily digest. (${reasons})`,
+    }
+  }
+  return { success: true, fired, skipped, subject: digest.subject }
 }
 
 // --- Lifecycle ---

--- a/src/v2/components/SettingsModal.jsx
+++ b/src/v2/components/SettingsModal.jsx
@@ -1502,6 +1502,59 @@ function NotificationsPanel({ settings, update }) {
         )}
       </div>
 
+      {/* Daily digest — per-channel opt-in. sendDigestNow gates on these flags,
+          not on channel masters, so users with push/email/pushover enabled still
+          need to opt into the digest separately. */}
+      <div className="v2-settings-block">
+        <div className="v2-form-label">Daily digest</div>
+        <div className="v2-settings-row-hint">Curated daily summary — yesterday recap + streak, today's focus, coming up, carrying, quick wins. Each channel must opt in separately.</div>
+        <div className="v2-settings-row">
+          <div className="v2-settings-row-text">
+            <div className="v2-settings-row-label">Web push digest</div>
+            <div className="v2-settings-row-hint">Requires Web push to be enabled and subscribed on this device.</div>
+          </div>
+          <Toggle
+            checked={settings.push_digest_enabled === true}
+            onChange={e => update('push_digest_enabled', e.target.checked)}
+            disabled={settings.push_notifications_enabled !== true}
+          />
+        </div>
+        <div className="v2-settings-row">
+          <div className="v2-settings-row-text">
+            <div className="v2-settings-row-label">Email digest</div>
+            <div className="v2-settings-row-hint">Requires Email to be enabled with a recipient address.</div>
+          </div>
+          <Toggle
+            checked={settings.email_digest_enabled === true}
+            onChange={e => update('email_digest_enabled', e.target.checked)}
+            disabled={settings.email_notifications_enabled !== true}
+          />
+        </div>
+        <div className="v2-settings-row">
+          <div className="v2-settings-row-text">
+            <div className="v2-settings-row-label">Pushover digest</div>
+            <div className="v2-settings-row-hint">Delivers as a single priority-0 Pushover message each morning.</div>
+          </div>
+          <Toggle
+            checked={settings.pushover_digest_enabled === true}
+            onChange={e => update('pushover_digest_enabled', e.target.checked)}
+            disabled={settings.pushover_notifications_enabled !== true}
+          />
+        </div>
+        <div className="v2-settings-row" style={{ marginTop: 8 }}>
+          <div className="v2-settings-row-text">
+            <label className="v2-settings-row-label">Delivery time</label>
+            <div className="v2-settings-row-hint">Local time on the server. Default 07:00.</div>
+          </div>
+          <input
+            type="time"
+            className="v2-form-input v2-settings-time-input"
+            value={settings.digest_time || '07:00'}
+            onChange={e => update('digest_time', e.target.value)}
+          />
+        </div>
+      </div>
+
       {/* Test channels — fire a one-off notification per channel to verify config */}
       <div className="v2-settings-block">
         <div className="v2-form-label">Test channels</div>
@@ -1514,7 +1567,8 @@ function NotificationsPanel({ settings, update }) {
               fn: () => import('../../api').then(m => m.testEmail()) },
             { key: 'pushover', label: 'Test Pushover', enabled: settings.pushover_notifications_enabled === true && !!settings.pushover_user_key,
               fn: () => import('../../api').then(m => m.testPushover({ userKey: settings.pushover_user_key, appToken: settings.pushover_app_token })) },
-            { key: 'digest', label: 'Test digest', enabled: settings.push_notifications_enabled || settings.email_notifications_enabled || settings.pushover_digest_enabled,
+            { key: 'digest', label: 'Test digest',
+              enabled: settings.push_digest_enabled === true || settings.email_digest_enabled === true || settings.pushover_digest_enabled === true,
               fn: () => import('../../api').then(m => m.testDigest()) },
           ].map(t => {
             const state = tests[t.key] || {}

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,15 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-17
 
+- fix(notifications): v2 Settings missing digest config; digest test failed silently [S]
+  - **Bug.** "Test digest" button in v2 Settings → Notifications returned a generic "Send failed" with no useful info. There was no UI anywhere in v2 to opt a specific channel into the digest, so even with push/email/pushover channel masters on, all three `*_digest_enabled` flags defaulted to falsy and `sendDigestNow()` skipped every channel.
+  - **Causes.** (1) v2's `NotificationsPanel` never exposed the three per-channel digest toggles (`push_digest_enabled`, `email_digest_enabled`, `pushover_digest_enabled`) or the `digest_time` picker — v1 has them all under "Morning Digest" but v2 omitted the whole block. (2) `sendDigestNow()` returned `{success: false, fired: [], skipped: [...]}` with no `error` field when no channel delivered, so the v2 test runner fell back to the generic "Send failed" message. (3) The test button's `enabled` predicate checked channel masters, not the digest opt-in flags — so the button was clickable even when nothing could deliver.
+  - **Fixes.**
+    - Add "Daily digest" block to v2 `NotificationsPanel` with three per-channel toggles (each disabled if its channel master is off), digest-time picker, and explanatory hints.
+    - `sendDigestNow()` now returns a clear `error` string when `fired.length === 0`, listing each channel and why it was skipped.
+    - Test-digest button `enabled` predicate now requires at least one `*_digest_enabled` flag to be on.
+  - Modified: `src/v2/components/SettingsModal.jsx`, `pushoverNotifications.js`, `wiki/Version-History.md`
+
 - fix(notifications): v2 Settings never wired up web-push subscribe flow [S]
   - **Bug.** Toggling "Web push" ON in v2 Settings → Notifications never triggered an iOS notification permission prompt, never registered a device subscription, and never caused Boomerang to appear in iOS Settings → Notifications. Web push couldn't actually deliver.
   - **Cause.** v2's `NotificationsPanel` only flipped the server-side `push_notifications_enabled` boolean. It never imported `usePushSubscription`, never called `Notification.requestPermission()`, never called `pushManager.subscribe()`, never POSTed an endpoint to the server. v1 has the correct flow (the "Enable on this device" button at `Settings.jsx:2625`) but v2 has been the default since the 2026-05-03 cutover, so anyone who newly enabled web push in v2 silently got no delivery. Server-side `subscription_count` could still read >0 because of stale subscriptions from before the cutover, hiding the bug from the diagnostic endpoint.


### PR DESCRIPTION
Mirror of `f4199bd` from main to keep dev in sync.

- fix(notifications): v2 missing digest config; digest test failed silently [S]

User approved blanket "fix in dev and prod" earlier in this session. Same commit content as what just landed on main.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NoYVqzgys5WDWLdALTsZrS)_