### PR TITLE
fix(gmail): much stricter classifier — kill MFA / OTP / sign-in noise

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -605,10 +605,11 @@ Connects to Gmail via OAuth and uses AI to automatically extract tasks and packa
 1. Queries inbox (excluding promotions/social/updates/forums) for recent emails
 2. Filters out already-processed messages via `gmail_processed` table
 3. Fetches full message content, extracts plain text (HTML stripped)
-4. Batches emails (10 at a time) to Claude for analysis
-5. AI extracts: actionable tasks (title, due date, notes) and tracking numbers (number, carrier, label)
-6. Creates tasks/packages with `gmail_pending: 1` flag for user review
-7. Broadcasts SSE update so all clients see new items immediately
+4. **Phase 0 — obvious-junk pre-filter (free, no AI).** `isObviousJunk(subject, from)` short-circuits MFA / OTP / verification-code / sign-in-attempt / password-reset / "verify your email" / suspicious-activity / auto-reply / bounce subjects, plus common transactional sender shapes (`noreply@accounts.*`, `security-alerts@*`, `verify@*`). Match → mark `skipped` immediately. Saves AI tokens AND avoids the digit-regex misfiring on auth codes.
+5. **Phase 1 — tracking-number regex extraction (free, instant)** on survivors. Hits become pending packages.
+6. **Phase 2 — AI classifier** on the rest. Batched 10 at a time to Claude with a strict "default to skip" prompt: explicit ALWAYS-SKIP list (verification codes, password resets, sign-in alerts, receipts, marketing, social notifications, etc.) and a short ONLY-CREATE list (appointments with dates, bills due, documents to sign, returns, RSVPs, real human asks, government deadlines, medical follow-ups). Temperature pinned to 0 for deterministic, conservative output. Every result includes a required `reason` field — logged on every `[Gmail]` line so the user has visibility into classifications when tuning.
+7. Creates tasks/packages with `gmail_pending: 1` flag for user review.
+8. Broadcasts SSE update so all clients see new items immediately.
 
 **Pending Review Flow:**
 - Gmail-imported items have yellow left border + envelope badge on cards
@@ -630,9 +631,10 @@ Connects to Gmail via OAuth and uses AI to automatically extract tasks and packa
 **Known Limitations:**
 - Requires Gmail API enabled in Google Cloud project (same project as GCal)
 - No webhook support (polling only)
-- AI analysis costs Anthropic API tokens (~10 emails per batch)
+- AI analysis costs Anthropic API tokens (~10 emails per batch); the Phase 0 pre-filter and "skip" default cut this materially
 - Email body truncated to 4000 chars for AI processing
 - Only scans primary inbox (excludes promotions, social, updates, forums)
+- Pending items still surface in the main task list with a yellow border + Keep/Dismiss buttons. Moving them out into a dedicated Suggestions inbox surface is a separate (parked) UX change.
 
 ### Quokka (AI Adviser)
 Free-form natural-language control surface — user says "I've rescheduled my FAA exam to May 12, adjust everything" and Quokka finds related tasks/GCal events/routines and queues the fix. Named after the quokka (a small, perpetually-smiling Australian marsupial). User-facing branding uses "Quokka"; internal code (module names, CSS classes, endpoints under `/api/adviser/`, state vars like `showAdviser`) stays as `adviser`/`Adviser` — renaming plumbing provides no value.

--- a/gmailSync.js
+++ b/gmailSync.js
@@ -161,6 +161,60 @@ function extractEmailContent(message) {
   return { subject, from, date, body, messageId: message.id, threadId: message.threadId }
 }
 
