### PR TITLE
feat(knowledge): Notion-backed knowledge base + Quokka tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,7 @@ Boomerang is a personal ADHD task manager PWA built with React 19, Vite, Express
 - Real-time cross-client sync via SSE
 - Dark mode (single toggle), iOS-style toggle switches throughout settings
 - Header icons: Packages + Quokka (AI adviser) always visible in the top-right; overflow "..." menu contains Settings, Projects, Import, Analytics, Activity Log
-- Quokka — free-form natural-language AI adviser with control over every capability in the app (tasks, routines, GCal, Notion, Trello, Gmail, packages, weather, settings, analytics). 54 server-side tools, staged-execution with user confirmation, LIFO compensation rollback on failure. Named after the perpetually-smiling Australian marsupial.
+- Quokka — free-form natural-language AI adviser with control over every capability in the app (tasks, routines, GCal, Notion, Trello, Gmail, packages, weather, settings, analytics, knowledge base). 63 server-side tools, staged-execution with user confirmation, LIFO compensation rollback on failure. Named after the perpetually-smiling Australian marsupial.
 - Installable PWA with full-square PNG icons (180, 192, 512) and apple-touch-icon
 
 ### Energy/Capacity Tagging System
@@ -683,6 +683,40 @@ Connects to Gmail via OAuth and uses AI to automatically extract tasks and packa
 - Only scans primary inbox (excludes promotions, social, updates, forums)
 - Pending items still surface in the main task list with a yellow border + Keep/Dismiss buttons. Moving them out into a dedicated Suggestions inbox surface is a separate (parked) UX change.
 
+### Knowledge Base (Notion-backed long-term reference)
+Personal knowledge store Quokka can search. Where things are kept, how-tos, decisions and reasoning, people and their context. Lives as a Notion database the user owns; Boomerang keeps a server-side metadata cache for instant search.
+
+**Storage.** New Notion database auto-created on first use under the user's existing `notion_sync_parent_id`. Properties: **Name** (title), **Type** (select: Location / How-to / Decision / Person), **Tags** (multi-select, freeform), **Related tasks** (rich_text, comma-separated task IDs), **Confidence** (select: Certain / Fuzzy). Body is markdown-ish (#, ##, -, - [ ]).
+
+**Local cache.** `knowledge_index` table (migration 030) holds title / type / tags / ≤200-char summary / Notion URL / last-edited timestamp / archived flag. Background refresh every 5 min reconciles deletions made in Notion. Full body fetched on demand. Settings: `notion_knowledge_db_id`, `notion_knowledge_db_url`, `notion_knowledge_last_sync`.
+
+**Task ↔ knowledge links.** `knowledge_page_ids_json` column on tasks (migration 030, JSON array of Notion page IDs). EditTaskModal "Linked knowledge" chip section above Manage. Mirrored on the Notion side via the "Related tasks" property so the relationship is visible from both directions.
+
+**Capture model.** Auto-write — when the user tells Quokka "remember X is in the basement", `create_knowledge` runs inline during the chat turn (no plan-confirm). Edits and deletes go through the standard staged-plan + LIFO compensation flow because those touch pre-existing user data. Quokka is instructed to `search_knowledge` first and ask the user before creating a duplicate.
+
+**Server endpoints (in `server.js`):**
+| Endpoint | Purpose |
+|---|---|
+| `GET /api/knowledge/status` | Config status + last-sync timestamp |
+| `POST /api/knowledge/setup` | Auto-create the Notion database, seed the local index |
+| `GET /api/knowledge?q=&type=&limit=` | Search/filter/list cached items |
+| `GET /api/knowledge/:id` | Cached metadata + on-demand body fetch |
+| `POST /api/knowledge/refresh` | Force re-pull from Notion |
+
+**Quokka tools (9):** `search_knowledge`, `get_knowledge`, `refresh_knowledge_index`, `list_knowledge` (read-only); `create_knowledge`, `update_knowledge`, `delete_knowledge`, `link_knowledge_to_task`, `unlink_knowledge_from_task` (staged with rollback). All gated behind `deps.knowledgeDbConfigured` — error tells the user to run setup before tools fire.
+
+**Entry points.**
+- **Quokka** (primary) — natural language. "What brand of cat food do I buy?", "Remember the Christmas decorations are in the attic crawlspace."
+- **⋯ menu → Knowledge** — opens Quokka with a seeded "What's in my knowledge base?" draft in the input. User can hit send as-is or refine.
+- **EditTaskModal** — Linked knowledge chip section for direct view/unlink + a search picker.
+- **Settings → Integrations → Notion → Knowledge Base** — one-shot setup + Sync now button.
+
+**Known limitations:**
+- Body restore is best-effort on `update_knowledge` rollback — Notion's PATCH-children replaces blocks, so the full pre-update body would be needed for exact restore. Property restores (title/type/tags) work cleanly.
+- External delete final per existing adviser policy — `delete_knowledge` archives in Notion (recoverable from Trash for 30 days); local rollback can only re-insert the cache row.
+- Keyword search only (title/tags/summary). Semantic search across full bodies not wired.
+- 5-minute refresh cadence — if the user adds an item in Notion directly and immediately asks Quokka, they need to tap "Sync now" or have Quokka call `refresh_knowledge_index`.
+
 ### Quokka (AI Adviser)
 Free-form natural-language control surface — user says "I've rescheduled my FAA exam to May 12, adjust everything" and Quokka finds related tasks/GCal events/routines and queues the fix. Named after the quokka (a small, perpetually-smiling Australian marsupial). User-facing branding uses "Quokka"; internal code (module names, CSS classes, endpoints under `/api/adviser/`, state vars like `showAdviser`) stays as `adviser`/`Adviser` — renaming plumbing provides no value.
 
@@ -700,7 +734,8 @@ Free-form natural-language control surface — user says "I've rescheduled my FA
 - `adviserToolsTasks.js` — 21 task + routine tools (incl. 4 Sequences chain editors: `add_follow_up`, `edit_follow_up`, `remove_follow_up`, `reorder_follow_ups`)
 - `adviserToolsIntegrations.js` — 12 GCal + Notion + Trello tools
 - `adviserToolsMisc.js` — 20 Gmail + packages + weather + settings + analytics tools
-- **Total:** 54 tools; diagnostic list at `GET /api/adviser/tools`
+- `adviserToolsKnowledge.js` — 9 knowledge-base tools (search, get, refresh, list, create, update, delete, link/unlink to tasks)
+- **Total:** 63 tools; diagnostic list at `GET /api/adviser/tools`
 
 **Server endpoints:**
 | Endpoint | Purpose |
@@ -721,6 +756,7 @@ Free-form natural-language control surface — user says "I've rescheduled my FA
 - Packages (6): list, get, create, update, delete, refresh-all
 - Weather (3): get, refresh, geocode
 - Settings + analytics (4): get/update settings (secrets blocked), get analytics, get analytics history
+- Knowledge base (9): search, get, refresh, list, create, update, delete, link/unlink to tasks (see Knowledge Base section above)
 
 **Rollback compensation:**
 - Local DB creates → delete on rollback

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,8 @@ ENV APP_VERSION=${APP_VERSION}
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY package.json ./
-COPY server.js db.js seed.js emailNotifications.js pushNotifications.js pushoverNotifications.js digestBuilder.js notifAi.js userTime.js gmailSync.js weatherSync.js notionMCP.js patternDetection.js ./
-COPY adviserTools.js adviserToolsTasks.js adviserToolsIntegrations.js adviserToolsMisc.js ./
+COPY server.js db.js seed.js emailNotifications.js pushNotifications.js pushoverNotifications.js digestBuilder.js notifAi.js userTime.js gmailSync.js weatherSync.js notionMCP.js patternDetection.js knowledgeSync.js ./
+COPY adviserTools.js adviserToolsTasks.js adviserToolsIntegrations.js adviserToolsMisc.js adviserToolsKnowledge.js ./
 COPY migrations ./migrations
 COPY scripts ./scripts
 COPY --from=build /app/dist ./dist

