### PR TITLE
fix(projects): backstage subs no longer leak into the main list on desktop

### DIFF
--- a/src/hooks/useTasks.js
+++ b/src/hooks/useTasks.js
@@ -300,15 +300,21 @@ export function useTasks() {
   // Pre-2026-05-17: openTasks unconditionally filtered out children of pinned
   // projects so they wouldn't double-render (once in the regular section,
   // once under the project card). That left desktop with NO way to surface
-  // them — the Kanban path doesn't draw a ProjectPinnedSection. Result:
-  // subs were invisible on desktop unless the user changed the project's
-  // status away from 'project'. Now openTasks ignores pinning; the mobile
-  // renderer filters via isPinnedChild for its own sections, and desktop
-  // shows everything in their natural columns. `isPinnedChild` exported so
-  // mobile callers can apply the filter themselves.
+  // them — the Kanban path doesn't draw a ProjectPinnedSection. Now openTasks
+  // ignores pinning for ACTIVE subs; the mobile renderer filters them via
+  // `isPinnedChild` and shows them under the project card, and desktop shows
+  // them in their natural columns. BACKSTAGE subs are filtered unconditionally
+  // — those should never appear in the main list (only inside the Projects
+  // drill-down), regardless of platform or whether the parent is pinned.
   const isPinnedChild = (t) => t.parent_id && pinnedProjectIds.has(t.parent_id) && t.child_visibility === 'active'
+  const isBackstageSub = (t) => {
+    if (!t.parent_id) return false
+    if (t.child_visibility !== 'backstage') return false
+    const parent = tasks.find(x => x.id === t.parent_id)
+    return parent?.status === 'project'
+  }
 
-  const openTasks = tasks.filter(t => isActiveTask(t))
+  const openTasks = tasks.filter(t => isActiveTask(t) && !isBackstageSub(t))
   const staleTasks = openTasks.filter(t => isStale(t))
   const snoozedTasks = openTasks.filter(t => isSnoozed(t))
   const waitingTasks = openTasks.filter(t => (t.status === 'waiting') && !isStale(t) && !isSnoozed(t))

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,12 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-17
 
+- fix(projects): backstage subs no longer leak into the main list on desktop [XS]
+  - **Bug.** "Show in main list when the parent project is pinned" checkbox respected on mobile but not desktop — backstage subs were appearing in the Kanban Up Next column even when the toggle was off.
+  - **Cause.** The earlier fix that made pinned-project subs visible on desktop (PR #176, "C. Pinned-child filter on desktop") removed the filter unconditionally instead of narrowing it to active children only. Result: backstage subs also fell through into the regular sections on desktop.
+  - **Fix.** New `isBackstageSub(t)` helper in `useTasks`: returns true when `t.parent_id` is set, `t.child_visibility === 'backstage'`, and the parent is a project. Applied to `openTasks` unconditionally — backstage subs never show in the main list (mobile or desktop), only inside the Projects drill-down. The existing `isPinnedChild` filter still handles avoiding double-display of active subs on mobile.
+  - Modified: `src/hooks/useTasks.js`, `wiki/Version-History.md`
+
 - fix(git): correct dev→main flow — never use dev as PR head, GitHub deletes it [XS]
   - **What happened.** PR #179 was head=`dev`, base=`main`, rebase-merge. GitHub's "automatically delete head branches" setting deleted `dev` from the remote when the PR merged. Discovered when `git ls-remote origin refs/heads/dev` returned nothing right after a "successful" merge.
   - **Recovery.** `git push origin refs/remotes/origin/main:refs/heads/dev` recreated dev from main's tip. Branches realigned, zero content delta.


### PR DESCRIPTION
Quick fix from your screenshot: backstage subs of a pinned project were showing in the Kanban Up Next column on desktop even though the "Show in main list when the parent project is pinned" checkbox was off.

## Cause

PR #176's "C. Pinned-child filter on desktop" fix removed the filter unconditionally on desktop. It should have narrowed to active children only — backstage children fell through.

## Fix

New `isBackstageSub(t)` helper in `useTasks` filters them at the source. Applied to `openTasks` unconditionally so backstage subs never appear in the main list, mobile or desktop — only inside the Projects modal drill-down.

The existing `isPinnedChild` filter still handles avoiding double-display of *active* subs on mobile (they show under the pinned-project card via ProjectPinnedSection).

## Rule, restated

- **Active + pinned parent:** main list. Mobile under the pinned section; desktop in natural columns.
- **Active + unpinned parent:** main list as a regular task.
- **Backstage + any parent state:** only in the Projects drill-down. Never main list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ax21nq2htqFKx72gqbzXTi)_