+// --- Obvious-junk pre-filter ---
+// Tight patterns ONLY. False positives here silently drop real tasks, so each
+// pattern must match emails that are almost certainly transactional noise.
+// The AI prompt handles the long tail (receipts, marketing, etc.).
+const JUNK_SUBJECT_PATTERNS = [
+  // MFA / OTP / verification codes — by far the noisiest category
+  /\bverification code\b/i,
+  /\bsecurity code\b/i,
+  /\bauthentication code\b/i,
+  /\bone[- ]time (?:code|password|passcode|pin)\b/i,
+  /\bOTP\b/,
+  /\b2FA\b/i,
+  /\btwo[- ]factor\b/i,
+  /\b(?:your|sign[- ]in) code\b/i,
+  /\bsign[- ]in (?:link|attempt)\b/i,
+  /\bmagic link\b/i,
+  /^\d{4,8} is your\b/i,                       // "123456 is your verification code"
+  /\bis your (?:verification|security|sign[- ]in|login|access) code\b/i,
+  /\bconfirm your email\b/i,
+  /\bverify your (?:email|account|identity)\b/i,
+  /\bactivate your account\b/i,
+  // Password / account security
+  /\bpassword (?:was |has been )?(?:reset|changed|updated)\b/i,
+  /\breset your password\b/i,
+  /\bnew (?:sign[- ]in|login|device)\b/i,
+  /\bsuspicious (?:activity|sign[- ]in|login)\b/i,
+  /\bsecurity alert\b/i,
+  /\bwas that you\b/i,
+  // Auto-replies / bounces
+  /^(?:auto(?:matic)?[- ]?reply|out of office|automatic reply)\b/i,
+  /^undeliverable:/i,
+  /^delivery (?:status|failure) notification/i,
+]
+
+const JUNK_FROM_PATTERNS = [
+  /no[- ]?reply@accounts\./i,
+  /security[-_]?(?:noreply|alerts?)@/i,
+  /<verify@/i,
+  /<verification@/i,
+  /<otp@/i,
+]
+
+function isObviousJunk(subject, from) {
+  const subj = subject || ''
+  const sender = from || ''
+  for (const re of JUNK_SUBJECT_PATTERNS) {
+    if (re.test(subj)) return { junk: true, reason: `subject matches ${re}` }
+  }
+  for (const re of JUNK_FROM_PATTERNS) {
+    if (re.test(sender)) return { junk: true, reason: `sender matches ${re}` }
+  }
+  return { junk: false }
+}
+
 // --- AI analysis ---
 
 async function callClaude(systemPrompt, userMessage) {
@@ -183,6 +237,8 @@ async function callClaude(systemPrompt, userMessage) {
     body: JSON.stringify({
       model: 'claude-sonnet-4-20250514',
       max_tokens: 2048,
+      // Conservative classifier — drift from "skip" should require strong signal.
+      temperature: 0,
       system,
       messages: [{ role: 'user', content: userMessage }],
     }),
@@ -206,13 +262,48 @@ async function analyzeEmails(emails) {
     `--- EMAIL ${i + 1} ---\nMessage ID: ${e.messageId}\nFrom: ${e.from}\nDate: ${e.date}\nSubject: ${e.subject}\nBody:\n${e.body}\n`
   )).join('\n')
 
-  const systemPrompt = `You analyze emails to extract actionable items. For each email, determine if it contains:
-1. An actionable task (appointment, deadline, action required, bill due, document to submit, etc.)
-2. A package tracking number (from order confirmations, shipping notifications, etc.)
-3. Neither (newsletters, marketing, social notifications, receipts with no action needed)
+  const systemPrompt = `You are a strict email classifier. Your job is to AVOID creating noise. The default answer is "skip". Only create a task when the user clearly needs to DO something with a real deadline or commitment. When in doubt, skip.
 
-For tracking numbers, look for patterns like:
-- USPS: starts with 92, 93, 94, 95 (20+ digits), or prefixed with 420+ZIP (e.g., 420501499300...), or two letters + 9 digits + US
+For each email, classify as one of:
+1. "task" — the user must take a concrete action with a clear deadline or commitment
+2. "package" — the email contains a shipment tracking number that isn't already obvious from the subject
+3. "skip" — everything else (default)
+
+ALWAYS SKIP these categories — no exceptions, no matter how the email is worded:
+- Verification codes, OTP, one-time passwords, MFA / 2FA / two-factor codes, sign-in codes, security codes, magic links
+- Password reset emails, "your password was changed", "set up your password"
+- Sign-in / login alerts ("new sign-in to your account", "we detected a login from…", "was that you?")
+- Account security alerts, suspicious activity notices, device added / removed
+- "Verify your email" / "confirm your email address" / account activation
+- Order confirmations, receipts, payment confirmations, refund notifications, invoices marked PAID — these are FYI, not action
+- Subscription renewal notices, billing reminders that auto-charge, "your trial ends in N days" (unless explicit cancellation needed by a date the user set)
+- Shipping notifications (the package extractor handles these — never create a task for "your order has shipped")
+- Marketing, promotions, sales, newsletters, digests, "weekly summary", product announcements
+- Social media notifications, "X mentioned you", "Y commented", LinkedIn invites, friend requests
+- Calendar invites (handled by Google Calendar sync)
+- "Welcome to…", onboarding sequences, tips & tricks emails
+- Surveys, feedback requests, NPS prompts
+- GitHub / GitLab / Jira / Slack / Discord activity notifications
+- Status pages, uptime reports, system notices, deployment notifications
+- Read receipts, auto-replies, out-of-office bounces
+- Newsletters, blog post notifications, content digests
+- Donation receipts, charity acknowledgments
+- "Your statement is ready", "your bill is ready to view" (unless an explicit DUE date appears AND it's not on autopay)
+
+ONLY create a task when the email contains ONE of these clear signals:
+- An appointment that the user must attend (with a specific date/time) and that isn't already on their calendar via GCal sync
+- A bill or payment DUE by a specific date that requires manual action (NOT autopay confirmations)
+- A document to sign, form to fill out, or paperwork to submit by a deadline
+- An item to return / exchange within a return window
+- An RSVP or reservation that must be confirmed/declined by a date
+- A real human writing personally and asking for a reply or action
+- A jury duty notice, tax deadline, legal filing, court date, or government deadline
+- A medical follow-up / prescription pickup / lab result requiring action
+
+If an email is borderline ("could be useful to track" / "might want to do something"), SKIP it. The user can star it in Gmail if they want a reminder.
+
+For tracking numbers (carrier patterns):
+- USPS: starts with 92, 93, 94, 95 (20+ digits), or prefixed with 420+ZIP, or two letters + 9 digits + US
 - UPS: starts with 1Z (18 chars)
 - FedEx: 12, 15, 20, or 22 digits
 - Amazon: starts with TBA (15+ chars)
@@ -224,19 +315,19 @@ Return ONLY valid JSON with this structure:
     {
       "message_id": "the gmail message id",
       "type": "task" | "package" | "skip",
+      "reason": "one short sentence — WHY this classification (helps the user tune the filter)",
       "task": { "title": "...", "notes": "...", "due_date": "YYYY-MM-DD or null" },
       "package": { "tracking_number": "...", "carrier": "usps|ups|fedex|amazon|dhl|other", "label": "item description" }
     }
   ]
 }
 