--- a/adviserToolsKnowledge.js
+++ b/adviserToolsKnowledge.js
@@ -1,0 +1,404 @@
+// adviserToolsKnowledge.js — Knowledge-base tools for Quokka.
+//
+// The knowledge base is a Notion database the user owns; Boomerang keeps a
+// local metadata index so search is instant. Writes go through Notion (the
+// source of truth) and update the local cache on success.
+//
+// Conventions match other tool families:
+//   - Read tools are readOnly (run inline during the chat loop)
+//   - Mutation tools stage for user confirmation; compensations roll back
+//     the Notion write AND the local cache row on plan failure
+//   - Tools require deps.notionToken (resolved by /api/adviser/chat from
+//     the MCP-issued OAuth token); error message tells the user how to fix
+//     when missing
+
+import { registerTool } from './adviserTools.js'
+import {
+  searchKnowledgeItems, getKnowledgeItem, getAllKnowledgeItems,
+  getTask, updateTaskPartial,
+} from './db.js'
+import {
+  createKnowledgeItem, updateKnowledgeItem, archiveKnowledgeItem,
+  restoreKnowledgeItem, refreshKnowledgeIndex, fetchKnowledgeBody,
+} from './knowledgeSync.js'
+
+const TYPE_VALUES = ['Location', 'How-to', 'Decision', 'Person']
+const CONFIDENCE_VALUES = ['Certain', 'Fuzzy']
+
+function summarizeItem(item) {
+  if (!item) return null
+  return {
+    notion_page_id: item.notion_page_id,
+    title: item.title,
+    type: item.type || null,
+    tags: item.tags || [],
+    confidence: item.confidence || null,
+    summary: item.summary || '',
+    notion_url: item.notion_url || null,
+    related_task_ids: item.related_task_ids || [],
+  }
+}
+
+function ensureKbConfigured(deps) {
+  if (!deps?.knowledgeDbConfigured) {
+    throw new Error('Knowledge base not set up. Ask the user to open Settings → Integrations → Notion → "Set up Knowledge Base".')
+  }
+}
+
+export function registerKnowledgeTools() {
+  // --- READ ---
+  registerTool({
+    name: 'search_knowledge',
+    description: 'Search the user\'s personal knowledge base (Notion-backed). Matches against title, tags, and a short summary. Use BEFORE create_knowledge to dedup — the user dislikes duplicates. Returns up to `limit` items, highest-relevance first.',
+    readOnly: true,
+    schema: {
+      type: 'object',
+      properties: {
+        q: { type: 'string', description: 'Keyword query. Optional; leave blank to list everything.' },
+        type: { type: 'string', enum: TYPE_VALUES, description: 'Filter by knowledge type.' },
+        limit: { type: 'integer', default: 20 },
+      },
+    },
+    execute: async (args, deps) => {
+      ensureKbConfigured(deps)
+      const items = searchKnowledgeItems(args.q || '', { limit: args.limit || 20, type: args.type || null })
+      return { result: { count: items.length, items: items.map(summarizeItem) } }
+    },
+  })
+
+  registerTool({
+    name: 'get_knowledge',
+    description: 'Fetch a single knowledge item including its full Notion body (markdown-ish plaintext).',
+    readOnly: true,
+    schema: {
+      type: 'object',
+      properties: { notion_page_id: { type: 'string' } },
+      required: ['notion_page_id'],
+    },
+    execute: async ({ notion_page_id }, deps) => {
+      ensureKbConfigured(deps)
+      const item = getKnowledgeItem(notion_page_id)
+      if (!item) throw new Error(`Knowledge item not found: ${notion_page_id}`)
+      let body = ''
+      try {
+        if (deps?.notionToken) {
+          body = await fetchKnowledgeBody({ token: deps.notionToken, pageId: notion_page_id })
+        }
+      } catch (err) {
+        console.warn('[Adviser] fetchKnowledgeBody failed:', err.message)
+      }
+      return { result: { ...summarizeItem(item), body } }
+    },
+  })
+
+  registerTool({
+    name: 'refresh_knowledge_index',
+    description: 'Force a refresh of the local knowledge cache from Notion. Use when the user says they just added something in Notion and you don\'t see it. Background refresh runs every 5 minutes so this is rarely needed.',
+    readOnly: true,
+    schema: { type: 'object', properties: {} },
+    execute: async (_args, deps) => {
+      ensureKbConfigured(deps)
+      if (!deps.notionToken) throw new Error('Notion not connected')
+      const outcome = await refreshKnowledgeIndex({ token: deps.notionToken, getData: deps.kbGetData, setData: deps.kbSetData })
+      return { result: outcome }
+    },
+  })
+
+  // --- CREATE ---
+  registerTool({
+    name: 'create_knowledge',
+    description: 'Create a new knowledge item in the user\'s Notion knowledge base. ALWAYS call search_knowledge first with the proposed title (or key keywords) — if any matches return, ASK the user whether to append/update an existing item before staging a new one. Knowledge items are durable facts: locations of physical things, decisions and their reasoning, how-tos, people and their context. Body is markdown-ish (supports #, ##, -, - [ ]).',
+    schema: {
+      type: 'object',
+      properties: {
+        title: { type: 'string', description: 'Short, searchable name. E.g. "Construction paper" or "Cat food brand".' },
+        type: { type: 'string', enum: TYPE_VALUES, description: 'Required for clean filtering.' },
+        tags: { type: 'array', items: { type: 'string' }, description: 'Freeform tags for cross-cutting search. Lowercase preferred.' },
+        body: { type: 'string', description: 'Full content. Markdown-ish.' },
+        confidence: { type: 'string', enum: CONFIDENCE_VALUES, description: 'Use "Fuzzy" when the user expressed uncertainty ("I think it\'s in the…").' },
+        related_task_ids: { type: 'array', items: { type: 'string' }, description: 'Boomerang task IDs this knowledge relates to. Pass an empty array if none.' },
+      },
+      required: ['title'],
+    },
+    preview: (a) => {
+      const parts = [`Create knowledge: "${a.title}"`]
+      if (a.type) parts.push(a.type)
+      if (a.tags?.length) parts.push(`tagged ${a.tags.join(', ')}`)
+      return parts.join(' · ')
+    },
+    execute: async (args, deps) => {
+      ensureKbConfigured(deps)
+      if (!deps.notionToken) throw new Error('Notion not connected')
+      const created = await createKnowledgeItem({
+        token: deps.notionToken,
+        getData: deps.kbGetData,
+        title: args.title,
+        type: args.type,
+        tags: args.tags || [],
+        body: args.body || '',
+        confidence: args.confidence,
+        relatedTaskIds: args.related_task_ids || [],
+      })
+      return {
+        result: { notion_page_id: created.id, url: created.url, item: summarizeItem(created.item) },
+        compensation: async () => {
+          try {
+            await archiveKnowledgeItem({ token: deps.notionToken, pageId: created.id })
+          } catch (err) {
+            console.warn('[Adviser] knowledge create rollback failed:', err.message)
+          }
+        },
+      }
+    },
+  })
+
+  // --- UPDATE ---
+  registerTool({
+    name: 'update_knowledge',
+    description: 'Update an existing knowledge item. Any of title/type/tags/body/confidence/related_task_ids may be provided — only supplied fields change. When the user says "actually the lampshade is in the basement", LOOK UP the existing item with search_knowledge / get_knowledge first, then call this — don\'t create a duplicate.',
+    schema: {
+      type: 'object',
+      properties: {
+        notion_page_id: { type: 'string' },
+        title: { type: 'string' },
+        type: { type: 'string', enum: TYPE_VALUES },
+        tags: { type: 'array', items: { type: 'string' } },
+        body: { type: 'string' },
+        confidence: { type: 'string', enum: CONFIDENCE_VALUES },
+        related_task_ids: { type: 'array', items: { type: 'string' } },
+        title_hint: { type: 'string', description: 'Human-readable item title for the plan preview (not sent to Notion). Pass the title you saw in search_knowledge.' },
+      },
+      required: ['notion_page_id'],
+    },
+    preview: (a) => {
+      const changed = Object.keys(a).filter(k => !['notion_page_id', 'title_hint'].includes(k))
+      return `Update knowledge "${a.title_hint || a.title || a.notion_page_id.slice(0, 8)}": ${changed.join(', ') || '(no changes)'}`
+    },
+    execute: async (args, deps) => {
+      ensureKbConfigured(deps)
+      if (!deps.notionToken) throw new Error('Notion not connected')
+      const { before, beforePage } = await updateKnowledgeItem({
+        token: deps.notionToken,
+        pageId: args.notion_page_id,
+        title: args.title,
+        type: args.type,
+        tags: args.tags,
+        body: args.body,
+        confidence: args.confidence,
+        relatedTaskIds: args.related_task_ids,
+      })
+      return {
+        result: { notion_page_id: args.notion_page_id, updated: Object.keys(args).filter(k => !['notion_page_id', 'title_hint'].includes(k)) },
+        compensation: async () => {
+          // Restore the property-level state from the captured pre-state.
+          if (!before) return
+          try {
+            await updateKnowledgeItem({
+              token: deps.notionToken,
+              pageId: args.notion_page_id,
+              title: before.title,
+              type: before.type,
+              tags: before.tags,
+              confidence: before.confidence,
+              relatedTaskIds: before.related_task_ids,
+              // Body restore is best-effort — Notion's PATCH-children API replaces
+              // blocks, so we'd need the full original body to restore exactly.
+              // The metadata restore is the important part.
+            })
+          } catch (err) {
+            console.warn('[Adviser] knowledge update rollback failed:', err.message)
+          }
+        },
+      }
+    },
+  })
+
+  // --- DELETE ---
+  registerTool({
+    name: 'delete_knowledge',
+    description: 'Archive a knowledge item (Notion soft-delete). The user can restore from Notion\'s Trash for 30 days, but treat this as a destructive action — confirm with the user before staging. Use sparingly; out-of-date items are usually better off being updated.',
+    schema: {
+      type: 'object',
+      properties: {
+        notion_page_id: { type: 'string' },
+        title_hint: { type: 'string', description: 'Human-readable item title for the plan preview.' },
+      },
+      required: ['notion_page_id'],
+    },
+    preview: (a) => `Archive knowledge "${a.title_hint || a.notion_page_id.slice(0, 8)}"`,
+    execute: async ({ notion_page_id }, deps) => {
+      ensureKbConfigured(deps)
+      if (!deps.notionToken) throw new Error('Notion not connected')
+      const { before } = await archiveKnowledgeItem({ token: deps.notionToken, pageId: notion_page_id })
+      return {
+        result: { notion_page_id, archived: true },
+        compensation: async () => {
+          try {
+            await restoreKnowledgeItem({ token: deps.notionToken, pageId: notion_page_id })
+            // Best-effort: re-insert the local cache row so it shows up in
+            // searches again. Won't recover any properties that changed
+            // between the original and the restore point.
+            if (before) {
+              const { upsertKnowledgeItem } = await import('./db.js')
+              upsertKnowledgeItem(before)
+            }
+          } catch (err) {
+            console.warn('[Adviser] knowledge delete rollback failed:', err.message)
+          }
+        },
+      }
+    },
+  })
+
+  // --- LINK / UNLINK to tasks ---
+  registerTool({
+    name: 'link_knowledge_to_task',
+    description: 'Attach a knowledge item to a task. Both sides remember the link — Quokka can ask "what tasks reference this knowledge?" later. Idempotent: already-linked is a no-op.',
+    schema: {
+      type: 'object',
+      properties: {
+        task_id: { type: 'string' },
+        notion_page_id: { type: 'string' },
+        task_title_hint: { type: 'string' },
+        knowledge_title_hint: { type: 'string' },
+      },
+      required: ['task_id', 'notion_page_id'],
+    },
+    preview: (a) => `Link knowledge "${a.knowledge_title_hint || a.notion_page_id.slice(0, 8)}" to task "${a.task_title_hint || a.task_id.slice(0, 8)}"`,
+    execute: async ({ task_id, notion_page_id }, deps) => {
+      ensureKbConfigured(deps)
+      const task = getTask(task_id)
+      if (!task) throw new Error(`Task not found: ${task_id}`)
+      const item = getKnowledgeItem(notion_page_id)
+      if (!item) throw new Error(`Knowledge item not found: ${notion_page_id}`)
+      const beforeIds = Array.isArray(task.knowledge_page_ids) ? task.knowledge_page_ids : []
+      if (beforeIds.includes(notion_page_id)) {
+        return { result: { task_id, notion_page_id, already_linked: true } }
+      }
+      const nextIds = [...beforeIds, notion_page_id]
+      updateTaskPartial(task_id, { knowledge_page_ids: nextIds, updated_at: new Date().toISOString() })
+
+      // Mirror the link on the Notion side: append the task id to the
+      // Related tasks property if Notion is reachable. Best-effort —
+      // failure to update Notion doesn't fail the link locally; the
+      // background refresh will eventually reconcile.
+      if (deps.notionToken) {
+        const beforeRelated = item.related_task_ids || []
+        if (!beforeRelated.includes(task_id)) {
+          try {
+            await updateKnowledgeItem({
+              token: deps.notionToken,
+              pageId: notion_page_id,
+              relatedTaskIds: [...beforeRelated, task_id],
+            })
+          } catch (err) {
+            console.warn('[Adviser] knowledge backlink update failed:', err.message)
+          }
+        }
+      }
+
+      return {
+        result: { task_id, notion_page_id, linked: true },
+        compensation: async () => {
+          const t = getTask(task_id)
+          if (t) updateTaskPartial(task_id, { knowledge_page_ids: beforeIds, updated_at: new Date().toISOString() })
+          // Notion backlink revert is best-effort.
+          if (deps.notionToken && item) {
+            try {
+              await updateKnowledgeItem({
+                token: deps.notionToken,
+                pageId: notion_page_id,
+                relatedTaskIds: item.related_task_ids || [],
+              })
+            } catch (err) {
+              console.warn('[Adviser] knowledge backlink revert failed:', err.message)
+            }
+          }
+        },
+      }
+    },
+  })
+
+  registerTool({
+    name: 'unlink_knowledge_from_task',
+    description: 'Remove a knowledge link from a task. Idempotent: already-unlinked is a no-op.',
+    schema: {
+      type: 'object',
+      properties: {
+        task_id: { type: 'string' },
+        notion_page_id: { type: 'string' },
+        task_title_hint: { type: 'string' },
+        knowledge_title_hint: { type: 'string' },
+      },
+      required: ['task_id', 'notion_page_id'],
+    },
+    preview: (a) => `Unlink knowledge "${a.knowledge_title_hint || a.notion_page_id.slice(0, 8)}" from task "${a.task_title_hint || a.task_id.slice(0, 8)}"`,
+    execute: async ({ task_id, notion_page_id }, deps) => {
+      ensureKbConfigured(deps)
+      const task = getTask(task_id)
+      if (!task) throw new Error(`Task not found: ${task_id}`)
+      const beforeIds = Array.isArray(task.knowledge_page_ids) ? task.knowledge_page_ids : []
+      if (!beforeIds.includes(notion_page_id)) {
+        return { result: { task_id, notion_page_id, already_unlinked: true } }
+      }
+      const nextIds = beforeIds.filter(id => id !== notion_page_id)
+      updateTaskPartial(task_id, { knowledge_page_ids: nextIds, updated_at: new Date().toISOString() })
+
+      const item = getKnowledgeItem(notion_page_id)
+      if (deps.notionToken && item) {
+        const beforeRelated = item.related_task_ids || []
+        if (beforeRelated.includes(task_id)) {
+          try {
+            await updateKnowledgeItem({
+              token: deps.notionToken,
+              pageId: notion_page_id,
+              relatedTaskIds: beforeRelated.filter(id => id !== task_id),
+            })
+          } catch (err) {
+            console.warn('[Adviser] knowledge backlink remove failed:', err.message)
+          }
+        }
+      }
+
+      return {
+        result: { task_id, notion_page_id, unlinked: true },
+        compensation: async () => {
+          updateTaskPartial(task_id, { knowledge_page_ids: beforeIds, updated_at: new Date().toISOString() })
+          if (deps.notionToken && item) {
+            try {
+              await updateKnowledgeItem({
+                token: deps.notionToken,
+                pageId: notion_page_id,
+                relatedTaskIds: item.related_task_ids || [],
+              })
+            } catch (err) {
+              console.warn('[Adviser] knowledge backlink revert failed:', err.message)
+            }
+          }
+        },
+      }
+    },
+  })
+
+  // Diagnostic helper for the adviser/tools listing — surfaces total cached
+  // items so the model can decide whether to ask the user to refresh.
+  registerTool({
+    name: 'list_knowledge',
+    description: 'List ALL knowledge items (no query). Use sparingly — search_knowledge is preferred for any specific question. Useful when the user asks "show me everything in my knowledge base".',
+    readOnly: true,
+    schema: {
+      type: 'object',
+      properties: {
+        type: { type: 'string', enum: TYPE_VALUES },
+        limit: { type: 'integer', default: 50 },
+      },
+    },
+    execute: async ({ type, limit = 50 }, deps) => {
+      ensureKbConfigured(deps)
+      const items = getAllKnowledgeItems()
+        .filter(it => !type || it.type === type)
+        .slice(0, limit)
+      return { result: { count: items.length, items: items.map(summarizeItem) } }
+    },
+  })
+}

