### PR TITLE
copy(projects): "children" → "subs" everywhere user-visible

### DIFF
--- a/src/v2/components/AddTaskModal.jsx
+++ b/src/v2/components/AddTaskModal.jsx
@@ -47,19 +47,19 @@ export default function AddTaskModal({ open, onAdd, onClose, parentProject = nul
     <ModalShell
       open={open}
       onClose={onClose}
-      title={parentProject ? `New step in ${parentProject.title}` : 'New task'}
+      title={parentProject ? `New sub in ${parentProject.title}` : 'New task'}
       terminalTitle={parentProject ? `> task --new --parent="${parentProject.title}"` : '> task --new'}
       width="narrow"
     >
       {parentProject && (
         <div className="v2-form-parent-banner">
-          Adding a child step to <strong>{parentProject.title}</strong>. It surfaces under the pinned project automatically.
+          Adding a sub-task to <strong>{parentProject.title}</strong>. It surfaces under the pinned project automatically.
         </div>
       )}
       <input
         ref={titleRef}
         className="v2-form-input v2-form-title"
-        placeholder={parentProject ? 'What\'s the next step?' : 'What needs doing?'}
+        placeholder={parentProject ? 'What\'s the next sub?' : 'What needs doing?'}
         value={form.title}
         onChange={e => form.setTitle(e.target.value)}
         onKeyDown={e => { if (e.key === 'Enter' && !e.shiftKey) handleSubmit() }}

--- a/src/v2/components/EditTaskModal.jsx
+++ b/src/v2/components/EditTaskModal.jsx
@@ -98,7 +98,7 @@ export default function EditTaskModal({ task, onSave, onClose, onDelete, onBackl
       setSessionFeedback({ ok: true, text: `+${result.points} pts logged · ${result.sessionCount}/${result.sessionCap} sessions` })
     } catch (err) {
       if (err.code === 'SESSION_CAP_REACHED') {
-        setSessionFeedback({ ok: false, text: `Cap reached — complete a child or the project to log more.` })
+        setSessionFeedback({ ok: false, text: `Cap reached — complete a sub or the project to log more.` })
       } else {
         setSessionFeedback({ ok: false, text: 'Failed to log session.' })
       }
@@ -1001,9 +1001,9 @@ export default function EditTaskModal({ task, onSave, onClose, onDelete, onBackl
                   type="button"
                   className="v2-edit-action"
                   onClick={() => onAddChild(task)}
-                  title="Add a child task under this project"
+                  title="Add a sub-task under this project"
                 >
-                  + Add child step
+                  + Add sub
                 </button>
               )}
             </div>

--- a/src/v2/components/ProjectPinnedSection.jsx
+++ b/src/v2/components/ProjectPinnedSection.jsx
@@ -96,7 +96,7 @@ function ProjectPinnedSection({
                     {sessionCount > 0 ? `🔥 ${sessionCount} session${sessionCount === 1 ? '' : 's'}` : 'no sessions yet'}
                   </span>
                   <span className="v2-pp-meta-sep">·</span>
-                  <span>{children.length} active step{children.length === 1 ? '' : 's'}</span>
+                  <span>{children.length} active sub{children.length === 1 ? '' : 's'}</span>
                   <span className="v2-pp-meta-sep">·</span>
                   <span>budget {budget} pts</span>
                   {daysSinceLast !== null && (
@@ -115,7 +115,7 @@ function ProjectPinnedSection({
                   className={`v2-pp-action v2-pp-action-primary${capped ? ' v2-pp-action-disabled' : ''}`}
                   onClick={() => !capped && handleLog(project)}
                   disabled={capped || logging === project.id}
-                  title={capped ? `Cap reached — complete a child or the project to log more` : `Log a +${sessionPts}-pt session`}
+                  title={capped ? `Cap reached — complete a sub or the project to log more` : `Log a +${sessionPts}-pt session`}
                 >
                   <Activity size={14} strokeWidth={1.75} />
                   <span>{capped ? `Capped ${sessionCount}/${PROJECT_SESSION_CAP}` : `+${sessionPts} session`}</span>
@@ -124,10 +124,10 @@ function ProjectPinnedSection({
                   type="button"
                   className="v2-pp-action"
                   onClick={() => onAddChild(project)}
-                  title="Add a child task to this project"
+                  title="Add a sub-task under this project"
                 >
                   <Plus size={14} strokeWidth={1.75} />
-                  <span>Step</span>
+                  <span>Sub</span>
                 </button>
                 <button
                   type="button"

--- a/src/v2/components/ProjectsView.jsx
+++ b/src/v2/components/ProjectsView.jsx
@@ -46,8 +46,8 @@ export default function ProjectsView({
         <EmptyState
           icon={FolderKanban}
           title="No projects yet"
-          body={`Move longer-term work here so it stops nagging you. Pin projects to today when you want to chip away.`}
-          terminalCommand="// no projects — move long-haul work here, pin when you want to chip"
+          body={`Move longer-term work here so it stops nagging you. Add subs for the concrete steps, pin to today when you want to chip away.`}
+          terminalCommand="// no projects — move long-haul work here, add subs, pin to chip away"
         />
       ) : (
         <div className="v2-projects-list">
@@ -78,7 +78,7 @@ export default function ProjectsView({
                             <span className="v2-pv-meta-sep">·</span>
                           </>
                         )}
-                        {children.length === 0 ? 'no children' : `${activeChildren.length}/${children.length} active`}
+                        {children.length === 0 ? 'no subs' : `${activeChildren.length}/${children.length} subs`}
                         <span className="v2-pv-meta-sep">·</span>
                         {sessionCount > 0 ? `🔥 ${sessionCount}${capped ? ` (capped)` : ''}` : 'no sessions'}
                         <span className="v2-pv-meta-sep">·</span>
@@ -103,11 +103,11 @@ export default function ProjectsView({
                       type="button"
                       className="v2-pv-action"
                       onClick={(e) => { e.stopPropagation(); onAddChild && onAddChild(project) }}
-                      aria-label="Add child step"
-                      title="Add child step"
+                      aria-label="Add sub"
+                      title="Add a sub-task under this project"
                     >
                       <Plus size={14} strokeWidth={1.75} />
-                      <span>Step</span>
+                      <span>Sub</span>
                     </button>
                     <button
                       type="button"
@@ -123,7 +123,7 @@ export default function ProjectsView({
                   <div className="v2-pv-children">
                     {children.length === 0 ? (
                       <div className="v2-pv-empty-children">
-                        No child tasks yet. Use the + button above to add one, or ask Quokka.
+                        No subs yet. Use the + button above to add one, or ask Quokka.
                       </div>
                     ) : (
                       <>

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,12 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-17
 
+- copy(projects): "children" → "subs" everywhere user-visible [XS]
+  - **Why.** "no children · no sessions · budget 20" sounded clinical/awkward on the Projects modal meta line. User preference: subs.
+  - **Visible strings updated.** ProjectsView meta `"no children"` / `"X/Y active"` → `"no subs"` / `"X/Y subs"`. Empty drill-down `"No child tasks yet."` → `"No subs yet."` Empty Projects state body mentions "subs" explicitly now. Pinned-section meta `"N active steps"` → `"N active subs"`. Cap-feedback strings `"complete a child or the project"` → `"complete a sub or the project"`. Add-child buttons relabeled `"Sub"` (was `"Step"`). AddTaskModal title `"New step in X"` → `"New sub in X"`; banner copy + placeholder updated to match. Tooltips and aria-labels harmonized.
+  - **Code names unchanged.** `child_visibility`, `parent_id`, `getChildTasks()`, `getChildren`, `activeChildren`, `onAddChild` etc. stay as-is — they're internal terminology, not user-facing.
+  - Modified: `src/v2/components/ProjectsView.jsx`, `src/v2/components/ProjectPinnedSection.jsx`, `src/v2/components/EditTaskModal.jsx`, `src/v2/components/AddTaskModal.jsx`, `wiki/Version-History.md`
+
 - fix(projects): mobile layout — title truncated to "Canc...", actions too cramped [XS]
   - **Bug.** ProjectsView card rendered chev + title + meta + 3 action buttons all on one row. On a narrow viewport (iPhone, etc.) the title got `text-overflow: ellipsis`-clipped to "Canc..." for any project longer than ~5 characters, and the icon-only Pin/Add/Edit buttons jammed against the title's right edge with no breathing room.
   - **Fixes (`ProjectsView.{jsx,css}`):**


### PR DESCRIPTION
User-facing copy change: "children" → "subs" everywhere it shows up in the UI. Internal code names (`parent_id`, `child_visibility`, `getChildTasks`, `onAddChild`, etc.) unchanged — that's developer vocabulary, not user vocabulary.

## Strings touched

| Where | Before | After |
|---|---|---|
| ProjectsView meta | `no children` / `X/Y active` | `no subs` / `X/Y subs` |
| ProjectsView empty drill-down | `No child tasks yet.` | `No subs yet.` |
| Projects empty state body | `Move longer-term work here so it stops nagging you. Pin projects to today when you want to chip away.` | `… Add subs for the concrete steps, pin to today when you want to chip away.` |
| Pinned-section meta | `N active steps` | `N active subs` |
| Add-child buttons | `Step` | `Sub` |
| AddTaskModal title (when parent set) | `New step in X` | `New sub in X` |
| AddTaskModal banner | `Adding a child step to X.` | `Adding a sub-task to X.` |
| AddTaskModal placeholder | `What's the next step?` | `What's the next sub?` |
| Cap-feedback strings | `complete a child or the project` | `complete a sub or the project` |
| Tooltips + aria-labels | `Add child step` / `Add a child task under this project` | `Add sub` / `Add a sub-task under this project` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ax21nq2htqFKx72gqbzXTi)_