### PR TITLE
fix(weekstrip): date tap always toggles, setting seeds default

### DIFF
--- a/src/v2/AppV2.jsx
+++ b/src/v2/AppV2.jsx
@@ -96,9 +96,11 @@ export default function AppV2() {
   const [showAnalytics, setShowAnalytics] = useState(false)
   const [showSuggestions, setShowSuggestions] = useState(false)
   // Terminal-mode 7-day strip visibility. The calendar+date span in the
-  // home stats line acts as the toggle (default closed). The
-  // `week_strip_always_open` setting forces it visible regardless.
-  const [weekStripShown, setWeekStripShown] = useState(false)
+  // home stats line acts as the toggle. Initial state mirrors the
+  // `week_strip_always_open` setting (so users who opt into always-open
+  // get the strip shown on load), but the date tap can always flip it
+  // either way — the setting controls the default, not a forced lock.
+  const [weekStripShown, setWeekStripShown] = useState(() => !!loadSettings().week_strip_always_open)
   const [expandedTaskId, setExpandedTaskId] = useState(null)
   const [activeFilter, setActiveFilter] = useState('all')
   const [sortBy, setSortBy] = useState(() => loadSettings().sort_by || 'age')
@@ -892,43 +894,35 @@ export default function AppV2() {
           />
         ) : (
           <div className="v2-list">
-            {/* Terminal home header: date + streak + today's progress as a
-              * single segmented line. Originally terminal-only; lifted
-              * to all themes 2026-05-17 because users want the streak +
-              * today's progress glanceable across the board. Date is a
-              * toggle for the WeekStrip below. */}
-            {(() => {
-              const alwaysOpen = !!settingsForRings.week_strip_always_open
-              const open = alwaysOpen || weekStripShown
-              return (
-                <div className="v2-home-stats" aria-hidden="false">
-                  <button
-                    type="button"
-                    className={`v2-thx-date v2-thx-date-toggle${open ? ' v2-thx-date-open' : ''}`}
-                    onClick={() => !alwaysOpen && setWeekStripShown(v => !v)}
-                    aria-expanded={open}
-                    aria-controls="v2-week-strip-days"
-                    aria-label={open ? 'Hide 7-day strip' : 'Show 7-day strip'}
-                    disabled={alwaysOpen}
-                  >
-                    📅 {new Date().toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' })}
-                    {!alwaysOpen && (
-                      <span className="v2-thx-date-chev" aria-hidden="true">{open ? '▴' : '▾'}</span>
-                    )}
-                  </button>
-                  <span className="v2-thx-sep">·</span>
-                  <span className="v2-thx-streak">
-                    🔥 {streak} day{streak === 1 ? '' : 's'}
-                  </span>
-                  <span className="v2-thx-sep">·</span>
-                  <span className="v2-thx-today">
-                    ✓ {dailyStats.tasksToday}/{settingsForRings.daily_task_goal || 3} today
-                  </span>
-                </div>
-              )
-            })()}
-            {(settingsForRings.week_strip_always_open || weekStripShown ||
-              (!isTerminal && settingsForRings.show_week_strip)) && (
+            {/* Home header: date + streak + today's progress on one line.
+              * Lifted to all themes 2026-05-17. The 📅 date is the
+              * always-tappable toggle for the WeekStrip below — works
+              * regardless of the `week_strip_always_open` setting (which
+              * only seeds the initial state). User can hide-on-demand
+              * even when the always-open default is on; next reload
+              * restores the default. */}
+            <div className="v2-home-stats" aria-hidden="false">
+              <button
+                type="button"
+                className={`v2-thx-date v2-thx-date-toggle${weekStripShown ? ' v2-thx-date-open' : ''}`}
+                onClick={() => setWeekStripShown(v => !v)}
+                aria-expanded={weekStripShown}
+                aria-controls="v2-week-strip-days"
+                aria-label={weekStripShown ? 'Hide 7-day strip' : 'Show 7-day strip'}
+              >
+                📅 {new Date().toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' })}
+                <span className="v2-thx-date-chev" aria-hidden="true">{weekStripShown ? '▴' : '▾'}</span>
+              </button>
+              <span className="v2-thx-sep">·</span>
+              <span className="v2-thx-streak">
+                🔥 {streak} day{streak === 1 ? '' : 's'}
+              </span>
+              <span className="v2-thx-sep">·</span>
+              <span className="v2-thx-today">
+                ✓ {dailyStats.tasksToday}/{settingsForRings.daily_task_goal || 3} today
+              </span>
+            </div>
+            {(weekStripShown || (!isTerminal && settingsForRings.show_week_strip)) && (
               <WeekStrip
                 tasks={tasks}
                 dailyTaskGoal={settingsForRings.daily_task_goal || 3}

--- a/src/v2/components/SettingsModal.jsx
+++ b/src/v2/components/SettingsModal.jsx
@@ -2320,8 +2320,8 @@ export default function SettingsModal({
 
             <div className="v2-settings-row">
               <div className="v2-settings-row-text">
-                <div className="v2-settings-row-label">Keep 7-day strip always open</div>
-                <div className="v2-settings-row-hint">In terminal mode, force the strip visible permanently so you don't have to tap the date to expand it.</div>
+                <div className="v2-settings-row-label">Open 7-day strip by default</div>
+                <div className="v2-settings-row-hint">Show the strip expanded when the app loads. Tap the date in the home stats line any time to hide it or re-open it.</div>
               </div>
               <label className="v2-settings-toggle">
                 <input

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,12 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-22
 
+- fix(weekstrip): date tap always toggles + "always open" works in all themes [XS]
+  - **Bug.** With "Keep 7-day strip always open" turned ON, tapping the 📅 date in the home stats line did nothing — the button was hard-disabled by the setting. Date tap had been a no-op in this state since 2026-05-17 (commit ac164dc), but only surfaced now that the setting was discoverable across all themes (issue #208).
+  - **Fix.** Setting now seeds the initial WeekStrip visibility state on app load instead of force-locking it. The date tap is always live — user can hide-on-demand even with always-open ON; next reload restores the default. Drop the `disabled` attribute, drop the `alwaysOpen` ternary on the chevron, drop the JSX IIFE wrapper now that there's no derived state to compute.
+  - **Description copy.** Settings row renamed "Keep 7-day strip always open" → "Open 7-day strip by default". Hint now reads: "Show the strip expanded when the app loads. Tap the date in the home stats line any time to hide it or re-open it." Drops the terminal-only framing entirely (closes #208 description portion).
+  - Modified: `src/v2/AppV2.jsx`, `src/v2/components/SettingsModal.jsx`, `wiki/Version-History.md`
+
 - chore(spaces-badge): remove the Spaces tab attention dot [XS]
   - **Ask.** User found the dot more annoying than useful — even with the 3-day grace period, it kept firing on pinned projects that didn't actually need a nudge. Pulling it.
   - **Removal.** Drop `spacesBadge` prop + badge JSX from BottomTabs. Remove `.v2-bottom-tab-badge` styles from both BottomTabs.css and terminal/tabs.css. Drop `position: relative` from `.v2-bottom-tab` (was only there to anchor the badge). Drop `wantsAttention` + `stalePinnedCount` from useSpaces. Drop the AppV2 useSpaces import + call (no consumer left).


### PR DESCRIPTION
## Bug
Tapping the 📅 date in the home stats line did nothing when "Keep 7-day strip always open" was ON. The button was `disabled={alwaysOpen}` since 2026-05-17 (commit ac164dc) but only surfaced now that the setting was discoverable across all themes via #208's investigation.

## Fix
- Setting now seeds the **initial** WeekStrip visibility on app load instead of force-locking it. `useState(() => !!loadSettings().week_strip_always_open)`.
- Date tap is always live — drops the `disabled` attribute, the `!alwaysOpen &&` click guard, and the chevron's `!alwaysOpen` gate.
- Settings row retitled "Keep 7-day strip always open" → "Open 7-day strip by default". Hint drops the terminal-only framing entirely (closes #208's description portion).
- User can hide-on-demand even with the default ON; next reload restores the default.

## Test plan
- [x] Lint + production build clean.
- [ ] Validate: setting ON → strip shows on app load, tap date hides it; tap again shows it. Setting OFF → strip hidden on app load, tap shows. Works in light/dark/terminal-dark/terminal-light.

Closes part of #208 (description copy + all-themes behavior). The strip already showed in all themes since May 17; the issue was the disabled tap.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmpfJaWEpmFxNg4yJbepdP)_