### PR TITLE
sync(dev): activity log wiring (cherry-picked clean)

### DIFF
--- a/src/hooks/useTasks.js
+++ b/src/hooks/useTasks.js
@@ -1,6 +1,17 @@
 import { useState, useCallback, useEffect } from 'react'
 import { loadTasks, saveTasks, createTask, isStale, isSnoozed, isActiveTask, logActivity } from '../store'
 
+// Activity-log noise filter. updateTask is called from many paths
+// (user form saves, AI auto-sizing, sync writebacks, GCal id assignment,
+// weather_hidden toggles, etc.). Only the keys below count as user-visible
+// edits worth logging. Priority flips get their own action label.
+const MEANINGFUL_EDIT_KEYS = new Set([
+  'title', 'notes', 'tags', 'due_date',
+  'size', 'energy', 'energy_level', 'energyLevel',
+  'checklist_json', 'attachments',
+])
+const PRIORITY_KEYS = new Set(['high_priority', 'low_priority'])
+
 function remoteLog(...args) {
   const line = args.map(a => typeof a === 'object' ? JSON.stringify(a) : String(a)).join(' ')
   // Fire-and-forget log relay to server
@@ -44,6 +55,7 @@ export function useTasks() {
     if (attachments.length > 0) task.attachments = attachments
     if (highPriority) task.high_priority = true
     if (lowPriority) task.low_priority = true
+    logActivity('created', task)
     setTasks(prev => [task, ...prev])
     return task.id
   }, [])
