### PR TITLE
release: DateField tappable on iPhone PWA

### DIFF
--- a/src/v2/components/DateField.css
+++ b/src/v2/components/DateField.css
@@ -1,36 +1,37 @@
-/* DateField — bracketed text trigger that opens the native date picker.
+/* DateField — a real <input type="date"> overlaid invisibly on top of
+ * a visible display span. Tapping the field opens the native picker
+ * directly (no showPicker() JS call needed — that silently failed in
+ * iOS PWA Safari for some users). Two visual modes via theme:
  *
- * Light/dark: looks like a regular form input (bordered rect with the
- * date or "due date" placeholder text inside). Terminal: collapses to
- * bare bracketed text. Clear button is plain accent-colored text.
+ *   light/dark — display reads like a regular form input
+ *   terminal   — display reads as bracketed text
  *
- * Hidden input is positioned off-screen but still focusable for the
- * picker. We call .showPicker() on tap to open the native calendar
- * without ever rendering the input visually. */
+ * Architecture:
+ *   .v2-form-date-stack — relative-positioned wrapper
+ *     .v2-form-date-display — what the user sees (text + optional bracket)
+ *     .v2-form-date-input   — real date input, position:absolute, inset:0,
+ *                              opacity:0, full pointer events
+ */
 
 .v2-form-date-field {
-  position: relative;
   display: flex;
   align-items: center;
   gap: 12px;
   flex-wrap: wrap;
 }
 
