### PR TITLE
release: realign main with dev (end SHA-rewrite divergence)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,12 +33,18 @@ The proxy bug means direct `git push origin dev` and `git push origin --delete <
 
 ### Workflow: promoting dev → main
 
-**Canonical: direct dev → main PR.** No cherry-pick branches.
+**Canonical: push dev's tip to a fresh short-lived release branch, PR THAT to main.** **NEVER use `dev` itself as a PR head** — GitHub auto-deletes the head branch on merge (verified the hard way on PR #179, 2026-05-17: `head=dev, base=main, merge_method=rebase` → dev was deleted from the remote). The release-branch indirection is the only reliable workaround.
 
-1. After a feature PR merges to `dev`, open a PR with `head: 'dev'` and `base: 'main'` via `mcp__github__create_pull_request`. Title like `release: <feature>` and a brief body.
-2. Wait for user approval (every promotion is its own approval — previous approvals don't carry forward).
-3. `mcp__github__merge_pull_request` with `merge_method: "rebase"`.
-4. `git fetch origin && git checkout main && git reset --hard origin/main` to resync locally.
+1. Locally: `git fetch origin && git checkout dev && git reset --hard origin/dev`.
+2. `git push origin dev:refs/heads/claude/release-<thing>` — pushes dev's current tip to a new short-lived ref. The proxy accepts fresh-ref pushes.
+3. `mcp__github__create_pull_request` with `head: 'claude/release-<thing>'`, `base: 'main'`. Title like `release: <feature>`.
+4. Wait for user approval (every promotion is its own approval — previous approvals don't carry forward).
+5. `mcp__github__merge_pull_request` with `merge_method: "rebase"`. GitHub deletes `claude/release-<thing>` automatically on merge; `dev` is untouched.
+6. `git fetch origin && git checkout main && git reset --hard origin/main` to resync locally.
+
+After step 5, `dev` and `main` are content-identical at the tip. Verify with `git diff origin/main origin/dev --stat` returning empty output.
+
+**If dev gets deleted anyway** (e.g. someone forgot the indirection): recreate it from main with `git push origin refs/remotes/origin/main:refs/heads/dev`. Branches are now realigned and ready for the next feature loop.
 
 **Why cherry-pick branches went away (2026-05-17):** earlier in this codebase's life, dev → main promotions ran through a cherry-pick branch off main. Each cherry-pick produced a new SHA on main even though the content matched dev exactly. After ~10 promotions, the branches accumulated 10 same-content / different-SHA commit pairs and a direct dev → main PR started failing with conflicts because git's 3-way merge couldn't tell the cherry-picked versions and the original dev versions were the same change. A one-time alignment merge resolved it: `git merge -X theirs origin/dev` on main (always take dev's version on conflict) produced an identical-content main with a clean merge commit bridging the histories. Followup commit (`align(adviser-modal-css)`) cleaned up a unique-to-main hunk the `-X theirs` couldn't auto-handle. Going forward: never cherry-pick — direct dev → main PRs only.
 

--- a/src/hooks/useTasks.js
+++ b/src/hooks/useTasks.js
@@ -300,15 +300,21 @@ export function useTasks() {
   // Pre-2026-05-17: openTasks unconditionally filtered out children of pinned
   // projects so they wouldn't double-render (once in the regular section,
   // once under the project card). That left desktop with NO way to surface
-  // them — the Kanban path doesn't draw a ProjectPinnedSection. Result:
-  // subs were invisible on desktop unless the user changed the project's
-  // status away from 'project'. Now openTasks ignores pinning; the mobile
-  // renderer filters via isPinnedChild for its own sections, and desktop
-  // shows everything in their natural columns. `isPinnedChild` exported so
-  // mobile callers can apply the filter themselves.
+  // them — the Kanban path doesn't draw a ProjectPinnedSection. Now openTasks
+  // ignores pinning for ACTIVE subs; the mobile renderer filters them via
+  // `isPinnedChild` and shows them under the project card, and desktop shows
+  // them in their natural columns. BACKSTAGE subs are filtered unconditionally
+  // — those should never appear in the main list (only inside the Projects
+  // drill-down), regardless of platform or whether the parent is pinned.
   const isPinnedChild = (t) => t.parent_id && pinnedProjectIds.has(t.parent_id) && t.child_visibility === 'active'
+  const isBackstageSub = (t) => {
+    if (!t.parent_id) return false
+    if (t.child_visibility !== 'backstage') return false
+    const parent = tasks.find(x => x.id === t.parent_id)
+    return parent?.status === 'project'
+  }
 
-  const openTasks = tasks.filter(t => isActiveTask(t))
+  const openTasks = tasks.filter(t => isActiveTask(t) && !isBackstageSub(t))
   const staleTasks = openTasks.filter(t => isStale(t))
   const snoozedTasks = openTasks.filter(t => isSnoozed(t))
   const waitingTasks = openTasks.filter(t => (t.status === 'waiting') && !isStale(t) && !isSnoozed(t))

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,12 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-17
 
+- fix(projects): backstage subs no longer leak into the main list on desktop [XS]
+  - **Bug.** "Show in main list when the parent project is pinned" checkbox respected on mobile but not desktop — backstage subs were appearing in the Kanban Up Next column even when the toggle was off.
+  - **Cause.** The earlier fix that made pinned-project subs visible on desktop (PR #176, "C. Pinned-child filter on desktop") removed the filter unconditionally instead of narrowing it to active children only. Result: backstage subs also fell through into the regular sections on desktop.
+  - **Fix.** New `isBackstageSub(t)` helper in `useTasks`: returns true when `t.parent_id` is set, `t.child_visibility === 'backstage'`, and the parent is a project. Applied to `openTasks` unconditionally — backstage subs never show in the main list (mobile or desktop), only inside the Projects drill-down. The existing `isPinnedChild` filter still handles avoiding double-display of active subs on mobile.
+  - Modified: `src/hooks/useTasks.js`, `wiki/Version-History.md`
+
 - fix(git): correct dev→main flow — never use dev as PR head, GitHub deletes it [XS]
   - **What happened.** PR #179 was head=`dev`, base=`main`, rebase-merge. GitHub's "automatically delete head branches" setting deleted `dev` from the remote when the PR merged. Discovered when `git ls-remote origin refs/heads/dev` returned nothing right after a "successful" merge.
   - **Recovery.** `git push origin refs/remotes/origin/main:refs/heads/dev` recreated dev from main's tip. Branches realigned, zero content delta.

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,12 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-17
 
+- fix(git): correct dev→main flow — never use dev as PR head, GitHub deletes it [XS]
+  - **What happened.** PR #179 was head=`dev`, base=`main`, rebase-merge. GitHub's "automatically delete head branches" setting deleted `dev` from the remote when the PR merged. Discovered when `git ls-remote origin refs/heads/dev` returned nothing right after a "successful" merge.
+  - **Recovery.** `git push origin refs/remotes/origin/main:refs/heads/dev` recreated dev from main's tip. Branches realigned, zero content delta.
+  - **Corrected flow** (documented in CLAUDE.md): always push dev's tip to a fresh short-lived release branch first, then PR that branch to main. Auto-delete then nukes the release branch on merge, leaving dev untouched.
+  - Modified: `CLAUDE.md`, `wiki/Version-History.md`
+
 - chore(git): end the dev→main cherry-pick era; CLAUDE.md updated with new flow [XS]
   - **What happened.** Earlier dev→main promotions ran through a cherry-pick branch off main. Each cherry-pick produced a new SHA even though content matched dev exactly. After ~10 promotions, branches accumulated 10 same-content / different-SHA commit pairs. A direct dev→main PR started failing with 13 file conflicts because git's 3-way merge can't tell that the cherry-picked and original versions are the same change.
   - **Fix.** One-time alignment merge on main: `git merge -X theirs origin/dev` (always take dev's version on conflict) → identical-content main with a clean merge commit bridging the histories. Followup commit (`align(adviser-modal-css)`) cleaned up a unique-to-main hunk left over from an earlier cherry-pick that `-X theirs` couldn't auto-handle (an old `position: sticky` rule the polish round had removed).


### PR DESCRIPTION
Realigning main with dev to end the SHA-rewrite divergence. Previous PR #181 used `merge_method=rebase` which rewrote the doc commit's SHA on main, causing PR #183 to fail with conflicts despite identical file content.

## What's here

- A merge commit on top of main bringing in dev's tip (backstage subs fix + corrected-flow doc with dev's original SHA).
- The `-X theirs` strategy resolved every conflict by taking dev's version (since dev has the latest content and all conflicts were SHA-equivalent).

## What to do on merge

**Use `merge_method: "merge"`** (not rebase) to preserve the merge commit structure. The merge commit is what bridges the two branches and keeps SHAs aligned. If we rebase this we'll undo the very thing we're trying to fix.

## Going forward

dev → main always uses merge_method=merge from now on. Feature → dev keeps rebase. CLAUDE.md update lands in the next PR (sub-deps PR or its own).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ax21nq2htqFKx72gqbzXTi)_