### PR TITLE
fix(git): correct dev→main flow — never use dev as PR head

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,12 +33,18 @@ The proxy bug means direct `git push origin dev` and `git push origin --delete <
 
 ### Workflow: promoting dev → main
 
-**Canonical: direct dev → main PR.** No cherry-pick branches.
+**Canonical: push dev's tip to a fresh short-lived release branch, PR THAT to main.** **NEVER use `dev` itself as a PR head** — GitHub auto-deletes the head branch on merge (verified the hard way on PR #179, 2026-05-17: `head=dev, base=main, merge_method=rebase` → dev was deleted from the remote). The release-branch indirection is the only reliable workaround.
 
-1. After a feature PR merges to `dev`, open a PR with `head: 'dev'` and `base: 'main'` via `mcp__github__create_pull_request`. Title like `release: <feature>` and a brief body.
-2. Wait for user approval (every promotion is its own approval — previous approvals don't carry forward).
-3. `mcp__github__merge_pull_request` with `merge_method: "rebase"`.
-4. `git fetch origin && git checkout main && git reset --hard origin/main` to resync locally.
+1. Locally: `git fetch origin && git checkout dev && git reset --hard origin/dev`.
+2. `git push origin dev:refs/heads/claude/release-<thing>` — pushes dev's current tip to a new short-lived ref. The proxy accepts fresh-ref pushes.
+3. `mcp__github__create_pull_request` with `head: 'claude/release-<thing>'`, `base: 'main'`. Title like `release: <feature>`.
+4. Wait for user approval (every promotion is its own approval — previous approvals don't carry forward).
+5. `mcp__github__merge_pull_request` with `merge_method: "rebase"`. GitHub deletes `claude/release-<thing>` automatically on merge; `dev` is untouched.
+6. `git fetch origin && git checkout main && git reset --hard origin/main` to resync locally.
+
+After step 5, `dev` and `main` are content-identical at the tip. Verify with `git diff origin/main origin/dev --stat` returning empty output.
+
+**If dev gets deleted anyway** (e.g. someone forgot the indirection): recreate it from main with `git push origin refs/remotes/origin/main:refs/heads/dev`. Branches are now realigned and ready for the next feature loop.
 
 **Why cherry-pick branches went away (2026-05-17):** earlier in this codebase's life, dev → main promotions ran through a cherry-pick branch off main. Each cherry-pick produced a new SHA on main even though the content matched dev exactly. After ~10 promotions, the branches accumulated 10 same-content / different-SHA commit pairs and a direct dev → main PR started failing with conflicts because git's 3-way merge couldn't tell the cherry-picked versions and the original dev versions were the same change. A one-time alignment merge resolved it: `git merge -X theirs origin/dev` on main (always take dev's version on conflict) produced an identical-content main with a clean merge commit bridging the histories. Followup commit (`align(adviser-modal-css)`) cleaned up a unique-to-main hunk the `-X theirs` couldn't auto-handle. Going forward: never cherry-pick — direct dev → main PRs only.
 

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,12 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-17
 
+- fix(git): correct dev→main flow — never use dev as PR head, GitHub deletes it [XS]
+  - **What happened.** PR #179 was head=`dev`, base=`main`, rebase-merge. GitHub's "automatically delete head branches" setting deleted `dev` from the remote when the PR merged. Discovered when `git ls-remote origin refs/heads/dev` returned nothing right after a "successful" merge.
+  - **Recovery.** `git push origin refs/remotes/origin/main:refs/heads/dev` recreated dev from main's tip. Branches realigned, zero content delta.
+  - **Corrected flow** (documented in CLAUDE.md): always push dev's tip to a fresh short-lived release branch first, then PR that branch to main. Auto-delete then nukes the release branch on merge, leaving dev untouched.
+  - Modified: `CLAUDE.md`, `wiki/Version-History.md`
+
 - chore(git): end the dev→main cherry-pick era; CLAUDE.md updated with new flow [XS]
   - **What happened.** Earlier dev→main promotions ran through a cherry-pick branch off main. Each cherry-pick produced a new SHA even though content matched dev exactly. After ~10 promotions, branches accumulated 10 same-content / different-SHA commit pairs. A direct dev→main PR started failing with 13 file conflicts because git's 3-way merge can't tell that the cherry-picked and original versions are the same change.
   - **Fix.** One-time alignment merge on main: `git merge -X theirs origin/dev` (always take dev's version on conflict) → identical-content main with a clean merge commit bridging the histories. Followup commit (`align(adviser-modal-css)`) cleaned up a unique-to-main hunk left over from an earlier cherry-pick that `-X theirs` couldn't auto-handle (an old `position: sticky` rule the polish round had removed).


### PR DESCRIPTION
Correction to the workflow doc that just shipped. PR #179 (head=`dev`, base=`main`, rebase-merge) caused GitHub to auto-delete `dev` from the remote when it merged.

Recovery (already done locally + pushed): `git push origin refs/remotes/origin/main:refs/heads/dev` recreated dev from main's tip. Branches are realigned, zero content lost.

Lesson, captured in CLAUDE.md: **never use `dev` as a PR head.** The promote-to-main flow now requires pushing dev's tip to a short-lived release branch first, then PR that branch to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ax21nq2htqFKx72gqbzXTi)_