-.v2-form-date-hidden-input {
-  position: absolute;
-  left: 0;
-  top: 0;
-  width: 1px;
-  height: 1px;
-  opacity: 0;
-  pointer-events: none;
-  border: 0;
-  padding: 0;
+.v2-form-date-stack {
+  position: relative;
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
-/* Light/dark: regular input-styled trigger */
-.v2-form-date-trigger {
-  flex: 1 1 auto;
+/* Visible read-out — styled to look like a regular input in light/dark
+ * and bracketed text in terminal. Pointer-events: none so taps fall
+ * through to the input layered above. */
+.v2-form-date-display {
+  display: block;
+  width: 100%;
   min-height: 44px;
   padding: 12px 14px;
   border-radius: 10px;
@@ -38,18 +39,50 @@
   background: var(--v2-bg);
   color: var(--v2-text);
   font: 400 14px/1.4 var(--v2-font-body);
-  text-align: left;
-  cursor: pointer;
-  transition: border-color var(--v2-dur-quick) var(--v2-ease-standard);
+  pointer-events: none;
+  box-sizing: border-box;
 }
 
-.v2-form-date-trigger:hover {
-  border-color: var(--v2-text-meta);
-}
-
-.v2-form-date-trigger:not(.v2-form-date-trigger-filled) {
+.v2-form-date-field:not(.v2-form-date-field-filled) .v2-form-date-display {
   color: var(--v2-text-meta);
 }
+
+/* The real date input — invisible but tappable, covers the display.
+ * Native picker opens on tap. Min-height matches the display so iOS
+ * Safari hit-tests find it reliably. */
+.v2-form-date-input {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  min-height: 44px;
+  padding: 12px 14px;
+  margin: 0;
+  border: 0;
+  border-radius: 10px;
+  background: transparent;
+  color: transparent;
+  font: 400 14px/1.4 var(--v2-font-body);
+  cursor: pointer;
+  opacity: 0;
+  -webkit-appearance: none;
+  appearance: none;
+  /* iOS doesn't honor color: transparent on type="date" — use a wash
+   * via -webkit-text-fill-color in case any future style leaks. Also
+   * opacity:0 above means it's all invisible regardless. */
+  -webkit-text-fill-color: transparent;
+}
+
+.v2-form-date-input:focus-visible + .v2-form-date-display,
+.v2-form-date-stack:focus-within .v2-form-date-display {
+  border-color: var(--v2-accent);
+  outline: 2px solid transparent; /* keep our own focus ring */
+}
+
+/* Strip default appearance on iOS Safari so the input's space is just
+ * a tap target. */
+.v2-form-date-input::-webkit-date-and-time-value { text-align: left; }
+.v2-form-date-input::-webkit-calendar-picker-indicator { opacity: 0; }
 
 .v2-form-date-clear {
   background: transparent;
@@ -71,7 +104,7 @@
   gap: 10px;
 }
 
-:root[data-ui="v2"][data-theme^="terminal"] .v2-form-date-trigger {
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-date-display {
   background: transparent !important;
   border: none !important;
   border-radius: 0 !important;
@@ -81,27 +114,27 @@
   font: 500 13px/1 var(--v2-font-body);
 }
 
-:root[data-ui="v2"][data-theme^="terminal"] .v2-form-date-trigger::before {
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-date-display::before {
   content: "[ ";
   color: var(--v2-text-faint);
 }
 
-:root[data-ui="v2"][data-theme^="terminal"] .v2-form-date-trigger::after {
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-date-display::after {
   content: " ]";
   color: var(--v2-text-faint);
 }
 
-:root[data-ui="v2"][data-theme^="terminal"] .v2-form-date-trigger-filled {
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-date-field-filled .v2-form-date-display {
   color: var(--v2-accent) !important;
   text-shadow: var(--v2-glow);
 }
 
-:root[data-ui="v2"][data-theme^="terminal"] .v2-form-date-trigger-filled::before,
-:root[data-ui="v2"][data-theme^="terminal"] .v2-form-date-trigger-filled::after {
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-date-field-filled .v2-form-date-display::before,
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-date-field-filled .v2-form-date-display::after {
   color: var(--v2-accent);
 }
 
-:root[data-ui="v2"][data-theme^="terminal"] .v2-form-date-trigger:hover {
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-date-input:hover + .v2-form-date-display {
   color: var(--v2-text) !important;
   text-shadow: 0 0 6px rgba(194, 209, 197, 0.3);
 }
@@ -113,4 +146,9 @@
 :root[data-ui="v2"][data-theme^="terminal"] .v2-form-date-clear:hover {
   color: var(--v2-alert-overdue) !important;
   text-shadow: 0 0 6px rgba(248, 81, 73, 0.4);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-form-date-input {
+  min-height: 32px !important;
+  padding: 4px 0 !important;
 }

--- a/src/v2/components/DateField.jsx
+++ b/src/v2/components/DateField.jsx
@@ -1,38 +1,27 @@
-import { useRef } from 'react'
 import './DateField.css'
 
-// Date picker field that renders as a bracketed text trigger and opens
-// the native calendar picker on tap. Empty: `[ due date ]`. Filled:
-// `[ YYYY-MM-DD ] × clear`. Same UX in every theme — terminal-flat
-// monospace gets it for free since the trigger is just text + the
-// clear button is bracketed text.
-//
-// We hide the actual <input type="date"> off-screen and call
-// `.showPicker()` on tap. Falls back to focus+click if the browser
-// doesn't support showPicker (older Safari, etc.). Modern browsers
-// (iOS 16.4+, Chrome 99+, Firefox 101+) all support it.
+// Date picker field. The visible trigger reads as bracketed text in
+// terminal and a regular field in light/dark. The actual <input type="date">
+// is overlaid on top of the trigger at opacity:0 with full pointer events
+// — so tapping anywhere on the trigger opens the native picker directly,
+// no JS showPicker() dance required. That dance silently failed on iOS
+// PWA Safari in some versions; overlaying the input bypasses the bug.
 export default function DateField({ value, onChange, min }) {
-  const inputRef = useRef(null)
-
-  const open = () => {
-    const el = inputRef.current
-    if (!el) return
-    if (typeof el.showPicker === 'function') {
-      try { el.showPicker(); return } catch { /* fall through */ }
-    }
-    el.focus()
-    el.click()
-  }
-
   return (
-    <div className="v2-form-date-field">
-      <button
-        type="button"
-        className={`v2-form-date-trigger${value ? ' v2-form-date-trigger-filled' : ''}`}
-        onClick={open}
-      >
-        {value ? value : 'due date'}
-      </button>
+    <div className={`v2-form-date-field${value ? ' v2-form-date-field-filled' : ''}`}>
+      <div className="v2-form-date-stack">
+        <span className="v2-form-date-display" aria-hidden="true">
+          {value ? value : 'due date'}
+        </span>
+        <input
+          type="date"
+          className="v2-form-date-input"
+          value={value || ''}
+          min={min || undefined}
+          onChange={e => onChange(e.target.value)}
+          aria-label={value ? `Due ${value} — tap to change` : 'Pick due date'}
+        />
+      </div>
       {value && (
         <button
           type="button"
@@ -44,16 +33,6 @@ export default function DateField({ value, onChange, min }) {
           × clear
         </button>
       )}
-      <input
-        ref={inputRef}
-        type="date"
-        className="v2-form-date-hidden-input"
-        value={value || ''}
-        min={min || undefined}
-        onChange={e => onChange(e.target.value)}
-        tabIndex={-1}
-        aria-hidden="true"
-      />
     </div>
   )
 }

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,12 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-17
 
+- fix(datefield): date picker not opening on iPhone PWA [XS]
+  - **Bug.** Tapping the Due date field in the EditTaskModal on iPhone PWA (light theme) did nothing — the native picker never opened.
+  - **Cause.** DateField rendered a visible `<button>` trigger plus an off-screen 1×1 `<input type="date">` and called `.showPicker()` on tap. Modern Safari supports `showPicker()` but it can silently fail on iOS PWA in some versions — try/catch swallowed the error, then the fallback `el.focus(); el.click()` on a 1×1 opacity:0 input never opened the native picker either.
+  - **Fix.** Drop the trigger-button + showPicker pattern. Now the real `<input type="date">` is overlaid full-size on top of a styled display span at `opacity: 0` with pointer-events enabled. Tapping the field hits the native input directly — iOS opens the picker the way it always has, no JS required. The display span underneath is `pointer-events: none` so taps pass through. Same bracketed terminal look + the regular border in light/dark.
+  - Modified: `src/v2/components/DateField.jsx`, `src/v2/components/DateField.css`, `wiki/Version-History.md`
+
 - fix(settings): notifications panel cleanup — collapsible sections, descriptions on every type, Quokka card matches the rest [S]
   - **Three asks from the screenshots:**
     1. Collapse the noisy notif sections so the panel isn't a wall of toggles.


### PR DESCRIPTION
DateField iOS PWA fix. Promoted via merge-commit flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ax21nq2htqFKx72gqbzXTi)_