### PR TITLE
feat(projects): + New project button inside the Projects modal

### DIFF
--- a/src/v2/AppV2.jsx
+++ b/src/v2/AppV2.jsx
@@ -518,6 +518,17 @@ export default function AppV2() {
     setShowAdd(true)
   }, [])
 
+  // "+ New project" launcher — opens AddTaskModal with a flag so the
+  // created task lands as status='project' instead of the default
+  // 'not_started'. Mutually exclusive with the "Add child" path
+  // (parents are tasks, projects are top-level).
+  const [createAsProject, setCreateAsProject] = useState(false)
+  const handleCreateProject = useCallback(() => {
+    setShowProjects(false)
+    setCreateAsProject(true)
+    setShowAdd(true)
+  }, [])
+
   // Log a project session. Renders a toast with the points awarded, or an
   // explanatory message when capped. Falls back silently to a local-only
   // update if the network is unavailable so the user doesn't lose the tap.
@@ -586,13 +597,19 @@ export default function AppV2() {
   // when not manually set, and prefetch the completion toast copy. If the
   // user opened the modal via "Add child" on a pinned project, stamp the
   // parent_id + active visibility so the new task surfaces under the
-  // project. The "addChildOfProject" state is cleared after one use.
+  // project. If the user opened via "+ New project" from ProjectsView,
+  // promote the new task to status='project' immediately. Both context
+  // flags clear after one use.
   const handleAddTask = useCallback((taskData) => {
     const taskId = addTask(taskData)
     if (addChildOfProject) {
       setTaskParent(taskId, addChildOfProject.id)
       setChildVisibility(taskId, 'active')
       setAddChildOfProject(null)
+    }
+    if (createAsProject) {
+      updateTask(taskId, { status: 'project' })
+      setCreateAsProject(false)
     }
     if (!taskData.size && taskData.title) {
       inferSize(taskData.title, taskData.notes).then(inferred => {
@@ -609,7 +626,7 @@ export default function AppV2() {
     } else {
       prefetchToast(taskId, taskData.title, taskData.energy, taskData.energyLevel)
     }
-  }, [addTask, updateTask, prefetchToast, addChildOfProject, setTaskParent, setChildVisibility])
+  }, [addTask, updateTask, prefetchToast, addChildOfProject, setTaskParent, setChildVisibility, createAsProject])
 
   const renderSection = (label, list, sigil) => {
     if (list.length === 0) return null
@@ -855,8 +872,9 @@ export default function AppV2() {
       <AddTaskModal
         open={showAdd}
         onAdd={handleAddTask}
-        onClose={() => { setShowAdd(false); setAddChildOfProject(null) }}
+        onClose={() => { setShowAdd(false); setAddChildOfProject(null); setCreateAsProject(false) }}
         parentProject={addChildOfProject}
+        createAsProject={createAsProject}
       />
 
       {editTarget && (
@@ -1014,6 +1032,7 @@ export default function AppV2() {
         onTogglePin={(id, pinned) => setProjectPinned(id, pinned)}
         onAddChild={(project) => { setShowProjects(false); handleAddChildToProject(project) }}
         onSetChildVisibility={setChildVisibility}
+        onCreateProject={handleCreateProject}
       />
       <DoneList
         open={showDone}

--- a/src/v2/components/AddTaskModal.jsx
+++ b/src/v2/components/AddTaskModal.jsx
@@ -14,7 +14,7 @@ const ENERGY_LEVEL_LABELS = [
 
 const SIZE_OPTIONS = ['XS', 'S', 'M', 'L', 'XL']
 
-export default function AddTaskModal({ open, onAdd, onClose, parentProject = null }) {
+export default function AddTaskModal({ open, onAdd, onClose, parentProject = null, createAsProject = false }) {
   const form = useTaskForm({ dueDate: getDefaultDueDate() })
   const titleRef = useRef(null)
 
@@ -47,8 +47,8 @@ export default function AddTaskModal({ open, onAdd, onClose, parentProject = nul
     <ModalShell
       open={open}
       onClose={onClose}
-      title={parentProject ? `New sub in ${parentProject.title}` : 'New task'}
-      terminalTitle={parentProject ? `> task --new --parent="${parentProject.title}"` : '> task --new'}
+      title={createAsProject ? 'New project' : parentProject ? `New sub in ${parentProject.title}` : 'New task'}
+      terminalTitle={createAsProject ? '> project --new' : parentProject ? `> task --new --parent="${parentProject.title}"` : '> task --new'}
       width="narrow"
     >
       {parentProject && (
@@ -56,10 +56,15 @@ export default function AddTaskModal({ open, onAdd, onClose, parentProject = nul
           Adding a sub-task to <strong>{parentProject.title}</strong>. It surfaces under the pinned project automatically.
         </div>
       )}
+      {createAsProject && !parentProject && (
+        <div className="v2-form-parent-banner">
+          Creating a <strong>project</strong> — silent by default, no nags unless you set a due date or opt in. Add subs after creation to break it into concrete steps.
+        </div>
+      )}
       <input
         ref={titleRef}
         className="v2-form-input v2-form-title"
-        placeholder={parentProject ? 'What\'s the next sub?' : 'What needs doing?'}
+        placeholder={createAsProject ? 'What\'s the project?' : parentProject ? 'What\'s the next sub?' : 'What needs doing?'}
         value={form.title}
         onChange={e => form.setTitle(e.target.value)}
         onKeyDown={e => { if (e.key === 'Enter' && !e.shiftKey) handleSubmit() }}

--- a/src/v2/components/ProjectsView.css
+++ b/src/v2/components/ProjectsView.css
@@ -4,6 +4,49 @@
   gap: 14px;
 }
 
+/* "+ New project" toolbar above the list. Right-aligned so it doesn't
+ * compete with the modal title for visual weight on first glance. */
+.v2-pv-toolbar {
+  display: flex;
+  justify-content: flex-end;
+  margin: 0 0 14px;
+}
+
+.v2-pv-create {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 14px;
+  border-radius: var(--v2-radius-pill, 999px);
+  background: var(--v2-accent);
+  color: #fff;
+  border: none;
+  font: 500 13px/1 var(--v2-font-body);
+  cursor: pointer;
+  transition: filter var(--v2-dur-quick) var(--v2-ease-standard);
+}
+
+.v2-pv-create:hover {
+  filter: brightness(1.08);
+}
+
+[data-theme^="terminal"] .v2-pv-create {
+  background: transparent;
+  color: var(--v2-accent);
+  border: 1px dashed var(--v2-accent);
+  border-radius: 0;
+}
+
+[data-theme^="terminal"] .v2-pv-create span {
+  font-size: 0;
+}
+
+[data-theme^="terminal"] .v2-pv-create span::before {
+  content: attr(data-terminal-cmd);
+  font-size: 12px;
+  font-family: var(--v2-font-body);
+}
+
 .v2-pv-block {
   border-radius: var(--v2-radius-lg, 14px);
 }

--- a/src/v2/components/ProjectsView.jsx
+++ b/src/v2/components/ProjectsView.jsx
@@ -8,14 +8,17 @@ import TaskCard from './TaskCard'
 import './ProjectsView.css'
 
 // Projects modal — list of all projects with drill-down. Each project
-// card surfaces session/budget/child counts + Pin and Add-child buttons.
-// Tap a project to expand its children inline (active + backstage). Active
-// children render as full TaskCards (so they can be completed/snoozed in
-// place); backstage children show as compact rows.
+// card surfaces session/budget/sub counts + Pin and Add-sub buttons.
+// Tap a project to expand its subs inline (active + backstage). Active
+// subs render as full TaskCards (so they can be completed/snoozed in
+// place); backstage subs show as compact rows.
+// "+ New project" lives in the modal header so the user can spin up a
+// project from this surface — no more "create a task, then move it"
+// roundabout.
 
 export default function ProjectsView({
   open, tasks, onClose, onComplete, onEdit, onSnooze, weatherByDate, routineStreaks,
-  onTogglePin, onAddChild, onSetChildVisibility,
+  onTogglePin, onAddChild, onSetChildVisibility, onCreateProject,
 }) {
   const [expandedTaskId, setExpandedTaskId] = useState(null)
   const [expandedProjectId, setExpandedProjectId] = useState(null)
@@ -42,12 +45,26 @@ export default function ProjectsView({
         : undefined}
       width="wide"
     >
+      {onCreateProject && (
+        <div className="v2-pv-toolbar">
+          <button
+            type="button"
+            className="v2-pv-create"
+            onClick={onCreateProject}
+          >
+            <Plus size={14} strokeWidth={1.75} />
+            <span data-terminal-cmd="> project --new">New project</span>
+          </button>
+        </div>
+      )}
       {projectTasks.length === 0 ? (
         <EmptyState
           icon={FolderKanban}
           title="No projects yet"
-          body={`Move longer-term work here so it stops nagging you. Add subs for the concrete steps, pin to today when you want to chip away.`}
-          terminalCommand="// no projects — move long-haul work here, add subs, pin to chip away"
+          body={`Start a long-haul project to track the work without nagging yourself. Add subs for the concrete steps, pin to today when you want to chip away.`}
+          terminalCommand="// no projects yet — tap '+ new project' above"
+          cta={onCreateProject ? 'New project' : undefined}
+          ctaOnClick={onCreateProject}
         />
       ) : (
         <div className="v2-projects-list">

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,12 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-17
 
+- feat(projects): "+ New project" button inside the Projects modal [XS]
+  - **The hole.** After the projects-integration feature shipped, projects were first-class — but the only way to *create* one was the legacy "create a regular task, open EditTaskModal, hit Move to Projects" path. Awkward when the Projects modal is the primary surface for managing them.
+  - **Fix.** New `+ New project` button in the ProjectsView toolbar. Click → ProjectsView closes, AddTaskModal opens with a project-flavored title (`New project` / terminal `> project --new`), explanatory banner ("silent by default, no nags unless you set a due date or opt in"), and the created task lands directly as `status='project'`. EmptyState also gains a tappable CTA when no projects exist yet so first-time users have an obvious way in.
+  - Plumbing: new `createAsProject` boolean state on AppV2 mirrors the existing `addChildOfProject` pattern. `handleAddTask` reads the flag and bumps status post-creation. Both context flags clear on close.
+  - Modified: `src/v2/components/ProjectsView.jsx`, `src/v2/components/ProjectsView.css`, `src/v2/components/AddTaskModal.jsx`, `src/v2/AppV2.jsx`, `wiki/Version-History.md`
+
 - copy(projects): "children" → "subs" everywhere user-visible [XS]
   - **Why.** "no children · no sessions · budget 20" sounded clinical/awkward on the Projects modal meta line. User preference: subs.
   - **Visible strings updated.** ProjectsView meta `"no children"` / `"X/Y active"` → `"no subs"` / `"X/Y subs"`. Empty drill-down `"No child tasks yet."` → `"No subs yet."` Empty Projects state body mentions "subs" explicitly now. Pinned-section meta `"N active steps"` → `"N active subs"`. Cap-feedback strings `"complete a child or the project"` → `"complete a sub or the project"`. Add-child buttons relabeled `"Sub"` (was `"Step"`). AddTaskModal title `"New step in X"` → `"New sub in X"`; banner copy + placeholder updated to match. Tooltips and aria-labels harmonized.


### PR DESCRIPTION
After the projects-integration feature shipped, projects were first-class but the only path to *create* one was the legacy "create a regular task, open EditTaskModal, hit Move to Projects." Awkward when Projects is the primary surface for managing them.

## Fix

New **+ New project** button in the ProjectsView toolbar. Click → ProjectsView closes, AddTaskModal opens with a project-flavored title (`New project` / terminal `> project --new`), an explanatory banner ("silent by default, no nags unless you set a due date or opt in"), and the created task lands directly as `status='project'`.

`EmptyState` also gains a tappable `New project` CTA when no projects exist yet, so first-time users have an obvious entry instead of the "go to Settings, find a task, move it" rabbit hole.

## Plumbing

New `createAsProject` boolean state on AppV2 mirrors the existing `addChildOfProject` pattern. `handleAddTask` reads the flag and bumps status post-creation. Both context flags clear on close (Escape, X, or Save).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ax21nq2htqFKx72gqbzXTi)_