### PR TITLE
release: Notion MCP auto-reconnect

### DIFF
--- a/notionMCP.js
+++ b/notionMCP.js
@@ -24,6 +24,7 @@ let provider = null
 let transport = null
 let client = null
 let clientConnected = false
+let lastError = null
 let toolCache = null // [{ name, description, inputSchema }, ...]
 
 // --- Provider ---
@@ -78,6 +79,16 @@ class NotionMCPProvider {
 
   async codeVerifier() {
     return deps.getData(PKCE_KEY)?.code_verifier || ''
+  }
+
+  prepareTokenRequest(scope) {
+    const tokens = deps.getData(TOKENS_KEY)
+    if (tokens?.refresh_token) {
+      const params = new URLSearchParams({ grant_type: 'refresh_token', refresh_token: tokens.refresh_token })
+      if (scope) params.set('scope', scope)
+      return params
+    }
+    return null
   }
 
   async invalidateCredentials(scope) {
@@ -174,27 +185,62 @@ export function initNotionMCP(injectedDeps) {
   transport = makeTransport()
 }
 
+let reconnectTimer = null
+
 export async function autoReconnect() {
   if (!deps?.getData(TOKENS_KEY)) return false
   try {
+    clientConnected = false
+    client = new Client({ name: 'boomerang', version: '1.0.0' })
+    transport = makeTransport()
     await ensureClient()
     await refreshToolCache()
+    lastError = null
+    if (reconnectTimer) { clearInterval(reconnectTimer); reconnectTimer = null }
+    console.log('[NotionMCP] reconnected successfully')
     return true
   } catch (err) {
-    console.warn('[NotionMCP] auto-reconnect failed:', err?.message || err)
+    const msg = err?.message || String(err)
+    console.warn('[NotionMCP] auto-reconnect failed:', msg)
+    clientConnected = false
+    lastError = msg
+    scheduleRetry()
     return false
   }
 }
 
+function scheduleRetry() {
+  if (reconnectTimer) return
+  reconnectTimer = setInterval(async () => {
+    if (clientConnected) { clearInterval(reconnectTimer); reconnectTimer = null; return }
+    console.log('[NotionMCP] retrying auto-reconnect…')
+    try {
+      clientConnected = false
+      client = new Client({ name: 'boomerang', version: '1.0.0' })
+      transport = makeTransport()
+      await ensureClient()
+      await refreshToolCache()
+      lastError = null
+      clientConnected = true
+      clearInterval(reconnectTimer)
+      reconnectTimer = null
+      console.log('[NotionMCP] reconnected on retry')
+    } catch (err) {
+      console.warn('[NotionMCP] retry failed:', err?.message || err)
+    }
+  }, 5 * 60 * 1000)
+}
+
 export async function startAuth(redirectBase) {
   provider.setRedirectUrl(`${redirectBase}/api/notion/mcp/callback`)
-  // Reset connection state so a fresh auth attempt runs
   clientConnected = false
+  lastError = null
   transport = makeTransport()
   client = new Client({ name: 'boomerang', version: '1.0.0' })
   try {
     await client.connect(transport)
     clientConnected = true
+    lastError = null
     await refreshToolCache()
     return { alreadyAuthorized: true }
   } catch {
@@ -208,20 +254,23 @@ export async function finishAuth(code) {
   if (!transport) throw new Error('No pending auth flow')
   await transport.finishAuth(code)
   clientConnected = false
+  lastError = null
   client = new Client({ name: 'boomerang', version: '1.0.0' })
   transport = makeTransport()
   await ensureClient()
   await refreshToolCache()
-  // PKCE done, clear transient state
   deps.setData(PKCE_KEY, null)
 }
 
 export function getStatus() {
   const tokens = deps?.getData(TOKENS_KEY)
+  const connected = clientConnected && !!tokens
   return {
-    connected: clientConnected && !!tokens,
+    connected,
     hasTokens: !!tokens,
     toolCount: toolCache?.length || 0,
+    needsReauth: !!tokens && !clientConnected && !!lastError,
+    error: lastError,
   }
 }
 

--- a/server.js
+++ b/server.js
@@ -774,13 +774,11 @@ app.patch('/api/notion/pages/:id', async (req, res) => {
 })
 
 app.get('/api/notion/status', async (req, res) => {
-  // Reports whether *any* Notion auth path resolves to a working token — used by Settings UI
-  // as a quick "is there anything working at all" indicator. MCP connection status has its
-  // own dedicated endpoint at /api/notion/mcp/status.
   const mcpActive = !!getData('notion_mcp_tokens')?.access_token
   const legacyActive = !!getLegacyNotionToken(req)
+  const mcpHealth = notionMCP.getStatus()
   const token = await getNotionAccessToken(req)
-  if (!token) return res.json({ connected: false, auth: null, mcp: false, legacy: false })
+  if (!token) return res.json({ connected: false, auth: null, mcp: false, legacy: false, mcpHealth })
   try {
     const response = await fetch(`${NOTION_BASE}/users/me`, { headers: makeNotionHeaders(token) })
     const data = await response.json()
@@ -790,9 +788,10 @@ app.get('/api/notion/status', async (req, res) => {
       mcp: mcpActive,
       legacy: legacyActive,
       bot: data.name || data.bot?.owner?.user?.name,
+      mcpHealth,
     })
   } catch {
-    res.json({ connected: false, auth: null, mcp: mcpActive, legacy: legacyActive })
+    res.json({ connected: false, auth: null, mcp: mcpActive, legacy: legacyActive, mcpHealth })
   }
 })
 

--- a/src/v2/components/SettingsModal.css
+++ b/src/v2/components/SettingsModal.css
@@ -1037,6 +1037,11 @@
   background: var(--v2-text-faint);
 }
 
+.v2-integrations-dot-warn {
+  background: #FF9500;
+  box-shadow: 0 0 0 3px rgba(255, 149, 0, 0.15);
+}
+
 .v2-integrations-meta {
   flex: 1;
   min-width: 0;
@@ -1083,6 +1088,25 @@
 .v2-integrations-error {
   font: 400 12px/1.4 var(--v2-font-body);
   color: var(--v2-alert-overdue);
+}
+
+.v2-integrations-warn {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 12px;
+  margin-bottom: 8px;
+  font: 400 12px/1.4 var(--v2-font-body);
+  color: #7a5900;
+  background: rgba(255, 149, 0, 0.10);
+  border: 1px solid rgba(255, 149, 0, 0.25);
+  border-radius: 8px;
+}
+
+[data-theme="dark"] .v2-integrations-warn,
+[data-theme^="terminal"] .v2-integrations-warn {
+  color: #FFB347;
 }
 
 .v2-integrations-status-ok {

--- a/src/v2/components/SettingsModal.jsx
+++ b/src/v2/components/SettingsModal.jsx
@@ -327,6 +327,7 @@ function IntegrationsPanel({
   const [notionSearchResults, setNotionSearchResults] = useState(null)
   const [notionSearching, setNotionSearching] = useState(false)
   const [notionSearchError, setNotionSearchError] = useState(null)
+  const [notionReconnecting, setNotionReconnecting] = useState(false)
   const [notionChildCount, setNotionChildCount] = useState(null)
   // Knowledge base setup state — separate from sync-parent so the two
   // Notion features stay independent.
@@ -521,6 +522,21 @@ function IntegrationsPanel({
     setNotionChildCount(null)
   }
 
+  const reconnectNotionMCP = async () => {
+    setNotionReconnecting(true)
+    try {
+      const api = await import('../../api')
+      const result = await api.notionMCPConnect()
+      if (result.alreadyAuthorized) {
+        const s = await api.notionStatus()
+        setStatuses(prev => ({ ...prev, notion: s }))
+      } else if (result.authUrl) {
+        window.open(result.authUrl, 'notion-mcp-auth', 'width=600,height=700')
+      }
+    } catch { /* swallow */ }
+    finally { setNotionReconnecting(false) }
+  }
+
   // Auto-load child count for already-configured parent pages on mount.
   useEffect(() => {
     if (!settings.notion_sync_parent_id || !statuses.notion?.connected) return
@@ -652,8 +668,10 @@ function IntegrationsPanel({
     {
       key: 'notion',
       label: 'Notion',
-      hint: 'Pull pages as tasks, sync edits both ways. MCP-based connection (recommended).',
-      connected: !!statuses.notion?.connected,
+      hint: statuses.notion?.mcpHealth?.needsReauth
+        ? 'MCP connection expired — Quokka and Knowledge Base won\'t work until you reconnect.'
+        : 'Pull pages as tasks, sync edits both ways. MCP-based connection (recommended).',
+      connected: statuses.notion?.mcpHealth?.needsReauth ? 'warn' : !!statuses.notion?.connected,
       v1Section: 'Integrations → Notion',
       sync: onNotionSync && settings.notion_sync_parent_id ? { fn: onNotionSync, busy: notionSyncing } : null,
       inline: statuses.notion?.connected ? 'notion-config' : null,
@@ -747,7 +765,7 @@ function IntegrationsPanel({
         <ul className="v2-integrations-list">
           {integrations.map(int => (
             <li key={int.key} className="v2-integrations-row">
-              <span className={`v2-integrations-dot v2-integrations-dot-${int.connected ? 'connected' : 'unconfigured'}`} />
+              <span className={`v2-integrations-dot v2-integrations-dot-${int.connected === 'warn' ? 'warn' : int.connected ? 'connected' : 'unconfigured'}`} />
               <div className="v2-integrations-meta">
                 <div className="v2-integrations-name">{int.label}</div>
                 {int.sub && <div className="v2-integrations-sub">{int.sub}</div>}
@@ -776,6 +794,18 @@ function IntegrationsPanel({
                 )}
                 {int.inline === 'notion-config' && (
                   <div className="v2-integrations-inline">
+                    {statuses.notion?.mcpHealth?.needsReauth && (
+                      <div className="v2-integrations-warn">
+                        <span>⚠️ MCP connection expired. Quokka + Knowledge Base won't work until reconnected.</span>
+                        <button
+                          className="v2-settings-btn"
+                          onClick={reconnectNotionMCP}
+                          disabled={notionReconnecting}
+                        >
+                          {notionReconnecting ? 'Reconnecting…' : 'Reconnect'}
+                        </button>
+                      </div>
+                    )}
                     {settings.notion_sync_parent_id ? (
                       <div className="v2-weather-current">
                         <div className="v2-weather-current-label">

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,11 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-23
 
+- fix(notion): MCP auto-reconnect + expired connection UI warning [M]
+  - **Root cause.** MCP SDK v1.29 calls `provider.prepareTokenRequest()` for token refresh, but `NotionMCPProvider` didn't implement it. Auto-reconnect always failed.
+  - Added `prepareTokenRequest()` returning `grant_type=refresh_token`. 5-min retry loop on failure. Transport reset on reconnect. `needsReauth` + `error` in status. Orange dot + warning banner + Reconnect button in Settings.
+  - Modified: `notionMCP.js`, `server.js`, `src/v2/components/SettingsModal.jsx`, `src/v2/components/SettingsModal.css`
+
 - fix(notion): search returns "No pages found" — response shape mismatch [XS]
   - Server returns `{ pages: [...] }` but client expected a flat array. `Array.isArray({ pages })` → false → empty results. Unwrap `.pages` in `notionSearch()`.
   - Modified: `src/api.js`


### PR DESCRIPTION
Promotes PR #232 — MCP auto-reconnect via prepareTokenRequest() + expired connection UI warning.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmpfJaWEpmFxNg4yJbepdP)_