### PR TITLE
docs(git): end the dev→main cherry-pick era; new workflow documented

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@
 
 ### Workflow: how dev work lands
 
-The proxy bug means direct `git push origin dev` and `git push origin --delete <branch>` both 403. Workaround loop, fully automated end-to-end with no GitHub-UI clicks:
+The proxy bug means direct `git push origin dev` and `git push origin --delete <branch>` both 403. Direct `git push origin main` DOES work (verified 2026-05-17). Workaround loop for dev, fully automated end-to-end with no GitHub-UI clicks:
 
 1. Branch off `origin/dev` locally → commit
 2. `git push origin <local-branch>:refs/heads/claude/v2-<thing>` (fresh ref, proxy accepts)
@@ -31,7 +31,18 @@ The proxy bug means direct `git push origin dev` and `git push origin --delete <
 5. `mcp__github__merge_pull_request` with `merge_method: "rebase"` (linear history; rebase-merges also auto-delete the source branch on the remote — verified PR #22, 2026-05-09)
 6. `git fetch origin && git reset --hard origin/dev` locally to resync (rebase changes the SHA server-side)
 
-**Cherry-picking from main onto dev** uses the same loop. Conflicts typically appear in `wiki/Version-History.md` since both branches add entries to the top — keep dev's entries, add main's below.
+### Workflow: promoting dev → main
+
+**Canonical: direct dev → main PR.** No cherry-pick branches.
+
+1. After a feature PR merges to `dev`, open a PR with `head: 'dev'` and `base: 'main'` via `mcp__github__create_pull_request`. Title like `release: <feature>` and a brief body.
+2. Wait for user approval (every promotion is its own approval — previous approvals don't carry forward).
+3. `mcp__github__merge_pull_request` with `merge_method: "rebase"`.
+4. `git fetch origin && git checkout main && git reset --hard origin/main` to resync locally.
+
+**Why cherry-pick branches went away (2026-05-17):** earlier in this codebase's life, dev → main promotions ran through a cherry-pick branch off main. Each cherry-pick produced a new SHA on main even though the content matched dev exactly. After ~10 promotions, the branches accumulated 10 same-content / different-SHA commit pairs and a direct dev → main PR started failing with conflicts because git's 3-way merge couldn't tell the cherry-picked versions and the original dev versions were the same change. A one-time alignment merge resolved it: `git merge -X theirs origin/dev` on main (always take dev's version on conflict) produced an identical-content main with a clean merge commit bridging the histories. Followup commit (`align(adviser-modal-css)`) cleaned up a unique-to-main hunk the `-X theirs` couldn't auto-handle. Going forward: never cherry-pick — direct dev → main PRs only.
+
+**Cherry-picking from main onto dev** (the reverse direction — e.g. main-only hotfixes that need to land on dev) uses the standard feature loop above. Conflicts typically appear in `wiki/Version-History.md` since both branches add entries to the top — keep dev's entries, add main's below.
 
 **Stranded refs** that never had a PR (e.g. the legacy `test-push-probe` diagnostic) cannot be deleted via the proxy or MCP. Ask the user to delete via the GitHub UI when convenient.
 

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,12 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-17
 
+- chore(git): end the dev→main cherry-pick era; CLAUDE.md updated with new flow [XS]
+  - **What happened.** Earlier dev→main promotions ran through a cherry-pick branch off main. Each cherry-pick produced a new SHA even though content matched dev exactly. After ~10 promotions, branches accumulated 10 same-content / different-SHA commit pairs. A direct dev→main PR started failing with 13 file conflicts because git's 3-way merge can't tell that the cherry-picked and original versions are the same change.
+  - **Fix.** One-time alignment merge on main: `git merge -X theirs origin/dev` (always take dev's version on conflict) → identical-content main with a clean merge commit bridging the histories. Followup commit (`align(adviser-modal-css)`) cleaned up a unique-to-main hunk left over from an earlier cherry-pick that `-X theirs` couldn't auto-handle (an old `position: sticky` rule the polish round had removed).
+  - **Going forward.** Direct dev→main PRs only. No cherry-pick branches. The merge-base is now dev's tip, so each future dev commit applies cleanly. Workflow documented in CLAUDE.md.
+  - Modified: `CLAUDE.md`, `wiki/Version-History.md` (plus the historical `align(adviser-modal-css)` commit + the merge commit, already on main)
+
 - fix(projects+quokka): polish round — composer overlap, project-aware edit modal, desktop sub visibility, sort-by-due, vertical fill, chained-create ids [M]
   - **Single PR bundling A–E from the bug-dump conversation plus the highest-impact Quokka fixes from the sub-agent analysis.** All shipped together because they're entangled with the same projects+subs workflow.
   - **A. Quokka modal overlap.** The "APPLIED N CHANGES" green bar and the composer were two independent `position: sticky` blocks at different `bottom:` offsets — they collided on commit. Replaced with a single `.v2-adviser-footer` flex column that contains both bars + the composer in one sticky-bottom unit. No more overlap; action buttons stay reachable.


### PR DESCRIPTION
Documents the new dev → main flow and adds a Version-History entry for the alignment merge already on main.

## What

- `CLAUDE.md` git rules split into two workflow sections: `feature → PR → dev` (unchanged) and `dev → main` (NEW: direct PR, no cherry-picks)
- Documents why the old cherry-pick approach diverged the histories and the one-time `git merge -X theirs` alignment that fixed it
- `wiki/Version-History.md` gets the retroactive entry for the alignment work already on main

## Test plan

After this merges to dev: open a direct `dev → main` PR. Should show exactly this one commit to apply (no conflicts). If clean → workflow is validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ax21nq2htqFKx72gqbzXTi)_