### PR TITLE
release: backdate task completion

### DIFF
--- a/src/hooks/useRoutines.js
+++ b/src/hooks/useRoutines.js
@@ -44,6 +44,29 @@ export function useRoutines() {
     ))
   }, [])
 
+  // Backdate-completion follow-through. When the user edits a routine-spawned
+  // task's `completed_at` (e.g. "I actually did this yesterday"), the matching
+  // entry in the routine's completed_history needs to move too so cadence
+  // calculations stay aligned. Replaces the entry at exact-ISO match; falls
+  // back to the most recent entry as a heuristic when the timestamps don't
+  // match exactly (covers the small drift between completeRoutine's stamp
+  // and the task's completed_at). Sorts the history after the swap so
+  // getNextDueDate's "last entry = newest" assumption holds.
+  const adjustRoutineHistory = useCallback((id, fromIso, toIso) => {
+    if (!toIso) return
+    setRoutines(prev => prev.map(r => {
+      if (r.id !== id) return r
+      const history = Array.isArray(r.completed_history) ? r.completed_history : []
+      if (history.length === 0) return r
+      let idx = fromIso ? history.indexOf(fromIso) : -1
+      if (idx === -1) idx = history.length - 1
+      const next = [...history]
+      next[idx] = toIso
+      next.sort()
+      return { ...r, completed_history: next }
+    }))
+  }, [])
+
   const updateRoutine = useCallback((id, updates) => {
     setRoutines(prev => prev.map(r =>
       r.id === id ? { ...r, ...updates } : r
@@ -199,6 +222,7 @@ export function useRoutines() {
     deleteRoutine,
     togglePause,
     completeRoutine,
+    adjustRoutineHistory,
     updateRoutine,
     updateRoutineNotion,
     spawnDueTasks,

--- a/src/v2/AppV2.jsx
+++ b/src/v2/AppV2.jsx
@@ -150,7 +150,7 @@ export default function AppV2() {
   } = useTasks()
   const {
     routines, addRoutine, deleteRoutine, togglePause, updateRoutine,
-    completeRoutine, spawnDueTasks, spawnNow, logHabit, skipCycle, hydrateRoutines,
+    completeRoutine, adjustRoutineHistory, spawnDueTasks, spawnNow, logHabit, skipCycle, hydrateRoutines,
   } = useRoutines()
 
   // Background work that must keep running even when v2 is the active shell:
@@ -568,6 +568,22 @@ export default function AppV2() {
     setEditTarget(null)
   }, [addRoutine, updateTask])
 
+  // Wrapper around updateTask used by EditTaskModal. When the user backdates
+  // a routine-spawned task's completed_at, sync the matching entry in the
+  // parent routine's completed_history so cadence calculations (next due,
+  // skip counts) don't drift from the visible task data.
+  const handleEditModalSave = useCallback((id, payload) => {
+    const existing = tasks.find(t => t.id === id)
+    updateTask(id, payload)
+    if (
+      existing?.routine_id &&
+      payload.completed_at &&
+      payload.completed_at !== existing.completed_at
+    ) {
+      adjustRoutineHistory(existing.routine_id, existing.completed_at, payload.completed_at)
+    }
+  }, [tasks, updateTask, adjustRoutineHistory])
+
   const handleUncomplete = useCallback((task) => {
     uncompleteTask(task.id)
     setToast({ task, variant: 'reopen' })
@@ -909,7 +925,7 @@ export default function AppV2() {
       {editTarget && (
         <EditTaskModal
           task={editTarget}
-          onSave={updateTask}
+          onSave={handleEditModalSave}
           onClose={() => setEditTarget(null)}
           onDelete={(id) => { handleDelete(id); setEditTarget(null) }}
           onBacklog={handleBacklog}

--- a/src/v2/components/DateField.jsx
+++ b/src/v2/components/DateField.jsx
@@ -6,29 +6,44 @@ import './DateField.css'
 // — so tapping anywhere on the trigger opens the native picker directly,
 // no JS showPicker() dance required. That dance silently failed on iOS
 // PWA Safari in some versions; overlaying the input bypasses the bug.
-export default function DateField({ value, onChange, min }) {
+export default function DateField({
+  value,
+  onChange,
+  min,
+  max,
+  placeholder = 'due date',
+  ariaLabelEmpty,
+  ariaLabelFilled,
+  clearLabel = 'Clear due date',
+  showClear = true,
+}) {
+  const emptyLabel = ariaLabelEmpty || 'Pick due date'
+  const filledLabel = ariaLabelFilled
+    ? ariaLabelFilled(value)
+    : `Due ${value} — tap to change`
   return (
     <div className={`v2-form-date-field${value ? ' v2-form-date-field-filled' : ''}`}>
       <div className="v2-form-date-stack">
         <span className="v2-form-date-display" aria-hidden="true">
-          {value ? value : 'due date'}
+          {value ? value : placeholder}
         </span>
         <input
           type="date"
           className="v2-form-date-input"
           value={value || ''}
           min={min || undefined}
+          max={max || undefined}
           onChange={e => onChange(e.target.value)}
-          aria-label={value ? `Due ${value} — tap to change` : 'Pick due date'}
+          aria-label={value ? filledLabel : emptyLabel}
         />
       </div>
-      {value && (
+      {value && showClear && (
         <button
           type="button"
           className="v2-form-date-clear"
           onClick={() => onChange('')}
-          title="Clear due date"
-          aria-label="Clear due date"
+          title={clearLabel}
+          aria-label={clearLabel}
         >
           × clear
         </button>

--- a/src/v2/components/EditTaskModal.jsx
+++ b/src/v2/components/EditTaskModal.jsx
@@ -135,6 +135,13 @@ export default function EditTaskModal({
   const [cadence, setCadence] = useState('weekly')
   const [customDays, setCustomDays] = useState(14)
 
+  // Backdated completion. When the user did the task earlier but forgot to
+  // tick it off, they can edit "Completed on" here so the daily streak and
+  // points credit the right calendar day. The ISO string is the source of
+  // truth (preserves time-of-day across edits); the picker converts to/from
+  // YYYY-MM-DD. Field is only rendered when currentStatus === 'done'.
+  const [completedAtIso, setCompletedAtIso] = useState(task.completed_at || '')
+
   // Checklists — multi-list shape: [{ id, name, items: [{id, text, completed}], hideCompleted }]
   // Migrate old flat task.checklist if present (covered by migration 018 server-side
   // but kept here for localStorage tasks that haven't round-tripped yet).
@@ -180,6 +187,10 @@ export default function EditTaskModal({
     parent_id: parentId || null,
     child_visibility: parentId ? childVisibility : 'backstage',
     blocked_by: parentId ? blockedBy : [],
+    // Only persist completed_at while the task is done. changeStatus()
+    // already clears it on done→active transitions; including it here
+    // when not-done would re-stamp a stale value on every save.
+    ...(currentStatus === 'done' && completedAtIso ? { completed_at: completedAtIso } : {}),
   }), [
     form.title, form.notes, form.selectedTags, form.dueDate,
     form.size, form.energy, form.energyLevel,
@@ -187,6 +198,7 @@ export default function EditTaskModal({
     form.attachments, form.notionResult,
     checklists, comments, weatherHidden, gcalDuration,
     pinnedToToday, nagAllowed, parentId, childVisibility, blockedBy,
+    currentStatus, completedAtIso,
   ])
 
   const lastSavedJson = useRef(null)
@@ -287,6 +299,15 @@ export default function EditTaskModal({
 
   const handleStatusChange = (newStatus) => {
     setCurrentStatus(newStatus)
+    // Stamp a default completed_at when transitioning into done so the
+    // "Completed on" picker shows today out of the gate. Keep the existing
+    // value if the user is just re-confirming done. Clear it on done→active
+    // so a future re-completion doesn't reuse the stale timestamp.
+    if (newStatus === 'done') {
+      if (!completedAtIso) setCompletedAtIso(new Date().toISOString())
+    } else {
+      setCompletedAtIso('')
+    }
     onStatusChange(task.id, newStatus)
   }
 
@@ -371,6 +392,34 @@ export default function EditTaskModal({
           </button>
         </div>
       </div>
+
+      {currentStatus === 'done' && (
+        <div className="v2-form-section">
+          <label className="v2-form-label">Completed on</label>
+          <div className="v2-settings-row-hint" style={{ marginTop: -4, marginBottom: 4 }}>
+            Backdate if you finished this earlier — fixes streak and points credit.
+          </div>
+          <DateField
+            value={completedAtIso ? localYMD(new Date(completedAtIso)) : ''}
+            onChange={(ymd) => {
+              if (!ymd) { setCompletedAtIso(''); return }
+              const [y, m, d] = ymd.split('-').map(Number)
+              const original = completedAtIso ? new Date(completedAtIso) : new Date()
+              const hh = original.getHours()
+              const mm = original.getMinutes()
+              const ss = original.getSeconds()
+              const next = new Date(y, m - 1, d, hh, mm, ss, 0)
+              setCompletedAtIso(next.toISOString())
+            }}
+            max={today}
+            placeholder="pick a date"
+            ariaLabelEmpty="Pick completion date"
+            ariaLabelFilled={(v) => `Completed ${v} — tap to change`}
+            clearLabel="Clear completion date"
+            showClear={false}
+          />
+        </div>
+      )}
 
       <div className="v2-form-section">
         <label className="v2-form-label">Notes</label>

--- a/wiki/Features.md
+++ b/wiki/Features.md
@@ -26,6 +26,7 @@ Modal headers in terminal mode read as commands: `> task --new`, `> snooze`, `> 
 - **Quick add** — type and hit Enter from the bottom bar to instantly create a task
 - **Full add modal** — title, notes, due date, labels, T-shirt size, and Notion link
 - **Edit tasks** — full edit modal with all fields, including the ability to convert a one-off task into a routine
+- **Backdate completion** — "Completed on" date picker appears in the edit modal whenever a task is marked done. Did the task yesterday but forgot to tick it off? Open the task, hit Done, pick the date you actually finished. Daily streak and points re-bucket to the right calendar day, and routine-spawned tasks also sync the parent routine's `completed_history` so cadence stays aligned.
 - **Swipe gestures** — iMessage-style swipe actions on task cards. Swipe right-to-left to reveal Edit and Done buttons. Swipe left-to-right to delete. Clean SVG icons (pencil, checkmark, trash) instead of text labels.
 - **Delete tasks** — delete any task via swipe gesture or from the expanded card actions
 - **Expanded actions** — tap a task to expand it and reveal Done, Snooze, Extend, Edit, Backlog, and Delete buttons

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -4,6 +4,21 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ---
 
+## 2026-05-20
+
+- feat(tasks): backdate task completion to fix streak credit [S]
+  - **Ask.** "I did a task and forgot to come back to it to check it off and I didn't get credit for it." Need to mark a task done as of an earlier date so the daily streak and points land on the day the work actually happened.
+  - **Surface.** EditTaskModal (v2) — when `currentStatus === 'done'`, a new "Completed on" section appears directly under the Status row with a date picker. Hint copy: "Backdate if you finished this earlier — fixes streak and points credit." Field defaults to the task's current `completed_at` (or today if the user just flipped status to done in this modal). Max=today; no future dates.
+  - **Flow for the forgot-to-check-off case.** Open the task → tap ✓ Done (status flips, completed_at stamps to now, "Completed on" appears with today's date) → tap the field, pick yesterday → autosave fires after 500ms with `completed_at = yesterday ISO`. Streak (`computeStreak` in `src/store.js`) and daily stats (`computeDailyStats` in `src/scoring.js`) both bucket by `new Date(t.completed_at).toDateString()` — no new code needed, they just see the updated date.
+  - **Routine cadence sync.** Routine-spawned tasks need a second touch: `completeRoutine` appends `new Date().toISOString()` to the routine's `completed_history` at the moment of completion. If the user later backdates the task's `completed_at`, the routine's history entry would drift. New `adjustRoutineHistory(routineId, fromIso, toIso)` on `useRoutines` swaps the matching entry (or falls back to the last entry if exact-ISO match misses, since the task and routine timestamps drift by a few ms even when stamped from the same handler). `AppV2.handleEditModalSave` detects `completed_at` changes on routine-tagged tasks and propagates. Sorts history after the swap so `getNextDueDate`'s "last entry = newest" assumption holds.
+  - **Time-of-day preservation.** ISO is the source of truth in local state; the picker converts YYYY-MM-DD ↔ ISO and preserves the original hours/minutes/seconds across edits (defaults to "now" the first time a task transitions to done). So a 2pm-yesterday completion stays at 2pm yesterday when reformatted, not midnight.
+  - **DateField extension.** Existing `DateField` had a hardcoded "due date" placeholder and "Clear due date" aria label. Extended with `placeholder`, `max`, `ariaLabelEmpty`, `ariaLabelFilled`, `clearLabel`, `showClear` props (all backward-compatible defaults). The completion-date instance disables the clear button via `showClear={false}` — clearing the date would leave the task in done-status with no completion timestamp, which the streak code treats as "not counted at all," and there's no UI affordance to recover from that. Status flip away from done already clears `completed_at` cleanly via `changeStatus`.
+  - **Save semantics.** `savePayload` only includes `completed_at` when `currentStatus === 'done' && completedAtIso`. Avoids re-stamping a stale value when the task is active. `changeStatus` continues to clear `completed_at` on done→active transitions; the modal also resets `completedAtIso` locally so the field re-defaults to today on re-completion.
+  - **Out of scope.** No backdate UI on the TaskCard itself — the user picked "edit modal only" so backdating stays a deliberate, edit-mode-gated action rather than something easy to do by accident on the main list.
+  - Modified: `src/v2/components/EditTaskModal.jsx`, `src/v2/components/DateField.jsx`, `src/hooks/useRoutines.js`, `src/v2/AppV2.jsx`, `wiki/Features.md`, `wiki/Version-History.md`
+
+---
+
 ## 2026-05-17
 
 - fix(datefield): date picker not opening on iPhone PWA [XS]


### PR DESCRIPTION
## Summary

Promotes the backdate-task-completion feature from `dev` to `main`.

Single feature in this release (PR #201, merged to dev). Adds a "Completed on" date picker in the v2 EditTaskModal whenever a task is marked done — pick an earlier date and the daily streak + points re-bucket to that day. For routine-spawned tasks, the matching entry in the routine's `completed_history` also moves so cadence stays aligned.

`git diff origin/main...origin/dev` shows only the 6 files from PR #201 (128 insertions, 8 deletions).

## Test plan

- [ ] After merge: `git diff origin/main origin/dev --stat` returns empty
- [ ] Production `:latest` Docker image picks up the v2 EditTaskModal change
- [ ] Backdate flow works end-to-end in prod (mark a task done with yesterday's date → streak counts yesterday)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KWorKS3oCgoTsCNKi77wYY)_