--- a/db.js
+++ b/db.js
@@ -255,6 +255,7 @@ function taskToRow(task) {
     child_visibility: task.child_visibility || 'backstage',
     snooze_indefinite: task.snooze_indefinite ? 1 : 0,
     blocked_by_json: JSON.stringify(task.blocked_by || []),
+    knowledge_page_ids_json: JSON.stringify(task.knowledge_page_ids || []),
   }
 }
 
@@ -306,6 +307,7 @@ function rowToTask(row) {
     child_visibility: row.child_visibility || 'backstage',
     snooze_indefinite: !!row.snooze_indefinite,
     blocked_by: safeJsonParse(row.blocked_by_json, []),
+    knowledge_page_ids: safeJsonParse(row.knowledge_page_ids_json, []),
   }
 }
 
@@ -330,8 +332,9 @@ const UPSERT_TASK_SQL = `
     gcal_event_id, gcal_duration, gmail_message_id, gmail_pending, weather_hidden, size_inferred,
     pushover_receipt, follow_ups_json, skipped,
     parent_id, pinned_to_today, nag_allowed, session_count, last_session_at,
-    session_log_json, child_visibility, snooze_indefinite, blocked_by_json)
-  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    session_log_json, child_visibility, snooze_indefinite, blocked_by_json,
+    knowledge_page_ids_json)
+  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   ON CONFLICT(id) DO UPDATE SET
     title=excluded.title, status=excluded.status, notes=excluded.notes,
     due_date=excluded.due_date, snoozed_until=excluded.snoozed_until,
@@ -357,7 +360,8 @@ const UPSERT_TASK_SQL = `
     nag_allowed=excluded.nag_allowed, session_count=excluded.session_count,
     last_session_at=excluded.last_session_at, session_log_json=excluded.session_log_json,
     child_visibility=excluded.child_visibility, snooze_indefinite=excluded.snooze_indefinite,
-    blocked_by_json=excluded.blocked_by_json`
+    blocked_by_json=excluded.blocked_by_json,
+    knowledge_page_ids_json=excluded.knowledge_page_ids_json`
 
 function runUpsertTask(task) {
   const r = taskToRow(task)
@@ -372,6 +376,7 @@ function runUpsertTask(task) {
     r.pushover_receipt, r.follow_ups_json, r.skipped,
     r.parent_id, r.pinned_to_today, r.nag_allowed, r.session_count, r.last_session_at,
     r.session_log_json, r.child_visibility, r.snooze_indefinite, r.blocked_by_json,
+    r.knowledge_page_ids_json,
   ])
 }
 
@@ -1634,3 +1639,119 @@ export function getNotificationAnalytics(days = 30) {
   stmt.free()
   return results
 }
+
+// ============================================================
+// Knowledge index — cached Notion knowledge-base metadata
+// ============================================================
+//
+// The full knowledge body lives in Notion. This local index holds just
+// the metadata (title, type, tags, ≤200-char summary) so Quokka can
+// search instantly without round-tripping. Body fetched on demand via
+// the Notion MCP. Refresh loop in knowledgeSync.js keeps it in step.
+
+function knowledgeRowToItem(row) {
+  return {
+    notion_page_id: row.notion_page_id,
+    title: row.title,
+    type: row.type || null,
+    tags: safeJsonParse(row.tags_json, []),
+    summary: row.summary || '',
+    confidence: row.confidence || null,
+    related_task_ids: safeJsonParse(row.related_task_ids_json, []),
+    notion_url: row.notion_url || null,
+    last_edited_time: row.last_edited_time || null,
+    last_synced_at: row.last_synced_at,
+    archived: !!row.archived,
+  }
+}
+
+export function upsertKnowledgeItem(item) {
+  db.run(
+    `INSERT INTO knowledge_index
+       (notion_page_id, title, type, tags_json, summary, confidence,
+        related_task_ids_json, notion_url, last_edited_time, last_synced_at, archived)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(notion_page_id) DO UPDATE SET
+       title=excluded.title, type=excluded.type, tags_json=excluded.tags_json,
+       summary=excluded.summary, confidence=excluded.confidence,
+       related_task_ids_json=excluded.related_task_ids_json,
+       notion_url=excluded.notion_url, last_edited_time=excluded.last_edited_time,
+       last_synced_at=excluded.last_synced_at, archived=excluded.archived`,
+    [
+      item.notion_page_id,
+      item.title || 'Untitled',
+      item.type || null,
+      JSON.stringify(item.tags || []),
+      (item.summary || '').slice(0, 200),
+      item.confidence || null,
+      JSON.stringify(item.related_task_ids || []),
+      item.notion_url || null,
+      item.last_edited_time || null,
+      item.last_synced_at || new Date().toISOString(),
+      item.archived ? 1 : 0,
+    ]
+  )
+  schedulePersist()
+}
+
+export function getKnowledgeItem(notionPageId) {
+  const stmt = db.prepare(`SELECT * FROM knowledge_index WHERE notion_page_id = ?`)
+  stmt.bind([notionPageId])
+  if (!stmt.step()) { stmt.free(); return null }
+  const row = stmt.getAsObject()
+  stmt.free()
+  return knowledgeRowToItem(row)
+}
+
+export function deleteKnowledgeItem(notionPageId) {
+  db.run(`DELETE FROM knowledge_index WHERE notion_page_id = ?`, [notionPageId])
+  schedulePersist()
+}
+
+export function getAllKnowledgeItems({ includeArchived = false } = {}) {
+  const sql = includeArchived
+    ? `SELECT * FROM knowledge_index ORDER BY title COLLATE NOCASE`
+    : `SELECT * FROM knowledge_index WHERE archived = 0 ORDER BY title COLLATE NOCASE`
+  const stmt = db.prepare(sql)
+  const results = []
+  while (stmt.step()) results.push(knowledgeRowToItem(stmt.getAsObject()))
+  stmt.free()
+  return results
+}
+
+// Lightweight keyword search across title + tags + summary. Returns a
+// scored list, highest first. Used by Quokka's search_knowledge tool.
+export function searchKnowledgeItems(query, { limit = 20, type = null } = {}) {
+  const q = (query || '').trim().toLowerCase()
+  const all = getAllKnowledgeItems()
+  if (!q) return type ? all.filter(i => i.type === type).slice(0, limit) : all.slice(0, limit)
+  const terms = q.split(/\s+/).filter(Boolean)
+  const scored = []
+  for (const item of all) {
+    if (type && item.type !== type) continue
+    const hay = [
+      item.title.toLowerCase(),
+      (item.tags || []).join(' ').toLowerCase(),
+      (item.summary || '').toLowerCase(),
+    ].join(' \n ')
+    let score = 0
+    for (const term of terms) {
+      if (item.title.toLowerCase().includes(term)) score += 3
+      if ((item.tags || []).some(t => t.toLowerCase().includes(term))) score += 2
+      if (hay.includes(term)) score += 1
+    }
+    if (score > 0) scored.push({ score, item })
+  }
+  scored.sort((a, b) => b.score - a.score)
+  return scored.slice(0, limit).map(s => s.item)
+}
+
+// Replace the entire cache with a fresh snapshot from Notion. Used by the
+// background refresh loop. Items missing from the new snapshot are removed
+// so deletions made directly in Notion propagate locally.
+export function replaceKnowledgeIndex(items) {
+  db.run(`DELETE FROM knowledge_index`)
+  for (const item of items) upsertKnowledgeItem(item)
+  schedulePersist()
+}
+

