### PR TITLE
release: spaces-badge grace period + iOS viewport gap fix

### DIFF
--- a/src/v2/AppV2.css
+++ b/src/v2/AppV2.css
@@ -12,6 +12,25 @@
   overflow: hidden;
 }
 
+/* iOS PWA viewport fix (issue #213). After keyboard show/hide on iOS
+ * Safari standalone, `position: fixed; inset: 0` anchors to a stale
+ * layout viewport — the v2-app draws shorter than the visual viewport
+ * and exposes a strip of body bg below the bottom tab bar that only
+ * a hard PWA-kill restores. `100dvh` (dynamic viewport height) tracks
+ * the live visual viewport across all the iOS URL bar / keyboard /
+ * orientation transitions, so the app stays correctly sized.
+ *
+ * Wrapped in @supports so older browsers (pre-iOS 16 Safari) fall back
+ * to the inset:0 anchoring above. Boomerang's PWA targets iOS 16.4+
+ * for Web Push anyway, so dvh is the default path for nearly all
+ * users; the fallback is just defensive. */
+@supports (height: 100dvh) {
+  .v2-app {
+    bottom: auto;
+    height: 100dvh;
+  }
+}
+
 .v2-main {
   flex: 1;
   overflow-y: auto;

--- a/src/v2/hooks/useSpaces.js
+++ b/src/v2/hooks/useSpaces.js
@@ -26,13 +26,24 @@ export function useSpaces({ tasks, routines }) {
     const pinnedProjects = allProjects.filter(t => t.pinned_to_today)
     const activeRoutines = routines.filter(r => !r.paused)
 
-    // Pinned projects with no session activity in STALE_PROJECT_DAYS.
-    // `last_session_at` null counts as stale — a pinned project that has
-    // never been touched needs more attention than one touched yesterday.
+    // Pinned projects whose most-recent attention signal is older than
+    // STALE_PROJECT_DAYS. References checked, in priority order:
+    //   1. last_session_at — most authoritative ("I worked on it")
+    //   2. last_touched — covers the pinning event itself, plus any edit
+    //      (`setProjectPinned` stamps this on the pin flip, so a brand-
+    //      new pin gets a full 3-day grace period before the dot fires)
+    //   3. created_at — final fallback for ancient routines that pre-date
+    //      last_touched
+    // If none exist (truly unknown), don't ping — silence beats a false
+    // positive that discourages pinning.
     const stalePinnedCount = pinnedProjects.filter(p => {
-      if (!p.last_session_at) return true
-      const last = new Date(p.last_session_at).getTime()
-      return Number.isFinite(last) && (now - last) > STALE_THRESHOLD_MS
+      const candidates = [p.last_session_at, p.last_touched, p.created_at]
+        .filter(Boolean)
+        .map(ts => new Date(ts).getTime())
+        .filter(n => Number.isFinite(n))
+      if (candidates.length === 0) return false
+      const mostRecent = Math.max(...candidates)
+      return (now - mostRecent) > STALE_THRESHOLD_MS
     }).length
 
     // Routines that fired today. Not currently a badge signal — the

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,12 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-22
 
+- fix(viewport): iOS PWA grey gap below BottomTabs after keyboard interaction [XS]
+  - **Bug.** After typing in any modal input (Add task, Adviser, Edit, etc.), closing the keyboard left a grey strip of body-background visible below the bottom tab bar on iOS PWA standalone mode. Force-quitting the PWA was the only way to restore correct layout (issue #213).
+  - **Cause.** `.v2-app { position: fixed; inset: 0 }` anchors to the layout viewport. iOS Safari leaves the layout viewport in a stale state across keyboard show/hide cycles, which makes the v2-app draw shorter than the actual visual viewport.
+  - **Fix.** Use `height: 100dvh` (dynamic viewport height) instead of `inset: 0`'s implicit bottom anchoring. `dvh` tracks the live visual viewport so the app stays correctly sized through every iOS URL-bar / keyboard / orientation transition. Wrapped in `@supports (height: 100dvh)` so older browsers fall back to the inset:0 path. Boomerang targets iOS 16.4+ for Web Push anyway, so dvh is the default path for nearly all users.
+  - Modified: `src/v2/AppV2.css`, `wiki/Version-History.md`
+
 - fix(spaces-badge): grace period for newly-pinned projects [XS]
   - **Bug.** Spaces tab attention dot fired immediately on any newly-pinned project. `useSpaces` treated `last_session_at = null` as "stale forever," which made the badge a false positive every time a user pinned something — defeating the signal it was supposed to send (issue #212).
   - **Fix.** Use the most-recent of `last_session_at`, `last_touched`, `created_at` as the staleness reference. `setProjectPinned` already stamps `last_touched`, so a brand-new pin now gets a full 3-day grace window before the dot fires. Projects with no reference timestamps at all (truly unknown state) don't fire either — silence beats a false positive.

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,11 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-22
 
+- fix(spaces-badge): grace period for newly-pinned projects [XS]
+  - **Bug.** Spaces tab attention dot fired immediately on any newly-pinned project. `useSpaces` treated `last_session_at = null` as "stale forever," which made the badge a false positive every time a user pinned something — defeating the signal it was supposed to send (issue #212).
+  - **Fix.** Use the most-recent of `last_session_at`, `last_touched`, `created_at` as the staleness reference. `setProjectPinned` already stamps `last_touched`, so a brand-new pin now gets a full 3-day grace window before the dot fires. Projects with no reference timestamps at all (truly unknown state) don't fire either — silence beats a false positive.
+  - Modified: `src/v2/hooks/useSpaces.js`, `wiki/Version-History.md`
+
 - feat(routines): custom cadence supports "every N months" alongside "every N days" [S]
   - **Ask.** Existing custom cadence only supported days. Quarterly + annually are fixed presets; in-between cadences like "every 2 months" / "every 6 months" weren't expressible.
   - **Schema.** Migration 031 adds `custom_unit TEXT DEFAULT 'days'` to the routines table. `custom_days` keeps its name as the interval count (regardless of unit) — kept for backward compat with all callers; renaming would have touched a dozen files. Null/missing `custom_unit` is treated as `'days'` everywhere so pre-migration routines preserve exact behavior.


### PR DESCRIPTION
## Summary
Two bug fixes from the bottom-tabs ship — both XS, both validated on `:dev`.

## Ships to prod
- **#212 fix** — Spaces tab attention dot grace period. Newly-pinned projects no longer fire the badge immediately; the dot waits 3 days (using `last_touched` as the grace-window reference) before flagging stale.
- **#213 fix** — iOS PWA grey gap below BottomTabs after keyboard interaction. `.v2-app` switches from `inset: 0` → `height: 100dvh` (wrapped in `@supports` for pre-iOS-16 fallback).

## Test plan
- [x] Both PRs (#215, #216) merged to dev clean.
- [x] User signed off on `:dev` deploy.

## Notes
Merge method: **merge** (dev→main convention).

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmpfJaWEpmFxNg4yJbepdP)_