### PR TITLE
release: Spaces tab attention-badge + useSpaces data layer

### DIFF
--- a/src/v2/AppV2.jsx
+++ b/src/v2/AppV2.jsx
@@ -48,6 +48,7 @@ import { useNotionSync } from '../hooks/useNotionSync'
 import { useGCalSync } from '../hooks/useGCalSync'
 import { useKeyboardShortcuts } from '../hooks/useKeyboardShortcuts'
 import { useTerminalMode } from './hooks/useTerminalMode'
+import { useSpaces } from './hooks/useSpaces'
 import { inferSize, trelloUpdateCard, serverSkipAdvanceTask } from '../api'
 import { loadLabels, loadSettings, saveSettings, saveLabels, sortTasks, computeDailyStats, computeStreak, computeRoutineStreak, logActivity, localYMD } from '../store'
 import './AppV2.css'
@@ -189,6 +190,12 @@ export default function AppV2() {
     routines, addRoutine, deleteRoutine, togglePause, updateRoutine,
     completeRoutine, adjustRoutineHistory, spawnDueTasks, spawnNow, logHabit, skipCycle, hydrateRoutines,
   } = useRoutines()
+
+  // Spaces data layer — drives the BottomTabs badge dot today, and
+  // will feed rich preview cards inside SpacesHub on the C-upgrade.
+  // Pure derivation from tasks + routines — no fetches, no extra
+  // state — so it re-renders on the same cadence as the rest of v2.
+  const spaces = useSpaces({ tasks, routines })
 
   // Background work that must keep running even when v2 is the active shell:
   // notifications, AI inference, external (Trello/Notion) outbound sync,
