### PR TITLE
fix(notion): search returns no results — response shape mismatch

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -443,7 +443,8 @@ export async function notionSearch(query) {
     body: JSON.stringify({ query, limit: 5 }),
   })
   if (!res.ok) throw new Error('Notion search failed')
-  return res.json()
+  const data = await res.json()
+  return data.pages || data
 }
 
 export async function notionCreatePage(title, content, parentPageId) {

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,10 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-23
 
+- fix(notion): search returns "No pages found" — response shape mismatch [XS]
+  - Server returns `{ pages: [...] }` but client expected a flat array. `Array.isArray({ pages })` → false → empty results. Unwrap `.pages` in `notionSearch()`.
+  - Modified: `src/api.js`
+
 - feat(ui): clickable WeekStrip dates + fix best-streak math [S]
   - **Clickable dates.** Each day cell in the WeekStrip is now a tappable button. Tapping a day opens an inline detail panel below the strip showing tasks completed that day with their point values. Summary line shows total tasks + points. Selected day gets accent highlight. Navigating weeks clears the selection.
   - **Best-streak fix.** `computeRecords.longestStreak` used a simpler algorithm than `computeStreak` — it only counted raw done-task days, not no-fault days or project sessions. This produced "Best streak: 10" when the current streak was 18. Fixed by using `Math.max(currentStreak, historicalLongest)` so the best streak is always ≥ current.


### PR DESCRIPTION
## Bug
Notion page search in Settings always returns "No pages found." Server responds with `{ pages: [...] }` but `notionSearch()` in `api.js` returned the raw object. The UI checked `Array.isArray(results)` which was `false` for `{ pages: [...] }`, so it fell through to an empty array.

## Fix
Unwrap `.pages` from the response in `notionSearch()`: `return data.pages || data`

## Test plan
- [ ] Settings → Notion → type a page name → Search → results appear
- [ ] Pick a parent page → Knowledge Base "Set up" button becomes enabled

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmpfJaWEpmFxNg4yJbepdP)_