@@ -51,6 +63,7 @@ export function useTasks() {
   const addSpawnedTasks = useCallback((spawnedTasks) => {
     if (spawnedTasks.length === 0) return
     remoteLog('addSpawnedTasks:', spawnedTasks.length, 'tasks')
+    for (const t of spawnedTasks) logActivity('created', t)
     setTasks(prev => [...spawnedTasks, ...prev])
   }, [])
 
@@ -74,14 +87,18 @@ export function useTasks() {
 
   const snoozeTask = useCallback((id, until) => {
     remoteLog('snoozeTask:', `id=${id.slice(0, 8)}`, 'until=', until.toISOString())
-    setTasks(prev => prev.map(t =>
-      t.id === id ? {
-        ...t,
-        snoozed_until: until.toISOString(),
-        snooze_count: t.snooze_count + 1,
-        last_touched: new Date().toISOString(),
-      } : t
-    ))
+    setTasks(prev => {
+      const task = prev.find(t => t.id === id)
+      if (task) logActivity('snoozed', task)
+      return prev.map(t =>
+        t.id === id ? {
+          ...t,
+          snoozed_until: until.toISOString(),
+          snooze_count: t.snooze_count + 1,
+          last_touched: new Date().toISOString(),
+        } : t
+      )
+    })
   }, [])
 
   const replaceTask = useCallback((id, newTitles, tags = []) => {
@@ -100,16 +117,30 @@ export function useTasks() {
       if (k === 'notes' || k === 'attachments') return `${k}=(${String(v).length} chars)`
       return `${k}=${v}`
     }).join(', '))
-    setTasks(prev => prev.map(t =>
-      t.id === id ? { ...t, ...updates, last_touched: new Date().toISOString() } : t
-    ))
+    setTasks(prev => {
+      const task = prev.find(t => t.id === id)
+      if (task) {
+        const keys = Object.keys(updates)
+        const hasPriorityChange = keys.some(k => PRIORITY_KEYS.has(k))
+        const hasMeaningfulEdit = keys.some(k => MEANINGFUL_EDIT_KEYS.has(k))
+        if (hasPriorityChange) logActivity('priority_changed', task)
+        else if (hasMeaningfulEdit) logActivity('edited', task)
+      }
+      return prev.map(t =>
+        t.id === id ? { ...t, ...updates, last_touched: new Date().toISOString() } : t
+      )
+    })
   }, [])
 
   const uncompleteTask = useCallback((id) => {
     remoteLog('uncompleteTask:', `id=${id.slice(0, 8)}`)
-    setTasks(prev => prev.map(t =>
-      t.id === id ? { ...t, status: 'not_started', completed_at: null, last_touched: new Date().toISOString() } : t
-    ))
+    setTasks(prev => {
+      const task = prev.find(t => t.id === id)
+      if (task) logActivity('reopened', task)
+      return prev.map(t =>
+        t.id === id ? { ...t, status: 'not_started', completed_at: null, last_touched: new Date().toISOString() } : t
+      )
+    })
   }, [])
 
   const clearCompleted = useCallback(() => {
@@ -133,13 +164,23 @@ export function useTasks() {
 
   const changeStatus = useCallback((id, newStatus) => {
     remoteLog('changeStatus:', `id=${id.slice(0, 8)}`, '→', newStatus)
-    setTasks(prev => prev.map(t => {
-      if (t.id !== id) return t
-      const updates = { status: newStatus, last_touched: new Date().toISOString() }
-      if (newStatus === 'done') updates.completed_at = new Date().toISOString()
-      if (t.status === 'done' && newStatus !== 'done') updates.completed_at = null
-      return { ...t, ...updates }
-    }))
+    setTasks(prev => {
+      const task = prev.find(t => t.id === id)
+      if (task && task.status !== newStatus) {
+        // 'done' transition gets the full completed label; other status flips
+        // (project, backlog, waiting, doing) share status_changed.
+        if (newStatus === 'done') logActivity('completed', task)
+        else if (task.status === 'done') logActivity('reopened', task)
+        else logActivity('status_changed', task)
+      }
+      return prev.map(t => {
+        if (t.id !== id) return t
+        const updates = { status: newStatus, last_touched: new Date().toISOString() }
+        if (newStatus === 'done') updates.completed_at = new Date().toISOString()
+        if (t.status === 'done' && newStatus !== 'done') updates.completed_at = null
+        return { ...t, ...updates }
+      })
+    })
   }, [])
 
   const hydrateTasks = useCallback((data) => {

--- a/src/v2/components/ActivityLog.jsx
+++ b/src/v2/components/ActivityLog.jsx
@@ -8,10 +8,12 @@ import './ActivityLog.css'
 const ACTION_LABELS = {
   created: 'Created',
   completed: 'Completed',
+  reopened: 'Reopened',
   deleted: 'Deleted',
   status_changed: 'Status changed',
   edited: 'Edited',
   snoozed: 'Snoozed',
+  skipped: 'Skipped',
   priority_changed: 'Priority changed',
 }
 
@@ -19,10 +21,12 @@ const ACTION_LABELS = {
 const ACTION_TONE = {
   created: 'var(--v2-accent)',
   completed: '#5DBC9B',
+  reopened: '#6B8AFD',
   deleted: 'var(--v2-alert-overdue)',
   status_changed: '#6B8AFD',
   edited: 'var(--v2-alert-high-pri)',
   snoozed: 'var(--v2-text-faint)',
+  skipped: 'var(--v2-text-faint)',
   priority_changed: 'var(--v2-alert-high-pri)',
 }
 
@@ -90,8 +94,8 @@ export default function ActivityLog({ open, onRestore, onClose }) {
         <EmptyState
           icon={History}
           title="No activity yet"
-          body="Edits, completions, and deletes show up here as you work."
-          terminalCommand="// log empty — edits, completions, and deletes will appear here"
+          body="Creates, edits, completions, snoozes, status changes, and deletes show up here as you work."
+          terminalCommand="// log empty — creates, edits, completions, snoozes, status changes, and deletes will appear here"
         />
       ) : (
         <ul className="v2-activity-list">

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,19 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-17
 
+- feat(activity-log): fully wire activity log to all task mutations [S]
+  - **Bug.** The Activity Log in the v2 overflow menu was almost always empty. `ACTION_LABELS` in `ActivityLog.jsx` declared seven action types (created, completed, deleted, status_changed, edited, snoozed, priority_changed) but `logActivity()` was only called from three places: complete, delete, and skipped (chain-step). Creates, edits, snoozes, status changes, priority flips, and reopens all silently dropped on the floor.
+  - **Fix.** Wire `logActivity()` into every user-facing mutation in `src/hooks/useTasks.js`:
+    - `addTask` → `created`
+    - `addSpawnedTasks` → `created` per task (covers routine spawns, markdown import, GCal pull, etc.)
+    - `snoozeTask` → `snoozed`
+    - `updateTask` → `priority_changed` if `high_priority`/`low_priority` touched; `edited` if any of `title`/`notes`/`tags`/`due_date`/`size`/`energy`/`energyLevel`/`checklist_json`/`attachments` touched; otherwise no entry (filters out background housekeeping like `size_inferred` flips, sync-back assignments, `weather_hidden` toggles)
+    - `uncompleteTask` → `reopened`
+    - `changeStatus` → `completed` for done transitions, `reopened` for coming-out-of-done, `status_changed` for everything else (project, backlog, waiting, doing)
+  - **UI.** Added `reopened` + `skipped` to `ACTION_LABELS` and `ACTION_TONE` (the `skipped` action was already being logged from AppV2's chain-step path but had no label/color, so it was rendering as bare action name). Updated empty-state body text to enumerate all logged action types.
+  - **Out of scope (left for future).** UI filters still just toggle "All / Deleted." With more action types now flowing in, faceted filters (by action, by date) would help — but this is the wiring fix the user asked for, not a UI redesign. localStorage 500-entry cap unchanged.
+  - Modified: `src/hooks/useTasks.js`, `src/v2/components/ActivityLog.jsx`, `wiki/Version-History.md`
+
 - fix(notifications): v2 Settings missing digest config; digest test failed silently [S]
   - **Bug.** "Test digest" button in v2 Settings → Notifications returned a generic "Send failed" with no useful info. There was no UI anywhere in v2 to opt a specific channel into the digest, so even with push/email/pushover channel masters on, all three `*_digest_enabled` flags defaulted to falsy and `sendDigestNow()` skipped every channel.
   - **Causes.** (1) v2's `NotificationsPanel` never exposed the three per-channel digest toggles (`push_digest_enabled`, `email_digest_enabled`, `pushover_digest_enabled`) or the `digest_time` picker — v1 has them all under "Morning Digest" but v2 omitted the whole block. (2) `sendDigestNow()` returned `{success: false, fired: [], skipped: [...]}` with no `error` field when no channel delivered, so the v2 test runner fell back to the generic "Send failed" message. (3) The test button's `enabled` predicate checked channel masters, not the digest opt-in flags — so the button was clickable even when nothing could deliver.


### PR DESCRIPTION
Activity log wiring — cherry-picked onto current `origin/dev` to avoid the merge-conflict issue PR #160 hit (dev had drifted from main via earlier rebase merges).

- feat(activity-log): fully wire activity log to all task mutations [S]

Same content as `418dff8` on main, replayed atop current dev.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NoYVqzgys5WDWLdALTsZrS)_