### PR TITLE
fix(viewport): use 100dvh on .v2-app to fix iOS PWA grey gap

### DIFF
--- a/src/v2/AppV2.css
+++ b/src/v2/AppV2.css
@@ -12,6 +12,25 @@
   overflow: hidden;
 }
 
+/* iOS PWA viewport fix (issue #213). After keyboard show/hide on iOS
+ * Safari standalone, `position: fixed; inset: 0` anchors to a stale
+ * layout viewport — the v2-app draws shorter than the visual viewport
+ * and exposes a strip of body bg below the bottom tab bar that only
+ * a hard PWA-kill restores. `100dvh` (dynamic viewport height) tracks
+ * the live visual viewport across all the iOS URL bar / keyboard /
+ * orientation transitions, so the app stays correctly sized.
+ *
+ * Wrapped in @supports so older browsers (pre-iOS 16 Safari) fall back
+ * to the inset:0 anchoring above. Boomerang's PWA targets iOS 16.4+
+ * for Web Push anyway, so dvh is the default path for nearly all
+ * users; the fallback is just defensive. */
+@supports (height: 100dvh) {
+  .v2-app {
+    bottom: auto;
+    height: 100dvh;
+  }
+}
+
 .v2-main {
   flex: 1;
   overflow-y: auto;

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,12 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-22
 
+- fix(viewport): iOS PWA grey gap below BottomTabs after keyboard interaction [XS]
+  - **Bug.** After typing in any modal input (Add task, Adviser, Edit, etc.), closing the keyboard left a grey strip of body-background visible below the bottom tab bar on iOS PWA standalone mode. Force-quitting the PWA was the only way to restore correct layout (issue #213).
+  - **Cause.** `.v2-app { position: fixed; inset: 0 }` anchors to the layout viewport. iOS Safari leaves the layout viewport in a stale state across keyboard show/hide cycles, which makes the v2-app draw shorter than the actual visual viewport.
+  - **Fix.** Use `height: 100dvh` (dynamic viewport height) instead of `inset: 0`'s implicit bottom anchoring. `dvh` tracks the live visual viewport so the app stays correctly sized through every iOS URL-bar / keyboard / orientation transition. Wrapped in `@supports (height: 100dvh)` so older browsers fall back to the inset:0 path. Boomerang targets iOS 16.4+ for Web Push anyway, so dvh is the default path for nearly all users.
+  - Modified: `src/v2/AppV2.css`, `wiki/Version-History.md`
+
 - fix(spaces-badge): grace period for newly-pinned projects [XS]
   - **Bug.** Spaces tab attention dot fired immediately on any newly-pinned project. `useSpaces` treated `last_session_at = null` as "stale forever," which made the badge a false positive every time a user pinned something — defeating the signal it was supposed to send (issue #212).
   - **Fix.** Use the most-recent of `last_session_at`, `last_touched`, `created_at` as the staleness reference. `setProjectPinned` already stamps `last_touched`, so a brand-new pin now gets a full 3-day grace window before the dot fires. Projects with no reference timestamps at all (truly unknown state) don't fire either — silence beats a false positive.


### PR DESCRIPTION
Fixes #213.

## Bug
After typing in any modal input (Add task, Adviser, Edit, etc.) on iOS PWA standalone mode, closing the keyboard leaves a grey strip of body-background visible below the bottom tab bar. Force-quitting the PWA is the only way to restore correct layout.

## Cause
`.v2-app { position: fixed; inset: 0 }` anchors to the **layout** viewport. iOS Safari leaves the layout viewport in a stale state across keyboard show/hide cycles, so the v2-app draws shorter than the actual **visual** viewport — exposing whatever's behind (body bg).

## Fix
Switch from `inset: 0`'s implicit bottom anchoring to explicit `height: 100dvh` (dynamic viewport height). `dvh` tracks the live visual viewport through every iOS URL-bar / keyboard / orientation transition, so the app stays correctly sized regardless of where iOS leaves the layout viewport.

```css
.v2-app {
  position: fixed;
  inset: 0;          /* fallback for old browsers */
  ...
}

@supports (height: 100dvh) {
  .v2-app {
    bottom: auto;
    height: 100dvh;
  }
}
```

Wrapped in `@supports` so pre-iOS-16 Safari falls back to `inset: 0`. Boomerang targets iOS 16.4+ for Web Push anyway, so `dvh` is the default path for nearly every user — the fallback is defensive.

## Test plan
- [x] Production build clean.
- [ ] Validate on `:dev`: in iOS PWA standalone, open Add modal, type something, close keyboard. Tab bar should sit flush against the home indicator zone, no grey strip below. Repeat with EditTaskModal, AdviserModal, etc.
- [ ] Verify desktop layout unchanged (`100dvh` = `100vh` on desktop).

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmpfJaWEpmFxNg4yJbepdP)_