### PR TITLE
fix(notifications): respect backstage subs, blocked subs, and notifications_muted server-side

### DIFF
--- a/db.js
+++ b/db.js
@@ -709,9 +709,43 @@ export function isNotifiable(task) {
   if (!task) return false
   if (task.gmail_pending) return false
   if (task.snooze_indefinite) return false
+  if (task.notifications_muted) return false
   if (['not_started', 'doing', 'waiting'].includes(task.status)) return true
   if (task.status === 'project' && (task.due_date || task.nag_allowed)) return true
   return false
+}
+
+// Full notification-eligibility filter. Combines isNotifiable() with the
+// project-aware filters that previously only lived on the client:
+//   - Backstage subs of projects (child_visibility='backstage', parent
+//     is a project): never notify — they only show in the Projects
+//     drill-down, the user can't act on them from the main list.
+//   - Blocked subs (any task in `blocked_by` not yet completed): never
+//     notify — the task isn't actionable yet, surfacing it on a lock
+//     screen is just noise.
+// Returns an array containing only the tasks that should be considered
+// for notifications. Pass the full task list; the function builds an
+// internal id→task map for blocker/parent resolution.
+export function filterNotifiableTasks(allTasks) {
+  if (!Array.isArray(allTasks)) return []
+  const byId = new Map(allTasks.map(t => [t.id, t]))
+  return allTasks.filter(t => {
+    if (!isNotifiable(t)) return false
+    // Backstage sub of a project
+    if (t.parent_id && t.child_visibility === 'backstage') {
+      const parent = byId.get(t.parent_id)
+      if (parent?.status === 'project') return false
+    }
+    // Blocked by an incomplete sibling
+    if (Array.isArray(t.blocked_by) && t.blocked_by.length > 0) {
+      const someoneBlocking = t.blocked_by.some(id => {
+        const b = byId.get(id)
+        return b && b.status !== 'done'
+      })
+      if (someoneBlocking) return false
+    }
+    return true
+  })
 }
 
 // ============================================================

--- a/digestBuilder.js
+++ b/digestBuilder.js
@@ -18,7 +18,7 @@
  *   7. Weather — existing buildWeatherSummary() output if configured
  */
 
-import { queryTasks, getData, getAnalytics, isNotifiable } from './db.js'
+import { queryTasks, getData, getAnalytics, filterNotifiableTasks } from './db.js'
 import { getWeatherCache, buildWeatherSummary } from './weatherSync.js'
 
 // ACTIVE_STATUSES retained for any legacy refs; new code uses isNotifiable()
