### PR TITLE
fix(notion): MCP auto-reconnect + expired connection warning

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -443,7 +443,8 @@ export async function notionSearch(query) {
     body: JSON.stringify({ query, limit: 5 }),
   })
   if (!res.ok) throw new Error('Notion search failed')
-  return res.json()
+  const data = await res.json()
+  return data.pages || data
 }
 
 export async function notionCreatePage(title, content, parentPageId) {

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,10 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-23
 
+- fix(notion): search returns "No pages found" — response shape mismatch [XS]
+  - Server returns `{ pages: [...] }` but client expected a flat array. `Array.isArray({ pages })` → false → empty results. Unwrap `.pages` in `notionSearch()`.
+  - Modified: `src/api.js`
+
 - feat(ui): clickable WeekStrip dates + fix best-streak math [S]
   - **Clickable dates.** Each day cell in the WeekStrip is now a tappable button. Tapping a day opens an inline detail panel below the strip showing tasks completed that day with their point values. Summary line shows total tasks + points. Selected day gets accent highlight. Navigating weeks clears the selection.
   - **Best-streak fix.** `computeRecords.longestStreak` used a simpler algorithm than `computeStreak` — it only counted raw done-task days, not no-fault days or project sessions. This produced "Best streak: 10" when the current streak was 18. Fixed by using `Math.max(currentStreak, historicalLongest)` so the best streak is always ≥ current.


### PR DESCRIPTION
## Problem
Notion MCP connection silently dies when the OAuth token expires. Auto-reconnect always fails with: "Either provider.prepareTokenRequest() or authorizationCode is required." The Settings UI still shows a green "Connected" dot even though Quokka + Knowledge Base are broken.

## Root cause
MCP SDK v1.29 calls `provider.prepareTokenRequest()` for token refresh, but our `NotionMCPProvider` didn't implement it. Without this method, the SDK can't use the `refresh_token` grant and falls through to the authorization_code flow — which requires user interaction.

## Fixes
1. **Auto refresh** — `prepareTokenRequest()` on the provider returns `grant_type=refresh_token` when a refresh token exists. SDK can now silently refresh expired tokens.
2. **Retry loop** — If reconnect still fails (refresh token also expired), a 5-minute retry interval keeps trying. Clears on success.
3. **Transport reset** — `autoReconnect()` resets client + transport before connecting so the SDK picks up fresh provider state.
4. **Status transparency** — `getStatus()` returns `needsReauth` + `error` fields. `/api/notion/status` includes `mcpHealth`.
5. **UI warning** — Orange dot + "⚠️ MCP connection expired" banner with Reconnect button when `needsReauth` is true.

## Test plan
- [ ] Deploy → if Notion token is stale, auto-reconnect should succeed via refresh_token grant
- [ ] If refresh token is also expired: orange dot + warning banner appears in Settings, Reconnect button triggers re-auth
- [ ] After successful reconnect: green dot returns, KB setup button works
- [ ] Server logs show "[NotionMCP] reconnected successfully" or retry attempts

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmpfJaWEpmFxNg4yJbepdP)_