### PR TITLE
release: remove Spaces tab attention dot

### DIFF
--- a/src/v2/AppV2.jsx
+++ b/src/v2/AppV2.jsx
@@ -48,7 +48,6 @@ import { useNotionSync } from '../hooks/useNotionSync'
 import { useGCalSync } from '../hooks/useGCalSync'
 import { useKeyboardShortcuts } from '../hooks/useKeyboardShortcuts'
 import { useTerminalMode } from './hooks/useTerminalMode'
-import { useSpaces } from './hooks/useSpaces'
 import { inferSize, trelloUpdateCard, serverSkipAdvanceTask } from '../api'
 import { loadLabels, loadSettings, saveSettings, saveLabels, sortTasks, computeDailyStats, computeStreak, computeRoutineStreak, logActivity, localYMD } from '../store'
 import './AppV2.css'
@@ -190,12 +189,6 @@ export default function AppV2() {
     routines, addRoutine, deleteRoutine, togglePause, updateRoutine,
     completeRoutine, adjustRoutineHistory, spawnDueTasks, spawnNow, logHabit, skipCycle, hydrateRoutines,
   } = useRoutines()
-
-  // Spaces data layer — drives the BottomTabs badge dot today, and
-  // will feed rich preview cards inside SpacesHub on the C-upgrade.
-  // Pure derivation from tasks + routines — no fetches, no extra
-  // state — so it re-renders on the same cadence as the rest of v2.
-  const spaces = useSpaces({ tasks, routines })
 
   // Background work that must keep running even when v2 is the active shell:
   // notifications, AI inference, external (Trello/Notion) outbound sync,