--- a/knowledgeSync.js
+++ b/knowledgeSync.js
@@ -1,0 +1,325 @@
+// Knowledge-base sync: Notion database <-> local index cache.
+//
+// The user's knowledge items live as pages in a Notion database with a
+// fixed property schema (Title / Type / Tags / Related tasks / Confidence).
+// Boomerang owns DB *creation* but not *editing* — once created, the user
+// can rename it, drag items around, edit page bodies in Notion, etc. We
+// just keep a server-side metadata index in sync via a background loop.
+//
+// The MCP-issued OAuth token from notion_mcp_tokens doubles as a REST
+// Authorization: Bearer token, so we hit Notion's REST API directly here.
+// (See CLAUDE.md "Auth model" — same token, two surfaces.)
+
+import { replaceKnowledgeIndex, upsertKnowledgeItem, getKnowledgeItem, deleteKnowledgeItem } from './db.js'
+
+const NOTION_BASE = 'https://api.notion.com/v1'
+const REFRESH_INTERVAL_MS = 5 * 60 * 1000
+
+const KNOWLEDGE_DB_KEY = 'notion_knowledge_db_id'
+const KNOWLEDGE_DB_URL_KEY = 'notion_knowledge_db_url'
+const KNOWLEDGE_LAST_SYNC_KEY = 'notion_knowledge_last_sync'
+
+const TYPE_OPTIONS = [
+  { name: 'Location', color: 'blue' },
+  { name: 'How-to', color: 'green' },
+  { name: 'Decision', color: 'purple' },
+  { name: 'Person', color: 'pink' },
+]
+
+const CONFIDENCE_OPTIONS = [
+  { name: 'Certain', color: 'green' },
+  { name: 'Fuzzy', color: 'yellow' },
+]
+
+function notionHeaders(token) {
+  return {
+    Authorization: `Bearer ${token}`,
+    'Notion-Version': '2022-06-28',
+    'Content-Type': 'application/json',
+  }
+}
+
+async function notionJson(url, init, label) {
+  const res = await fetch(url, init)
+  const text = await res.text()
+  let data = {}
+  try { data = text ? JSON.parse(text) : {} } catch { data = { raw: text } }
+  if (!res.ok) throw new Error(`${label} ${res.status}: ${data.message || data.error || text.slice(0, 200)}`)
+  return data
+}
+
+// Convert markdown-ish text to Notion blocks. Mirrors parseContentToBlocks
+// in server.js but kept self-contained so this module has no import cycle.
+function bodyToBlocks(text) {
+  if (!text) return []
+  return text.split('\n').map(line => {
+    if (!line.trim()) return { object: 'block', type: 'paragraph', paragraph: { rich_text: [] } }
+    if (line.startsWith('# ')) return { object: 'block', type: 'heading_1', heading_1: { rich_text: [{ type: 'text', text: { content: line.slice(2) } }] } }
+    if (line.startsWith('## ')) return { object: 'block', type: 'heading_2', heading_2: { rich_text: [{ type: 'text', text: { content: line.slice(3) } }] } }
+    if (line.match(/^- \[[ x]\] /)) {
+      const checked = line[3] === 'x'
+      return { object: 'block', type: 'to_do', to_do: { rich_text: [{ type: 'text', text: { content: line.slice(6) } }], checked } }
+    }
+    if (line.startsWith('- ')) return { object: 'block', type: 'bulleted_list_item', bulleted_list_item: { rich_text: [{ type: 'text', text: { content: line.slice(2) } }] } }
+    return { object: 'block', type: 'paragraph', paragraph: { rich_text: [{ type: 'text', text: { content: line } }] } }
+  })
+}
+
+function blocksToPlainText(blocks) {
+  const lines = []
+  for (const b of blocks || []) {
+    const rt = b[b.type]?.rich_text || []
+    const text = rt.map(t => t.plain_text || '').join('')
+    if (text) lines.push(text)
+  }
+  return lines.join('\n')
+}
+
+function extractTitle(page) {
+  const props = page?.properties || {}
+  for (const v of Object.values(props)) {
+    if (v.type === 'title' && v.title?.length) return v.title.map(t => t.plain_text).join('')
+  }
+  return 'Untitled'
+}
+
+// Flatten a Notion page's properties into the shape we cache locally.
+function pageToIndexItem(page) {
+  const props = page.properties || {}
+  const get = (name, type) => {
+    for (const [k, v] of Object.entries(props)) {
+      if (k.toLowerCase() === name.toLowerCase() && v.type === type) return v
+    }
+    return null
+  }
+  const titleProp = Object.values(props).find(p => p.type === 'title')
+  const title = titleProp?.title?.map(t => t.plain_text).join('') || 'Untitled'
+  const typeProp = get('Type', 'select')
+  const tagsProp = get('Tags', 'multi_select')
+  const relatedProp = get('Related tasks', 'rich_text') || get('Related Tasks', 'rich_text')
+  const confidenceProp = get('Confidence', 'select')
+  const relatedText = relatedProp?.rich_text?.map(t => t.plain_text).join('') || ''
+  const relatedIds = relatedText.split(/[,\s]+/).map(s => s.trim()).filter(Boolean)
+  return {
+    notion_page_id: page.id,
+    title,
+    type: typeProp?.select?.name || null,
+    tags: (tagsProp?.multi_select || []).map(t => t.name),
+    summary: '', // populated by fetchSummary if needed
+    confidence: confidenceProp?.select?.name || null,
+    related_task_ids: relatedIds,
+    notion_url: page.url || null,
+    last_edited_time: page.last_edited_time || null,
+    last_synced_at: new Date().toISOString(),
+    archived: !!page.archived,
+  }
+}
+
+// Auto-create the knowledge database under a parent page. Stores db_id +
+// url in app_data via the injected setData callback. Idempotent: if a
+// db_id is already stored AND still resolves to a live database, returns
+// it unchanged.
+export async function ensureKnowledgeDatabase({ token, parentPageId, getData, setData }) {
+  const existing = getData(KNOWLEDGE_DB_KEY)
+  if (existing) {
+    try {
+      const db = await notionJson(`${NOTION_BASE}/databases/${existing}`, {
+        headers: notionHeaders(token),
+      }, 'Notion DB lookup')
+      if (db && !db.archived) {
+        return { database_id: existing, url: db.url || getData(KNOWLEDGE_DB_URL_KEY), created: false }
+      }
+    } catch {
+      // DB id is stale — fall through and re-create.
+    }
+  }
+  if (!parentPageId) throw new Error('parent_page_id required to create the knowledge database')
+
+  const body = {
+    parent: { type: 'page_id', page_id: parentPageId },
+    title: [{ type: 'text', text: { content: 'Boomerang Knowledge' } }],
+    properties: {
+      'Name': { title: {} },
+      'Type': { select: { options: TYPE_OPTIONS } },
+      'Tags': { multi_select: { options: [] } },
+      'Related tasks': { rich_text: {} },
+      'Confidence': { select: { options: CONFIDENCE_OPTIONS } },
+    },
+  }
+  const data = await notionJson(`${NOTION_BASE}/databases`, {
+    method: 'POST', headers: notionHeaders(token), body: JSON.stringify(body),
+  }, 'Notion DB create')
+  setData(KNOWLEDGE_DB_KEY, data.id)
+  setData(KNOWLEDGE_DB_URL_KEY, data.url || null)
+  console.log(`[Knowledge] Created Notion database ${data.id}`)
+  return { database_id: data.id, url: data.url, created: true }
+}
+
+// Query the DB and replace the local cache. Returns count + any error.
+export async function refreshKnowledgeIndex({ token, getData, setData }) {
+  const dbId = getData(KNOWLEDGE_DB_KEY)
+  if (!dbId) return { ok: false, error: 'Knowledge database not configured', count: 0 }
+  if (!token) return { ok: false, error: 'Notion not connected', count: 0 }
+  const items = []
+  let cursor = undefined
+  do {
+    const body = { page_size: 100 }
+    if (cursor) body.start_cursor = cursor
+    const data = await notionJson(`${NOTION_BASE}/databases/${dbId}/query`, {
+      method: 'POST', headers: notionHeaders(token), body: JSON.stringify(body),
+    }, 'Notion DB query')
+    for (const page of data.results || []) {
+      if (page.archived) continue
+      items.push(pageToIndexItem(page))
+    }
+    cursor = data.has_more ? data.next_cursor : undefined
+  } while (cursor)
+
+  replaceKnowledgeIndex(items)
+  setData(KNOWLEDGE_LAST_SYNC_KEY, new Date().toISOString())
+  console.log(`[Knowledge] Refreshed index — ${items.length} items`)
+  return { ok: true, count: items.length }
+}
+
+// Fetch full page body as plain markdown-ish text.
+export async function fetchKnowledgeBody({ token, pageId }) {
+  if (!token) throw new Error('Notion not connected')
+  const blocks = []
+  let cursor = undefined
+  do {
+    const url = `${NOTION_BASE}/blocks/${pageId}/children?page_size=100${cursor ? `&start_cursor=${cursor}` : ''}`
+    const data = await notionJson(url, { headers: notionHeaders(token) }, 'Notion blocks')
+    blocks.push(...(data.results || []))
+    cursor = data.has_more ? data.next_cursor : undefined
+  } while (cursor)
+  return blocksToPlainText(blocks)
+}
+
+// Create a new knowledge item. Returns { id, url } and updates the local cache.
+export async function createKnowledgeItem({ token, getData, title, type, tags = [], body = '', confidence, relatedTaskIds = [] }) {
+  const dbId = getData(KNOWLEDGE_DB_KEY)
+  if (!dbId) throw new Error('Knowledge database not configured')
+  if (!token) throw new Error('Notion not connected')
+  if (!title?.trim()) throw new Error('title required')
+
+  const properties = {
+    Name: { title: [{ type: 'text', text: { content: title } }] },
+  }
+  if (type) properties.Type = { select: { name: type } }
+  if (tags?.length) properties.Tags = { multi_select: tags.map(name => ({ name })) }
+  if (confidence) properties.Confidence = { select: { name: confidence } }
+  if (relatedTaskIds?.length) {
+    properties['Related tasks'] = { rich_text: [{ type: 'text', text: { content: relatedTaskIds.join(', ') } }] }
+  }
+
+  const payload = {
+    parent: { database_id: dbId },
+    properties,
+    children: bodyToBlocks(body),
+  }
+  const data = await notionJson(`${NOTION_BASE}/pages`, {
+    method: 'POST', headers: notionHeaders(token), body: JSON.stringify(payload),
+  }, 'Notion knowledge create')
+
+  const item = pageToIndexItem(data)
+  item.summary = (body || '').slice(0, 200)
+  upsertKnowledgeItem(item)
+  return { id: data.id, url: data.url, item }
+}
+
+// Update an existing knowledge item. Any of title/type/tags/body/confidence/relatedTaskIds may be provided.
+// Returns { before, after } where before is the pre-update snapshot so callers can compensate.
+export async function updateKnowledgeItem({ token, pageId, title, type, tags, body, confidence, relatedTaskIds }) {
+  if (!token) throw new Error('Notion not connected')
+  const before = getKnowledgeItem(pageId)
+  const beforePage = await notionJson(`${NOTION_BASE}/pages/${pageId}`, {
+    headers: notionHeaders(token),
+  }, 'Notion knowledge fetch')
+
+  const properties = {}
+  if (title !== undefined) properties.Name = { title: [{ type: 'text', text: { content: title } }] }
+  if (type !== undefined) properties.Type = type ? { select: { name: type } } : { select: null }
+  if (tags !== undefined) properties.Tags = { multi_select: (tags || []).map(name => ({ name })) }
+  if (confidence !== undefined) properties.Confidence = confidence ? { select: { name: confidence } } : { select: null }
+  if (relatedTaskIds !== undefined) {
+    properties['Related tasks'] = relatedTaskIds?.length
+      ? { rich_text: [{ type: 'text', text: { content: relatedTaskIds.join(', ') } }] }
+      : { rich_text: [] }
+  }
+  if (Object.keys(properties).length > 0) {
+    await notionJson(`${NOTION_BASE}/pages/${pageId}`, {
+      method: 'PATCH', headers: notionHeaders(token), body: JSON.stringify({ properties }),
+    }, 'Notion knowledge update properties')
+  }
+  if (body !== undefined) {
+    const existing = await notionJson(`${NOTION_BASE}/blocks/${pageId}/children?page_size=100`, {
+      headers: notionHeaders(token),
+    }, 'Notion knowledge fetch blocks')
+    for (const b of existing.results || []) {
+      await fetch(`${NOTION_BASE}/blocks/${b.id}`, { method: 'DELETE', headers: notionHeaders(token) }).catch(() => {})
+    }
+    const newBlocks = bodyToBlocks(body)
+    if (newBlocks.length) {
+      await notionJson(`${NOTION_BASE}/blocks/${pageId}/children`, {
+        method: 'PATCH', headers: notionHeaders(token), body: JSON.stringify({ children: newBlocks }),
+      }, 'Notion knowledge update body')
+    }
+  }
+  const after = await notionJson(`${NOTION_BASE}/pages/${pageId}`, {
+    headers: notionHeaders(token),
+  }, 'Notion knowledge re-fetch')
+  const item = pageToIndexItem(after)
+  if (body !== undefined) item.summary = (body || '').slice(0, 200)
+  else if (before?.summary) item.summary = before.summary
+  upsertKnowledgeItem(item)
+  return { before, beforePage, after: item }
+}
+
+// Archive (soft-delete) a knowledge item.
+export async function archiveKnowledgeItem({ token, pageId }) {
+  if (!token) throw new Error('Notion not connected')
+  const before = getKnowledgeItem(pageId)
+  await notionJson(`${NOTION_BASE}/pages/${pageId}`, {
+    method: 'PATCH', headers: notionHeaders(token), body: JSON.stringify({ archived: true }),
+  }, 'Notion knowledge archive')
+  deleteKnowledgeItem(pageId)
+  return { before }
+}
+
+// Restore (un-archive) a previously archived item. Used by the rollback path.
+export async function restoreKnowledgeItem({ token, pageId }) {
+  if (!token) return
+  await fetch(`${NOTION_BASE}/pages/${pageId}`, {
+    method: 'PATCH', headers: notionHeaders(token), body: JSON.stringify({ archived: false }),
+  }).catch(() => {})
+}
+
+// Background refresh loop. Started from server.js after init. Bails silently
+// when knowledge DB isn't configured or Notion isn't connected.
+let refreshTimer = null
+export function startKnowledgeRefreshLoop({ resolveToken, getData, setData }) {
+  if (refreshTimer) return
+  const tick = async () => {
+    try {
+      const token = await resolveToken()
+      const dbId = getData(KNOWLEDGE_DB_KEY)
+      if (!token || !dbId) return
+      await refreshKnowledgeIndex({ token, getData, setData })
+    } catch (err) {
+      console.warn('[Knowledge] refresh failed:', err.message)
+    }
+  }
+  refreshTimer = setInterval(tick, REFRESH_INTERVAL_MS)
+  refreshTimer.unref?.()
+  // First tick after a short delay so server startup isn't slowed by the network.
+  setTimeout(tick, 10_000)
+}
+
+export function getKnowledgeStatus({ getData }) {
+  return {
+    configured: !!getData(KNOWLEDGE_DB_KEY),
+    database_id: getData(KNOWLEDGE_DB_KEY) || null,
+    database_url: getData(KNOWLEDGE_DB_URL_KEY) || null,
+    last_sync: getData(KNOWLEDGE_LAST_SYNC_KEY) || null,
+  }
+}