@@ -98,7 +98,7 @@ function getYesterdayCompletions() {
  */
 export function buildDigest(settings) {
   const allTasks = queryTasks({})
-  const activeTasks = allTasks.filter(isNotifiable)
+  const activeTasks = filterNotifiableTasks(allTasks)
   const nonSnoozed = activeTasks.filter(t => !t.snoozed_until || new Date(t.snoozed_until) <= new Date())
   const nonMuted = nonSnoozed.filter(t => !t.notifications_muted)
 

--- a/emailNotifications.js
+++ b/emailNotifications.js
@@ -10,7 +10,7 @@
 import nodemailer from 'nodemailer'
 import { readFileSync, existsSync } from 'fs'
 import crypto from 'crypto'
-import { queryTasks, getAllRoutines, getData, getNotifThrottle, setNotifThrottle, logNotifEmail, countPendingSuggestions, isNotifiable } from './db.js'
+import { queryTasks, getAllRoutines, getData, getNotifThrottle, setNotifThrottle, logNotifEmail, countPendingSuggestions, filterNotifiableTasks } from './db.js'
 import { getWeatherCache, buildWeatherSummary } from './weatherSync.js'
 import { rewriteNotifBody, canRewriteThisTick } from './notifAi.js'
 import { isInQuietHours, getUserTimeParts } from './userTime.js'
@@ -366,7 +366,7 @@ async function runNotificationCheck() {
     const batchItems = [] // collect items when batching
 
     const allTasks = queryTasks({})
-    const activeTasks = allTasks.filter(isNotifiable)
+    const activeTasks = filterNotifiableTasks(allTasks)
     if (activeTasks.length === 0) return
 
     const nonSnoozed = activeTasks.filter(t => !t.snoozed_until || new Date(t.snoozed_until) <= new Date())

--- a/pushNotifications.js
+++ b/pushNotifications.js
@@ -9,7 +9,7 @@
 import webpush from 'web-push'
 import { readFileSync, existsSync } from 'fs'
 import crypto from 'crypto'
-import { queryTasks, getAllRoutines, getData, setData, getAllPushSubscriptions, deletePushSubscription, getNotifThrottle, setNotifThrottle, logNotifPush, countPendingSuggestions, isNotifiable } from './db.js'
+import { queryTasks, getAllRoutines, getData, setData, getAllPushSubscriptions, deletePushSubscription, getNotifThrottle, setNotifThrottle, logNotifPush, countPendingSuggestions, filterNotifiableTasks } from './db.js'
 import { getWeatherCache, buildWeatherSummary } from './weatherSync.js'
 import { rewriteNotifBody, canRewriteThisTick } from './notifAi.js'
 import { isInQuietHours, getUserTimeParts } from './userTime.js'
@@ -267,7 +267,7 @@ async function runPushCheck() {
     if (subscriptions.length === 0) return
 
     const allTasks = queryTasks({})
-    const activeTasks = allTasks.filter(isNotifiable)
+    const activeTasks = filterNotifiableTasks(allTasks)
     if (activeTasks.length === 0) return
 
     const nonSnoozed = activeTasks.filter(t => !t.snoozed_until || new Date(t.snoozed_until) <= new Date())

--- a/pushoverNotifications.js
+++ b/pushoverNotifications.js
@@ -18,7 +18,7 @@ import crypto from 'crypto'
 import {
   queryTasks, getData, getNotifThrottle, setNotifThrottle,
   logNotifPush, getTask, updateTaskPartial,
-  getEffectiveThrottleMultiplier, countPendingSuggestions, isNotifiable,
+  getEffectiveThrottleMultiplier, countPendingSuggestions, filterNotifiableTasks,
 } from './db.js'
 import { rewriteNotifBody, canRewriteThisTick, shouldRewrite } from './notifAi.js'
 import { isInQuietHours, getUserTimeParts } from './userTime.js'
@@ -332,7 +332,7 @@ async function runPushoverCheck() {
     if (!userKey || !appToken) return
 
     const allTasks = queryTasks({})
-    const activeTasks = allTasks.filter(isNotifiable)
+    const activeTasks = filterNotifiableTasks(allTasks)
     if (activeTasks.length === 0) return
 
     const nonSnoozed = activeTasks.filter(t => !t.snoozed_until || new Date(t.snoozed_until) <= new Date())

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,17 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-17
 
+- fix(notifications): respect backstage subs, blocked subs, and notifications_muted server-side [S]
+  - **Bug.** A "Quick win available" push fired with `"Organize travel documents & confirmations" (S)` — a backstage sub of the Summer '26 Vacation project that's blocked behind several earlier subs. Not in the user's main list, not actionable yet, definitely shouldn't be on the lock screen.
+  - **Cause.** Server-side notification dispatchers (push, email, pushover, digest) used `isNotifiable(task)` which only checks status / snooze_indefinite / gmail_pending. The project-aware filters (`isBackstageSub`, `isBlockedSub`) and the `notifications_muted` flag were enforced only by the client when building the visible task list. Server-side never saw them.
+  - **Fix.** New `filterNotifiableTasks(allTasks)` helper in `db.js` — composes `isNotifiable` plus per-context filters:
+    - Backstage subs of projects (`child_visibility === 'backstage'` AND parent is a project) → skip.
+    - Blocked subs (any id in `blocked_by` not yet `done`) → skip.
+    - Also: `isNotifiable` now respects `task.notifications_muted` directly so dispatcher branches that didn't already filter for it get the rule too.
+  - Replaced `allTasks.filter(isNotifiable)` with `filterNotifiableTasks(allTasks)` in `pushNotifications.js`, `emailNotifications.js`, `pushoverNotifications.js`, `digestBuilder.js`.
+  - **Out of scope.** The general-nudge picker still chooses a small task at random from the eligible pool. With this filter applied, random will now pick from a much smaller, accurate set — but priority-aware picking (high-pri first, then earliest due) is the obvious follow-up if random still feels noisy.
+  - Modified: `db.js`, `pushNotifications.js`, `emailNotifications.js`, `pushoverNotifications.js`, `digestBuilder.js`, `wiki/Version-History.md`
+
 - fix(tz): replace every UTC-based date key with a local-timezone helper [S]
   - **Bug originally reported.** At 7pm Central on Sunday May 17, the home-stats header said "Sun, May 17" but the WeekStrip highlighted MON 18 as today with a 0/3 count.
   - **Cause.** `date.toISOString().slice(0, 10)` (or `.split('T')[0]`) converts to UTC before slicing. After ~6-7pm Central, UTC has already rolled to the next calendar day. Anywhere this was used for "today" / "due date" / per-day bucket keys, the date silently shifted forward at night Central.


### PR DESCRIPTION
From your screenshot: "Quick win available" fired with `"Organize travel documents & confirmations" (S)` — a backstage sub of the Summer '26 Vacation project that's blocked behind several earlier subs. Not in your visible list, not actionable. Shouldn't notify.

## Cause

Server-side notification dispatchers (push, email, pushover, digest) called `isNotifiable(task)` which only checks status / snooze_indefinite / gmail_pending. The project-aware filters (`isBackstageSub`, `isBlockedSub`) and the `notifications_muted` flag were enforced **only by the client** when building the visible task list. The server-side dispatcher saw and notified about every active task regardless of whether the user could see/act on it.

## Fix

New `filterNotifiableTasks(allTasks)` helper in `db.js` composes the existing checks plus:
- **Backstage subs of projects** (`child_visibility === 'backstage'` AND parent is a project) → skip.
- **Blocked subs** (any id in `blocked_by` not yet `done`) → skip.
- **`notifications_muted`** now also gates `isNotifiable` directly.

Replaced `allTasks.filter(isNotifiable)` with `filterNotifiableTasks(allTasks)` in `pushNotifications.js`, `emailNotifications.js`, `pushoverNotifications.js`, `digestBuilder.js`.

## Out of scope

The general-nudge picker still picks a small task **at random** from the eligible pool. With this filter applied, "eligible" is now correct. If random still feels noisy, the obvious follow-up is priority-aware picking (high-pri first, then earliest due) — flag it if you want that next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ax21nq2htqFKx72gqbzXTi)_