### PR TITLE
fix(spaces-badge): grace period for newly-pinned projects

### DIFF
--- a/src/v2/hooks/useSpaces.js
+++ b/src/v2/hooks/useSpaces.js
@@ -26,13 +26,24 @@ export function useSpaces({ tasks, routines }) {
     const pinnedProjects = allProjects.filter(t => t.pinned_to_today)
     const activeRoutines = routines.filter(r => !r.paused)
 
-    // Pinned projects with no session activity in STALE_PROJECT_DAYS.
-    // `last_session_at` null counts as stale — a pinned project that has
-    // never been touched needs more attention than one touched yesterday.
+    // Pinned projects whose most-recent attention signal is older than
+    // STALE_PROJECT_DAYS. References checked, in priority order:
+    //   1. last_session_at — most authoritative ("I worked on it")
+    //   2. last_touched — covers the pinning event itself, plus any edit
+    //      (`setProjectPinned` stamps this on the pin flip, so a brand-
+    //      new pin gets a full 3-day grace period before the dot fires)
+    //   3. created_at — final fallback for ancient routines that pre-date
+    //      last_touched
+    // If none exist (truly unknown), don't ping — silence beats a false
+    // positive that discourages pinning.
     const stalePinnedCount = pinnedProjects.filter(p => {
-      if (!p.last_session_at) return true
-      const last = new Date(p.last_session_at).getTime()
-      return Number.isFinite(last) && (now - last) > STALE_THRESHOLD_MS
+      const candidates = [p.last_session_at, p.last_touched, p.created_at]
+        .filter(Boolean)
+        .map(ts => new Date(ts).getTime())
+        .filter(n => Number.isFinite(n))
+      if (candidates.length === 0) return false
+      const mostRecent = Math.max(...candidates)
+      return (now - mostRecent) > STALE_THRESHOLD_MS
     }).length
 
     // Routines that fired today. Not currently a badge signal — the

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,11 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-22
 
+- fix(spaces-badge): grace period for newly-pinned projects [XS]
+  - **Bug.** Spaces tab attention dot fired immediately on any newly-pinned project. `useSpaces` treated `last_session_at = null` as "stale forever," which made the badge a false positive every time a user pinned something — defeating the signal it was supposed to send (issue #212).
+  - **Fix.** Use the most-recent of `last_session_at`, `last_touched`, `created_at` as the staleness reference. `setProjectPinned` already stamps `last_touched`, so a brand-new pin now gets a full 3-day grace window before the dot fires. Projects with no reference timestamps at all (truly unknown state) don't fire either — silence beats a false positive.
+  - Modified: `src/v2/hooks/useSpaces.js`, `wiki/Version-History.md`
+
 - feat(routines): custom cadence supports "every N months" alongside "every N days" [S]
   - **Ask.** Existing custom cadence only supported days. Quarterly + annually are fixed presets; in-between cadences like "every 2 months" / "every 6 months" weren't expressible.
   - **Schema.** Migration 031 adds `custom_unit TEXT DEFAULT 'days'` to the routines table. `custom_days` keeps its name as the interval count (regardless of unit) — kept for backward compat with all callers; renaming would have touched a dozen files. Null/missing `custom_unit` is treated as `'days'` everywhere so pre-migration routines preserve exact behavior.


### PR DESCRIPTION
Fixes #212.

## Bug
Spaces tab attention dot fired immediately on any newly-pinned project. `useSpaces.js` treated `last_session_at = null` as stale-forever. False positive on every fresh pin defeated the signal it was supposed to send.

## Fix
Use the most-recent of `last_session_at`, `last_touched`, `created_at` as the staleness reference:

```js
const candidates = [p.last_session_at, p.last_touched, p.created_at]
  .filter(Boolean)
  .map(ts => new Date(ts).getTime())
  .filter(n => Number.isFinite(n))
if (candidates.length === 0) return false
const mostRecent = Math.max(...candidates)
return (now - mostRecent) > STALE_THRESHOLD_MS
```

`setProjectPinned` already stamps `last_touched` on the pin flip, so a brand-new pin now gets the full 3-day grace window before the dot fires. Projects with no reference timestamps at all stay silent — better than false-positive nagging.

## Test plan
- [x] Lint + production build clean.
- [ ] Validate on `:dev`: pin a fresh project, dot stays off. After 3+ days with no session, dot turns on. Log a session, dot clears.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmpfJaWEpmFxNg4yJbepdP)_