### PR TITLE
sync(dev): activity log wiring from main

### DIFF
--- a/pushoverNotifications.js
+++ b/pushoverNotifications.js
@@ -691,7 +691,16 @@ export async function sendDigestNow() {
     skipped.push({ channel: 'push', reason: 'disabled' })
   }
 
-  return { success: fired.length > 0, fired, skipped, subject: digest.subject }
+  if (fired.length === 0) {
+    const reasons = skipped.map(s => `${s.channel}: ${s.reason}`).join('; ')
+    return {
+      success: false,
+      fired,
+      skipped,
+      error: `No digest channel delivered. Enable at least one of push_digest, email_digest, or pushover_digest in Settings → Notifications → Daily digest. (${reasons})`,
+    }
+  }
+  return { success: true, fired, skipped, subject: digest.subject }
 }
 
 // --- Lifecycle ---

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -103,9 +103,9 @@ function NotificationHistory() {
               </span>
             </span>
             <span className="notif-history-time">
-              {new Date(entry.timestamp).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}
+              {new Date(entry.sent_at).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}
               {' '}
-              {new Date(entry.timestamp).toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' })}
+              {new Date(entry.sent_at).toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' })}
             </span>
           </div>
           <div className="notif-history-title">{entry.title}</div>

--- a/src/hooks/useTasks.js
+++ b/src/hooks/useTasks.js
@@ -1,6 +1,17 @@
 import { useState, useCallback, useEffect } from 'react'
 import { loadTasks, saveTasks, createTask, isStale, isSnoozed, isActiveTask, logActivity } from '../store'
 
+// Activity-log noise filter. updateTask is called from many paths
+// (user form saves, AI auto-sizing, sync writebacks, GCal id assignment,
+// weather_hidden toggles, etc.). Only the keys below count as user-visible
+// edits worth logging. Priority flips get their own action label.
+const MEANINGFUL_EDIT_KEYS = new Set([
+  'title', 'notes', 'tags', 'due_date',
+  'size', 'energy', 'energy_level', 'energyLevel',
+  'checklist_json', 'attachments',
+])
+const PRIORITY_KEYS = new Set(['high_priority', 'low_priority'])
+
 function remoteLog(...args) {
   const line = args.map(a => typeof a === 'object' ? JSON.stringify(a) : String(a)).join(' ')
   // Fire-and-forget log relay to server
@@ -44,6 +55,7 @@ export function useTasks() {
     if (attachments.length > 0) task.attachments = attachments
     if (highPriority) task.high_priority = true
     if (lowPriority) task.low_priority = true
+    logActivity('created', task)
     setTasks(prev => [task, ...prev])
     return task.id
   }, [])
@@ -51,6 +63,7 @@ export function useTasks() {
   const addSpawnedTasks = useCallback((spawnedTasks) => {
     if (spawnedTasks.length === 0) return
     remoteLog('addSpawnedTasks:', spawnedTasks.length, 'tasks')
+    for (const t of spawnedTasks) logActivity('created', t)
     setTasks(prev => [...spawnedTasks, ...prev])
   }, [])
 
@@ -74,14 +87,18 @@ export function useTasks() {
 
   const snoozeTask = useCallback((id, until) => {
     remoteLog('snoozeTask:', `id=${id.slice(0, 8)}`, 'until=', until.toISOString())
-    setTasks(prev => prev.map(t =>
-      t.id === id ? {
-        ...t,
-        snoozed_until: until.toISOString(),
-        snooze_count: t.snooze_count + 1,
-        last_touched: new Date().toISOString(),
-      } : t
-    ))
+    setTasks(prev => {
+      const task = prev.find(t => t.id === id)
+      if (task) logActivity('snoozed', task)
+      return prev.map(t =>
+        t.id === id ? {
+          ...t,
+          snoozed_until: until.toISOString(),
+          snooze_count: t.snooze_count + 1,
+          last_touched: new Date().toISOString(),
+        } : t
+      )
+    })
   }, [])
 
   const replaceTask = useCallback((id, newTitles, tags = []) => {
@@ -100,16 +117,30 @@ export function useTasks() {
       if (k === 'notes' || k === 'attachments') return `${k}=(${String(v).length} chars)`
       return `${k}=${v}`
     }).join(', '))
-    setTasks(prev => prev.map(t =>
-      t.id === id ? { ...t, ...updates, last_touched: new Date().toISOString() } : t
-    ))
+    setTasks(prev => {
+      const task = prev.find(t => t.id === id)
+      if (task) {
+        const keys = Object.keys(updates)
+        const hasPriorityChange = keys.some(k => PRIORITY_KEYS.has(k))
+        const hasMeaningfulEdit = keys.some(k => MEANINGFUL_EDIT_KEYS.has(k))
+        if (hasPriorityChange) logActivity('priority_changed', task)
+        else if (hasMeaningfulEdit) logActivity('edited', task)
+      }
+      return prev.map(t =>
+        t.id === id ? { ...t, ...updates, last_touched: new Date().toISOString() } : t
+      )
+    })
   }, [])
 
   const uncompleteTask = useCallback((id) => {
     remoteLog('uncompleteTask:', `id=${id.slice(0, 8)}`)
-    setTasks(prev => prev.map(t =>
-      t.id === id ? { ...t, status: 'not_started', completed_at: null, last_touched: new Date().toISOString() } : t
-    ))
+    setTasks(prev => {
+      const task = prev.find(t => t.id === id)
+      if (task) logActivity('reopened', task)
+      return prev.map(t =>
+        t.id === id ? { ...t, status: 'not_started', completed_at: null, last_touched: new Date().toISOString() } : t
+      )
+    })
   }, [])
 
   const clearCompleted = useCallback(() => {
@@ -133,13 +164,23 @@ export function useTasks() {
 
   const changeStatus = useCallback((id, newStatus) => {
     remoteLog('changeStatus:', `id=${id.slice(0, 8)}`, '→', newStatus)
-    setTasks(prev => prev.map(t => {
-      if (t.id !== id) return t
-      const updates = { status: newStatus, last_touched: new Date().toISOString() }
-      if (newStatus === 'done') updates.completed_at = new Date().toISOString()
-      if (t.status === 'done' && newStatus !== 'done') updates.completed_at = null
-      return { ...t, ...updates }
-    }))
+    setTasks(prev => {
+      const task = prev.find(t => t.id === id)
+      if (task && task.status !== newStatus) {
+        // 'done' transition gets the full completed label; other status flips
+        // (project, backlog, waiting, doing) share status_changed.
+        if (newStatus === 'done') logActivity('completed', task)
+        else if (task.status === 'done') logActivity('reopened', task)
+        else logActivity('status_changed', task)
+      }
+      return prev.map(t => {
+        if (t.id !== id) return t
+        const updates = { status: newStatus, last_touched: new Date().toISOString() }
+        if (newStatus === 'done') updates.completed_at = new Date().toISOString()
+        if (t.status === 'done' && newStatus !== 'done') updates.completed_at = null
+        return { ...t, ...updates }
+      })
+    })
   }, [])
 
   const hydrateTasks = useCallback((data) => {

--- a/src/v2/components/ActivityLog.jsx
+++ b/src/v2/components/ActivityLog.jsx
@@ -8,10 +8,12 @@ import './ActivityLog.css'
 const ACTION_LABELS = {
   created: 'Created',
   completed: 'Completed',
+  reopened: 'Reopened',
   deleted: 'Deleted',
   status_changed: 'Status changed',
   edited: 'Edited',
   snoozed: 'Snoozed',
+  skipped: 'Skipped',
   priority_changed: 'Priority changed',
 }
 
@@ -19,10 +21,12 @@ const ACTION_LABELS = {
 const ACTION_TONE = {
   created: 'var(--v2-accent)',
   completed: '#5DBC9B',
+  reopened: '#6B8AFD',
   deleted: 'var(--v2-alert-overdue)',
   status_changed: '#6B8AFD',
   edited: 'var(--v2-alert-high-pri)',
   snoozed: 'var(--v2-text-faint)',
+  skipped: 'var(--v2-text-faint)',
   priority_changed: 'var(--v2-alert-high-pri)',
 }
 
@@ -90,8 +94,8 @@ export default function ActivityLog({ open, onRestore, onClose }) {
         <EmptyState
           icon={History}
           title="No activity yet"
-          body="Edits, completions, and deletes show up here as you work."
-          terminalCommand="// log empty — edits, completions, and deletes will appear here"
+          body="Creates, edits, completions, snoozes, status changes, and deletes show up here as you work."
+          terminalCommand="// log empty — creates, edits, completions, snoozes, status changes, and deletes will appear here"
         />
       ) : (
         <ul className="v2-activity-list">

--- a/src/v2/components/SettingsModal.jsx
+++ b/src/v2/components/SettingsModal.jsx
@@ -6,6 +6,7 @@ import {
   LABEL_COLORS, uuid,
 } from '../../store'
 import { restoreFromBackup } from '../../api'
+import { usePushSubscription } from '../../hooks/usePushSubscription'
 import ModalShell from './ModalShell'
 import EmptyState from './EmptyState'
 import AutosaveIndicator from './AutosaveIndicator'
@@ -1205,6 +1206,13 @@ function NotificationsPanel({ settings, update }) {
     { key: 'pushover_notifications_enabled', label: 'Pushover', hint: 'iOS-friendly transport via the Pushover app. Credentials in v1 → Integrations.' },
   ]
 
+  // Web push needs a per-device subscribe step (browser permission +
+  // pushManager.subscribe). The master toggle alone only flips the server-side
+  // boolean — without this, no iOS permission prompt fires and the server
+  // never gets an endpoint to push to.
+  const pushSub = usePushSubscription()
+  const [subscribeError, setSubscribeError] = useState(null)
+
   const Toggle = ({ checked, onChange, disabled }) => (
     <label className={`v2-settings-toggle${disabled ? ' v2-settings-toggle-disabled' : ''}`}>
       <input type="checkbox" checked={!!checked} onChange={onChange} disabled={disabled} />
@@ -1280,6 +1288,56 @@ function NotificationsPanel({ settings, update }) {
             />
           </div>
         ))}
+
+        {/* Per-device subscribe — only relevant when Web push is enabled. */}
+        {settings.push_notifications_enabled === true && pushSub.supported && (
+          <div className="v2-settings-row" style={{ alignItems: 'flex-start', flexDirection: 'column', gap: 8 }}>
+            <div className="v2-settings-row-text">
+              <div className="v2-settings-row-label">This device</div>
+              <div className="v2-settings-row-hint">
+                {pushSub.subscribed
+                  ? 'Subscribed. Push notifications will deliver to this browser.'
+                  : 'Not subscribed. Grant notification permission to receive web push on this device.'}
+              </div>
+            </div>
+            {!pushSub.subscribed && (
+              <button
+                className="v2-settings-btn"
+                disabled={pushSub.loading}
+                onClick={async () => {
+                  setSubscribeError(null)
+                  const result = await pushSub.subscribe()
+                  if (!result.success) setSubscribeError(result.error)
+                }}
+              >
+                {pushSub.loading ? 'Enabling…' : 'Enable on this device'}
+              </button>
+            )}
+            {pushSub.subscribed && (
+              <button
+                className="v2-settings-btn"
+                disabled={pushSub.loading}
+                onClick={async () => {
+                  setSubscribeError(null)
+                  const result = await pushSub.unsubscribe()
+                  if (!result.success) setSubscribeError(result.error)
+                }}
+              >
+                {pushSub.loading ? 'Disabling…' : 'Disable on this device'}
+              </button>
+            )}
+            {subscribeError && (
+              <div className="v2-settings-row-hint" style={{ color: 'var(--v2-danger, #c83a3a)' }}>
+                {subscribeError}
+              </div>
+            )}
+          </div>
+        )}
+        {settings.push_notifications_enabled === true && !pushSub.supported && (
+          <div className="v2-settings-row-hint" style={{ marginTop: 8 }}>
+            Web push isn't supported in this browser. On iOS, add Boomerang to the Home Screen and open from there.
+          </div>
+        )}
       </div>
 
       {/* Per-type × per-channel — card-per-type layout works at any width */}

--- a/src/v2/components/SettingsModal.jsx
+++ b/src/v2/components/SettingsModal.jsx
@@ -1527,7 +1527,7 @@ function NotificationsPanel({ settings, update }) {
                     <div className="v2-notif-history-meta">
                       <span className="v2-notif-history-channel">{entry.channel || 'unknown'}</span>
                       <span className="v2-notif-history-type">{entry.type}</span>
-                      <span className="v2-notif-history-time">{new Date(entry.timestamp).toLocaleString(undefined, { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' })}</span>
+                      <span className="v2-notif-history-time">{new Date(entry.sent_at).toLocaleString(undefined, { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' })}</span>
                     </div>
                     {entry.title && <div className="v2-notif-history-title">{entry.title}</div>}
                     {entry.body && <div className="v2-notif-history-body">{entry.body}</div>}

--- a/src/v2/components/SettingsModal.jsx
+++ b/src/v2/components/SettingsModal.jsx
@@ -1502,6 +1502,59 @@ function NotificationsPanel({ settings, update }) {
         )}
       </div>
 
+      {/* Daily digest — per-channel opt-in. sendDigestNow gates on these flags,
+          not on channel masters, so users with push/email/pushover enabled still
+          need to opt into the digest separately. */}
+      <div className="v2-settings-block">
+        <div className="v2-form-label">Daily digest</div>
+        <div className="v2-settings-row-hint">Curated daily summary — yesterday recap + streak, today's focus, coming up, carrying, quick wins. Each channel must opt in separately.</div>
+        <div className="v2-settings-row">
+          <div className="v2-settings-row-text">
+            <div className="v2-settings-row-label">Web push digest</div>
+            <div className="v2-settings-row-hint">Requires Web push to be enabled and subscribed on this device.</div>
+          </div>
+          <Toggle
+            checked={settings.push_digest_enabled === true}
+            onChange={e => update('push_digest_enabled', e.target.checked)}
+            disabled={settings.push_notifications_enabled !== true}
+          />
+        </div>
+        <div className="v2-settings-row">
+          <div className="v2-settings-row-text">
+            <div className="v2-settings-row-label">Email digest</div>
+            <div className="v2-settings-row-hint">Requires Email to be enabled with a recipient address.</div>
+          </div>
+          <Toggle
+            checked={settings.email_digest_enabled === true}
+            onChange={e => update('email_digest_enabled', e.target.checked)}
+            disabled={settings.email_notifications_enabled !== true}
+          />
+        </div>
+        <div className="v2-settings-row">
+          <div className="v2-settings-row-text">
+            <div className="v2-settings-row-label">Pushover digest</div>
+            <div className="v2-settings-row-hint">Delivers as a single priority-0 Pushover message each morning.</div>
+          </div>
+          <Toggle
+            checked={settings.pushover_digest_enabled === true}
+            onChange={e => update('pushover_digest_enabled', e.target.checked)}
+            disabled={settings.pushover_notifications_enabled !== true}
+          />
+        </div>
+        <div className="v2-settings-row" style={{ marginTop: 8 }}>
+          <div className="v2-settings-row-text">
+            <label className="v2-settings-row-label">Delivery time</label>
+            <div className="v2-settings-row-hint">Local time on the server. Default 07:00.</div>
+          </div>
+          <input
+            type="time"
+            className="v2-form-input v2-settings-time-input"
+            value={settings.digest_time || '07:00'}
+            onChange={e => update('digest_time', e.target.value)}
+          />
+        </div>
+      </div>
+
       {/* Test channels — fire a one-off notification per channel to verify config */}
       <div className="v2-settings-block">
         <div className="v2-form-label">Test channels</div>
@@ -1514,7 +1567,8 @@ function NotificationsPanel({ settings, update }) {
               fn: () => import('../../api').then(m => m.testEmail()) },
             { key: 'pushover', label: 'Test Pushover', enabled: settings.pushover_notifications_enabled === true && !!settings.pushover_user_key,
               fn: () => import('../../api').then(m => m.testPushover({ userKey: settings.pushover_user_key, appToken: settings.pushover_app_token })) },
-            { key: 'digest', label: 'Test digest', enabled: settings.push_notifications_enabled || settings.email_notifications_enabled || settings.pushover_digest_enabled,
+            { key: 'digest', label: 'Test digest',
+              enabled: settings.push_digest_enabled === true || settings.email_digest_enabled === true || settings.pushover_digest_enabled === true,
               fn: () => import('../../api').then(m => m.testDigest()) },
           ].map(t => {
             const state = tests[t.key] || {}

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,12 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-17
 
+- fix(settings): notification history showed "Invalid Date" on every row [XS]
+  - **Bug.** Notification history list rendered every timestamp as "INVALID DATE" in both v1 and v2 Settings.
+  - **Cause.** Server's `GET /api/notifications/log` returns rows with `sent_at` (matching the SQLite column name), but both `Settings.jsx` and v2 `SettingsModal.jsx` read `entry.timestamp` — a field that doesn't exist on the response. `new Date(undefined)` → Invalid Date.
+  - **Fix.** Read `entry.sent_at` in both components. No server-side change.
+  - Modified: `src/components/Settings.jsx`, `src/v2/components/SettingsModal.jsx`, `wiki/Version-History.md`
+
 - fix(ui): tighten PWA manifest for iOS install recognition [XS]
   - **Why.** Diagnosing Pushover-on-iOS deep-link UX. Tapping a notification opens Safari (per Pushover settings), but Safari was not showing the "Open in Boomerang" affordance that hands a URL off to an installed PWA. iOS Safari's PWA install-matching logic is opaque, but `id` (stable identity anchor) and explicit `scope` are documented prerequisites for reliable association across manifest updates. Current manifest had neither.
   - **Fix.** Add `id: '/'`, explicit `scope: '/'`, and `handle_links: 'preferred'` to the VitePWA manifest. `id` anchors PWA identity so iOS doesn't treat post-update manifests as a different app. Explicit `scope` removes ambiguity vs. the implicit start_url-derived default. `handle_links` is a Chrome-respected hint that doesn't hurt Safari.

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,15 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-17
 
+- fix(notifications): v2 Settings missing digest config; digest test failed silently [S]
+  - **Bug.** "Test digest" button in v2 Settings → Notifications returned a generic "Send failed" with no useful info. There was no UI anywhere in v2 to opt a specific channel into the digest, so even with push/email/pushover channel masters on, all three `*_digest_enabled` flags defaulted to falsy and `sendDigestNow()` skipped every channel.
+  - **Causes.** (1) v2's `NotificationsPanel` never exposed the three per-channel digest toggles (`push_digest_enabled`, `email_digest_enabled`, `pushover_digest_enabled`) or the `digest_time` picker — v1 has them all under "Morning Digest" but v2 omitted the whole block. (2) `sendDigestNow()` returned `{success: false, fired: [], skipped: [...]}` with no `error` field when no channel delivered, so the v2 test runner fell back to the generic "Send failed" message. (3) The test button's `enabled` predicate checked channel masters, not the digest opt-in flags — so the button was clickable even when nothing could deliver.
+  - **Fixes.**
+    - Add "Daily digest" block to v2 `NotificationsPanel` with three per-channel toggles (each disabled if its channel master is off), digest-time picker, and explanatory hints.
+    - `sendDigestNow()` now returns a clear `error` string when `fired.length === 0`, listing each channel and why it was skipped.
+    - Test-digest button `enabled` predicate now requires at least one `*_digest_enabled` flag to be on.
+  - Modified: `src/v2/components/SettingsModal.jsx`, `pushoverNotifications.js`, `wiki/Version-History.md`
+
 - fix(notifications): v2 Settings never wired up web-push subscribe flow [S]
   - **Bug.** Toggling "Web push" ON in v2 Settings → Notifications never triggered an iOS notification permission prompt, never registered a device subscription, and never caused Boomerang to appear in iOS Settings → Notifications. Web push couldn't actually deliver.
   - **Cause.** v2's `NotificationsPanel` only flipped the server-side `push_notifications_enabled` boolean. It never imported `usePushSubscription`, never called `Notification.requestPermission()`, never called `pushManager.subscribe()`, never POSTed an endpoint to the server. v1 has the correct flow (the "Enable on this device" button at `Settings.jsx:2625`) but v2 has been the default since the 2026-05-03 cutover, so anyone who newly enabled web push in v2 silently got no delivery. Server-side `subscription_count` could still read >0 because of stale subscriptions from before the cutover, hiding the bug from the diagnostic endpoint.

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,19 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-17
 
+- feat(activity-log): fully wire activity log to all task mutations [S]
+  - **Bug.** The Activity Log in the v2 overflow menu was almost always empty. `ACTION_LABELS` in `ActivityLog.jsx` declared seven action types (created, completed, deleted, status_changed, edited, snoozed, priority_changed) but `logActivity()` was only called from three places: complete, delete, and skipped (chain-step). Creates, edits, snoozes, status changes, priority flips, and reopens all silently dropped on the floor.
+  - **Fix.** Wire `logActivity()` into every user-facing mutation in `src/hooks/useTasks.js`:
+    - `addTask` → `created`
+    - `addSpawnedTasks` → `created` per task (covers routine spawns, markdown import, GCal pull, etc.)
+    - `snoozeTask` → `snoozed`
+    - `updateTask` → `priority_changed` if `high_priority`/`low_priority` touched; `edited` if any of `title`/`notes`/`tags`/`due_date`/`size`/`energy`/`energyLevel`/`checklist_json`/`attachments` touched; otherwise no entry (filters out background housekeeping like `size_inferred` flips, sync-back assignments, `weather_hidden` toggles)
+    - `uncompleteTask` → `reopened`
+    - `changeStatus` → `completed` for done transitions, `reopened` for coming-out-of-done, `status_changed` for everything else (project, backlog, waiting, doing)
+  - **UI.** Added `reopened` + `skipped` to `ACTION_LABELS` and `ACTION_TONE` (the `skipped` action was already being logged from AppV2's chain-step path but had no label/color, so it was rendering as bare action name). Updated empty-state body text to enumerate all logged action types.
+  - **Out of scope (left for future).** UI filters still just toggle "All / Deleted." With more action types now flowing in, faceted filters (by action, by date) would help — but this is the wiring fix the user asked for, not a UI redesign. localStorage 500-entry cap unchanged.
+  - Modified: `src/hooks/useTasks.js`, `src/v2/components/ActivityLog.jsx`, `wiki/Version-History.md`
+
 - fix(notifications): v2 Settings missing digest config; digest test failed silently [S]
   - **Bug.** "Test digest" button in v2 Settings → Notifications returned a generic "Send failed" with no useful info. There was no UI anywhere in v2 to opt a specific channel into the digest, so even with push/email/pushover channel masters on, all three `*_digest_enabled` flags defaulted to falsy and `sendDigestNow()` skipped every channel.
   - **Causes.** (1) v2's `NotificationsPanel` never exposed the three per-channel digest toggles (`push_digest_enabled`, `email_digest_enabled`, `pushover_digest_enabled`) or the `digest_time` picker — v1 has them all under "Morning Digest" but v2 omitted the whole block. (2) `sendDigestNow()` returned `{success: false, fired: [], skipped: [...]}` with no `error` field when no channel delivered, so the v2 test runner fell back to the generic "Send failed" message. (3) The test button's `enabled` predicate checked channel masters, not the digest opt-in flags — so the button was clickable even when nothing could deliver.

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,12 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-17
 
+- fix(notifications): v2 Settings never wired up web-push subscribe flow [S]
+  - **Bug.** Toggling "Web push" ON in v2 Settings → Notifications never triggered an iOS notification permission prompt, never registered a device subscription, and never caused Boomerang to appear in iOS Settings → Notifications. Web push couldn't actually deliver.
+  - **Cause.** v2's `NotificationsPanel` only flipped the server-side `push_notifications_enabled` boolean. It never imported `usePushSubscription`, never called `Notification.requestPermission()`, never called `pushManager.subscribe()`, never POSTed an endpoint to the server. v1 has the correct flow (the "Enable on this device" button at `Settings.jsx:2625`) but v2 has been the default since the 2026-05-03 cutover, so anyone who newly enabled web push in v2 silently got no delivery. Server-side `subscription_count` could still read >0 because of stale subscriptions from before the cutover, hiding the bug from the diagnostic endpoint.
+  - **Fix.** Wire `usePushSubscription` into v2 `NotificationsPanel`. When `push_notifications_enabled === true` and the device isn't yet subscribed, render an "Enable on this device" button that runs the full subscribe handshake (permission prompt → pushManager.subscribe → POST endpoint). When subscribed, render a "Disable on this device" button. Surface any subscribe error inline.
+  - Modified: `src/v2/components/SettingsModal.jsx`, `wiki/Version-History.md`
+
 - fix(settings): notification history showed "Invalid Date" on every row [XS]
   - **Bug.** Notification history list rendered every timestamp as "INVALID DATE" in both v1 and v2 Settings.
   - **Cause.** Server's `GET /api/notifications/log` returns rows with `sent_at` (matching the SQLite column name), but both `Settings.jsx` and v2 `SettingsModal.jsx` read `entry.timestamp` — a field that doesn't exist on the response. `new Date(undefined)` → Invalid Date.


### PR DESCRIPTION
Mirror of `418dff8` from main to keep dev in sync.

- feat(activity-log): fully wire activity log to all task mutations [S]

Same commit content as what just landed on main per user request to "fix in dev and prod".

---
_Generated by [Claude Code](https://claude.ai/code/session_01NoYVqzgys5WDWLdALTsZrS)_