@@ -960,6 +967,7 @@ export default function AppV2() {
       {!isDesktop && (
         <BottomTabs
           activeTab={activeTab}
+          spacesBadge={spaces.wantsAttention}
           onTabChange={(next) => {
             if (next === 'today') {
               setActiveTab('today')

--- a/src/v2/components/BottomTabs.css
+++ b/src/v2/components/BottomTabs.css
@@ -13,6 +13,7 @@
 }
 
 .v2-bottom-tab {
+  position: relative;
   flex: 1;
   display: flex;
   flex-direction: column;
@@ -40,6 +41,26 @@
   padding: 4px 14px;
   border-radius: var(--v2-radius-pill);
   transition: background var(--v2-dur-quick) var(--v2-ease-standard);
+}
+
+/* Attention badge — small accent-colored dot anchored to the
+ * tab button itself (button is position: relative). Floats above the
+ * icon's top-right corner. Presence boolean only, no counter.
+ * Sourced from useSpaces().wantsAttention. */
+.v2-bottom-tab-badge {
+  position: absolute;
+  /* Center-align horizontally on the icon: icon-wrap is 22px icon + 14px*2
+   * horizontal padding = 50px wide. Right-edge offset from button center
+   * lands the dot ~3px past the icon-wrap's right edge. */
+  top: 6px;
+  left: calc(50% + 16px);
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--v2-accent);
+  /* Soft surface ring so the dot reads cleanly over the active-tab
+   * pill background. */
+  box-shadow: 0 0 0 2px var(--v2-bg);
 }
 
 .v2-bottom-tab-icon {

--- a/src/v2/components/BottomTabs.jsx
+++ b/src/v2/components/BottomTabs.jsx
@@ -5,9 +5,16 @@ import './BottomTabs.css'
 // Desktop intentionally skipped — it has the Kanban + side drawer
 // pattern, doesn't need bottom chrome eating screen height.
 //
+// `spacesBadge` is a presence boolean (not a counter) sourced from
+// useSpaces().wantsAttention — a dot if a pinned project has drifted
+// past the stale threshold OR any other future signal worth pinging.
+// Counter would invite "I have 4 stale projects, that's bad" anxiety;
+// a dot is "hey, peek in here."
+//
 // Terminal-theme styling lives in src/v2/terminal/tabs.css — lucide
-// SVGs hide, labels become `[ today ]` bracketed mono.
-export default function BottomTabs({ activeTab, onTabChange }) {
+// SVGs hide, labels become `[ today ]` bracketed mono, badge renders
+// as a small `•` glyph to the right of the active label.
+export default function BottomTabs({ activeTab, onTabChange, spacesBadge = false }) {
   return (
     <nav className="v2-bottom-tabs" role="tablist" aria-label="Primary navigation">
       <button
@@ -26,13 +33,15 @@ export default function BottomTabs({ activeTab, onTabChange }) {
         type="button"
         role="tab"
         aria-selected={activeTab === 'spaces'}
-        className={`v2-bottom-tab${activeTab === 'spaces' ? ' is-active' : ''}`}
+        aria-label={spacesBadge ? 'Spaces (attention needed)' : 'Spaces'}
+        className={`v2-bottom-tab${activeTab === 'spaces' ? ' is-active' : ''}${spacesBadge ? ' has-badge' : ''}`}
         onClick={() => onTabChange('spaces')}
       >
         <span className="v2-bottom-tab-icon-wrap">
           <FolderKanban size={22} strokeWidth={1.75} className="v2-bottom-tab-icon" aria-hidden="true" />
         </span>
         <span className="v2-bottom-tab-label" data-terminal-label="spaces">Spaces</span>
+        {spacesBadge && <span className="v2-bottom-tab-badge" aria-hidden="true" />}
       </button>
     </nav>
   )

--- a/src/v2/hooks/useSpaces.js
+++ b/src/v2/hooks/useSpaces.js
@@ -1,0 +1,72 @@
+import { useMemo } from 'react'
+
+// Spaces data layer. Reads from existing useTasks / useRoutines state —
+// no new fetches — so re-renders track the same dependency graph the
+// rest of v2 already invalidates on.
+//
+// In D this hook powers a single boolean (`wantsAttention`) for the
+// BottomTabs badge dot. In the future C-upgrade, the same hook feeds
+// rich preview cards inside SpacesHub (per-space counts, last-touched
+// timestamps, "fresh" vs "stale" treatment per row). Same data layer,
+// two render paths.
+
+// A pinned project is "stale" if it has no recent session activity.
+// Three days is the threshold where the user committed to caring
+// (pinning) but the project is drifting; sooner than that is just
+// "give it time."
+const STALE_PROJECT_DAYS = 3
+const STALE_THRESHOLD_MS = STALE_PROJECT_DAYS * 24 * 60 * 60 * 1000
+
+export function useSpaces({ tasks, routines }) {
+  return useMemo(() => {
+    const now = Date.now()
+    const todayStr = new Date().toDateString()
+
+    const allProjects = tasks.filter(t => t.status === 'project')
+    const pinnedProjects = allProjects.filter(t => t.pinned_to_today)
+    const activeRoutines = routines.filter(r => !r.paused)
+
+    // Pinned projects with no session activity in STALE_PROJECT_DAYS.
+    // `last_session_at` null counts as stale — a pinned project that has
+    // never been touched needs more attention than one touched yesterday.
+    const stalePinnedCount = pinnedProjects.filter(p => {
+      if (!p.last_session_at) return true
+      const last = new Date(p.last_session_at).getTime()
+      return Number.isFinite(last) && (now - last) > STALE_THRESHOLD_MS
+    }).length
+
+    // Routines that fired today. Not currently a badge signal — the
+    // spawned tasks already appear in the Today list — but exposed for
+    // the C-upgrade's per-row meta ("1 routine spawned today").
+    const spawnedTodayCount = activeRoutines.filter(r => {
+      const history = r.completed_history
+      if (!Array.isArray(history) || history.length === 0) return false
+      return new Date(history[history.length - 1]).toDateString() === todayStr
+    }).length
+
+    // Knowledge count is fetched lazily in the C-upgrade (one-shot
+    // network call on mount). For D we stub the object so the hook
+    // contract is stable and consumers can switch over without renaming.
+    const knowledge = {
+      itemCount: null,
+      lastAddedTitle: null,
+    }
+
+    return {
+      projects: {
+        pinnedCount: pinnedProjects.length,
+        totalCount: allProjects.length,
+        stalePinnedCount,
+      },
+      routines: {
+        activeCount: activeRoutines.length,
+        spawnedTodayCount,
+      },
+      knowledge,
+      // Single boolean that drives the tab-bar badge dot. Future
+      // signals (e.g. new knowledge in last 24h, routine ready to
+      // spawn) can OR in here without changing BottomTabs' contract.
+      wantsAttention: stalePinnedCount > 0,
+    }
+  }, [tasks, routines])
+}

--- a/src/v2/terminal/tabs.css
+++ b/src/v2/terminal/tabs.css
@@ -34,6 +34,25 @@
   display: none;
 }
 
+/* Attention badge — terminal renders as a small accent-colored `•`
+ * glyph inline after the bracketed label. The standard dot is
+ * absolute-positioned over the icon (which doesn't render in terminal),
+ * so swap to an inline glyph via the pseudo-element content. */
+:root[data-ui="v2"][data-theme^="terminal"] .v2-bottom-tab-badge {
+  position: static;
+  width: auto;
+  height: auto;
+  background: transparent;
+  box-shadow: none;
+  font: 500 14px/1 var(--v2-font-body);
+  margin-left: 4px;
+}
+:root[data-ui="v2"][data-theme^="terminal"] .v2-bottom-tab-badge::before {
+  content: "•";
+  color: var(--v2-accent);
+  text-shadow: var(--v2-glow);
+}
+
 :root[data-ui="v2"][data-theme^="terminal"] .v2-bottom-tab {
   font: 500 13px/1 var(--v2-font-body);
   color: var(--v2-text-meta);

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,15 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-22
 
+- feat(ui): Spaces tab attention-badge + useSpaces data layer [S]
+  - **Ask.** Bottom tab bar (just shipped) was missing the "something in here wants your attention" signal. A pinned project drifting past the no-session-in-3-days threshold is the exact case the user needs surfaced without opening Spaces — they committed to caring (pinned it), but haven't touched it. Add a presence-only badge dot on the Spaces tab.
+  - **Data layer.** New `src/v2/hooks/useSpaces.js` derives `{ projects, routines, knowledge, wantsAttention }` from existing useTasks + useRoutines state — no fetches. `projects.stalePinnedCount` counts pinned projects where `last_session_at` is null OR more than 3 days old. `wantsAttention` is a single boolean (today: `stalePinnedCount > 0`) that future signals can OR into without changing the BottomTabs contract.
+  - **Badge render.** New `spacesBadge` prop on BottomTabs. In light/dark: 8px accent-colored dot anchored top-right of the icon pill via `position: absolute` on the tab button (which is now `position: relative`), with a 2px surface ring so it reads cleanly over the active-tab pill background. In terminal: dot is `position: static` and renders as a small accent-color `•` glyph inline after the bracketed label with `--v2-glow` text-shadow, matching the bracketed mono idiom. `aria-label` swaps to "Spaces (attention needed)" when the badge is on.
+  - **Presence, not counts.** Deliberately a dot, not a number. Counter would invite "I have 4 stale projects, that's bad" anxiety; the dot says "hey, peek in here." Per-project breakdown lives inside the SpacesHub when the C-upgrade lands.
+  - **C-upgrade prep.** `useSpaces` already returns the data shape the future preview-card render will consume (`pinnedCount`, `totalCount`, `stalePinnedCount`, `activeCount`, `spawnedTodayCount`, stubbed `knowledge.itemCount`). When SpacesHub graduates from picker rows to rich cards, the data layer doesn't change — only the SpacesHub JSX.
+  - **Verification.** `npm run check:terminal-titles` clean. `npx eslint src/v2/` clean. Production build clean.
+  - Modified: new `src/v2/hooks/useSpaces.js`; `src/v2/AppV2.jsx`, `src/v2/components/BottomTabs.jsx`, `src/v2/components/BottomTabs.css`, `src/v2/terminal/tabs.css`, `wiki/Version-History.md`
+
 - feat(ui): mobile bottom tabs + Spaces hub + SystemMenu — retire the ⋯ More menu [L]
   - **Ask.** The single ⋯ overflow menu had grown to 8 items (Settings, Projects, Knowledge, Routines, Done, Analytics, Suggestions, Activity log) — too long to scan, no grouping, no live information, every destination one extra tap deep. Replace it with a layered navigation pattern sized to each surface's frequency.
   - **Three new surfaces, each frequency-appropriate.**


### PR DESCRIPTION
## Summary
Single feature promotion: `useSpaces` data layer + Spaces tab attention-badge (PR #209). Merged to dev, user signed off on `:dev` deploy.

## What ships to prod
- New `src/v2/hooks/useSpaces.js` — derives projects / routines / knowledge counters + `wantsAttention` boolean from existing state. No fetches.
- Badge dot on the Spaces tab when at least one pinned project has no session in the last 3+ days. Light/dark: absolute-positioned 8px accent dot top-right of the icon pill. Terminal: inline `•` glyph after the bracketed label.
- C-upgrade prep — hook contract already returns the data shape SpacesHub preview cards will consume.

## Test plan
- [x] Smoke + lint + build clean on the dev merge.
- [x] Validated on `:dev` deploy — user signed off.

## Notes
- Merge method: **merge** (not rebase) per CLAUDE.md dev→main convention.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmpfJaWEpmFxNg4yJbepdP)_