### PR TITLE
feat(ui): tappable home stats + fix iOS bottom panel gap

### DIFF
--- a/src/v2/AppV2.css
+++ b/src/v2/AppV2.css
@@ -15,19 +15,19 @@
 /* iOS PWA viewport fix (issue #213). After keyboard show/hide on iOS
  * Safari standalone, `position: fixed; inset: 0` anchors to a stale
  * layout viewport — the v2-app draws shorter than the visual viewport
- * and exposes a strip of body bg below the bottom tab bar that only
- * a hard PWA-kill restores. `100dvh` (dynamic viewport height) tracks
- * the live visual viewport across all the iOS URL bar / keyboard /
- * orientation transitions, so the app stays correctly sized.
+ * and exposes body bg below BottomTabs. `min-height: 100dvh` (dynamic
+ * viewport height) prevents the container from shrinking after keyboard
+ * transitions, while `inset: 0` (specifically bottom: 0) keeps the
+ * container anchored to the screen bottom on first render when iOS may
+ * report a stale dvh value.
  *
- * Wrapped in @supports so older browsers (pre-iOS 16 Safari) fall back
- * to the inset:0 anchoring above. Boomerang's PWA targets iOS 16.4+
- * for Web Push anyway, so dvh is the default path for nearly all
- * users; the fallback is just defensive. */
+ * Previous approach (bottom: auto + height: 100dvh) dropped the bottom
+ * anchor entirely, which caused the container to float short on some
+ * iOS PWA cold starts — surfacing as BottomTabs "raised" with a gap
+ * underneath. Keeping bottom: 0 + min-height solves both directions. */
 @supports (height: 100dvh) {
   .v2-app {
-    bottom: auto;
-    height: 100dvh;
+    min-height: 100dvh;
   }
 }
 
@@ -71,6 +71,76 @@
   font: 500 13px/1.2 var(--v2-font-body);
   color: var(--v2-text-meta);
   text-align: center;