-Rules:
-- Be conservative — only create tasks for genuinely actionable items that require the user to DO something
-- Do NOT create tasks for: order confirmations with no action needed, password reset emails, social media notifications, newsletters, marketing
-- DO create tasks for: appointment confirmations (with date), bills due, documents to sign/submit, items to return, reservations to confirm
-- For packages: extract the tracking number and identify the carrier. Include a short item description as the label.
-- Keep task titles short and actionable (imperative mood). Include relevant details in notes.
-- If an email contains BOTH a task and a tracking number, return both as separate results with the same message_id.`
+Output rules:
+- Every email MUST appear in results exactly once. Use "skip" liberally.
+- "reason" is required for every result. Be specific ("contains MFA code", "Amazon order receipt — no action needed", "appointment on 2026-05-22 needs RSVP"). This is the user's only window into your reasoning, so don't be vague.
+- Task titles: short imperative phrasing ("Pay water bill", "Sign refi paperwork", "Return Patagonia jacket"). No "Email re:" prefix, no "Reply to John about…" unless a real reply is genuinely required.
+- Put dates, amounts, and confirmation numbers in notes — keep titles clean.
+- If an email contains BOTH a real task AND a tracking number, return two results with the same message_id (one task, one package).`
 
   const response = await callClaude(systemPrompt, emailSummaries)
   const parsed = extractJSON(response)
