### PR TITLE
release: mobile bottom tabs + Spaces hub + SystemMenu

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -848,11 +848,21 @@ Each PR is independently mergeable. v2 currently renders the calm header + a rea
 **Reusable v2 primitives** (in `src/v2/components/`):
 - `ModalShell` — sheet/panel wrapper. Props: `open`, `onClose`, `title`, `subtitle?`, `width: 'narrow' | 'wide'`, `children`. Circular-pill X top-right, hairline below title, body padding 24px.
 - `EmptyState` — calm empty/placeholder. Props: `icon` (lucide component), `title`, `body?`, `cta?`, `ctaOnClick?`. Soft circular icon backdrop, ghost CTA.
-- `Header` — calm 4-affordance header. Props: `onOpenAdviser`, `onOpenPackages`, `onOpenMenu`. Logo + wordmark left, three icon buttons right.
+- `Header` — calm 4-affordance header. Props: `onOpenAdviser`, `onOpenPackages`, `onOpenSystemMenu`, `systemMenuOpen`. Logo + wordmark left, three icon buttons right (sparkle / package / ⚙). The legacy `MoreVertical` ⋯ slot was replaced by the ⚙ Settings glyph that toggles the `SystemMenu` popover (2026-05-22).
 - `SectionLabel` — `--type-section` ALL-CAPS label with sparkle bullet + optional count chip.
 - `TaskCard` — v2 list card. Status economy: only overdue + high-pri get a colored left border; stale → inline meta; low-pri → opacity 0.78. Energy as a single chip (lucide icon + N small Zap glyphs in the type color).
+- `BottomTabs` — mobile-only bottom navigation. Two tabs: Today (current task list) and Spaces (opens SpacesHub). Hidden on desktop (≥769px) by both AppV2 render gate AND a CSS @media — desktop keeps Kanban + side drawer.
+- `SystemMenu` — anchored popover off the ⚙ icon. Hosts low-frequency system surfaces: Settings, Analytics, Done, Suggestions, Activity log. Same row treatment as the brand popover so the two header popovers feel like siblings.
+- `SpacesHub` — modal-sheet picker for Projects / Routines / Knowledge. Tapping a row closes the hub and launches the existing dedicated modal. Future C-upgrade swaps the picker rows for live preview cards (session counts, last-edited timestamps) without changing the launcher contract.
 
-These five primitives are the v2 task-surface language. Every subsequent v2 surface uses them — never reach for a one-off chrome.
+The first five primitives are the v2 task-surface language. The last three (added 2026-05-22) are the v2 mobile-navigation language. Every subsequent v2 surface uses them — never reach for a one-off chrome.
+
+**Mobile navigation model (2026-05-22).** The legacy ⋯ More menu (8 items, single sheet) was retired in favor of three separate surfaces, each sized to its frequency:
+1. **BottomTabs (mobile only)** — Today + Spaces. Persistent across the app; one tap to switch contexts.
+2. **SystemMenu (popover off ⚙)** — Settings, Analytics, Done, Suggestions, Activity log. Low-frequency system stuff.
+3. **SpacesHub (modal from Spaces tab)** — Projects, Routines, Knowledge. Each row launches the existing dedicated modal.
+
+The Boomerang wordmark popover (Analytics + Done, top-left) was already in place and remains the brand-zone shortcut. `activeTab` state plus a safety-net `useEffect` snap the tab indicator back to 'today' whenever every spaces-related surface (hub + Projects/Routines/Adviser-from-knowledge) is closed. Desktop is unaffected — Kanban + side drawer was never under the ⋯ menu's discoverability problem.
 
 **Branch model.** v2 work lands on the `dev` branch (auto-builds `:dev` Docker image via `.github/workflows/build-and-publish-dev.yml`, deploys to `boomerang-dev` container on port 3002 via `docker-compose.dev.yml`). Once v2 stabilizes, dev gets merged into main.
 

--- a/src/v2/AppV2.jsx
+++ b/src/v2/AppV2.jsx
@@ -1,7 +1,10 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { ListChecks, Settings as SettingsIcon, FolderKanban, BarChart3, History, ChevronRight, CheckCircle2, RotateCw, Lightbulb, BookOpen } from 'lucide-react'
+import { ListChecks } from 'lucide-react'
 import Header from './components/Header'
 import ModalShell from './components/ModalShell'
+import BottomTabs from './components/BottomTabs'
+import SystemMenu from './components/SystemMenu'
+import SpacesHub from './components/SpacesHub'
 import EmptyState from './components/EmptyState'
 import SectionLabel from './components/SectionLabel'
 import TaskCard from './components/TaskCard'
@@ -56,13 +59,33 @@ export default function AppV2() {
   const [showAdd, setShowAdd] = useState(false)
   const [toast, setToast] = useState(null)
   const [showWhatNow, setShowWhatNow] = useState(false)
-  const [showMenu, setShowMenu] = useState(false)
+  // Bottom-tab navigation state. 'today' = main task list, 'spaces' =
+  // SpacesHub picker for Projects/Routines/Knowledge. Mobile only —
+  // desktop keeps Kanban + side drawer. Modal-driven sub-destinations
+  // (the existing ProjectsView etc.) reset activeTab to 'today' on
+  // their close so the tab indicator never lies about where the user is.
+  const [activeTab, setActiveTab] = useState('today')
+  // Anchored-popover off the header ⚙ icon. Hosts Settings, Analytics,
+  // Done, Suggestions, Activity log. Replaces the legacy ⋯ More menu
+  // sheet; the ⋯ button is gone and the ⚙ icon takes its slot.
+  const [systemMenuOpen, setSystemMenuOpen] = useState(false)
+  // When the user is on the Spaces tab and every spaces-related surface
+  // (hub + sub-destinations launched from it) has closed, snap the tab
+  // indicator back to 'today'. Safety net so the active-tab pill never
+  // claims "spaces" while the user is actually looking at the Today
+  // list. Effect runs after each render — no race with the close
+  // handlers that fire synchronously.
   const [showSettings, setShowSettings] = useState(false)
   const [showProjects, setShowProjects] = useState(false)
   const [showDone, setShowDone] = useState(false)
   const [showActivityLog, setShowActivityLog] = useState(false)
   const [showMarkdownImport, setShowMarkdownImport] = useState(false)
   const [updateVersion, setUpdateVersion] = useState(null)
+  // SpacesHub is the destination for the Spaces tab. Opens a picker
+  // for Projects / Routines / Knowledge; tapping a row closes the hub
+  // and launches the existing dedicated modal. C-upgrade replaces the
+  // picker rows with rich preview cards but keeps the contract.
+  const [spacesHubOpen, setSpacesHubOpen] = useState(false)
   const [showRoutines, setShowRoutines] = useState(false)
   const [editRoutineId, setEditRoutineId] = useState(null)
   const [showPackages, setShowPackages] = useState(false)
@@ -119,6 +142,17 @@ export default function AppV2() {
       return next
     })
   }, [])
