### PR TITLE
release: backstage subs fix + merge-commit dev→main flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,10 +39,14 @@ The proxy bug means direct `git push origin dev` and `git push origin --delete <
 2. `git push origin dev:refs/heads/claude/release-<thing>` — pushes dev's current tip to a new short-lived ref. The proxy accepts fresh-ref pushes.
 3. `mcp__github__create_pull_request` with `head: 'claude/release-<thing>'`, `base: 'main'`. Title like `release: <feature>`.
 4. Wait for user approval (every promotion is its own approval — previous approvals don't carry forward).
-5. `mcp__github__merge_pull_request` with `merge_method: "rebase"`. GitHub deletes `claude/release-<thing>` automatically on merge; `dev` is untouched.
+5. `mcp__github__merge_pull_request` with `merge_method: "merge"` (creates a merge commit on main with dev's tip as a parent — **NEVER use rebase here**, see "Why merge not rebase" below). GitHub deletes `claude/release-<thing>` automatically on merge; `dev` is untouched.
 6. `git fetch origin && git checkout main && git reset --hard origin/main` to resync locally.
 
-After step 5, `dev` and `main` are content-identical at the tip. Verify with `git diff origin/main origin/dev --stat` returning empty output.
+After step 5, `dev` and `main` are content-identical at the tip. Verify with `git diff origin/main origin/dev --stat` returning empty output. dev's tip SHA stays reachable from main (as a parent of the merge commit), so future `git log origin/main..origin/dev` returns empty.
+
+**Why merge not rebase for dev→main (2026-05-17):** rebase-merge rewrites commit SHAs on the target branch. Each promotion would land dev's commit on main under a brand-new SHA — even though the content is identical. `git log origin/main..origin/dev` would show the original commit as "not on main" by SHA, and the NEXT release PR would conflict because git's 3-way merge can't tell that two same-content commits are the same change. Merge-commit method preserves SHAs: main contains dev's tip exactly, as a parent of a merge commit. Histories stay linked. No conflicts on future promotions.
+
+Feature → dev still uses `merge_method: "rebase"` for linear history within dev. The rebase rewrite there is fine because dev is the source of truth for its own commits — no cross-branch alignment to preserve.
 
 **If dev gets deleted anyway** (e.g. someone forgot the indirection): recreate it from main with `git push origin refs/remotes/origin/main:refs/heads/dev`. Branches are now realigned and ready for the next feature loop.
 

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,12 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-17
 
+- fix(git): use merge-commit for dev→main; rebase rewrites SHAs and recreates divergence [XS]
+  - **The actual root cause of the "branches keep diverging" problem.** Not cherry-picking (that was already gone). Not using dev as PR head (already fixed). It's that `merge_method=rebase` rewrites the commit's SHA when it lands on the target. Every dev→main promotion via rebase produces a new SHA on main for the same content. `git log` then sees the commits as different by SHA → next promotion has 3-way-merge conflicts on same-content changes.
+  - **Fix.** dev→main always uses `merge_method=merge`. Merge commits preserve dev's SHAs as parents. `git diff origin/main origin/dev` stays empty after every promotion forever.
+  - **Feature → dev keeps `merge_method=rebase`** for linear history within dev. dev is its own source of truth there, no cross-branch alignment to preserve.
+  - Modified: `CLAUDE.md`, `wiki/Version-History.md`
+
 - fix(projects): backstage subs no longer leak into the main list on desktop [XS]
   - **Bug.** "Show in main list when the parent project is pinned" checkbox respected on mobile but not desktop — backstage subs were appearing in the Kanban Up Next column even when the toggle was off.
   - **Cause.** The earlier fix that made pinned-project subs visible on desktop (PR #176, "C. Pinned-child filter on desktop") removed the filter unconditionally instead of narrowing it to active children only. Result: backstage subs also fell through into the regular sections on desktop.


### PR DESCRIPTION
First test of the corrected dev→main flow with `merge_method=merge`.

After merge, verify with `git diff origin/main origin/dev --stat` returning empty AND `git log origin/main..origin/dev` returning empty. If both empty, the flow is fixed.

**MUST merge with `merge_method=merge`, NOT rebase.** Rebase recreates the SHA divergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ax21nq2htqFKx72gqbzXTi)_