@@ -434,12 +525,33 @@ export async function syncGmail(daysBack = 7) {
     let tasksCreated = 0
     let packagesCreated = 0
     let skipped = 0
+    let prefiltered = 0
+
+    // --- Phase 0: Obvious-junk pre-filter (no AI, no regex scan) ---
+    // MFA codes / sign-in alerts / password resets etc. never contain
+    // shipping context AND never become tasks. Short-circuit them here
+    // to save AI tokens AND avoid the digit-regex misfiring on auth codes.
+    const survivors = []
+    for (const email of emails) {
+      const verdict = isObviousJunk(email.subject, email.from)
+      if (verdict.junk) {
+        markGmailProcessed(email.messageId, email.threadId, email.subject, email.from, 'skipped', null)
+        skipped++
+        prefiltered++
+        console.log(`[Gmail] Pre-filter skip: "${email.subject}" — ${verdict.reason}`)
+      } else {
+        survivors.push(email)
+      }
+    }
+    if (prefiltered > 0) {
+      console.log(`[Gmail] Pre-filtered ${prefiltered}/${emails.length} as obvious junk`)
+    }
 
     // --- Phase 1: Regex-based tracking number extraction (free, instant) ---
     const existingPackages = getAllPackages()
     const existingTrackingNums = new Set(existingPackages.map(p => p.tracking_number.toLowerCase()))
     const emailsForAI = []
-    for (const email of emails) {
+    for (const email of survivors) {
       const trackingNumbers = extractTrackingNumbers(email.subject, email.body)
       console.log(`[Gmail] Regex scan "${email.subject}": ${trackingNumbers.length} tracking number(s) found${trackingNumbers.length > 0 ? ': ' + trackingNumbers.map(t => t.tracking_number).join(', ') : ''}`)
       if (trackingNumbers.length > 0) {
@@ -500,12 +612,14 @@ export async function syncGmail(daysBack = 7) {
         const email = batch.find(e => e.messageId === result.message_id)
         if (!email) continue
 
+        // Reason is the user's only window into the AI's decision.
+        const reason = result.reason ? ` (${result.reason})` : ''
         if (result.type === 'task' && result.task?.title) {
           const taskId = createTaskFromGmail(result, result.message_id)
           markGmailProcessed(result.message_id, email.threadId, email.subject, email.from, 'task', taskId)
           processedIds.add(result.message_id)
           tasksCreated++
-          console.log(`[Gmail] Created task: "${result.task.title}" from "${email.subject}"`)
+          console.log(`[Gmail] Created task: "${result.task.title}" from "${email.subject}"${reason}`)
         } else if (result.type === 'package' && result.package?.tracking_number) {
           if (existingTrackingNums.has(result.package.tracking_number.toLowerCase())) {
             console.log(`[Gmail] AI: skipping duplicate tracking ${result.package.tracking_number}`)
@@ -513,7 +627,7 @@ export async function syncGmail(daysBack = 7) {
             const pkgId = createPackageFromGmail(result, result.message_id)
             existingTrackingNums.add(result.package.tracking_number.toLowerCase())
             packagesCreated++
-            console.log(`[Gmail] Created package: ${result.package.tracking_number} from "${email.subject}"`)
+            console.log(`[Gmail] Created package: ${result.package.tracking_number} from "${email.subject}"${reason}`)
           }
           markGmailProcessed(result.message_id, email.threadId, email.subject, email.from, 'package', null)
           processedIds.add(result.message_id)
@@ -521,6 +635,7 @@ export async function syncGmail(daysBack = 7) {
           if (!processedIds.has(result.message_id)) {
             markGmailProcessed(result.message_id, email.threadId, email.subject, email.from, 'skipped', null)
             processedIds.add(result.message_id)
+            console.log(`[Gmail] AI skip: "${email.subject}"${reason}`)
           }
           skipped++
         }
@@ -541,7 +656,7 @@ export async function syncGmail(daysBack = 7) {
       broadcastFn(newVersion, null)
     }
 
-    const summary = { tasks: tasksCreated, packages: packagesCreated, skipped, total: emails.length }
+    const summary = { tasks: tasksCreated, packages: packagesCreated, skipped, prefiltered, total: emails.length }
     console.log(`[Gmail] Sync complete:`, summary)
 
     // Update last sync timestamp

--- a/wiki/Features.md
+++ b/wiki/Features.md
@@ -275,7 +275,8 @@ GOOGLE_CLIENT_SECRET=your_client_secret
 AI-powered email scanning that automatically finds tasks and package tracking numbers in your inbox.
 
 - **OAuth connection** — uses the same Google OAuth credentials as Google Calendar. Just enable the Gmail API in your Cloud project.
-- **AI email analysis** — Claude analyzes your inbox emails to find actionable tasks (appointments, deadlines, documents to submit) and package tracking numbers from shipping confirmations.
+- **AI email analysis** — Claude analyzes your inbox emails to find actionable tasks (appointments, deadlines, documents to submit) and package tracking numbers from shipping confirmations. The classifier defaults to "skip" — when in doubt, it doesn't create anything.
+- **Junk pre-filter** — verification codes, MFA / OTP, sign-in alerts, password resets, "verify your email" prompts, suspicious-activity notices, and auto-replies / bounces are rejected via a cheap subject/sender regex before they ever reach the AI. Saves tokens AND prevents tracking-number regex from misfiring on auth codes.
 - **Pending review** — imported items appear with a yellow border and envelope badge. Expand a card to "Keep" (approve) or "Dismiss" it. No items are auto-committed without your review.
 - **Configurable scan window** — defaults to 7 days back, adjustable in Settings.
 - **Auto-scan** — optional 5-minute polling for new emails when enabled.

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,17 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-17
 
+- fix(gmail): much stricter classifier — kill MFA / OTP / sign-in noise [S]
+  - **Bug.** The Gmail auto-add was creating pending tasks for verification codes, sign-in alerts, password resets, and other transactional noise. The system prompt had a one-liner "don't create tasks for password resets" but no explicit reject categories, no temperature pin, and no cheap pre-filter — so the model was inventing actions ("Enter verification code 487291", "Review sign-in attempt") out of obvious junk.
+  - **Fixes (all in `gmailSync.js`):**
+    - **Pre-filter (Phase 0).** New `isObviousJunk(subject, from)` runs before the tracking-regex scan. Tight subject/sender patterns catch verification codes, OTP, 2FA, sign-in attempts, magic links, password reset/changed notifications, "confirm/verify your email", suspicious-activity alerts, "was that you", auto-replies, undeliverable bounces, and common transactional sender shapes (`noreply@accounts.*`, `security-alerts@*`, `verify@*`, etc.). Match → mark processed as `skipped` immediately. Saves AI tokens AND avoids the digit-regex misfiring on auth codes.
+    - **Strengthened system prompt.** Reframed as a strict classifier with "default to skip" guidance. Explicit ALWAYS-SKIP list (15+ categories including all the noise types above plus marketing, social, system alerts, calendar invites already on GCal, etc.). Explicit short ONLY-CREATE list (appointments, bills with real due dates, documents to sign, returns, RSVPs, real human asks, government deadlines, medical follow-ups). Every result now includes a required `reason` field so the user (via server logs) can see exactly why something was classified the way it was.
+    - **Temperature pinned to 0.** Deterministic, conservative output — drift away from "skip" should require strong signal, not a creative roll.
+    - **Reason logged.** AI's `reason` is appended to every `[Gmail]` log line (created task, created package, skipped). First diagnostic surface when the filter is too strict or too loose.
+  - **Pre-filter smoke test.** 20/21 obvious-junk subjects flagged; 0/7 real tasks falsely flagged. The one miss ("Your password was changed" with "was" between the words) was fixed by widening the pattern to `password (?:was |has been )?(?:reset|changed|updated)`.
+  - **Out of scope.** Moving pending Gmail items out of the main task list into a dedicated Suggestions inbox surface (the user's "wrapped into suggestions" suggestion) — that's a separate UX change, this PR keeps the existing pending-review UX (yellow border + Keep/Dismiss on cards). The AI-smartness fix is what the actual complaint was about.
+  - Modified: `gmailSync.js`, `wiki/Version-History.md`, `CLAUDE.md`
+
 - feat(activity-log): fully wire activity log to all task mutations [S]
   - **Bug.** The Activity Log in the v2 overflow menu was almost always empty. `ACTION_LABELS` in `ActivityLog.jsx` declared seven action types (created, completed, deleted, status_changed, edited, snoozed, priority_changed) but `logActivity()` was only called from three places: complete, delete, and skipped (chain-step). Creates, edits, snoozes, status changes, priority flips, and reopens all silently dropped on the floor.
   - **Fix.** Wire `logActivity()` into every user-facing mutation in `src/hooks/useTasks.js`:


### PR DESCRIPTION
## Summary

Gmail auto-add was creating pending tasks for verification codes, sign-in alerts, and password resets. Fix is a two-layer tightening:

- **Phase 0 — obvious-junk pre-filter (cheap regex, no AI).** Subject/sender patterns short-circuit MFA / OTP / 2FA / sign-in attempts / magic links / password resets / "verify your email" / suspicious-activity alerts / auto-replies / undeliverable bounces, plus common transactional sender shapes (`noreply@accounts.*`, `security-alerts@*`, `verify@*`). Match → mark `skipped` immediately. Saves AI tokens AND avoids the digit-regex misfiring on auth codes.
- **AI classifier rewrite.** Reframed as a strict classifier with "default to skip" guidance. Explicit ALWAYS-SKIP list (15+ categories). Short ONLY-CREATE list. Every result now includes a required `reason` field, logged on every `[Gmail]` line — first diagnostic surface when tuning.
- **Temperature pinned to 0.** Drift from "skip" should require strong signal, not a creative roll.

## Out of scope

Moving Gmail-pending items out of the main task list into a dedicated Suggestions inbox surface — separate UX change, parked. This PR keeps the existing pending-review UX (yellow border + Keep/Dismiss on cards) and just fixes the actual reported pain: MFA codes becoming tasks.

## Test plan

- [x] Pre-filter regex smoke test: 20/21 obvious-junk subjects flagged, 0/7 real-task subjects falsely flagged. Fixed the one miss ("Your password was changed") by widening the password pattern.
- [x] `node --check gmailSync.js` — syntax OK.
- [x] `npm audit --omit=dev` — 0 vulnerabilities.
- [ ] After merge: watch a sync cycle's `[Gmail]` logs. Expect: `Pre-filter skip` lines for any MFA / sign-in / password emails, `AI skip` lines with `reason` for borderline items the AI rejected, fewer net pending tasks appearing in the list.
- [ ] If anything legit still falls through, the `reason` field in the log line should make it easy to either tighten the prompt further or relax the pre-filter regex.

## Files

- `gmailSync.js` — new `isObviousJunk()` + Phase 0 wiring + strict system prompt + temperature 0 + reason logging
- `CLAUDE.md` — Gmail Integration section reflects the new Phase 0 + classifier behavior
- `wiki/Features.md` — user-facing note about the junk pre-filter
- `wiki/Version-History.md` — entry under 2026-05-17

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ax21nq2htqFKx72gqbzXTi)_