+
+  // Safety net for the Spaces tab indicator. The hub launches Projects /
+  // Routines / Adviser (Knowledge) modals, which close independently.
+  // When all of them AND the hub itself are closed, snap activeTab back
+  // to 'today' so the bottom-tab pill never claims 'spaces' over an
+  // empty Today list.
+  useEffect(() => {
+    if (activeTab === 'spaces' && !spacesHubOpen && !showProjects && !showRoutines && !showAdviser) {
+      setActiveTab('today')
+    }
+  }, [activeTab, spacesHubOpen, showProjects, showRoutines, showAdviser])
 
   // Mark the document so v2-namespaced tokens activate. Also apply the saved
   // theme on mount so the rendered UI matches whatever the Settings theme
@@ -371,7 +405,8 @@ export default function AppV2() {
   if (showAdviser) activeModals.push('adviser')
   if (showAnalytics) activeModals.push('analytics')
   if (showSuggestions) activeModals.push('suggestions')
-  if (showMenu) activeModals.push('menu')
+  if (spacesHubOpen) activeModals.push('spaces')
+  if (systemMenuOpen) activeModals.push('systemMenu')
   if (searchOpen) activeModals.push('search')
 
   const closeTopModal = useCallback(() => {
@@ -389,9 +424,10 @@ export default function AppV2() {
     if (showAdviser) { setShowAdviser(false); return }
     if (showAnalytics) { setShowAnalytics(false); return }
     if (showSuggestions) { setShowSuggestions(false); return }
-    if (showMenu) { setShowMenu(false); return }
+    if (spacesHubOpen) { setSpacesHubOpen(false); setActiveTab('today'); return }
+    if (systemMenuOpen) { setSystemMenuOpen(false); return }
     if (searchOpen) { handleCloseSearch(); return }
-  }, [snoozeTarget, reframeTarget, editTarget, showAdd, showWhatNow, showSettings, showProjects, showDone, showActivityLog, showRoutines, showPackages, showAdviser, showAnalytics, showSuggestions, showMenu, searchOpen, handleCloseSearch])
+  }, [snoozeTarget, reframeTarget, editTarget, showAdd, showWhatNow, showSettings, showProjects, showDone, showActivityLog, showRoutines, showPackages, showAdviser, showAnalytics, showSuggestions, spacesHubOpen, systemMenuOpen, searchOpen, handleCloseSearch])
 
   const focusSearchInput = useCallback(() => {
     setSearchOpen(true)
@@ -709,7 +745,8 @@ export default function AppV2() {
       <Header
         onOpenAdviser={() => setShowAdviser(true)}
         onOpenPackages={() => setShowPackages(true)}
-        onOpenMenu={() => setShowMenu(true)}
+        onOpenSystemMenu={() => setSystemMenuOpen(o => !o)}
+        systemMenuOpen={systemMenuOpen}
         miniRingsData={miniRingsData}
         onOpenAnalytics={() => setShowAnalytics(true)}
         todayCount={todayCount}
@@ -717,6 +754,15 @@ export default function AppV2() {
         onOpenDone={() => setShowDone(true)}
         syncStatus={syncStatus}
         queueLength={queueLength}
+      />
+      <SystemMenu
+        open={systemMenuOpen}
+        onClose={() => setSystemMenuOpen(false)}
+        onOpenSettings={() => setShowSettings(true)}
+        onOpenAnalytics={() => setShowAnalytics(true)}
+        onOpenDone={() => setShowDone(true)}
+        onOpenSuggestions={() => setShowSuggestions(true)}
+        onOpenActivityLog={() => setShowActivityLog(true)}
       />
       <main className={`v2-main${isDesktop ? ' v2-main-kanban' : ''}`}>
         {(tasks.length > 0 || searchOpen) && (
@@ -908,6 +954,43 @@ export default function AppV2() {
         )}
       </main>
 
+      {/* Bottom tab bar — mobile only. Hidden on desktop (which has
+       * its own Kanban + side-drawer navigation pattern). The strip
+       * itself also has a @media gate as belt-and-suspenders. */}
+      {!isDesktop && (
+        <BottomTabs
+          activeTab={activeTab}
+          onTabChange={(next) => {
+            if (next === 'today') {
+              setActiveTab('today')
+              setSpacesHubOpen(false)
+            } else if (next === 'spaces') {
+              setActiveTab('spaces')
+              setSpacesHubOpen(true)
+            }
+          }}
+        />
+      )}
+
+      {/* Spaces hub — picker for Projects / Routines / Knowledge. Each
+       * row launches the existing dedicated modal and resets activeTab
+       * to 'today' on that sub-modal close, so the tab indicator never
+       * lies about where the user is after the hub itself dismisses. */}
+      <SpacesHub
+        open={spacesHubOpen}
+        onClose={() => {
+          setSpacesHubOpen(false)
+          // X-out of the hub returns to Today.
+          setActiveTab('today')
+        }}
+        onOpenProjects={() => setShowProjects(true)}
+        onOpenRoutines={() => setShowRoutines(true)}
+        onOpenKnowledge={() => {
+          setAdviserDraftSeed("What's in my knowledge base?")
+          setShowAdviser(true)
+        }}
+      />
+
       {snoozeTarget && (
         <SnoozeModal
           task={snoozeTarget}
@@ -964,78 +1047,6 @@ export default function AppV2() {
         onClose={() => setShowWhatNow(false)}
         onComplete={handleComplete}
       />
-
-      {/* More-menu sheet. Each row's icon is tinted to match v1's color hint
-          system so users can recognize destinations at a glance. */}
-      <ModalShell open={showMenu} onClose={() => setShowMenu(false)} title="More" terminalTitle="> menu" width="narrow">
-        <ul className="v2-more-menu">
-          <li>
-            <button className="v2-more-row" onClick={() => { setShowMenu(false); setShowSettings(true) }}>
-              <SettingsIcon size={18} strokeWidth={1.75} className="v2-more-row-icon v2-more-row-icon-settings" />
-              <span className="v2-more-row-label" data-terminal-cmd="> settings">Settings</span>
-              <ChevronRight size={16} strokeWidth={1.75} className="v2-more-row-chev" />
-            </button>
-          </li>
-          <li>
-            <button className="v2-more-row" onClick={() => { setShowMenu(false); setShowProjects(true) }}>
-              <FolderKanban size={18} strokeWidth={1.75} className="v2-more-row-icon v2-more-row-icon-projects" />
-              <span className="v2-more-row-label" data-terminal-cmd="> projects">Projects</span>
-              <ChevronRight size={16} strokeWidth={1.75} className="v2-more-row-chev" />
-            </button>
-          </li>
-          <li>
-            <button
-              className="v2-more-row"
-              onClick={() => {
-                setShowMenu(false)
-                // Seed Quokka with a knowledge-base intro so the chat starts
-                // in the right context. User can hit send as-is or refine.
-                setAdviserDraftSeed("What's in my knowledge base?")
-                setShowAdviser(true)
-              }}
-            >
-              <BookOpen size={18} strokeWidth={1.75} className="v2-more-row-icon v2-more-row-icon-knowledge" />
-              <span className="v2-more-row-label" data-terminal-cmd="> knowledge">Knowledge</span>
-              <ChevronRight size={16} strokeWidth={1.75} className="v2-more-row-chev" />
-            </button>
-          </li>
-          <li>
-            <button className="v2-more-row" onClick={() => { setShowMenu(false); setShowRoutines(true) }}>
-              <RotateCw size={18} strokeWidth={1.75} className="v2-more-row-icon v2-more-row-icon-routines" />
-              <span className="v2-more-row-label" data-terminal-cmd="> routines">Routines</span>
-              <ChevronRight size={16} strokeWidth={1.75} className="v2-more-row-chev" />
-            </button>
-          </li>
-          <li>
-            <button className="v2-more-row" onClick={() => { setShowMenu(false); setShowDone(true) }}>
-              <CheckCircle2 size={18} strokeWidth={1.75} className="v2-more-row-icon v2-more-row-icon-done" />
-              <span className="v2-more-row-label" data-terminal-cmd="> done">Done</span>
-              <ChevronRight size={16} strokeWidth={1.75} className="v2-more-row-chev" />
-            </button>
-          </li>
-          <li>
-            <button className="v2-more-row" onClick={() => { setShowMenu(false); setShowAnalytics(true) }}>
-              <BarChart3 size={18} strokeWidth={1.75} className="v2-more-row-icon v2-more-row-icon-analytics" />
-              <span className="v2-more-row-label" data-terminal-cmd="> stats">Analytics</span>
-              <ChevronRight size={16} strokeWidth={1.75} className="v2-more-row-chev" />
-            </button>
-          </li>
-          <li>
-            <button className="v2-more-row" onClick={() => { setShowMenu(false); setShowSuggestions(true) }}>
-              <Lightbulb size={18} strokeWidth={1.75} className="v2-more-row-icon v2-more-row-icon-suggestions" />
-              <span className="v2-more-row-label" data-terminal-cmd="> suggestions">Suggestions</span>
-              <ChevronRight size={16} strokeWidth={1.75} className="v2-more-row-chev" />
-            </button>
-          </li>
-          <li>
-            <button className="v2-more-row" onClick={() => { setShowMenu(false); setShowActivityLog(true) }}>
-              <History size={18} strokeWidth={1.75} className="v2-more-row-icon v2-more-row-icon-activity" />
-              <span className="v2-more-row-label" data-terminal-cmd="> log">Activity log</span>
-              <ChevronRight size={16} strokeWidth={1.75} className="v2-more-row-chev" />
-            </button>
-          </li>
-        </ul>
-      </ModalShell>
 
       <MarkdownImportModal
         open={showMarkdownImport}

--- a/src/v2/components/BottomTabs.css
+++ b/src/v2/components/BottomTabs.css
@@ -1,0 +1,66 @@
+/* Bottom tab bar — mobile only. The .v2-app flex column hosts header +
+ * scrollable main + this strip. iOS safe-area inset is respected via
+ * padding-bottom so the home-bar gesture doesn't overlap the labels. */
+
+.v2-bottom-tabs {
+  display: flex;
+  align-items: stretch;
+  background: var(--v2-bg);
+  border-top: 1px solid var(--v2-hairline);
+  padding-bottom: env(safe-area-inset-bottom, 0px);
+  flex-shrink: 0;
+  z-index: 5;
+}
+
+.v2-bottom-tab {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 3px;
+  padding: 8px 4px 6px;
+  min-height: 56px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: var(--v2-text-meta);
+  font: 500 11px/1 var(--v2-font-body);
+  transition: color var(--v2-dur-quick) var(--v2-ease-standard);
+}
+
+.v2-bottom-tab:active {
+  opacity: 0.6;
+}
+
+.v2-bottom-tab-icon-wrap {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px 14px;
+  border-radius: var(--v2-radius-pill);
+  transition: background var(--v2-dur-quick) var(--v2-ease-standard);
+}
+
+.v2-bottom-tab-icon {
+  display: block;
+}
+
+.v2-bottom-tab.is-active {
+  color: var(--v2-accent);
+}
+
+.v2-bottom-tab.is-active .v2-bottom-tab-icon-wrap {
+  /* Soft accent-tinted pill behind the icon. Same convention as v2
+   * SuggestionsModal / PackagesModal — hardcoded rgba(255,98,64,x). */
+  background: rgba(255, 98, 64, 0.14);
+}
+
+/* Hide on desktop — the v2 Kanban + side drawer already covers the
+ * navigation surface there. AppV2 also gates render on isDesktop, but
+ * this is a belt-and-suspenders for any future render path. */
+@media (min-width: 769px) {
+  .v2-bottom-tabs {
+    display: none;
+  }
+}

--- a/src/v2/components/BottomTabs.jsx
+++ b/src/v2/components/BottomTabs.jsx
@@ -1,0 +1,39 @@
+import { ListChecks, FolderKanban } from 'lucide-react'
+import './BottomTabs.css'
+
+// Mobile-only bottom tab bar. Two tabs: Today (default) and Spaces.
+// Desktop intentionally skipped — it has the Kanban + side drawer
+// pattern, doesn't need bottom chrome eating screen height.
+//
+// Terminal-theme styling lives in src/v2/terminal/tabs.css — lucide
+// SVGs hide, labels become `[ today ]` bracketed mono.
+export default function BottomTabs({ activeTab, onTabChange }) {
+  return (
+    <nav className="v2-bottom-tabs" role="tablist" aria-label="Primary navigation">
+      <button
+        type="button"
+        role="tab"
+        aria-selected={activeTab === 'today'}
+        className={`v2-bottom-tab${activeTab === 'today' ? ' is-active' : ''}`}
+        onClick={() => onTabChange('today')}
+      >
+        <span className="v2-bottom-tab-icon-wrap">
+          <ListChecks size={22} strokeWidth={1.75} className="v2-bottom-tab-icon" aria-hidden="true" />
+        </span>
+        <span className="v2-bottom-tab-label" data-terminal-label="today">Today</span>
+      </button>
+      <button
+        type="button"
+        role="tab"
+        aria-selected={activeTab === 'spaces'}
+        className={`v2-bottom-tab${activeTab === 'spaces' ? ' is-active' : ''}`}
+        onClick={() => onTabChange('spaces')}
+      >
+        <span className="v2-bottom-tab-icon-wrap">
+          <FolderKanban size={22} strokeWidth={1.75} className="v2-bottom-tab-icon" aria-hidden="true" />
+        </span>
+        <span className="v2-bottom-tab-label" data-terminal-label="spaces">Spaces</span>
+      </button>
+    </nav>
+  )
+}

--- a/src/v2/components/FloatingCapture.css
+++ b/src/v2/components/FloatingCapture.css
@@ -8,7 +8,10 @@
 .v2-floating-capture {
   position: fixed;
   right: 16px;
-  bottom: max(16px, env(safe-area-inset-bottom, 0px));
+  /* On mobile, the bottom tab bar (~56px tall + safe-area inset) sits
+   * below the FAB. Bump the FAB above it. Desktop has no tab bar so
+   * the @media query below resets to the original 16px offset. */
+  bottom: calc(72px + env(safe-area-inset-bottom, 0px));
   z-index: 50;
   display: flex;
   flex-direction: column;
@@ -19,6 +22,15 @@
    * keyboard slide-in instead of snapping. Direct style.transform writes
    * inherit this transition. */
   transition: transform 200ms cubic-bezier(.4, 0, .2, 1);
+}
+
+/* Desktop has no bottom tab bar — reset the FAB offset to the original
+ * 16px so it doesn't float in dead space. Matches the bottom-tabs
+ * breakpoint (769px). */
+@media (min-width: 769px) {
+  .v2-floating-capture {
+    bottom: max(16px, env(safe-area-inset-bottom, 0px));
+  }
 }
 
 .v2-floating-capture > * {

--- a/src/v2/components/Header.jsx
+++ b/src/v2/components/Header.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { Sparkles, Package, MoreVertical } from 'lucide-react'
+import { Sparkles, Package, Settings as SettingsIcon } from 'lucide-react'
 import Logo from '../../components/Logo'
 import { MiniRings } from '../../components/Rings'
 import './Header.css'
@@ -22,7 +22,7 @@ function deriveSyncVisualState(syncStatus, queueLength, animState) {
 }
 
 export default function Header({
-  onOpenAdviser, onOpenPackages, onOpenMenu,
+  onOpenAdviser, onOpenPackages, onOpenSystemMenu, systemMenuOpen,
   miniRingsData, onOpenAnalytics,
   todayCount, hasDone, onOpenDone, onOpenLogs,
   syncStatus, queueLength,
@@ -177,8 +177,15 @@ export default function Header({
         <button className="v2-header-icon v2-header-icon-packages" onClick={onOpenPackages} aria-label="Packages">
           <Package size={20} strokeWidth={1.75} />
         </button>
-        <button className="v2-header-icon" onClick={onOpenMenu} aria-label="More">
-          <MoreVertical size={20} strokeWidth={1.75} />
+        <button
+          className="v2-header-icon"
+          onClick={onOpenSystemMenu}
+          aria-label="System menu"
+          aria-haspopup="menu"
+          aria-expanded={!!systemMenuOpen}
+          data-system-menu-anchor
+        >
+          <SettingsIcon size={20} strokeWidth={1.75} />
         </button>
       </nav>
     </header>

--- a/src/v2/components/SpacesHub.css
+++ b/src/v2/components/SpacesHub.css
@@ -1,0 +1,66 @@
+/* Spaces hub — picker for Projects / Routines / Knowledge. Three
+ * roomy hairline rows with icon + label + subtitle. C-upgrade replaces
+ * each row's render with a richer card carrying live state (session
+ * counts, last-touched timestamps); class structure stays identical so
+ * the swap is JSX-only. */
+
+.v2-spaces-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.v2-spaces-list li + li {
+  border-top: 1px solid var(--v2-hairline);
+}
+
+.v2-spaces-row {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  width: 100%;
+  padding: 16px 4px;
+  border: none;
+  background: transparent;
+  color: var(--v2-text);
+  cursor: pointer;
+  text-align: left;
+  transition: background var(--v2-dur-quick) var(--v2-ease-standard);
+}
+
+.v2-spaces-row:hover {
+  background: rgba(var(--v2-text-rgb), 0.03);
+}
+
+.v2-spaces-row-icon {
+  flex-shrink: 0;
+  color: var(--v2-text-meta);
+}
+
+/* Match the existing v2 destination tints used elsewhere. */
+.v2-spaces-row-icon-projects { color: #A78BFA; }
+.v2-spaces-row-icon-routines { color: #5DBC9B; }
+.v2-spaces-row-icon-knowledge { color: #6B8AFD; }
+
+.v2-spaces-row-text {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+}
+
+.v2-spaces-row-label {
+  font: 600 15px/1.2 var(--v2-font-body);
+  color: var(--v2-text);
+}
+
+.v2-spaces-row-subtitle {
+  font: 500 12px/1.3 var(--v2-font-body);
+  color: var(--v2-text-meta);
+}
+
+.v2-spaces-row-chev {
+  color: var(--v2-text-faint);
+  flex-shrink: 0;
+}

--- a/src/v2/components/SpacesHub.jsx
+++ b/src/v2/components/SpacesHub.jsx
@@ -1,0 +1,80 @@
+import { FolderKanban, RotateCw, BookOpen, ChevronRight } from 'lucide-react'
+import ModalShell from './ModalShell'
+import './SpacesHub.css'
+
+// Spaces tab destination. Hub of the three "not-today" surfaces:
+// Projects, Routines, Knowledge. Each row is a tappable launcher that
+// opens the existing dedicated modal — we don't embed the modals
+// inline. Reason: ProjectsView and RoutinesModal both ship their own
+// ModalShell, and refactoring them to render bodyless is more risk
+// than reward for D. C-upgrade replaces this row list with rich
+// preview cards (live session counts, last-edited timestamps, etc.)
+// without changing the launcher contract — `useSpaces()` will feed
+// the same hub a richer data shape.
+export default function SpacesHub({
+  open, onClose,
+  onOpenProjects, onOpenRoutines, onOpenKnowledge,
+}) {
+  const rows = [
+    {
+      key: 'projects',
+      icon: FolderKanban,
+      tint: 'projects',
+      label: 'Projects',
+      subtitle: 'Long-term work · pin to surface in Today',
+      terminalCmd: '> projects',
+      onClick: onOpenProjects,
+    },
+    {
+      key: 'routines',
+      icon: RotateCw,
+      tint: 'routines',
+      label: 'Routines',
+      subtitle: 'Recurring tasks · cadence + spawn-now',
+      terminalCmd: '> routines',
+      onClick: onOpenRoutines,
+    },
+    {
+      key: 'knowledge',
+      icon: BookOpen,
+      tint: 'knowledge',
+      label: 'Knowledge',
+      subtitle: 'Notion-backed reference · ask Quokka',
+      terminalCmd: '> knowledge',
+      onClick: onOpenKnowledge,
+    },
+  ]
+
+  return (
+    <ModalShell
+      open={open}
+      onClose={onClose}
+      title="Spaces"
+      terminalTitle="> spaces"
+      subtitle="Long-term work, recurring tasks, and reference"
+      width="narrow"
+    >
+      <ul className="v2-spaces-list">
+        {rows.map(r => {
+          const Icon = r.icon
+          return (
+            <li key={r.key}>
+              <button
+                type="button"
+                className="v2-spaces-row"
+                onClick={() => { onClose(); r.onClick?.() }}
+              >
+                <Icon size={22} strokeWidth={1.75} className={`v2-spaces-row-icon v2-spaces-row-icon-${r.tint}`} />
+                <span className="v2-spaces-row-text">
+                  <span className="v2-spaces-row-label" data-terminal-cmd={r.terminalCmd}>{r.label}</span>
+                  <span className="v2-spaces-row-subtitle">{r.subtitle}</span>
+                </span>
+                <ChevronRight size={18} strokeWidth={1.75} className="v2-spaces-row-chev" />
+              </button>
+            </li>
+          )
+        })}
+      </ul>
+    </ModalShell>
+  )
+}

--- a/src/v2/components/SystemMenu.css
+++ b/src/v2/components/SystemMenu.css
@@ -1,0 +1,79 @@
+/* SystemMenu — anchored popover off the header ⚙ icon. Position fixed
+ * top-right; sits below the sticky header by `var(--v2-header-height)`
+ * approximation (60px + safe-area-top). Reuses the brand-popover's
+ * surface treatment (white surface, hairline, soft shadow) so the two
+ * popovers feel like siblings. */
+
+.v2-system-menu {
+  position: fixed;
+  top: calc(env(safe-area-inset-top, 0px) + 56px);
+  right: 12px;
+  min-width: 220px;
+  z-index: 20;
+  background: var(--v2-surface);
+  border: 1px solid var(--v2-hairline);
+  border-radius: 14px;
+  padding: 6px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.12);
+  animation: v2-system-menu-in var(--v2-dur-quick) var(--v2-ease-emphasis);
+}
+
+@keyframes v2-system-menu-in {
+  from { opacity: 0; transform: translateY(-4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.v2-system-menu-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.v2-system-menu-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  padding: 10px 12px;
+  border: none;
+  background: transparent;
+  border-radius: 10px;
+  font: 500 13px/1.3 var(--v2-font-body);
+  color: var(--v2-text);
+  cursor: pointer;
+  text-align: left;
+  transition: background var(--v2-dur-quick) var(--v2-ease-standard);
+}
+
+.v2-system-menu-row:hover {
+  background: rgba(var(--v2-text-rgb), 0.04);
+}
+
+.v2-system-menu-icon {
+  flex-shrink: 0;
+  color: var(--v2-text-meta);
+}
+
+/* Tint icons by destination — matches the existing ⋯ menu icon hint
+ * system from the legacy v2-more-row-icon-* classes. */
+.v2-system-menu-icon-settings { color: #6B8AFD; }
+.v2-system-menu-icon-analytics { color: #5DBC9B; }
+.v2-system-menu-icon-done { color: #8AB454; }
+.v2-system-menu-icon-suggestions { color: #F2A100; }
+.v2-system-menu-icon-activity { color: #B58EE8; }
+
+.v2-system-menu-label {
+  flex: 1;
+}
+
+.v2-system-menu-chev {
+  color: var(--v2-text-faint);
+}
+
+.v2-system-menu-badge {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--v2-accent);
+  flex-shrink: 0;
+}

--- a/src/v2/components/SystemMenu.jsx
+++ b/src/v2/components/SystemMenu.jsx
@@ -1,0 +1,113 @@
+import { useEffect, useRef } from 'react'
+import { Settings as SettingsIcon, BarChart3, History, CheckCircle2, Lightbulb, ChevronRight } from 'lucide-react'
+import './SystemMenu.css'
+
+// Anchored popover off the header ⚙ icon. Hosts the low-frequency
+// system surfaces (Settings, Analytics, Done, Suggestions, Activity
+// log). The brand popover already exposes Analytics + Done via the
+// wordmark — we surface them here too so the gear menu is a complete
+// system index, not "everything except the random two."
+//
+// Positioned `position: fixed` top-right rather than absolute-inside-
+// header because AppV2 owns the open state; rendering inside Header.jsx
+// would force the system-menu wiring to pass through Header props.
+export default function SystemMenu({
+  open, onClose,
+  onOpenSettings, onOpenAnalytics, onOpenDone, onOpenSuggestions, onOpenActivityLog,
+  hasSuggestions = false,
+}) {
+  const panelRef = useRef(null)
+
+  // Tap outside closes. Wired at document level; ignores clicks inside
+  // the panel or on the originating gear button (which has its own
+  // toggle handler).
+  useEffect(() => {
+    if (!open) return
+    const onDocClick = (e) => {
+      if (panelRef.current?.contains(e.target)) return
+      // The ⚙ button has aria-label="More" — let its onClick handle close.
+      if (e.target.closest?.('[data-system-menu-anchor]')) return
+      onClose()
+    }
+    const t = setTimeout(() => {
+      document.addEventListener('mousedown', onDocClick)
+      document.addEventListener('touchstart', onDocClick)
+    }, 0)
+    return () => {
+      clearTimeout(t)
+      document.removeEventListener('mousedown', onDocClick)
+      document.removeEventListener('touchstart', onDocClick)
+    }
+  }, [open, onClose])
+
+  if (!open) return null
+
+  const rows = [
+    {
+      key: 'settings',
+      icon: SettingsIcon,
+      label: 'Settings',
+      terminalCmd: '> settings',
+      onClick: onOpenSettings,
+      tint: 'settings',
+    },
+    {
+      key: 'analytics',
+      icon: BarChart3,
+      label: 'Analytics',
+      terminalCmd: '> stats',
+      onClick: onOpenAnalytics,
+      tint: 'analytics',
+    },
+    {
+      key: 'done',
+      icon: CheckCircle2,
+      label: 'Done',
+      terminalCmd: '> done',
+      onClick: onOpenDone,
+      tint: 'done',
+    },
+    {
+      key: 'suggestions',
+      icon: Lightbulb,
+      label: 'Suggestions',
+      terminalCmd: '> suggestions',
+      onClick: onOpenSuggestions,
+      tint: 'suggestions',
+      badge: hasSuggestions,
+    },
+    {
+      key: 'activity',
+      icon: History,
+      label: 'Activity log',
+      terminalCmd: '> log',
+      onClick: onOpenActivityLog,
+      tint: 'activity',
+    },
+  ]
+
+  return (
+    <div ref={panelRef} className="v2-system-menu" role="menu" aria-label="System">
+      <ul className="v2-system-menu-list">
+        {rows.map(r => {
+          const Icon = r.icon
+          return (
+            <li key={r.key}>
+              <button
+                type="button"
+                role="menuitem"
+                className="v2-system-menu-row"
+                onClick={() => { onClose(); r.onClick?.() }}
+              >
+                <Icon size={18} strokeWidth={1.75} className={`v2-system-menu-icon v2-system-menu-icon-${r.tint}`} />
+                <span className="v2-system-menu-label" data-terminal-cmd={r.terminalCmd}>{r.label}</span>
+                {r.badge && <span className="v2-system-menu-badge" aria-label="New" />}
+                <ChevronRight size={16} strokeWidth={1.75} className="v2-system-menu-chev" />
+              </button>
+            </li>
+          )
+        })}
+      </ul>
+    </div>
+  )
+}

--- a/src/v2/terminal/index.css
+++ b/src/v2/terminal/index.css
@@ -23,3 +23,4 @@
 @import './cards.css';
 @import './controls.css';
 @import './init.css';
+@import './tabs.css';

--- a/src/v2/terminal/tabs.css
+++ b/src/v2/terminal/tabs.css
@@ -1,0 +1,167 @@
+/* Terminal — BottomTabs, SystemMenu, SpacesHub.
+ *
+ * BottomTabs:
+ *   - Strip stays a hairline-top strip; pill behind active icon
+ *     dissolves. Lucide icons hidden. Labels become `[ today ]`
+ *     bracketed mono; active label glows with --v2-accent + text-shadow
+ *     (same idiom as the filter-tabs in flatten.css).
+ *
+ * SystemMenu:
+ *   - Surface keeps its boxy 4px panel (radii already 0 via palette
+ *     tokens) — but lose the soft shadow + heavy border for a leaner
+ *     status-line vibe.
+ *   - Row icons stay (small monochrome glyphs work fine in terminal)
+ *     but lose their colored tints — everything renders in
+ *     --v2-text-meta. The label gets the `> command` data-attr tooling
+ *     already wired in the v2-more-row precedent.
+ *
+ * SpacesHub:
+ *   - Row icons hide entirely. Labels lead with `>` prompt (data-
+ *     terminal-cmd attribute on the label span). Subtitle stays as
+ *     // comment-style faded annotation. Chevron stays as a `→` text
+ *     glyph since chevron-right is structural for "this opens." */
+
+
+/* === BottomTabs ===================================================== */
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-bottom-tabs {
+  background: var(--v2-bg);
+  border-top: 1px solid var(--v2-text-faint);
+}
+
+/* Hide the lucide SVG icon entirely. The bracketed label IS the tab. */
+:root[data-ui="v2"][data-theme^="terminal"] .v2-bottom-tab-icon-wrap {
+  display: none;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-bottom-tab {
+  font: 500 13px/1 var(--v2-font-body);
+  color: var(--v2-text-meta);
+  letter-spacing: 0;
+  padding: 14px 4px;
+  min-height: 48px;
+}
+
+/* Inactive `[ today ]` — brackets faint, label muted. */
+:root[data-ui="v2"][data-theme^="terminal"] .v2-bottom-tab-label::before {
+  content: "[ ";
+  color: var(--v2-text-faint);
+}
+:root[data-ui="v2"][data-theme^="terminal"] .v2-bottom-tab-label::after {
+  content: " ]";
+  color: var(--v2-text-faint);
+}
+
+/* Active — accent color on the label content, glow text-shadow, brackets
+ * stay faint. Same idiom as section-label `[3]` count brackets. */
+:root[data-ui="v2"][data-theme^="terminal"] .v2-bottom-tab.is-active {
+  color: var(--v2-accent);
+}
+:root[data-ui="v2"][data-theme^="terminal"] .v2-bottom-tab.is-active .v2-bottom-tab-label {
+  color: var(--v2-accent);
+  text-shadow: var(--v2-glow);
+  font-weight: 700;
+}
+:root[data-ui="v2"][data-theme^="terminal"] .v2-bottom-tab.is-active .v2-bottom-tab-label::before,
+:root[data-ui="v2"][data-theme^="terminal"] .v2-bottom-tab.is-active .v2-bottom-tab-label::after {
+  color: var(--v2-text-faint);
+  text-shadow: none;
+}
+
+
+/* === SystemMenu ===================================================== */
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-system-menu {
+  background: var(--v2-surface);
+  border: 1px solid var(--v2-text-faint);
+  border-radius: var(--v2-radius-card);
+  box-shadow: none;
+  padding: 4px;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-system-menu-row {
+  border-radius: 0;
+  font: 500 13px/1.3 var(--v2-font-body);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-system-menu-row:hover {
+  background: rgba(var(--v2-text-rgb), 0.06);
+}
+
+/* Strip colored icon tints — terminal idiom is monochrome glyphs.
+ * Icons themselves stay visible (data-terminal-cmd label already
+ * carries the `> command` text). */
+:root[data-ui="v2"][data-theme^="terminal"] .v2-system-menu-icon {
+  color: var(--v2-text-meta) !important;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-system-menu-chev {
+  display: none;
+}
+
+/* The data-terminal-cmd attr renders the `> settings` form via the
+ * existing reusable hook (see useTerminalMode + matching CSS in
+ * init.css for .v2-more-row). Re-apply it here. */
+:root[data-ui="v2"][data-theme^="terminal"] .v2-system-menu-label[data-terminal-cmd] {
+  font-size: 0;
+}
+:root[data-ui="v2"][data-theme^="terminal"] .v2-system-menu-label[data-terminal-cmd]::before {
+  content: attr(data-terminal-cmd);
+  font: 500 13px/1.3 var(--v2-font-body);
+  color: var(--v2-text);
+}
+
+
+/* === SpacesHub ====================================================== */
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-spaces-list li + li {
+  border-top: 1px solid var(--v2-text-faint);
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-spaces-row {
+  padding: 14px 4px;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-spaces-row:hover {
+  background: rgba(var(--v2-text-rgb), 0.06);
+}
+
+/* Hide the colored launcher icons — `>` prompt on the label is the
+ * affordance in terminal mode. */
+:root[data-ui="v2"][data-theme^="terminal"] .v2-spaces-row-icon {
+  display: none;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-spaces-row-label[data-terminal-cmd] {
+  font-size: 0;
+}
+:root[data-ui="v2"][data-theme^="terminal"] .v2-spaces-row-label[data-terminal-cmd]::before {
+  content: attr(data-terminal-cmd);
+  font: 700 15px/1.2 var(--v2-font-body);
+  color: var(--v2-accent);
+  text-shadow: var(--v2-glow);
+  letter-spacing: 0;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-spaces-row-subtitle {
+  color: var(--v2-text-meta);
+  font-style: normal;
+}
+:root[data-ui="v2"][data-theme^="terminal"] .v2-spaces-row-subtitle::before {
+  content: "// ";
+  color: var(--v2-text-faint);
+}
+
+/* Chevron becomes a faded `→` mono glyph. */
+:root[data-ui="v2"][data-theme^="terminal"] .v2-spaces-row-chev {
+  width: auto;
+  height: auto;
+}
+:root[data-ui="v2"][data-theme^="terminal"] .v2-spaces-row-chev svg {
+  display: none;
+}
+:root[data-ui="v2"][data-theme^="terminal"] .v2-spaces-row-chev::before {
+  content: "→";
+  font: 500 14px/1 var(--v2-font-body);
+  color: var(--v2-text-faint);
+}

--- a/wiki/Features.md
+++ b/wiki/Features.md
@@ -49,7 +49,7 @@ Tasks are organized into sections on the main screen:
 - **Snoozed** — tasks with a future snooze date, showing when they'll return
 - **Backlog** — someday/maybe tasks in a collapsible section at the bottom. Move tasks to backlog to keep them out of your active list without losing them.
 - **Pinned projects** — projects you've pinned to today appear at the top of the main list as expanded cards with progress meta and a Log Session button. Sessions count toward your daily points and streak. Pin from the Projects modal or the project's edit modal.
-- **Projects** — long-term work lives here. Accessible via the overflow menu ("..."). Silent by default — no nagging, no stale/overdue pressure. Pin a project to today to surface it on the main list. Add child tasks under a project so completions also count toward project progress. Opt projects into nagging per-project (`Allow nags without a due date`) or just set a due date and the normal escalation rules apply.
+- **Projects** — long-term work lives here. Accessible via the Spaces tab in the bottom bar (mobile) or its v2 sheet (desktop). Silent by default — no nagging, no stale/overdue pressure. Pin a project to today to surface it on the main list. Add child tasks under a project so completions also count toward project progress. Opt projects into nagging per-project (`Allow nags without a due date`) or just set a due date and the normal escalation rules apply.
 
 ## Task Count Display
 
@@ -133,7 +133,7 @@ Recurring tasks with configurable cadence:
 - **Notion integration**: find or create a Notion page from the routine add/edit form. Linked pages appear on routine cards and are inherited by spawned task instances.
 - **Auto-roll** *(shipped — spec in `wiki/Activity-Prompts.md`)*: flag a routine `auto_roll` so missed days bump the existing task's due date instead of stacking duplicates. Use case: medication you can't double up on. When the cadence fires and a non-terminal instance already exists, its `due_date` is set to today (and any past `snoozed_until` is cleared) instead of spawning a new task. Toggle lives at the bottom of the routine form.
 - **Habit mode** *(shipped — spec in `wiki/Activity-Prompts.md`)*: set `spawn_mode: 'habit'` on a routine and it switches from cadence-driven spawning to target-frequency tracking — e.g., `2× / week` or `5× / month`. No automatic task creation; instead the routine card shows period progress (`1/2 this week`) plus a streak chip, with a "+ Log it" button that creates and completes a task in one tap. Behind-pace push notifications fire mid-period (past the 30% elapsed mark) with inline Log it / Not today action buttons — push priority-0 only, never Pushover, because habits are encouragement, not alarms.
-- **Historic suggestions** *(shipped — spec in `wiki/Activity-Prompts.md`)*: a weekly server scan (Sunday 3am local) over 12 months of completed-task history detects recurring patterns (daily / weekly / monthly / quarterly / annually) and surfaces them in a Suggestions inbox accessible from the overflow menu. Each suggestion can be accepted (creates a routine with cadence-aware defaults — daily/weekly → auto-roll, longer → plain auto), snoozed for 14 days, or permanently dismissed. Optional AI clustering pass merges near-duplicates ("mow lawn" / "mow the grass") when an Anthropic key is configured. A weekly `routine_suggestion` push / email summarizes pending suggestions; Quokka can list / dismiss / snooze via natural language.
+- **Historic suggestions** *(shipped — spec in `wiki/Activity-Prompts.md`)*: a weekly server scan (Sunday 3am local) over 12 months of completed-task history detects recurring patterns (daily / weekly / monthly / quarterly / annually) and surfaces them in a Suggestions inbox accessible from the SystemMenu (⚙ icon in the header). Each suggestion can be accepted (creates a routine with cadence-aware defaults — daily/weekly → auto-roll, longer → plain auto), snoozed for 14 days, or permanently dismissed. Optional AI clustering pass merges near-duplicates ("mow lawn" / "mow the grass") when an Anthropic key is configured. A weekly `routine_suggestion` push / email summarizes pending suggestions; Quokka can list / dismiss / snooze via natural language.
 
 ## Notion Integration
 
@@ -440,7 +440,7 @@ Scheduled daily summary notification via email and/or push at a configurable tim
 
 ## Markdown Import
 
-Bulk import tasks from markdown text or files. Accessible from the overflow menu ("...") in the header.
+Bulk import tasks from markdown text or files. Accessible from the Data tab inside Settings (open Settings via the ⚙ icon in the header).
 
 - **Supported formats** — checkboxes (`- [ ] task`), bullet lists (`- task`, `* task`), numbered lists (`1. task`)
 - **Sections** — `## Headings` become group labels in the preview
@@ -544,7 +544,7 @@ Speed bonuses reward fast turnaround:
 
 ## Analytics
 
-Accessible from the overflow menu ("...") in the header, the Analytics screen shows:
+Accessible two ways: the SystemMenu (⚙ icon, top-right) or by tapping the BOOMERANG wordmark and choosing "Open Analytics" in the brand popover. The Analytics screen shows:
 
 - **Activity rings** — full-size daily progress rings (tasks, points, streak)
 - **Stat cards** — current streak, longest streak, best daily points, best daily tasks

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -4,6 +4,25 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ---
 
+## 2026-05-22
+
+- feat(ui): mobile bottom tabs + Spaces hub + SystemMenu — retire the ⋯ More menu [L]
+  - **Ask.** The single ⋯ overflow menu had grown to 8 items (Settings, Projects, Knowledge, Routines, Done, Analytics, Suggestions, Activity log) — too long to scan, no grouping, no live information, every destination one extra tap deep. Replace it with a layered navigation pattern sized to each surface's frequency.
+  - **Three new surfaces, each frequency-appropriate.**
+    1. **BottomTabs (mobile only).** Persistent bottom strip with `[ Today ]` (default — the task list) and `[ Spaces ]` (opens the SpacesHub picker). Renders only when `!isDesktop` (≤768px) — desktop keeps Kanban + side drawer and never needed the ⋯ menu's discoverability problem. Active-tab indicator is a soft accent pill behind the icon in light/dark; in terminal mode the lucide icon hides and the bracketed mono label glows with accent + `var(--v2-glow)` text-shadow (matching the filter-tabs idiom already in `flatten.css`).
+    2. **SystemMenu (anchored popover off the ⚙ header icon).** Hosts low-frequency system surfaces: Settings, Analytics, Done, Suggestions, Activity log. Reuses the brand-popover's surface treatment (soft border, hairline-tinted rows, drop shadow) so the two header popovers feel like siblings. Click-outside closes; the originating ⚙ button's own onClick toggles open/closed. In terminal mode the lucide icon glyphs go monochrome, the colored chevron disappears, and labels render `> command` form via the existing `data-terminal-cmd` attribute pattern.
+    3. **SpacesHub (modal-sheet picker, opens from the Spaces tab).** Three roomy hairline rows — Projects, Routines, Knowledge — each with icon + label + subtitle. Tapping a row closes the hub and launches the existing dedicated modal (`ProjectsView`, `RoutinesModal`, or a Quokka chat seeded with "What's in my knowledge base?"). No internal sub-tab strip — keeps Tap-to-destination cheap (2 taps from Today) and leaves the structure ready for the C-upgrade (rich preview cards with live session counts / last-touched timestamps) without contract changes.
+  - **Header swap.** `MoreVertical` icon → `Settings` (⚙) glyph. Header prop renamed `onOpenMenu` → `onOpenSystemMenu`; new `systemMenuOpen` prop drives `aria-expanded`. `data-system-menu-anchor` attr on the button lets SystemMenu's outside-click handler ignore the source button (otherwise tap-to-toggle would immediately close).
+  - **Tab indicator safety net.** `activeTab` state ('today' | 'spaces') drives the BottomTabs render. A `useEffect` watches `spacesHubOpen`, `showProjects`, `showRoutines`, `showAdviser`: when activeTab is 'spaces' and all four are false, it snaps back to 'today'. Closing the hub's X also explicitly resets. The indicator never lies about which surface the user is looking at.
+  - **FAB offset.** `FloatingCapture` bottom offset bumped from `max(16px, env(safe-area-inset-bottom))` to `calc(72px + env(safe-area-inset-bottom))` so the speed-dial sits above the new tab bar. Desktop @media (≥769px) override resets the original 16px so the FAB doesn't float in dead space.
+  - **Terminal styling.** New `src/v2/terminal/tabs.css` carries all three components' terminal overrides — bracketed labels with glow on active tab, monochrome `> command` rows in SystemMenu, hidden icons + `>` prompts + `// comment` subtitles + `→` ASCII chevrons in SpacesHub. Imported from `terminal/index.css` alongside the other structural files.
+  - **What's gone.** The legacy `<ModalShell open={showMenu}>...</ModalShell>` block (~70 lines of `v2-more-menu`/`v2-more-row` markup, 8 destinations) is deleted from AppV2.jsx. The `showMenu`/`setShowMenu` state, the `MoreVertical` import, and the destination-icon imports (FolderKanban / BookOpen / RotateCw / CheckCircle2 / BarChart3 / Lightbulb / History / ChevronRight / SettingsIcon) all leave AppV2's import list. The legacy `.v2-more-menu` CSS in AppV2.css is kept for now — multiple v2 modals still reuse `v2-more-row` styling for hairline-list rows.
+  - **Out of scope (deferred to follow-up PRs).** `useSpaces()` data-layer hook + tab-bar badge dots for spaces-fresh activity. Rich preview cards inside SpacesHub (C-upgrade — session counts, last-touched timestamps, knowledge new-item counter). Tab-bar transition animation + reduced-motion handling.
+  - **Verification.** `npm run check:terminal-titles` clean. `npx eslint` clean on every touched file. `npm test` (build + boot smoke test) passes. Browser-side validation deferred to the `:dev` Docker deploy on `boomerang-dev` (port 3002) after merge.
+  - Modified: new `src/v2/components/BottomTabs.{jsx,css}`, new `src/v2/components/SystemMenu.{jsx,css}`, new `src/v2/components/SpacesHub.{jsx,css}`, new `src/v2/terminal/tabs.css`; `src/v2/AppV2.jsx`, `src/v2/components/Header.jsx`, `src/v2/components/FloatingCapture.css`, `src/v2/terminal/index.css`, `CLAUDE.md`, `wiki/Version-History.md`
+
+---
+
 ## 2026-05-21
 
 - feat(knowledge): Notion-backed knowledge base + Quokka tools [L]


### PR DESCRIPTION
## Summary
Single feature promotion: mobile bottom tabs + Spaces hub + SystemMenu (retired ⋯ More menu). Merged to dev as PR #205, validated on `:dev` deploy.

## What ships to prod

- **BottomTabs (mobile only)** — persistent `[ Today ]` + `[ Spaces ]` strip at the bottom of the viewport.
- **SystemMenu** — anchored popover off the new ⚙ header icon. Hosts Settings / Analytics / Done / Suggestions / Activity log.
- **SpacesHub** — modal-sheet picker launched from the Spaces tab. Three rows: Projects / Routines / Knowledge. Each launches the existing dedicated modal.
- Header `MoreVertical` → `Settings` (⚙). Old ⋯ menu deleted.
- Terminal-mode overrides for all three new components in `src/v2/terminal/tabs.css`.
- FAB bottom offset bumped on mobile to clear the tab bar; desktop unchanged.

## Test plan
- [x] Validated on `:dev` deploy (boomerang-dev, port 3002) — user signed off.
- [x] `npm test`, `npm run check:terminal-titles`, `npx eslint src/v2/` all clean on the dev merge.

## Notes
- Merge method: **merge** (not rebase). Per CLAUDE.md, dev→main promotions use a merge commit so SHA continuity is preserved across branches — rebase rewrites SHAs and breaks future promotions.
- No Dockerfile changes — all new files under `src/v2/` ship via the Vite bundle.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmpfJaWEpmFxNg4yJbepdP)_