### PR TITLE
feat(ui): home stats line in light/dark, not just terminal

### DIFF
--- a/src/v2/AppV2.css
+++ b/src/v2/AppV2.css
@@ -39,6 +39,21 @@
   padding: 8px 16px 32px;
 }
 
+/* Home stats line — date + streak + today's progress, centered above
+ * the WeekStrip and main task list. Renders in every theme; terminal
+ * adds its own monospace flavoring via terminal/init.css. */
+.v2-home-stats {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 6px 10px;
+  padding: 14px 0 10px;
+  font: 500 13px/1.2 var(--v2-font-body);
+  color: var(--v2-text-meta);
+  text-align: center;
+}
+
 /* Inline code in body copy (keyboard hints, URL flags, etc.) */
 :root[data-ui="v2"] code {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;

--- a/src/v2/AppV2.jsx
+++ b/src/v2/AppV2.jsx
@@ -793,15 +793,17 @@ export default function AppV2() {
           />
         ) : (
           <div className="v2-list">
-            {/* Terminal home header: date + streak + today's progress as a
-              * single powerlevel10k-style segmented line. Only renders in
-              * terminal mode; light/dark have the mini-rings in the app
-              * header for the same job. */}
-            {isTerminal && (() => {
+            {/* Home stats line: date + streak + today's progress.
+              * Originally terminal-only; lifted to all themes 2026-05-17
+              * because users still want the streak + today's progress
+              * glanceable even when the mini-rings are visible in the
+              * header (rings show ratios, this line names them). Date
+              * is a toggle for the WeekStrip below. */}
+            {(() => {
               const alwaysOpen = !!settingsForRings.week_strip_always_open
               const open = alwaysOpen || weekStripShown
               return (
-                <div className="v2-terminal-home-stats" aria-hidden="false">
+                <div className="v2-home-stats" aria-hidden="false">
                   <button
                     type="button"
                     className={`v2-thx-date v2-thx-date-toggle${open ? ' v2-thx-date-open' : ''}`}
@@ -827,7 +829,7 @@ export default function AppV2() {
                 </div>
               )
             })()}
-            {((isTerminal && (settingsForRings.week_strip_always_open || weekStripShown)) ||
+            {(settingsForRings.week_strip_always_open || weekStripShown ||
               (!isTerminal && settingsForRings.show_week_strip)) && (
               <WeekStrip
                 tasks={tasks}

--- a/src/v2/terminal/init.css
+++ b/src/v2/terminal/init.css
@@ -512,17 +512,12 @@
  * (errand-green). Separators in faint text.
  */
 
-.v2-terminal-home-stats {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: center;
-  gap: 6px 8px;
-  padding: 12px 0 10px;
+/* Terminal-specific surface for the home stats line. Light/dark get
+ * their own base styling in src/v2/AppV2.css; this just adds the
+ * terminal-flavor padding + segment alignment. */
+[data-theme^="terminal"] .v2-home-stats {
   font: 500 12px/1 var(--v2-font-body);
-  color: var(--v2-text-meta);
   letter-spacing: 0;
-  text-align: center;
 }
 
 .v2-thx-date {

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,12 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-17
 
+- feat(ui): home stats line now renders in light/dark, not just terminal [XS]
+  - **The gap.** Terminal mode shows a "📅 Sun, May 17 · 🔥 12 days · ✓ 3/3 today" line above the WeekStrip — a powerlevel10k-style status segment. Light + dark themes had this gated off via `isTerminal &&` in AppV2.jsx; users saw the WeekStrip but not the textual header. Mini-rings in the app header technically convey the same info but they're ratios, not named values.
+  - **Fix.** Drop the `isTerminal` JSX gate. The home-stats line renders in every theme. The wrapper class renamed from `.v2-terminal-home-stats` → `.v2-home-stats` (theme-agnostic). Base styling lives in `AppV2.css`; terminal-specific monospace flavoring stays in `terminal/init.css` under `[data-theme^="terminal"] .v2-home-stats`. Date toggle behavior (click to expand/collapse the WeekStrip) works in all themes.
+  - The WeekStrip-visibility condition also simplified — `weekStripShown` state now applies to all themes, not just terminal.
+  - Modified: `src/v2/AppV2.jsx`, `src/v2/AppV2.css`, `src/v2/terminal/init.css`, `wiki/Version-History.md`
+
 - fix(quokka): orphan sub-tasks + duplicate-delete crash + chat bar disappearing [M]
   - **Bug A — orphan sub-tasks.** Quokka asked to "build out sub-tasks for the vacation project" created 8 top-level tasks with NO `parent_id`. The model would then try a follow-up `link_task_to_project` for each, but `search_tasks` only returns 20 hits by default and the model couldn't find them all → most stayed orphan. Root cause: `create_task` schema didn't accept `parent_id`, forcing a two-step create-then-link workflow.
   - **Fix A.** `create_task` schema gains `parent_id` + `child_visibility` + `pinned_to_today` + `nag_allowed`. The new task is linked at creation time — no follow-up tool call. `update_task` gains the same four fields so existing orphans can be linked with a single call instead of a separate `link_task_to_project`. `TASK_FIELDS` updated so `pickTaskUpdates` passes them through. `child_visibility` defaults to `'active'` when `parent_id` is set (matches the manual "+ Add child step" UI). Validation: parent must exist and can't be self.


### PR DESCRIPTION
Closing — content is already on main via the dev→main alignment merge (commit 6d24b0e). The PR's branch (claude/home-stats-all-themes at a42b059) is now superseded by main's current tip which already contains these changes.