### PR TITLE
feat(ui): clickable WeekStrip dates + fix best-streak math

### DIFF
--- a/src/v2/AppV2.jsx
+++ b/src/v2/AppV2.jsx
@@ -940,7 +940,9 @@ export default function AppV2() {
                 dailyTaskGoal={settingsForRings.daily_task_goal || 3}
               />
             )}
-            {statsDetail === 'streak' && (
+            {statsDetail === 'streak' && (() => {
+              const bestStreak = Math.max(streak, records.longestStreak)
+              return (
               <div className="v2-stats-detail">
                 <div className="v2-stats-detail-row">
                   <span className="v2-stats-detail-label">Current streak</span>
@@ -948,7 +950,7 @@ export default function AppV2() {
                 </div>
                 <div className="v2-stats-detail-row">
                   <span className="v2-stats-detail-label">Best streak</span>
-                  <span className="v2-stats-detail-value">{records.longestStreak} day{records.longestStreak === 1 ? '' : 's'}</span>
+                  <span className="v2-stats-detail-value">{bestStreak} day{bestStreak === 1 ? '' : 's'}</span>
                 </div>
                 <div className="v2-stats-detail-row">
                   <span className="v2-stats-detail-label">Best day (tasks)</span>
@@ -959,7 +961,8 @@ export default function AppV2() {
                   <span className="v2-stats-detail-value">{records.bestPoints}</span>
                 </div>
               </div>
-            )}
+              )
+            })()}
             {statsDetail === 'today' && (() => {
               const todayStr = new Date().toDateString()
               const doneTasks = tasks.filter(t => t.status === 'done' && t.completed_at && new Date(t.completed_at).toDateString() === todayStr)

--- a/src/v2/components/WeekStrip.css
+++ b/src/v2/components/WeekStrip.css
@@ -66,7 +66,6 @@
   flex-direction: column;
   align-items: center;
   gap: 4px;
-  padding: 8px 4px;
   border: 1px solid var(--v2-hairline);
   border-radius: var(--v2-radius-card);
   font: 500 11px/1 var(--v2-font-body);
@@ -74,8 +73,33 @@
   transition: background var(--v2-dur-quick) var(--v2-ease-standard);
 }
 
+.v2-week-strip-day-btn {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  width: 100%;
+  padding: 8px 4px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  font: inherit;
+  color: inherit;
+}
+
+.v2-week-strip-day-btn:focus-visible {
+  outline: 2px solid var(--v2-accent);
+  outline-offset: -2px;
+  border-radius: var(--v2-radius-card);
+}
+
 .v2-week-strip-day-today {
   background: rgba(var(--v2-text-rgb), 0.06);
+  border-color: var(--v2-accent);
+}
+
+.v2-week-strip-day-selected {
+  background: rgba(255, 98, 64, 0.10);
   border-color: var(--v2-accent);
 }
 
@@ -135,6 +159,59 @@
   opacity: 1;
 }
 
+/* Day detail panel — appears below the strip when a date is tapped.
+ * Shows completed tasks with points for that day. */
+.v2-week-strip-detail {
+  max-width: 360px;
+  margin: 8px auto 0;
+  padding: 10px 14px;
+  background: var(--v2-surface);
+  border: 1px solid var(--v2-hairline);
+  border-radius: var(--v2-radius-card, 12px);
+  font: 400 13px/1.4 var(--v2-font-body);
+}
+
+.v2-week-strip-detail-summary {
+  font-weight: 600;
+  color: var(--v2-text);
+  margin-bottom: 6px;
+  padding-bottom: 6px;
+  border-bottom: 1px solid var(--v2-hairline);
+}
+
+.v2-week-strip-detail-empty {
+  color: var(--v2-text-meta);
+  text-align: center;
+  padding: 4px 0;
+}
+
+.v2-week-strip-detail-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 0;
+}
+
+.v2-week-strip-detail-item + .v2-week-strip-detail-item {
+  border-top: 1px solid var(--v2-hairline);
+}
+
+.v2-week-strip-detail-title {
+  color: var(--v2-text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
+.v2-week-strip-detail-pts {
+  flex-shrink: 0;
+  font-weight: 600;
+  color: var(--v2-text-meta);
+  font-size: 12px;
+}
+
 /* === Terminal mode override =========================================
  * Drop the card chrome — bare row of day cells. Each day's number gets
  * a `*` prefix when it's today. Intensity bar becomes a block character
@@ -166,6 +243,10 @@
   border: none;
   background: transparent;
   border-radius: 0;
+  gap: 2px;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-week-strip-day-btn {
   padding: 4px 0;
   gap: 2px;
 }
@@ -173,6 +254,10 @@
 :root[data-ui="v2"][data-theme^="terminal"] .v2-week-strip-day-today {
   background: transparent;
   border: none;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-week-strip-day-selected {
+  background: rgba(var(--v2-text-rgb), 0.06);
 }
 
 :root[data-ui="v2"][data-theme^="terminal"] .v2-week-strip-label {

--- a/src/v2/components/WeekStrip.jsx
+++ b/src/v2/components/WeekStrip.jsx
@@ -1,26 +1,10 @@
 import { useMemo, useState } from 'react'
 import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { localYMD } from '../../store'
+import { calculateTaskPoints } from '../../scoring'
 import './WeekStrip.css'
 
-// 7-day calendar strip rendered above the task list. Each day cell shows
-// day-of-week label + date number + an activity-intensity indicator
-// (dot in light/dark, block in terminal mode) reflecting how many tasks
-// were completed that day relative to `daily_task_goal`. Today's cell
-// also shows the exact `count/goal` inline.
-//
-// Visibility is owned by the parent (AppV2): the calendar date in the
-// home stats line is the show/hide toggle in terminal mode. This
-// component is "dumb display" — when mounted, it renders fully.
-//
-// Week navigation: < prev / next > arrows. State managed locally —
-// defaults to the week containing today; arrows shift by ±7 days.
-
 const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
-
-// `ymd` is just an alias for `localYMD` — kept as a local for backward
-// compatibility within this file. See store.localYMD for why we DON'T
-// use date.toISOString().slice(0, 10).
 const ymd = localYMD
 
 function startOfWeekSunday(date) {
@@ -32,13 +16,15 @@ function startOfWeekSunday(date) {
 
 export default function WeekStrip({ tasks, dailyTaskGoal }) {
   const [weekOffset, setWeekOffset] = useState(0)
+  const [selectedDate, setSelectedDate] = useState(null)
 
   const completionsByDate = useMemo(() => {
     const map = {}
     for (const t of tasks) {
       if (t.status !== 'done' || !t.completed_at) continue
       const key = ymd(new Date(t.completed_at))
-      map[key] = (map[key] || 0) + 1
+      if (!map[key]) map[key] = []
+      map[key].push(t)
     }
     return map
   }, [tasks])
@@ -52,7 +38,8 @@ export default function WeekStrip({ tasks, dailyTaskGoal }) {
       const d = new Date(start)
       d.setDate(d.getDate() + i)
       const key = ymd(d)
-      const count = completionsByDate[key] || 0
+      const dayTasks = completionsByDate[key] || []
+      const count = dayTasks.length
       const goal = dailyTaskGoal > 0 ? dailyTaskGoal : 3
       let intensity = 0
       if (count > 0 && count < goal) intensity = 1
@@ -84,12 +71,18 @@ export default function WeekStrip({ tasks, dailyTaskGoal }) {
     return `${firstMonth} ${first.getDate()}–${lastMonth} ${last.getDate()}`
   }, [days])
 
+  const selectedTasks = useMemo(() => {
+    if (!selectedDate) return null
+    const dayTasks = completionsByDate[selectedDate] || []
+    return dayTasks.map(t => ({ id: t.id, title: t.title, points: calculateTaskPoints(t) }))
+  }, [selectedDate, completionsByDate])
+
   return (
     <div className="v2-week-strip">
       <div className="v2-week-strip-head">
         <button
           className="v2-week-strip-nav"
-          onClick={() => setWeekOffset(o => o - 1)}
+          onClick={() => { setWeekOffset(o => o - 1); setSelectedDate(null) }}
           aria-label="Previous week"
         >
           <ChevronLeft size={14} strokeWidth={2} />
@@ -99,7 +92,7 @@ export default function WeekStrip({ tasks, dailyTaskGoal }) {
         </span>
         <button
           className="v2-week-strip-nav"
-          onClick={() => setWeekOffset(o => o + 1)}
+          onClick={() => { setWeekOffset(o => o + 1); setSelectedDate(null) }}
           aria-label="Next week"
         >
           <ChevronRight size={14} strokeWidth={2} />
@@ -113,19 +106,46 @@ export default function WeekStrip({ tasks, dailyTaskGoal }) {
               'v2-week-strip-day',
               d.isToday ? 'v2-week-strip-day-today' : '',
               d.isFuture ? 'v2-week-strip-day-future' : '',
+              selectedDate === d.key ? 'v2-week-strip-day-selected' : '',
               `v2-week-strip-day-i${d.intensity}`,
             ].filter(Boolean).join(' ')}
             aria-label={`${d.label} ${d.dayNumber}: ${d.count} task${d.count === 1 ? '' : 's'} completed`}
           >
-            <span className="v2-week-strip-label">{d.label}</span>
-            <span className="v2-week-strip-num">{d.dayNumber}</span>
-            {d.isToday && (
-              <span className="v2-week-strip-count">{d.count}/{d.goal}</span>
-            )}
-            <span className="v2-week-strip-bar" aria-hidden="true" />
+            <button
+              type="button"
+              className="v2-week-strip-day-btn"
+              onClick={() => setSelectedDate(prev => prev === d.key ? null : d.key)}
+              aria-expanded={selectedDate === d.key}
+            >
+              <span className="v2-week-strip-label">{d.label}</span>
+              <span className="v2-week-strip-num">{d.dayNumber}</span>
+              {d.isToday && (
+                <span className="v2-week-strip-count">{d.count}/{d.goal}</span>
+              )}
+              <span className="v2-week-strip-bar" aria-hidden="true" />
+            </button>
           </li>
         ))}
       </ol>
+      {selectedDate && selectedTasks && (
+        <div className="v2-week-strip-detail">
+          {selectedTasks.length === 0 ? (
+            <div className="v2-week-strip-detail-empty">No tasks completed</div>
+          ) : (
+            <>
+              <div className="v2-week-strip-detail-summary">
+                {selectedTasks.length} task{selectedTasks.length === 1 ? '' : 's'} · {selectedTasks.reduce((s, t) => s + t.points, 0)} pts
+              </div>
+              {selectedTasks.map(t => (
+                <div key={t.id} className="v2-week-strip-detail-item">
+                  <span className="v2-week-strip-detail-title">✓ {t.title}</span>
+                  <span className="v2-week-strip-detail-pts">{t.points} pts</span>
+                </div>
+              ))}
+            </>
+          )}
+        </div>
+      )}
     </div>
   )
 }

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,11 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-23
 
+- feat(ui): clickable WeekStrip dates + fix best-streak math [S]
+  - **Clickable dates.** Each day cell in the WeekStrip is now a tappable button. Tapping a day opens an inline detail panel below the strip showing tasks completed that day with their point values. Summary line shows total tasks + points. Selected day gets accent highlight. Navigating weeks clears the selection.
+  - **Best-streak fix.** `computeRecords.longestStreak` used a simpler algorithm than `computeStreak` — it only counted raw done-task days, not no-fault days or project sessions. This produced "Best streak: 10" when the current streak was 18. Fixed by using `Math.max(currentStreak, historicalLongest)` so the best streak is always ≥ current.
+  - Modified: `src/v2/components/WeekStrip.jsx`, `src/v2/components/WeekStrip.css`, `src/v2/AppV2.jsx`
+
 - feat(ui): tappable home stats — streak + today detail panels [S]
   - Streak and today counters in the home stats line are now tappable buttons. Tapping opens an inline detail card below the stats line (same slot as WeekStrip, mutually exclusive).
   - **Streak detail**: current streak, best streak, best day (tasks + points).


### PR DESCRIPTION
## Summary
Two fixes from the latest screenshot review:

### 1. Clickable WeekStrip dates
Day cells are now tappable buttons. Clicking a day opens an inline detail panel below the strip showing:
- Summary: "3 tasks · 28 pts"
- Each completed task title with its point value
- "No tasks completed" for empty days

Selected day gets accent-tinted background. Navigating weeks clears the selection.

### 2. Fix best-streak math
`computeRecords.longestStreak` used a simpler algorithm than `computeStreak` — only counted consecutive days with done tasks, ignoring no-fault days (no active tasks), project sessions, and easter egg wins. This produced "Best streak: 10" when the current streak was 18 — mathematically impossible.

Fixed with `Math.max(currentStreak, historicalLongest)` so the displayed best streak is always ≥ the current streak.

## Test plan
- [ ] Tap a WeekStrip date → detail panel shows completed tasks + points for that day
- [ ] Tap same date again → panel closes
- [ ] Tap a different date → panel switches to that day's tasks
- [ ] Navigate to prev/next week → selection clears
- [ ] Empty day shows "No tasks completed"
- [ ] Streak detail: best streak ≥ current streak always

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmpfJaWEpmFxNg4yJbepdP)_