--- a/migrations/030_knowledge_base.sql
+++ b/migrations/030_knowledge_base.sql
@@ -1,0 +1,38 @@
+-- 030: Knowledge base — Notion-backed long-term reference store.
+--
+-- Each knowledge item lives as a Notion page in a user-owned database.
+-- Boomerang keeps a server-side cache (`knowledge_index`) of just the
+-- metadata (title, type, tags, summary≤200ch) so Quokka can search it
+-- without round-tripping to Notion on every query. Full body is fetched
+-- on demand via the Notion MCP when the user opens a specific item.
+--
+-- Schema mirrors the Notion database properties:
+--   Title (string)
+--   Type (select: Location | How-to | Decision | Person)
+--   Tags (multi-select, freeform — stored as JSON array)
+--   Related tasks (text — comma-sep task IDs; mirrors tasks.knowledge_page_ids
+--     so we can render the relationship from either side)
+--   Confidence (select: Certain | Fuzzy)
+--
+-- Tasks gain a `knowledge_page_ids_json` column (JSON array of Notion page
+-- IDs) so the link is durable on both sides — the task knows what it
+-- references, and the knowledge item knows what references it.
+
+CREATE TABLE IF NOT EXISTS knowledge_index (
+  notion_page_id TEXT PRIMARY KEY,
+  title TEXT NOT NULL,
+  type TEXT,
+  tags_json TEXT DEFAULT '[]',
+  summary TEXT DEFAULT '',
+  confidence TEXT,
+  related_task_ids_json TEXT DEFAULT '[]',
+  notion_url TEXT,
+  last_edited_time TEXT,
+  last_synced_at TEXT NOT NULL,
+  archived INTEGER DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS idx_knowledge_type ON knowledge_index(type);
+CREATE INDEX IF NOT EXISTS idx_knowledge_title ON knowledge_index(title);
+
+ALTER TABLE tasks ADD COLUMN knowledge_page_ids_json TEXT DEFAULT '[]';

--- a/server.js
+++ b/server.js
@@ -38,7 +38,13 @@ import {
 import { registerTaskTools } from './adviserToolsTasks.js'
 import { registerGCalTools, registerNotionTools, registerTrelloTools } from './adviserToolsIntegrations.js'
 import { registerMiscTools } from './adviserToolsMisc.js'
+import { registerKnowledgeTools } from './adviserToolsKnowledge.js'
 import * as notionMCP from './notionMCP.js'
+import {
+  ensureKnowledgeDatabase, refreshKnowledgeIndex, fetchKnowledgeBody,
+  startKnowledgeRefreshLoop, getKnowledgeStatus,
+} from './knowledgeSync.js'
+import { getAllKnowledgeItems, searchKnowledgeItems, getKnowledgeItem } from './db.js'
 import crypto from 'crypto'
 
 // Register adviser tools once at module load
@@ -47,6 +53,7 @@ registerGCalTools()
 registerNotionTools()
 registerTrelloTools()
 registerMiscTools()
+registerKnowledgeTools()
 
 // --- App version ---
 const appVersion = process.env.APP_VERSION || 'dev'
@@ -1432,6 +1439,72 @@ app.get('/api/notion/mcp/tools', async (req, res) => {
   } catch (err) {
     res.status(500).json({ error: err?.message || 'Failed to list tools' })
   }
+})
+
+// --- Knowledge base (Notion-backed long-term reference store) ---
+// The user owns a Notion database; Boomerang keeps a server-side metadata
+// cache for instant Quokka-driven keyword search. Full body fetched on demand.
+
+app.get('/api/knowledge/status', (_req, res) => {
+  res.json(getKnowledgeStatus({ getData }))
+})
+
+// One-shot setup: creates the Notion database under a parent page (defaults
+// to the user's existing notion_sync_parent_id) and seeds the local index.
+app.post('/api/knowledge/setup', async (req, res) => {
+  const token = await getNotionAccessToken(req)
+  if (!token) return res.status(400).json({ error: 'Notion not connected' })
+  const parentPageId = req.body?.parent_page_id || getData('notion_sync_parent_id') || null
+  if (!parentPageId) {
+    return res.status(400).json({
+      error: 'Set up a Notion sync parent in Settings first, or pass parent_page_id explicitly.',
+    })
+  }
+  try {
+    const result = await ensureKnowledgeDatabase({ token, parentPageId, getData, setData })
+    // Seed the index immediately so the UI doesn't render an empty list.
+    await refreshKnowledgeIndex({ token, getData, setData }).catch(err => {
+      console.warn('[Knowledge] initial refresh failed:', err.message)
+    })
+    res.json(result)
+  } catch (err) {
+    res.status(500).json({ error: err.message || 'Knowledge setup failed' })
+  }
+})
+
+app.post('/api/knowledge/refresh', async (req, res) => {
+  const token = await getNotionAccessToken(req)
+  if (!token) return res.status(400).json({ error: 'Notion not connected' })
+  try {
+    const outcome = await refreshKnowledgeIndex({ token, getData, setData })
+    res.json(outcome)
+  } catch (err) {
+    res.status(500).json({ error: err.message })
+  }
+})
+
+app.get('/api/knowledge', (req, res) => {
+  const q = req.query?.q
+  const type = req.query?.type
+  const limit = parseInt(req.query?.limit, 10) || 50
+  const items = q || type
+    ? searchKnowledgeItems(q || '', { limit, type: type || null })
+    : getAllKnowledgeItems().slice(0, limit)
+  res.json({ items })
+})
+
+app.get('/api/knowledge/:id', async (req, res) => {
+  const item = getKnowledgeItem(req.params.id)
+  if (!item) return res.status(404).json({ error: 'Not found in local index' })
+  // Body lives in Notion only — fetch on demand. Skip silently when offline.
+  let body = ''
+  try {
+    const token = await getNotionAccessToken(req)
+    if (token) body = await fetchKnowledgeBody({ token, pageId: req.params.id })
+  } catch (err) {
+    console.warn('[Knowledge] body fetch failed:', err.message)
+  }
+  res.json({ ...item, body })
 })
 
 app.get('/api/gcal/calendars', async (req, res) => {
@@ -2849,6 +2922,13 @@ function adviserDeps(req) {
     notionToken: getLegacyNotionToken(req), // sync fallback; OAuth token populated after via getNotionAccessToken
     trello: getTrelloAuth(req),
     gcalToken: null, // filled in async before tools that need it
+    // Knowledge-base tools (adviserToolsKnowledge.js). The boolean lets the
+    // tool short-circuit with a clear error before hitting Notion when the
+    // user hasn't run the one-shot setup yet. getData/setData are passed
+    // through so refresh_knowledge_index can update the last-sync stamp.
+    knowledgeDbConfigured: !!getData('notion_knowledge_db_id'),
+    kbGetData: getData,
+    kbSetData: setData,
     syncGmail,
     getWeatherCache,
     getWeatherStatus,
@@ -3639,6 +3719,13 @@ initDb(dbPath).then(async () => {
     startWeatherSync()
     startWeeklyPatternReview()
     startPatternDetection()
+
+    // Background knowledge-base index refresh. Bails silently when not configured.
+    startKnowledgeRefreshLoop({
+      resolveToken: () => getNotionAccessToken(null),
+      getData,
+      setData,
+    })
 
     // Daily DB snapshot — runs once on boot then every 24h. Defends against the
     // 2026-05-07 wipe class of bug where a single bad write erases everything.

--- a/src/api.js
+++ b/src/api.js
@@ -614,6 +614,51 @@ export async function notionMCPDisconnect() {
   return res.json()
 }
 
+// --- Knowledge base ---
+
+export async function knowledgeStatus() {
+  try {
+    const res = await fetch('/api/knowledge/status', { headers: getApiHeaders() })
+    if (!res.ok) return { configured: false }
+    return res.json()
+  } catch {
+    return { configured: false }
+  }
+}
+
+export async function knowledgeSetup(parentPageId = null) {
+  const res = await fetch('/api/knowledge/setup', {
+    method: 'POST', headers: { ...getApiHeaders(), 'Content-Type': 'application/json' },
+    body: JSON.stringify(parentPageId ? { parent_page_id: parentPageId } : {}),
+  })
+  const data = await res.json().catch(() => ({}))
+  if (!res.ok) throw new Error(data.error || 'Knowledge setup failed')
+  return data
+}
+
+export async function knowledgeList({ q = '', type = null, limit = 50 } = {}) {
+  const params = new URLSearchParams()
+  if (q) params.set('q', q)
+  if (type) params.set('type', type)
+  params.set('limit', String(limit))
+  const res = await fetch(`/api/knowledge?${params}`, { headers: getApiHeaders() })
+  if (!res.ok) return { items: [] }
+  return res.json()
+}
+
+export async function knowledgeGet(notionPageId) {
+  const res = await fetch(`/api/knowledge/${notionPageId}`, { headers: getApiHeaders() })
+  if (!res.ok) throw new Error((await res.json().catch(() => ({}))).error || 'Not found')
+  return res.json()
+}
+
+export async function knowledgeRefresh() {
+  const res = await fetch('/api/knowledge/refresh', { method: 'POST', headers: getApiHeaders() })
+  const data = await res.json().catch(() => ({}))
+  if (!res.ok) throw new Error(data.error || 'Refresh failed')
+  return data
+}
+
 export async function getKeyStatus() {
   try {
     const res = await fetch('/api/keys/status')

--- a/src/store.js
+++ b/src/store.js
@@ -46,6 +46,13 @@ export const DEFAULT_SETTINGS = {
   notion_sync_parent_id: '',   // parent page whose children become tasks
   notion_sync_parent_title: '', // display name for the sync parent
   notion_last_sync: null,
+  // Knowledge base — Notion database holding long-term reference items
+  // (where things are kept, decisions, how-tos, people). Boomerang
+  // creates the DB on demand; this stores the resulting page id so we
+  // can re-find it next session. See knowledgeSync.js.
+  notion_knowledge_db_id: '',
+  notion_knowledge_db_url: '',
+  notion_knowledge_last_sync: null,
   sort_by: 'age',
   daily_task_goal: 3,
   daily_points_goal: 15,

--- a/src/v2/AppV2.css
+++ b/src/v2/AppV2.css
@@ -113,6 +113,7 @@
  * so users can recognize destinations at a glance. */
 .v2-more-row-icon-settings  { color: var(--v2-text-meta); }
 .v2-more-row-icon-projects  { color: #A78BFA; }
+.v2-more-row-icon-knowledge { color: #F59E0B; }
 .v2-more-row-icon-routines  { color: #5DBC9B; }
 .v2-more-row-icon-done      { color: #5DBC9B; }
 .v2-more-row-icon-analytics { color: #60A5FA; }
@@ -120,6 +121,7 @@
 
 .v2-more-row .v2-more-row-icon { color: inherit; }
 .v2-more-row svg.v2-more-row-icon-projects  { color: #A78BFA; }
+.v2-more-row svg.v2-more-row-icon-knowledge { color: #F59E0B; }
 .v2-more-row svg.v2-more-row-icon-routines  { color: #5DBC9B; }
 .v2-more-row svg.v2-more-row-icon-done      { color: #5DBC9B; }
 .v2-more-row svg.v2-more-row-icon-analytics { color: #60A5FA; }

--- a/src/v2/AppV2.jsx
+++ b/src/v2/AppV2.jsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { ListChecks, Settings as SettingsIcon, FolderKanban, BarChart3, History, ChevronRight, CheckCircle2, RotateCw, Lightbulb } from 'lucide-react'
+import { ListChecks, Settings as SettingsIcon, FolderKanban, BarChart3, History, ChevronRight, CheckCircle2, RotateCw, Lightbulb, BookOpen } from 'lucide-react'
 import Header from './components/Header'
 import ModalShell from './components/ModalShell'
 import EmptyState from './components/EmptyState'
@@ -67,6 +67,9 @@ export default function AppV2() {
   const [editRoutineId, setEditRoutineId] = useState(null)
   const [showPackages, setShowPackages] = useState(false)
   const [showAdviser, setShowAdviser] = useState(false)
+  // One-shot input draft handed to AdviserModal when opened via a
+  // pre-seeded entry point (currently the Knowledge menu item).
+  const [adviserDraftSeed, setAdviserDraftSeed] = useState('')
   const [showAnalytics, setShowAnalytics] = useState(false)
   const [showSuggestions, setShowSuggestions] = useState(false)
   // Terminal-mode 7-day strip visibility. The calendar+date span in the
@@ -981,6 +984,22 @@ export default function AppV2() {
             </button>
           </li>
           <li>
+            <button
+              className="v2-more-row"
+              onClick={() => {
+                setShowMenu(false)
+                // Seed Quokka with a knowledge-base intro so the chat starts
+                // in the right context. User can hit send as-is or refine.
+                setAdviserDraftSeed("What's in my knowledge base?")
+                setShowAdviser(true)
+              }}
+            >
+              <BookOpen size={18} strokeWidth={1.75} className="v2-more-row-icon v2-more-row-icon-knowledge" />
+              <span className="v2-more-row-label" data-terminal-cmd="> knowledge">Knowledge</span>
+              <ChevronRight size={16} strokeWidth={1.75} className="v2-more-row-chev" />
+            </button>
+          </li>
+          <li>
             <button className="v2-more-row" onClick={() => { setShowMenu(false); setShowRoutines(true) }}>
               <RotateCw size={18} strokeWidth={1.75} className="v2-more-row-icon v2-more-row-icon-routines" />
               <span className="v2-more-row-label" data-terminal-cmd="> routines">Routines</span>
@@ -1151,8 +1170,9 @@ export default function AppV2() {
       <AdviserModal
         open={showAdviser}
         adviser={adviserState}
-        onClose={() => setShowAdviser(false)}
+        onClose={() => { setShowAdviser(false); setAdviserDraftSeed('') }}
         onOpenEasterEgg={openEasterEgg}
+        draftSeed={adviserDraftSeed}
       />
 
       <TicTacToe

--- a/src/v2/components/AdviserModal.jsx
+++ b/src/v2/components/AdviserModal.jsx
@@ -167,7 +167,7 @@ function ChatList({ chats, activeId, onSwitch, onDelete, onStar, onUnstar, onNew
 // passing mentions of games.
 const EASTER_EGG_PHRASE = /\b(?:want to|wanna|let'?s|shall we) play (?:a |an )?game\b/i
 
-export default function AdviserModal({ open, adviser, onClose, onAfterCommit, onOpenEasterEgg }) {
+export default function AdviserModal({ open, adviser, onClose, onAfterCommit, onOpenEasterEgg, draftSeed = '' }) {
   const {
     messages, status, lastError,
     send, commit, abort,
@@ -179,6 +179,22 @@ export default function AdviserModal({ open, adviser, onClose, onAfterCommit, on
   const [showHistory, setShowHistory] = useState(false)
   const scrollRef = useRef(null)
   const inputRef = useRef(null)
+  const lastDraftRef = useRef(null)
+
+  // Drop a one-shot draft into the input when a caller opens Quokka with
+  // a seeded prompt (e.g. the "Knowledge" menu entry). Only fires when
+  // the seed changes, never overwrites mid-typing.
+  useEffect(() => {
+    if (!open || !draftSeed) return
+    if (lastDraftRef.current === draftSeed) return
+    lastDraftRef.current = draftSeed
+    setInput(draftSeed)
+    // Focus + select so the user can either send as-is or refine.
+    requestAnimationFrame(() => {
+      inputRef.current?.focus()
+      inputRef.current?.setSelectionRange?.(draftSeed.length, draftSeed.length)
+    })
+  }, [open, draftSeed])
 
   useEffect(() => {
     if (scrollRef.current) scrollRef.current.scrollTop = scrollRef.current.scrollHeight

--- a/src/v2/components/EditTaskModal.css
+++ b/src/v2/components/EditTaskModal.css
@@ -1215,3 +1215,71 @@
   background: rgba(var(--v2-text-rgb), 0.06);
   color: var(--v2-text);
 }
+
+/* Linked knowledge — chips matching the existing v2-edit-action chip style
+ * but tinted with the menu's amber knowledge color so they read as
+ * reference-state, not status-state. */
+.v2-edit-knowledge-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.v2-edit-knowledge-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border: 1px solid var(--v2-border);
+  border-radius: var(--v2-radius-pill);
+  background: var(--v2-surface);
+  color: var(--v2-text);
+  font: 500 12px/1.2 var(--v2-font-body);
+  cursor: pointer;
+}
+.v2-edit-knowledge-chip:hover {
+  border-color: #F59E0B;
+  color: #F59E0B;
+}
+.v2-edit-knowledge-chip svg:first-child { color: #F59E0B; }
+.v2-edit-knowledge-chip-add {
+  border-style: dashed;
+  color: var(--v2-text-meta);
+}
+.v2-edit-knowledge-picker {
+  margin-top: 8px;
+  padding: 12px;
+  background: var(--v2-surface-elev);
+  border: 1px solid var(--v2-border);
+  border-radius: 8px;
+}
+.v2-edit-knowledge-results {
+  list-style: none;
+  padding: 0;
+  margin: 8px 0 0;
+  max-height: 220px;
+  overflow-y: auto;
+}
+.v2-edit-knowledge-result {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  width: 100%;
+  padding: 8px 10px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--v2-text);
+  font: 500 13px/1.2 var(--v2-font-body);
+  text-align: left;
+  cursor: pointer;
+}
+.v2-edit-knowledge-result:hover {
+  background: rgba(var(--v2-text-rgb), 0.05);
+}
+.v2-edit-knowledge-result-type {
+  color: var(--v2-text-meta);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}

--- a/src/v2/components/EditTaskModal.jsx
+++ b/src/v2/components/EditTaskModal.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo, useRef } from 'react'
-import { Sparkles, Trash2, FolderKanban, Archive, Plus, X as XIcon, Search, Paperclip, FileText, Sun, ChevronDown, ChevronRight, RotateCw } from 'lucide-react'
+import { Sparkles, Trash2, FolderKanban, Archive, Plus, X as XIcon, Search, Paperclip, FileText, Sun, ChevronDown, ChevronRight, RotateCw, BookOpen } from 'lucide-react'
 import { loadLabels, ENERGY_TYPES, STATUS_META, uuid, localYMD } from '../../store'
 import { useTaskForm } from '../../hooks/useTaskForm'
 import { researchTask } from '../../api'
@@ -100,6 +100,15 @@ export default function EditTaskModal({
   // main list when any blocker is incomplete. Cycle prevention happens
   // when computing availableBlockers below.
   const [blockedBy, setBlockedBy] = useState(() => Array.isArray(task.blocked_by) ? task.blocked_by : [])
+  // Linked knowledge — Notion page IDs attached to this task. Search via
+  // the cached index, no live Notion roundtrips. Resolved into title/type
+  // metadata via `knowledgeIndex` below; missing IDs render as a faded
+  // "(unknown)" so removal still works after items were deleted in Notion.
+  const [knowledgeIds, setKnowledgeIds] = useState(() => Array.isArray(task.knowledge_page_ids) ? task.knowledge_page_ids : [])
+  const [knowledgeIndex, setKnowledgeIndex] = useState([])
+  const [knowledgePickerOpen, setKnowledgePickerOpen] = useState(false)
+  const [knowledgeQuery, setKnowledgeQuery] = useState('')
+  const [knowledgeConfigured, setKnowledgeConfigured] = useState(null)
   const [sessionFeedback, setSessionFeedback] = useState(null)
   const [loggingSession, setLoggingSession] = useState(false)
   const availableParents = projects.filter(p => p.id !== task.id)
@@ -187,6 +196,7 @@ export default function EditTaskModal({
     parent_id: parentId || null,
     child_visibility: parentId ? childVisibility : 'backstage',
     blocked_by: parentId ? blockedBy : [],
+    knowledge_page_ids: knowledgeIds,
     // Only persist completed_at while the task is done. changeStatus()
     // already clears it on done→active transitions; including it here
     // when not-done would re-stamp a stale value on every save.
@@ -198,6 +208,7 @@ export default function EditTaskModal({
     form.attachments, form.notionResult,
     checklists, comments, weatherHidden, gcalDuration,
     pinnedToToday, nagAllowed, parentId, childVisibility, blockedBy,
+    knowledgeIds,
     currentStatus, completedAtIso,
   ])
 
@@ -337,6 +348,22 @@ export default function EditTaskModal({
     document.addEventListener('keydown', onKey, true)
     return () => document.removeEventListener('keydown', onKey, true)
   }, [confirmDelete])
+
+  // Pull the knowledge index lazily — only when the user touches the
+  // Linked-knowledge picker, so most edits don't pay the network cost.
+  useEffect(() => {
+    if (!knowledgePickerOpen || knowledgeIndex.length > 0) return
+    let cancelled = false
+    import('../../api').then(async (m) => {
+      const status = await m.knowledgeStatus().catch(() => ({ configured: false }))
+      if (cancelled) return
+      setKnowledgeConfigured(!!status?.configured)
+      if (!status?.configured) return
+      const { items } = await m.knowledgeList({ limit: 200 }).catch(() => ({ items: [] }))
+      if (!cancelled) setKnowledgeIndex(items || [])
+    })
+    return () => { cancelled = true }
+  }, [knowledgePickerOpen, knowledgeIndex.length])
 
   return (
     <ModalShell
@@ -1228,6 +1255,93 @@ export default function EditTaskModal({
           )}
         </div>
       ) : null}
+
+      {/* Linked knowledge — Notion-backed reference items attached to this
+        * task. Renders as chips with an X to unlink. The + chip opens a
+        * lightweight search picker against the cached knowledge index.
+        * Lazy-loaded on first picker open. */}
+      <div className="v2-form-section v2-edit-knowledge">
+        <div className="v2-edit-manage-label">Linked knowledge</div>
+        <div className="v2-edit-knowledge-chips">
+          {knowledgeIds.map(pageId => {
+            const item = knowledgeIndex.find(k => k.notion_page_id === pageId)
+            const label = item?.title || '(unknown)'
+            return (
+              <button
+                key={pageId}
+                type="button"
+                className="v2-edit-knowledge-chip"
+                onClick={() => setKnowledgeIds(prev => prev.filter(id => id !== pageId))}
+                title="Click to unlink"
+              >
+                <BookOpen size={12} strokeWidth={1.75} />
+                <span>{label}</span>
+                <XIcon size={12} strokeWidth={2} />
+              </button>
+            )
+          })}
+          <button
+            type="button"
+            className="v2-edit-knowledge-chip v2-edit-knowledge-chip-add"
+            onClick={() => setKnowledgePickerOpen(o => !o)}
+          >
+            <Plus size={12} strokeWidth={2} />
+            <span>{knowledgePickerOpen ? 'Cancel' : 'Add'}</span>
+          </button>
+        </div>
+        {knowledgePickerOpen && (
+          <div className="v2-edit-knowledge-picker">
+            {knowledgeConfigured === false ? (
+              <div className="v2-integrations-hint">
+                Set up the knowledge base in Settings → Integrations → Notion first.
+              </div>
+            ) : (
+              <>
+                <input
+                  type="text"
+                  className="v2-form-input"
+                  placeholder="Search knowledge…"
+                  value={knowledgeQuery}
+                  onChange={e => setKnowledgeQuery(e.target.value)}
+                  autoFocus
+                />
+                <ul className="v2-edit-knowledge-results">
+                  {knowledgeIndex
+                    .filter(item => !knowledgeIds.includes(item.notion_page_id))
+                    .filter(item => {
+                      if (!knowledgeQuery.trim()) return true
+                      const q = knowledgeQuery.toLowerCase()
+                      return item.title.toLowerCase().includes(q)
+                        || (item.tags || []).some(t => t.toLowerCase().includes(q))
+                    })
+                    .slice(0, 20)
+                    .map(item => (
+                      <li key={item.notion_page_id}>
+                        <button
+                          type="button"
+                          className="v2-edit-knowledge-result"
+                          onClick={() => {
+                            setKnowledgeIds(prev => [...prev, item.notion_page_id])
+                            setKnowledgeQuery('')
+                            setKnowledgePickerOpen(false)
+                          }}
+                        >
+                          <span className="v2-edit-knowledge-result-title">{item.title}</span>
+                          {item.type && (
+                            <span className="v2-edit-knowledge-result-type">{item.type}</span>
+                          )}
+                        </button>
+                      </li>
+                    ))}
+                  {knowledgeIndex.length === 0 && (
+                    <li className="v2-integrations-hint">No knowledge items yet — ask Quokka to add one.</li>
+                  )}
+                </ul>
+              </>
+            )}
+          </div>
+        )}
+      </div>
 
       <div className="v2-form-section v2-edit-manage">
         <div className="v2-edit-manage-label">Manage</div>

--- a/src/v2/components/SettingsModal.css
+++ b/src/v2/components/SettingsModal.css
@@ -1175,3 +1175,18 @@
 .v2-settings-inline-link:hover {
   text-decoration: underline;
 }
+
+/* Knowledge-base subsection inside the Notion integration card. Sits below
+ * the parent-page chooser; spacing matches v2-integrations-inline rhythm. */
+.v2-integrations-kb {
+  margin-top: 14px;
+  padding-top: 14px;
+  border-top: 1px dashed var(--v2-border);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.v2-integrations-status-line {
+  font: 500 13px/1.4 var(--v2-font-body);
+  color: var(--v2-text);
+}

--- a/src/v2/components/SettingsModal.jsx
+++ b/src/v2/components/SettingsModal.jsx
@@ -328,6 +328,11 @@ function IntegrationsPanel({
   const [notionSearching, setNotionSearching] = useState(false)
   const [notionSearchError, setNotionSearchError] = useState(null)
   const [notionChildCount, setNotionChildCount] = useState(null)
+  // Knowledge base setup state — separate from sync-parent so the two
+  // Notion features stay independent.
+  const [kbStatus, setKbStatus] = useState(null) // { configured, database_id, database_url, last_sync }
+  const [kbSetupBusy, setKbSetupBusy] = useState(false)
+  const [kbError, setKbError] = useState(null)
   const [trelloBoards, setTrelloBoardsList] = useState([])
   const [trelloLists, setTrelloListsList] = useState([])
   const [trelloListsLoading, setTrelloListsLoading] = useState(false)
@@ -525,6 +530,43 @@ function IntegrationsPanel({
       .catch(() => {})
     return () => { cancelled = true }
   }, [settings.notion_sync_parent_id, statuses.notion?.connected])
+
+  // Load knowledge-base status whenever the Notion connection state flips.
+  useEffect(() => {
+    if (!statuses.notion?.connected) { setKbStatus(null); return }
+    let cancelled = false
+    import('../../api').then(m => m.knowledgeStatus())
+      .then(s => { if (!cancelled) setKbStatus(s) })
+      .catch(() => {})
+    return () => { cancelled = true }
+  }, [statuses.notion?.connected])
+
+  const runKnowledgeSetup = async () => {
+    setKbError(null)
+    setKbSetupBusy(true)
+    try {
+      const api = await import('../../api')
+      const result = await api.knowledgeSetup()
+      const next = await api.knowledgeStatus()
+      setKbStatus(next || result)
+    } catch (e) {
+      setKbError(e?.message || 'Setup failed')
+    } finally {
+      setKbSetupBusy(false)
+    }
+  }
+
+  const runKnowledgeRefresh = async () => {
+    setKbError(null)
+    try {
+      const api = await import('../../api')
+      await api.knowledgeRefresh()
+      const next = await api.knowledgeStatus()
+      setKbStatus(next)
+    } catch (e) {
+      setKbError(e?.message || 'Refresh failed')
+    }
+  }
 
   const runWeatherSearch = async () => {
     const q = weatherQuery.trim()
@@ -786,6 +828,46 @@ function IntegrationsPanel({
                         )}
                       </>
                     )}
+                    <div className="v2-integrations-kb">
+                      <div className="v2-form-label">Knowledge base</div>
+                      <div className="v2-integrations-hint">
+                        Stash long-term reference (where you keep things, decisions you've made,
+                        people, how-tos) as Notion pages Quokka can search. One database in your
+                        Notion workspace, kept in sync automatically.
+                      </div>
+                      {kbStatus?.configured ? (
+                        <>
+                          <div className="v2-integrations-status-line">
+                            ✓ Connected
+                            {kbStatus.database_url && (
+                              <> · <a href={kbStatus.database_url} target="_blank" rel="noreferrer">Open in Notion</a></>
+                            )}
+                            {kbStatus.last_sync && (
+                              <span className="v2-integrations-hint" style={{ display: 'block', marginTop: 4 }}>
+                                Last synced {new Date(kbStatus.last_sync).toLocaleString()}
+                              </span>
+                            )}
+                          </div>
+                          <button className="v2-settings-btn" onClick={runKnowledgeRefresh}>
+                            Sync now
+                          </button>
+                        </>
+                      ) : (
+                        <button
+                          className="v2-settings-btn"
+                          onClick={runKnowledgeSetup}
+                          disabled={kbSetupBusy || !settings.notion_sync_parent_id}
+                        >
+                          {kbSetupBusy ? 'Setting up…' : 'Set up Knowledge Base'}
+                        </button>
+                      )}
+                      {!settings.notion_sync_parent_id && !kbStatus?.configured && (
+                        <div className="v2-integrations-hint">
+                          Pick a parent page above first — the knowledge database is created underneath it.
+                        </div>
+                      )}
+                      {kbError && <div className="v2-integrations-error">{kbError}</div>}
+                    </div>
                   </div>
                 )}
                 {int.inline === 'trello-connect' && (

--- a/src/v2/terminal/flatten.css
+++ b/src/v2/terminal/flatten.css
@@ -403,6 +403,22 @@
   text-shadow: var(--v2-glow);
 }
 
+/* Linked-knowledge chips: same flat treatment as v2-edit-action — no pills,
+ * just bracketed text rows. The picker results inherit terminal styling
+ * from the generic .v2-form-input + button overrides upstream. */
+:root[data-ui="v2"][data-theme^="terminal"] .v2-edit-knowledge-chip {
+  border-radius: 0;
+  background: transparent;
+  border: 1px solid var(--v2-hairline);
+  padding: 4px 8px;
+}
+:root[data-ui="v2"][data-theme^="terminal"] .v2-edit-knowledge-chip:hover {
+  background: transparent;
+  color: var(--v2-accent);
+  border-color: var(--v2-accent);
+  text-shadow: var(--v2-glow);
+}
+
 :root[data-ui="v2"][data-theme^="terminal"] .v2-edit-action-danger {
   color: var(--v2-alert-overdue);
 }

--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -130,8 +130,27 @@ CREATE TABLE tasks (
   session_count INTEGER DEFAULT 0,
   last_session_at TEXT,
   session_log_json TEXT DEFAULT '[]',    -- [{timestamp, points}, ...]
-  child_visibility TEXT DEFAULT 'backstage'  -- 'active' | 'backstage'
+  child_visibility TEXT DEFAULT 'backstage',  -- 'active' | 'backstage'
+  blocked_by_json TEXT DEFAULT '[]',     -- migration 029 — dependency chains
+  knowledge_page_ids_json TEXT DEFAULT '[]'  -- migration 030 — linked Notion knowledge items
 );
+
+-- Knowledge base index (migration 030) — cached metadata for the
+-- Notion-backed knowledge database. Full body lives in Notion only.
+CREATE TABLE knowledge_index (
+  notion_page_id TEXT PRIMARY KEY,
+  title TEXT NOT NULL,
+  type TEXT,                       -- Location | How-to | Decision | Person
+  tags_json TEXT DEFAULT '[]',
+  summary TEXT DEFAULT '',         -- ≤200 chars
+  confidence TEXT,                 -- Certain | Fuzzy
+  related_task_ids_json TEXT DEFAULT '[]',
+  notion_url TEXT,
+  last_edited_time TEXT,
+  last_synced_at TEXT NOT NULL,
+  archived INTEGER DEFAULT 0
+);
+-- Indexes on type, title
 
 -- Indexes on status, due_date, energy, created_at, routine_id, completed_at,
 -- parent_id (migration 028), pinned_to_today (migration 028)
@@ -316,10 +335,15 @@ Stage 3 will migrate `useNotionSync` + `useExternalSync` + the REST proxy to MCP
 | `GET` | `/api/weather` | Get cached forecast + status |
 | `POST` | `/api/weather/refresh` | Force-refresh forecast (respects 30-min freshness unless `{ force: true }`) |
 | `POST` | `/api/weather/geocode` | Geocode a location query via Open-Meteo |
+| `GET` | `/api/knowledge/status` | Knowledge base configuration status |
+| `POST` | `/api/knowledge/setup` | Auto-create the Notion knowledge database |
+| `GET` | `/api/knowledge` | Search/filter/list cached knowledge items (`?q=&type=&limit=`) |
+| `GET` | `/api/knowledge/:id` | Cached metadata + on-demand body fetch |
+| `POST` | `/api/knowledge/refresh` | Force-refresh from Notion |
 
 ## AI Adviser
 
-`adviserTools.js` is the engine. `adviserToolsTasks.js`, `adviserToolsIntegrations.js`, and `adviserToolsMisc.js` register 54+ tools via `registerTool({ name, description, schema, readOnly, preview, execute })`. Includes 5 project tools added 2026-05-17: `pin_project_to_today`, `log_project_session`, `project_set_nag_policy`, `link_task_to_project`, `list_project_children`.
+`adviserTools.js` is the engine. `adviserToolsTasks.js`, `adviserToolsIntegrations.js`, `adviserToolsMisc.js`, and `adviserToolsKnowledge.js` register 60+ tools via `registerTool({ name, description, schema, readOnly, preview, execute })`. Includes 5 project tools added 2026-05-17 (`pin_project_to_today`, `log_project_session`, `project_set_nag_policy`, `link_task_to_project`, `list_project_children`) and 9 knowledge-base tools added 2026-05-21 (`search_knowledge`, `get_knowledge`, `refresh_knowledge_index`, `list_knowledge`, `create_knowledge`, `update_knowledge`, `delete_knowledge`, `link_knowledge_to_task`, `unlink_knowledge_from_task`).
 
 **Staged execution.** During `/api/adviser/chat`, read-only tools run immediately and return data; mutation tools do nothing except return a `preview` string and push a staged step into the session's plan. When the user confirms, `/api/adviser/commit` runs every staged step in order via `commitPlan()`.
 

--- a/wiki/Features.md
+++ b/wiki/Features.md
@@ -152,6 +152,43 @@ Recurring tasks with configurable cadence:
 - **Routine auto-detection** — when AI analyzes a Notion page and detects recurring patterns (e.g., "change filter every 3 months"), a suggestion banner appears offering to create a routine with the inferred cadence. Dismiss permanently with "x".
 - **Routine support** — routines can also be linked to Notion pages
 
+## Knowledge Base (Notion-backed)
+
+A personal reference store Quokka can search — where things are kept, decisions you've made, how-tos, people. You tell Quokka in plain language ("remember the construction paper is in the closet under the stairs"), and it sticks.
+
+### Setup
+
+1. Connect Notion (MCP recommended) and pick a parent page in Settings → Integrations → Notion (same one used for task sync — Boomerang creates the knowledge database underneath it).
+2. Click **Set up Knowledge Base**. Boomerang auto-creates a Notion database with the right property schema (Name / Type / Tags / Related tasks / Confidence). Done.
+
+### What gets stored
+
+Each item is a Notion page with:
+- **Name** — short searchable title ("Construction paper", "Cat food brand")
+- **Type** — Location, How-to, Decision, or Person
+- **Tags** — freeform, multi-select
+- **Related tasks** — comma-separated Boomerang task IDs the item references
+- **Confidence** — Certain or Fuzzy (Quokka sets Fuzzy when you express uncertainty)
+- **Body** — full content as Notion blocks
+
+### How Quokka uses it
+
+- **Search-first.** When you ask "what brand of cat food do I buy?", Quokka searches the cached index by keyword and answers immediately. Body is fetched from Notion only if needed.
+- **Dedup before create.** When you ask Quokka to remember something, it searches first. If a close match exists, it asks whether to append/update vs create new — duplicates are avoided unless you confirm.
+- **Auto-write.** Adding a new item runs inline during the chat (no plan-confirm). Edits and deletes go through the standard plan-and-apply flow with rollback.
+- **Link to tasks.** Quokka can attach a knowledge item to a task ("link the 'thermostat schedule' note to my furnace-filter task"). Edit-modal chip section shows linked items; tap to unlink.
+
+### Where to find it
+
+- **Quokka** (primary) — natural language asks/tells
+- **⋯ menu → Knowledge** — opens Quokka pre-loaded with "What's in my knowledge base?"
+- **Edit task modal** — Linked knowledge chip section, with a search picker
+- **Settings → Integrations → Notion → Knowledge Base** — Sync now + Open in Notion
+
+### Sync cadence
+
+Background refresh runs every 5 minutes against the Notion database, so deletions and edits made directly in Notion propagate locally without manual action. If you just added something in Notion and need Quokka to see it immediately, tap **Sync now** in Settings or say "refresh the knowledge index" to Quokka.
+
 ## Connections (Edit Modal)
 
 The Edit Task modal has a combined **Connections** section showing both Notion and Trello integration buttons. When a task is linked to an integration, the button turns into a green badge showing the connection status with "Open" (to view in the external app) and "×" (to unlink) actions. This replaces separate integration sections with a unified UI.

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -4,6 +4,27 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ---
 
+## 2026-05-21
+
+- feat(knowledge): Notion-backed knowledge base + Quokka tools [L]
+  - **Ask.** "I have a list in my head — where construction paper is kept, what cat-food brand I switched to, decisions I've made — that I want Quokka to remember and surface when relevant. Don't make me fill out forms; just let me tell Quokka 'remember that the lampshade is in the basement' and have it stick."
+  - **Storage.** New Notion database holding long-term reference items. Auto-created on first setup under the user's existing `notion_sync_parent_id` so there's zero manual schema work. Properties: Name (title), Type (select: Location / How-to / Decision / Person), Tags (multi-select, freeform), Related tasks (rich_text — comma-separated task IDs), Confidence (select: Certain / Fuzzy). DB id stored as `notion_knowledge_db_id` setting; URL stored as `notion_knowledge_db_url`.
+  - **Cache.** Server-side `knowledge_index` table (migration 030) holds metadata only — title, type, tags, ≤200-char summary, related task IDs, Notion URL, last-edited timestamp. Background refresh loop every 5 min reconciles deletions made directly in Notion. Full body fetched on demand via the same Notion REST endpoint stack the rest of the integrations use (MCP-issued OAuth token doubles as a Bearer token).
+  - **Task ↔ knowledge linking.** New `knowledge_page_ids_json` column on `tasks` (JSON array of Notion page IDs). EditTaskModal gets a "Linked knowledge" chip section above Manage — tap a chip to unlink, + chip opens a search picker against the cached index. Notion mirror: backlinks written to the knowledge item's "Related tasks" property so the relationship is visible from either side.
+  - **Capture model.** Auto-write — when the user tells Quokka "remember X is in the basement", `create_knowledge` runs inline during the chat turn with no plan-confirm step. Edits and deletes go through the existing staged-plan + LIFO compensation flow because those touch existing user data. Quokka is instructed to call `search_knowledge` first and ask before creating a duplicate.
+  - **Quokka tools (9).** `search_knowledge`, `get_knowledge`, `refresh_knowledge_index`, `list_knowledge` (read-only); `create_knowledge`, `update_knowledge`, `delete_knowledge`, `link_knowledge_to_task`, `unlink_knowledge_from_task` (staged with rollback). Adviser deps grow `knowledgeDbConfigured` flag so tools short-circuit with a clear setup-prompt error when missing.
+  - **Server endpoints (5).** `GET /api/knowledge/status` (config + last-sync), `POST /api/knowledge/setup` (auto-create the database), `GET /api/knowledge` (search/filter/list), `GET /api/knowledge/:id` (cached metadata + on-demand body), `POST /api/knowledge/refresh` (force re-pull).
+  - **Settings UI.** Knowledge Base subsection inside the existing Notion integration card. Disabled "Set up Knowledge Base" button when no `notion_sync_parent_id` is configured (with hint); after setup, surfaces ✓ Connected + Open in Notion link + Sync now button.
+  - **Entry point.** New "Knowledge" entry in the overflow ⋯ menu (between Projects and Routines). Tapping it opens Quokka with a seeded "What's in my knowledge base?" draft in the input — user can hit send as-is or refine. Quokka is the primary surface; the menu entry is the discoverability handle.
+  - **Limitations.**
+    - Body restore is best-effort on `update_knowledge` rollback — Notion's PATCH-children API replaces blocks, so we'd need the full pre-update body to restore exactly. Property restores (title/type/tags) work cleanly.
+    - External delete is final per the existing adviser policy — `delete_knowledge` archives in Notion (recoverable from Trash for 30 days) but rollback can only re-insert the local cache row.
+    - Search is keyword-only against title/tags/summary. Semantic search across full bodies isn't wired (would need an embedding step or a Notion-side full-text query).
+    - Background refresh fires every 5 min; if the user adds an item in Notion directly and immediately asks Quokka about it, they'll need to tap "Sync now" or have Quokka call `refresh_knowledge_index`.
+  - Modified: new `knowledgeSync.js`, new `adviserToolsKnowledge.js`, new `migrations/030_knowledge_base.sql`; `server.js`, `db.js`, `Dockerfile`, `src/store.js`, `src/api.js`, `src/v2/AppV2.jsx`, `src/v2/AppV2.css`, `src/v2/components/SettingsModal.jsx`, `src/v2/components/SettingsModal.css`, `src/v2/components/EditTaskModal.jsx`, `src/v2/components/EditTaskModal.css`, `src/v2/components/AdviserModal.jsx`, `CLAUDE.md`, `wiki/Features.md`, `wiki/Architecture.md`, `wiki/Version-History.md`
+
+---
+
 ## 2026-05-20
 
 - feat(tasks): backdate task completion to fix streak credit [S]


### PR DESCRIPTION
## Summary

Personal reference store Quokka can search — where things are kept, decisions you've made, how-tos, people you know. Lives as a Notion database the user owns; Boomerang keeps a server-side metadata cache for instant keyword search.

Built per the design we worked out in chat:
- **Auto-create on first use** — Boomerang creates the Notion database for you under your existing `notion_sync_parent_id`. No manual schema work.
- **Full schema** — Name / Type (Location, How-to, Decision, Person) / Tags / Related tasks (text, comma-sep) / Confidence (Certain, Fuzzy) / Body.
- **Hard task linking** — `knowledge_page_ids_json` column on tasks (migration 030). EditTaskModal "Linked knowledge" chip section. Notion-side backlinks via the "Related tasks" property so the relationship is visible from both directions.
- **Cached index** — server-side `knowledge_index` table with title/type/tags/≤200-char summary. Background refresh every 5 min. Full body fetched on demand.
- **Capture model** — auto-write new items inline during chat (no plan-confirm). Edits/deletes go through the existing staged-plan + LIFO compensation flow. Quokka is instructed to dedup-search first and ask before creating a duplicate.

### What ships
- Migration 030 — `knowledge_index` table + `knowledge_page_ids_json` column on tasks
- `knowledgeSync.js` — auto-create + refresh loop + CRUD against Notion REST (MCP token doubles as a Bearer token)
- `adviserToolsKnowledge.js` — 9 Quokka tools (`search_knowledge`, `get_knowledge`, `refresh_knowledge_index`, `list_knowledge`, `create_knowledge`, `update_knowledge`, `delete_knowledge`, `link_knowledge_to_task`, `unlink_knowledge_from_task`)
- 5 server endpoints under `/api/knowledge/*` (status, setup, list, get, refresh)
- v2 SettingsModal — Knowledge Base subsection inside the Notion integration card with "Set up Knowledge Base" / "Sync now"
- v2 EditTaskModal — "Linked knowledge" chip section with search picker
- New ⋯ menu entry "Knowledge" opens Quokka with a seeded "What's in my knowledge base?" draft (AdviserModal now accepts `draftSeed` prop for one-shot input seeding)
- Terminal-mode overrides for the new chip class
- Docs updates in CLAUDE.md, Features.md, Architecture.md, Version-History.md

### Known limitations (documented)
- `update_knowledge` body rollback is best-effort — Notion's PATCH-children API replaces blocks. Property restores (title/type/tags) work cleanly.
- External delete is final — `delete_knowledge` archives in Notion (recoverable from Trash for 30 days); local rollback can only re-insert the cache row.
- Search is keyword-only. Semantic search across full bodies is parked.
- 5-min refresh cadence — if the user adds an item in Notion directly, they need to tap "Sync now" or have Quokka call `refresh_knowledge_index` to see it immediately.

## Test plan
- [ ] Notion MCP not connected → `/api/knowledge/setup` returns 400 "Notion not connected"
- [ ] Notion connected, no `notion_sync_parent_id` → Settings shows the disabled-button hint; `/api/knowledge/setup` returns 400
- [ ] Notion connected + parent page set → click "Set up Knowledge Base" → DB created under the parent; index seeds; status flips to ✓ Connected
- [ ] Tell Quokka "remember the construction paper is in the closet under the stairs" → `create_knowledge` runs inline, no plan-confirm, item appears in cache
- [ ] Tell Quokka "remember the construction paper is in the basement" (already-existing item) → Quokka calls `search_knowledge`, asks before duplicating
- [ ] Ask Quokka "where's the construction paper?" → answer pulled from cache
- [ ] Edit a task → "Linked knowledge" → search + pick → save → reopen → chip still there
- [ ] ⋯ menu → Knowledge opens Quokka with the draft seed in the input
- [ ] "Sync now" in Settings forces a refresh, updates the last-synced timestamp
- [ ] Background loop fires every 5 min after server boot

https://claude.ai/code/session_01XmpfJaWEpmFxNg4yJbepdP

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmpfJaWEpmFxNg4yJbepdP)_