### PR TITLE
release: weekstrip toggle in light/dark

### DIFF
--- a/src/v2/AppV2.jsx
+++ b/src/v2/AppV2.jsx
@@ -47,7 +47,6 @@ import { useTrelloSync } from '../hooks/useTrelloSync'
 import { useNotionSync } from '../hooks/useNotionSync'
 import { useGCalSync } from '../hooks/useGCalSync'
 import { useKeyboardShortcuts } from '../hooks/useKeyboardShortcuts'
-import { useTerminalMode } from './hooks/useTerminalMode'
 import { inferSize, trelloUpdateCard, serverSkipAdvanceTask } from '../api'
 import { loadLabels, loadSettings, saveSettings, saveLabels, sortTasks, computeDailyStats, computeStreak, computeRoutineStreak, logActivity, localYMD } from '../store'
 import './AppV2.css'
@@ -95,12 +94,17 @@ export default function AppV2() {
   const [adviserDraftSeed, setAdviserDraftSeed] = useState('')
   const [showAnalytics, setShowAnalytics] = useState(false)
   const [showSuggestions, setShowSuggestions] = useState(false)
-  // Terminal-mode 7-day strip visibility. The calendar+date span in the
-  // home stats line acts as the toggle. Initial state mirrors the
-  // `week_strip_always_open` setting (so users who opt into always-open
-  // get the strip shown on load), but the date tap can always flip it
-  // either way — the setting controls the default, not a forced lock.
-  const [weekStripShown, setWeekStripShown] = useState(() => !!loadSettings().week_strip_always_open)
+  // 7-day strip visibility — single source of truth. Date tap toggles
+  // it in all themes. Two settings can seed the initial state on load:
+  //   - week_strip_always_open: explicit "open by default" toggle
+  //   - show_week_strip: legacy non-terminal setting (light/dark default
+  //     is true). Either being on means "start with the strip open".
+  const [weekStripShown, setWeekStripShown] = useState(() => {
+    const s = loadSettings()
+    const theme = s.theme || 'dark'
+    const isTerm = typeof theme === 'string' && theme.startsWith('terminal')
+    return !!s.week_strip_always_open || (!isTerm && !!s.show_week_strip)
+  })
   const [expandedTaskId, setExpandedTaskId] = useState(null)
   const [activeFilter, setActiveFilter] = useState('all')
   const [sortBy, setSortBy] = useState(() => loadSettings().sort_by || 'age')
@@ -114,7 +118,6 @@ export default function AppV2() {
   // same thread. Server session TTL still governs the staged-plan life.
   const adviserState = useAdviser()
   const isDesktop = useIsDesktop()
-  const isTerminal = useTerminalMode()
   const weather = useWeather()
 
   // Hidden tic-tac-toe Easter egg. Triggered by either: 7-tap the Build
@@ -922,7 +925,7 @@ export default function AppV2() {
                 ✓ {dailyStats.tasksToday}/{settingsForRings.daily_task_goal || 3} today
               </span>
             </div>
-            {(weekStripShown || (!isTerminal && settingsForRings.show_week_strip)) && (
+            {weekStripShown && (
               <WeekStrip
                 tasks={tasks}
                 dailyTaskGoal={settingsForRings.daily_task_goal || 3}

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,11 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-22
 
+- fix(weekstrip): date tap actually toggles in light/dark/default themes too [XS]
+  - **Bug.** After the prior PR #220 fix, the date tap worked in terminal but still no-op'd in light/dark. The render condition still had a `(!isTerminal && show_week_strip)` clause that kept the strip visible regardless of `weekStripShown` — light/dark's default is `show_week_strip=true`, so tapping toggled the state but the strip stayed open via the legacy clause.
+  - **Fix.** Make `weekStripShown` the single source of truth across all themes. Seed it from EITHER `week_strip_always_open` OR `(!isTerminal && show_week_strip)` on mount, then let the date tap drive it. Drops the redundant render-condition clause and the now-unused `isTerminal`/`useTerminalMode` ref in AppV2.
+  - Modified: `src/v2/AppV2.jsx`, `wiki/Version-History.md`
+
 - fix(weekstrip): date tap always toggles + "always open" works in all themes [XS]
   - **Bug.** With "Keep 7-day strip always open" turned ON, tapping the 📅 date in the home stats line did nothing — the button was hard-disabled by the setting. Date tap had been a no-op in this state since 2026-05-17 (commit ac164dc), but only surfaced now that the setting was discoverable across all themes (issue #208).
   - **Fix.** Setting now seeds the initial WeekStrip visibility state on app load instead of force-locking it. The date tap is always live — user can hide-on-demand even with always-open ON; next reload restores the default. Drop the `disabled` attribute, drop the `alwaysOpen` ternary on the chevron, drop the JSX IIFE wrapper now that there's no derived state to compute.


### PR DESCRIPTION
## Summary
Promotes PR #222 from dev to main.

## What lands
- **fix(weekstrip): date tap toggles in light/dark too [XS]** — Single source of truth for WeekStrip visibility across all themes. Either legacy setting seeds the initial state; tap always works.

## Test plan
- [x] Validated on `:dev` via the PR #222 cycle.
- [ ] Smoke: tap the 📅 date in light, dark, terminal-dark, terminal-light — strip hides/shows in all four.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmpfJaWEpmFxNg4yJbepdP)_