@@ -975,7 +968,6 @@ export default function AppV2() {
       {!isDesktop && (
         <BottomTabs
           activeTab={activeTab}
-          spacesBadge={spaces.wantsAttention}
           onTabChange={(next) => {
             if (next === 'today') {
               setActiveTab('today')

--- a/src/v2/components/BottomTabs.css
+++ b/src/v2/components/BottomTabs.css
@@ -13,7 +13,6 @@
 }
 
 .v2-bottom-tab {
-  position: relative;
   flex: 1;
   display: flex;
   flex-direction: column;
@@ -41,26 +40,6 @@
   padding: 4px 14px;
   border-radius: var(--v2-radius-pill);
   transition: background var(--v2-dur-quick) var(--v2-ease-standard);
-}
-
-/* Attention badge — small accent-colored dot anchored to the
- * tab button itself (button is position: relative). Floats above the
- * icon's top-right corner. Presence boolean only, no counter.
- * Sourced from useSpaces().wantsAttention. */
-.v2-bottom-tab-badge {
-  position: absolute;
-  /* Center-align horizontally on the icon: icon-wrap is 22px icon + 14px*2
-   * horizontal padding = 50px wide. Right-edge offset from button center
-   * lands the dot ~3px past the icon-wrap's right edge. */
-  top: 6px;
-  left: calc(50% + 16px);
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: var(--v2-accent);
-  /* Soft surface ring so the dot reads cleanly over the active-tab
-   * pill background. */
-  box-shadow: 0 0 0 2px var(--v2-bg);
 }
 
 .v2-bottom-tab-icon {

--- a/src/v2/components/BottomTabs.jsx
+++ b/src/v2/components/BottomTabs.jsx
@@ -5,16 +5,9 @@ import './BottomTabs.css'
 // Desktop intentionally skipped — it has the Kanban + side drawer
 // pattern, doesn't need bottom chrome eating screen height.
 //
-// `spacesBadge` is a presence boolean (not a counter) sourced from
-// useSpaces().wantsAttention — a dot if a pinned project has drifted
-// past the stale threshold OR any other future signal worth pinging.
-// Counter would invite "I have 4 stale projects, that's bad" anxiety;
-// a dot is "hey, peek in here."
-//
 // Terminal-theme styling lives in src/v2/terminal/tabs.css — lucide
-// SVGs hide, labels become `[ today ]` bracketed mono, badge renders
-// as a small `•` glyph to the right of the active label.
-export default function BottomTabs({ activeTab, onTabChange, spacesBadge = false }) {
+// SVGs hide, labels become `[ today ]` bracketed mono.
+export default function BottomTabs({ activeTab, onTabChange }) {
   return (
     <nav className="v2-bottom-tabs" role="tablist" aria-label="Primary navigation">
       <button
@@ -33,15 +26,13 @@ export default function BottomTabs({ activeTab, onTabChange, spacesBadge = false
         type="button"
         role="tab"
         aria-selected={activeTab === 'spaces'}
-        aria-label={spacesBadge ? 'Spaces (attention needed)' : 'Spaces'}
-        className={`v2-bottom-tab${activeTab === 'spaces' ? ' is-active' : ''}${spacesBadge ? ' has-badge' : ''}`}
+        className={`v2-bottom-tab${activeTab === 'spaces' ? ' is-active' : ''}`}
         onClick={() => onTabChange('spaces')}
       >
         <span className="v2-bottom-tab-icon-wrap">
           <FolderKanban size={22} strokeWidth={1.75} className="v2-bottom-tab-icon" aria-hidden="true" />
         </span>
         <span className="v2-bottom-tab-label" data-terminal-label="spaces">Spaces</span>
-        {spacesBadge && <span className="v2-bottom-tab-badge" aria-hidden="true" />}
       </button>
     </nav>
   )

--- a/src/v2/hooks/useSpaces.js
+++ b/src/v2/hooks/useSpaces.js
@@ -2,53 +2,26 @@ import { useMemo } from 'react'
 
 // Spaces data layer. Reads from existing useTasks / useRoutines state —
 // no new fetches — so re-renders track the same dependency graph the
-// rest of v2 already invalidates on.
+// rest of v2 already invalidates on. Kept here as the data shape the
+// future SpacesHub preview-card upgrade (C-upgrade) will consume.
 //
-// In D this hook powers a single boolean (`wantsAttention`) for the
-// BottomTabs badge dot. In the future C-upgrade, the same hook feeds
-// rich preview cards inside SpacesHub (per-space counts, last-touched
-// timestamps, "fresh" vs "stale" treatment per row). Same data layer,
-// two render paths.
-
-// A pinned project is "stale" if it has no recent session activity.
-// Three days is the threshold where the user committed to caring
-// (pinning) but the project is drifting; sooner than that is just
-// "give it time."
-const STALE_PROJECT_DAYS = 3
-const STALE_THRESHOLD_MS = STALE_PROJECT_DAYS * 24 * 60 * 60 * 1000
+// Note: an earlier iteration also exposed `wantsAttention` for a Spaces
+// tab-bar badge dot driven by stale pinned projects. The signal was
+// noisy in practice — the user found the dot more annoying than useful —
+// so the badge was removed. See PR-trail for the stalePinnedCount logic
+// if the signal is ever revisited (probably with a richer rule than
+// "3-day no-session").
 
 export function useSpaces({ tasks, routines }) {
   return useMemo(() => {
-    const now = Date.now()
     const todayStr = new Date().toDateString()
 
     const allProjects = tasks.filter(t => t.status === 'project')
     const pinnedProjects = allProjects.filter(t => t.pinned_to_today)
     const activeRoutines = routines.filter(r => !r.paused)
 
-    // Pinned projects whose most-recent attention signal is older than
-    // STALE_PROJECT_DAYS. References checked, in priority order:
-    //   1. last_session_at — most authoritative ("I worked on it")
-    //   2. last_touched — covers the pinning event itself, plus any edit
-    //      (`setProjectPinned` stamps this on the pin flip, so a brand-
-    //      new pin gets a full 3-day grace period before the dot fires)
-    //   3. created_at — final fallback for ancient routines that pre-date
-    //      last_touched
-    // If none exist (truly unknown), don't ping — silence beats a false
-    // positive that discourages pinning.
-    const stalePinnedCount = pinnedProjects.filter(p => {
-      const candidates = [p.last_session_at, p.last_touched, p.created_at]
-        .filter(Boolean)
-        .map(ts => new Date(ts).getTime())
-        .filter(n => Number.isFinite(n))
-      if (candidates.length === 0) return false
-      const mostRecent = Math.max(...candidates)
-      return (now - mostRecent) > STALE_THRESHOLD_MS
-    }).length
-
-    // Routines that fired today. Not currently a badge signal — the
-    // spawned tasks already appear in the Today list — but exposed for
-    // the C-upgrade's per-row meta ("1 routine spawned today").
+    // Routines that fired today. Exposed for the C-upgrade's per-row
+    // meta ("1 routine spawned today"). Not currently surfaced anywhere.
     const spawnedTodayCount = activeRoutines.filter(r => {
       const history = r.completed_history
       if (!Array.isArray(history) || history.length === 0) return false
@@ -67,17 +40,12 @@ export function useSpaces({ tasks, routines }) {
       projects: {
         pinnedCount: pinnedProjects.length,
         totalCount: allProjects.length,
-        stalePinnedCount,
       },
       routines: {
         activeCount: activeRoutines.length,
         spawnedTodayCount,
       },
       knowledge,
-      // Single boolean that drives the tab-bar badge dot. Future
-      // signals (e.g. new knowledge in last 24h, routine ready to
-      // spawn) can OR in here without changing BottomTabs' contract.
-      wantsAttention: stalePinnedCount > 0,
     }
   }, [tasks, routines])
 }

--- a/src/v2/terminal/tabs.css
+++ b/src/v2/terminal/tabs.css
@@ -34,25 +34,6 @@
   display: none;
 }
 
-/* Attention badge — terminal renders as a small accent-colored `•`
- * glyph inline after the bracketed label. The standard dot is
- * absolute-positioned over the icon (which doesn't render in terminal),
- * so swap to an inline glyph via the pseudo-element content. */
-:root[data-ui="v2"][data-theme^="terminal"] .v2-bottom-tab-badge {
-  position: static;
-  width: auto;
-  height: auto;
-  background: transparent;
-  box-shadow: none;
-  font: 500 14px/1 var(--v2-font-body);
-  margin-left: 4px;
-}
-:root[data-ui="v2"][data-theme^="terminal"] .v2-bottom-tab-badge::before {
-  content: "•";
-  color: var(--v2-accent);
-  text-shadow: var(--v2-glow);
-}
-
 :root[data-ui="v2"][data-theme^="terminal"] .v2-bottom-tab {
   font: 500 13px/1 var(--v2-font-body);
   color: var(--v2-text-meta);

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,13 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-22
 
+- chore(spaces-badge): remove the Spaces tab attention dot [XS]
+  - **Ask.** User found the dot more annoying than useful — even with the 3-day grace period, it kept firing on pinned projects that didn't actually need a nudge. Pulling it.
+  - **Removal.** Drop `spacesBadge` prop + badge JSX from BottomTabs. Remove `.v2-bottom-tab-badge` styles from both BottomTabs.css and terminal/tabs.css. Drop `position: relative` from `.v2-bottom-tab` (was only there to anchor the badge). Drop `wantsAttention` + `stalePinnedCount` from useSpaces. Drop the AppV2 useSpaces import + call (no consumer left).
+  - **What stays.** `src/v2/hooks/useSpaces.js` itself remains as the data shape the future SpacesHub preview-card upgrade (C-upgrade) will consume — `pinnedCount`, `totalCount`, `activeCount`, `spawnedTodayCount`, stubbed `knowledge`. The hook is just dormant until a consumer wires it back in.
+  - **Notes for the future.** If the attention signal is ever revisited, probably needs a richer rule than "3-day no-session" — maybe "pinned + no Today-list child + N+ days." Or replace the dot entirely with a one-tap "snooze the nudge" affordance. Either way, requires a UX redesign, not just a threshold tweak.
+  - Modified: `src/v2/AppV2.jsx`, `src/v2/components/BottomTabs.jsx`, `src/v2/components/BottomTabs.css`, `src/v2/hooks/useSpaces.js`, `src/v2/terminal/tabs.css`, `wiki/Version-History.md`
+
 - fix(viewport): iOS PWA grey gap below BottomTabs after keyboard interaction [XS]
   - **Bug.** After typing in any modal input (Add task, Adviser, Edit, etc.), closing the keyboard left a grey strip of body-background visible below the bottom tab bar on iOS PWA standalone mode. Force-quitting the PWA was the only way to restore correct layout (issue #213).
   - **Cause.** `.v2-app { position: fixed; inset: 0 }` anchors to the layout viewport. iOS Safari leaves the layout viewport in a stale state across keyboard show/hide cycles, which makes the v2-app draw shorter than the actual visual viewport.


### PR DESCRIPTION
## Summary
Promotion of PR #218: removes the Spaces tab attention dot. User feedback after the grace-period fix landed: the signal kept firing on pinned projects regardless of intent, more annoying than useful.

## Ships to prod
- Badge JSX + CSS gone from BottomTabs (light/dark + terminal)
- `wantsAttention` removed from useSpaces
- `src/v2/hooks/useSpaces.js` stays as dormant data layer for future C-upgrade

## Notes
Merge method: **merge** (dev→main convention).

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmpfJaWEpmFxNg4yJbepdP)_