+}
+
+/* Tappable streak + today buttons — same inline treatment as the date
+ * toggle: stripped button chrome, accent on active/hover. */
+.v2-thx-btn {
+  border: none;
+  background: transparent;
+  padding: 0;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+  transition: color var(--v2-dur-quick) var(--v2-ease-standard);
+}
+
+.v2-thx-btn:hover,
+.v2-thx-btn:focus-visible {
+  color: var(--v2-accent);
+  outline: none;
+}
+
+.v2-thx-btn-active {
+  color: var(--v2-accent);
+}
+
+/* Inline detail panel — slides below the home stats line for streak
+ * or today progress. Hairline-list aesthetic, centered like stats. */
+.v2-stats-detail {
+  max-width: 320px;
+  margin: 0 auto 8px;
+  padding: 10px 16px;
+  background: var(--v2-surface);
+  border: 1px solid var(--v2-hairline);
+  border-radius: var(--v2-radius-card, 12px);
+  font: 400 13px/1.4 var(--v2-font-body);
+  color: var(--v2-text-secondary);
+}
+
+.v2-stats-detail-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 5px 0;
+}
+
+.v2-stats-detail-row + .v2-stats-detail-row {
+  border-top: 1px solid var(--v2-hairline);
+}
+
+.v2-stats-detail-label {
+  color: var(--v2-text-meta);
+}
+
+.v2-stats-detail-value {
+  font-weight: 600;
+  color: var(--v2-text);
+}
+
+.v2-stats-detail-done {
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid var(--v2-hairline);
+}
+
+.v2-stats-detail-done-item {
+  padding: 3px 0;
+  color: var(--v2-text-meta);
+  font-size: 12px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 /* Inline code in body copy (keyboard hints, URL flags, etc.) */

--- a/src/v2/AppV2.jsx
+++ b/src/v2/AppV2.jsx
@@ -49,6 +49,7 @@ import { useGCalSync } from '../hooks/useGCalSync'
 import { useKeyboardShortcuts } from '../hooks/useKeyboardShortcuts'
 import { inferSize, trelloUpdateCard, serverSkipAdvanceTask } from '../api'
 import { loadLabels, loadSettings, saveSettings, saveLabels, sortTasks, computeDailyStats, computeStreak, computeRoutineStreak, logActivity, localYMD } from '../store'
+import { computeRecords } from '../scoring'
 import './AppV2.css'
 
 export default function AppV2() {
@@ -105,6 +106,8 @@ export default function AppV2() {
     const isTerm = typeof theme === 'string' && theme.startsWith('terminal')
     return !!s.week_strip_always_open || (!isTerm && !!s.show_week_strip)
   })
+  // Which home-stats detail section is expanded: 'streak' | 'today' | null
+  const [statsDetail, setStatsDetail] = useState(null)
   const [expandedTaskId, setExpandedTaskId] = useState(null)
   const [activeFilter, setActiveFilter] = useState('all')
   const [sortBy, setSortBy] = useState(() => loadSettings().sort_by || 'age')
@@ -369,6 +372,7 @@ export default function AppV2() {
   const settingsForRings = loadSettings()
   const dailyStats = computeDailyStats(tasks, settingsForRings)
   const streak = computeStreak(tasks, settingsForRings)
+  const records = useMemo(() => computeRecords(tasks), [tasks])
   // Per-routine streak map → threaded down to TaskCard so routine-spawned
   // tasks can render an inline 🔥N. Recomputed only when `routines` changes.
   const routineStreaks = useMemo(() => {
@@ -897,18 +901,13 @@ export default function AppV2() {
           />
         ) : (
           <div className="v2-list">
-            {/* Home header: date + streak + today's progress on one line.
-              * Lifted to all themes 2026-05-17. The 📅 date is the
-              * always-tappable toggle for the WeekStrip below — works
-              * regardless of the `week_strip_always_open` setting (which
-              * only seeds the initial state). User can hide-on-demand
-              * even when the always-open default is on; next reload
-              * restores the default. */}
+            {/* Home stats line — every segment is tappable.
+              * Date → WeekStrip. Streak → streak detail. Today → daily detail. */}
             <div className="v2-home-stats" aria-hidden="false">
               <button
                 type="button"
                 className={`v2-thx-date v2-thx-date-toggle${weekStripShown ? ' v2-thx-date-open' : ''}`}
-                onClick={() => setWeekStripShown(v => !v)}
+                onClick={() => { setWeekStripShown(v => !v); setStatsDetail(null) }}
                 aria-expanded={weekStripShown}
                 aria-controls="v2-week-strip-days"
                 aria-label={weekStripShown ? 'Hide 7-day strip' : 'Show 7-day strip'}
@@ -917,13 +916,23 @@ export default function AppV2() {
                 <span className="v2-thx-date-chev" aria-hidden="true">{weekStripShown ? '▴' : '▾'}</span>
               </button>
               <span className="v2-thx-sep">·</span>
-              <span className="v2-thx-streak">
+              <button
+                type="button"
+                className={`v2-thx-btn v2-thx-streak${statsDetail === 'streak' ? ' v2-thx-btn-active' : ''}`}
+                onClick={() => { setStatsDetail(v => v === 'streak' ? null : 'streak'); setWeekStripShown(false) }}
+                aria-expanded={statsDetail === 'streak'}
+              >
                 🔥 {streak} day{streak === 1 ? '' : 's'}
-              </span>
+              </button>
               <span className="v2-thx-sep">·</span>
-              <span className="v2-thx-today">
+              <button
+                type="button"
+                className={`v2-thx-btn v2-thx-today${statsDetail === 'today' ? ' v2-thx-btn-active' : ''}`}
+                onClick={() => { setStatsDetail(v => v === 'today' ? null : 'today'); setWeekStripShown(false) }}
+                aria-expanded={statsDetail === 'today'}
+              >
                 ✓ {dailyStats.tasksToday}/{settingsForRings.daily_task_goal || 3} today
-              </span>
+              </button>
             </div>
             {weekStripShown && (
               <WeekStrip
@@ -931,6 +940,56 @@ export default function AppV2() {
                 dailyTaskGoal={settingsForRings.daily_task_goal || 3}
               />
             )}
+            {statsDetail === 'streak' && (
+              <div className="v2-stats-detail">
+                <div className="v2-stats-detail-row">
+                  <span className="v2-stats-detail-label">Current streak</span>
+                  <span className="v2-stats-detail-value">{streak} day{streak === 1 ? '' : 's'}</span>
+                </div>
+                <div className="v2-stats-detail-row">
+                  <span className="v2-stats-detail-label">Best streak</span>
+                  <span className="v2-stats-detail-value">{records.longestStreak} day{records.longestStreak === 1 ? '' : 's'}</span>
+                </div>
+                <div className="v2-stats-detail-row">
+                  <span className="v2-stats-detail-label">Best day (tasks)</span>
+                  <span className="v2-stats-detail-value">{records.bestTasks}</span>
+                </div>
+                <div className="v2-stats-detail-row">
+                  <span className="v2-stats-detail-label">Best day (points)</span>
+                  <span className="v2-stats-detail-value">{records.bestPoints}</span>
+                </div>
+              </div>
+            )}
+            {statsDetail === 'today' && (() => {
+              const todayStr = new Date().toDateString()
+              const doneTasks = tasks.filter(t => t.status === 'done' && t.completed_at && new Date(t.completed_at).toDateString() === todayStr)
+              const activeTasks = tasks.filter(t => ['not_started', 'in_progress', 'waiting'].includes(t.status))
+              const taskGoal = settingsForRings.daily_task_goal || 3
+              const pointsGoal = settingsForRings.daily_points_goal || 15
+              return (
+                <div className="v2-stats-detail">
+                  <div className="v2-stats-detail-row">
+                    <span className="v2-stats-detail-label">Tasks done</span>
+                    <span className="v2-stats-detail-value">{dailyStats.tasksToday} / {taskGoal}</span>
+                  </div>
+                  <div className="v2-stats-detail-row">
+                    <span className="v2-stats-detail-label">Points earned</span>
+                    <span className="v2-stats-detail-value">{dailyStats.pointsToday} / {pointsGoal}</span>
+                  </div>
+                  <div className="v2-stats-detail-row">
+                    <span className="v2-stats-detail-label">Remaining active</span>
+                    <span className="v2-stats-detail-value">{activeTasks.length}</span>
+                  </div>
+                  {doneTasks.length > 0 && (
+                    <div className="v2-stats-detail-done">
+                      {doneTasks.map(t => (
+                        <div key={t.id} className="v2-stats-detail-done-item">✓ {t.title}</div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              )
+            })()}
             <ProjectPinnedSection
               projects={pinnedProjects}
               activeChildren={activeChildrenOfPinned}

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -4,6 +4,21 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ---
 
+## 2026-05-23
+
+- feat(ui): tappable home stats — streak + today detail panels [S]
+  - Streak and today counters in the home stats line are now tappable buttons. Tapping opens an inline detail card below the stats line (same slot as WeekStrip, mutually exclusive).
+  - **Streak detail**: current streak, best streak, best day (tasks + points).
+  - **Today detail**: tasks done / goal, points earned / goal, remaining active count, list of completed tasks.
+  - Each tap closes the other sections (WeekStrip closes when streak/today opens, and vice versa).
+  - Buttons highlight with accent color on hover/active.
+  - Modified: `src/v2/AppV2.jsx`, `src/v2/AppV2.css`
+
+- fix(ios): bottom panel raised on PWA cold start [XS]
+  - **Bug.** On some iOS PWA cold starts, BottomTabs floated above the screen bottom, leaving a gap. The previous 100dvh fix (issue #213) removed `bottom: 0` and relied solely on `height: 100dvh`, which iOS sometimes reports as stale on first render.
+  - **Fix.** Switch from `bottom: auto; height: 100dvh` to `min-height: 100dvh` while keeping `inset: 0` (bottom: 0 stays as anchor). The min-height prevents keyboard-triggered shrinking (the original bug), while the bottom anchor ensures the container always reaches the screen edge on first render.
+  - Modified: `src/v2/AppV2.css`
+
 ## 2026-05-22
 
 - fix(weekstrip): date tap actually toggles in light/dark/default themes too [XS]


### PR DESCRIPTION
## Summary
Two fixes from today's screenshots:

### 1. Tappable home stats — streak + today detail panels
The streak counter ("🔥 18 days") and today counter ("✓ 1/3 today") in the home stats line are now tappable buttons. Each opens an inline detail card below the stats line (same slot as WeekStrip, mutually exclusive):

- **Streak detail**: current streak, best streak, best day (tasks + points)
- **Today detail**: tasks done / goal, points earned / goal, remaining active count, list of today's completed tasks

Buttons highlight with accent color on hover/active. Tapping one section closes the others (WeekStrip included).

### 2. Fix iOS bottom panel gap on PWA cold start
BottomTabs floated above the screen bottom on some iOS PWA cold starts, leaving a visible gap. Root cause: the previous `100dvh` fix removed `bottom: 0` (`bottom: auto; height: 100dvh`), but iOS sometimes reports a stale `dvh` value on first render.

Fix: `min-height: 100dvh` (keeps the keyboard-shrink prevention) + keep `inset: 0` (bottom: 0 anchors the container to the screen edge).

## Test plan
- [ ] Tap 🔥 streak → detail card with current/best streak appears. Tap again to dismiss.
- [ ] Tap ✓ today → detail card with done/points/remaining appears. Completed tasks listed.
- [ ] Tapping streak closes WeekStrip; tapping date closes streak detail.
- [ ] iOS PWA cold start: no gap below BottomTabs.
- [ ] After iOS keyboard dismiss: no gap below BottomTabs (the original 100dvh fix still works).

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmpfJaWEpmFxNg4yJbepdP)_