### PR TITLE
fix(ui): full Notion lifecycle in v2 Settings + bottom gap fix

### DIFF
--- a/src/v2/AppV2.css
+++ b/src/v2/AppV2.css
@@ -1,6 +1,15 @@
 @import './tokens.css';
 @import './terminal/index.css';
 
+/* Match body bg to v2 app bg so any sub-pixel gap between the fixed
+ * container and the screen edge is invisible. The v1 body uses --bg
+ * (#F5F5F7 light) while v2 uses --v2-bg (#FFFFFF light) — mismatch
+ * showed as a grey strip below BottomTabs on iOS PWA. */
+:root[data-ui="v2"],
+:root[data-ui="v2"] body {
+  background: var(--v2-bg);
+}
+
 .v2-app {
   position: fixed;
   inset: 0;
@@ -12,22 +21,15 @@
   overflow: hidden;
 }
 
-/* iOS PWA viewport fix (issue #213). After keyboard show/hide on iOS
- * Safari standalone, `position: fixed; inset: 0` anchors to a stale
- * layout viewport — the v2-app draws shorter than the visual viewport
- * and exposes body bg below BottomTabs. `min-height: 100dvh` (dynamic
- * viewport height) prevents the container from shrinking after keyboard
- * transitions, while `inset: 0` (specifically bottom: 0) keeps the
- * container anchored to the screen bottom on first render when iOS may
- * report a stale dvh value.
- *
- * Previous approach (bottom: auto + height: 100dvh) dropped the bottom
- * anchor entirely, which caused the container to float short on some
- * iOS PWA cold starts — surfacing as BottomTabs "raised" with a gap
- * underneath. Keeping bottom: 0 + min-height solves both directions. */
+/* iOS PWA keyboard fix (issue #213). After keyboard show/hide,
+ * `inset: 0` can anchor to a stale layout viewport. `100dvh` tracks
+ * the live visual viewport. `bottom: auto` lets height win over the
+ * bottom anchor. The body-bg match above hides any sub-pixel gap on
+ * cold starts where dvh reports a fractionally short value. */
 @supports (height: 100dvh) {
   .v2-app {
-    min-height: 100dvh;
+    bottom: auto;
+    height: 100dvh;
   }
 }
 

--- a/src/v2/components/SettingsModal.css
+++ b/src/v2/components/SettingsModal.css
@@ -1109,6 +1109,13 @@
   color: #FFB347;
 }
 
+.v2-integrations-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 4px;
+}
+
 .v2-integrations-status-ok {
   font: 500 12px/1.4 var(--v2-font-body);
   color: var(--v2-energy-errand);

--- a/src/v2/components/SettingsModal.jsx
+++ b/src/v2/components/SettingsModal.jsx
@@ -537,6 +537,15 @@ function IntegrationsPanel({
     finally { setNotionReconnecting(false) }
   }
 
+  const disconnectNotionMCP = async () => {
+    try {
+      const api = await import('../../api')
+      await api.notionMCPDisconnect()
+      setStatuses(prev => ({ ...prev, notion: { connected: false } }))
+      clearNotionParent()
+    } catch { /* swallow */ }
+  }
+
   // Auto-load child count for already-configured parent pages on mount.
   useEffect(() => {
     if (!settings.notion_sync_parent_id || !statuses.notion?.connected) return
@@ -669,12 +678,11 @@ function IntegrationsPanel({
       key: 'notion',
       label: 'Notion',
       hint: statuses.notion?.mcpHealth?.needsReauth
-        ? 'MCP connection expired — Quokka and Knowledge Base won\'t work until you reconnect.'
+        ? 'MCP connection expired — reconnect to restore Quokka + Knowledge Base.'
         : 'Pull pages as tasks, sync edits both ways. MCP-based connection (recommended).',
       connected: statuses.notion?.mcpHealth?.needsReauth ? 'warn' : !!statuses.notion?.connected,
-      v1Section: 'Integrations → Notion',
       sync: onNotionSync && settings.notion_sync_parent_id ? { fn: onNotionSync, busy: notionSyncing } : null,
-      inline: statuses.notion?.connected ? 'notion-config' : null,
+      inline: 'notion-full',
     },
     {
       key: 'trello',
@@ -792,112 +800,135 @@ function IntegrationsPanel({
                     <AnthropicKeyBlock settings={settings} update={update} embedded />
                   </div>
                 )}
-                {int.inline === 'notion-config' && (
+                {int.inline === 'notion-full' && (
                   <div className="v2-integrations-inline">
-                    {statuses.notion?.mcpHealth?.needsReauth && (
-                      <div className="v2-integrations-warn">
-                        <span>⚠️ MCP connection expired. Quokka + Knowledge Base won't work until reconnected.</span>
+                    {/* Connection controls — always visible */}
+                    {!statuses.notion?.connected && !statuses.notion?.mcpHealth?.needsReauth && (
+                      <div className="v2-integrations-actions">
                         <button
                           className="v2-settings-btn"
                           onClick={reconnectNotionMCP}
                           disabled={notionReconnecting}
                         >
-                          {notionReconnecting ? 'Reconnecting…' : 'Reconnect'}
+                          {notionReconnecting ? 'Connecting…' : 'Connect via MCP'}
                         </button>
                       </div>
                     )}
-                    {settings.notion_sync_parent_id ? (
-                      <div className="v2-weather-current">
-                        <div className="v2-weather-current-label">
-                          📄 Syncing from <strong>{settings.notion_sync_parent_title || 'Selected page'}</strong>
-                          {notionChildCount != null && (
-                            <span className="v2-integrations-hint" style={{ display: 'block', marginTop: 4 }}>
-                              {notionChildCount} child page{notionChildCount === 1 ? '' : 's'} discovered
-                              {settings.notion_last_sync ? ` · last synced ${new Date(settings.notion_last_sync).toLocaleString()}` : ''}
-                            </span>
-                          )}
-                        </div>
-                        <button className="v2-settings-btn" onClick={clearNotionParent}>Change page</button>
-                      </div>
-                    ) : (
-                      <>
-                        <div className="v2-integrations-hint">
-                          Pick a parent Notion page — its child pages get pulled as tasks.
-                        </div>
-                        <div className="v2-weather-search">
-                          <input
-                            type="text"
-                            className="v2-form-input"
-                            placeholder="Search Notion pages…"
-                            value={notionSearchQuery}
-                            onChange={e => setNotionSearchQuery(e.target.value)}
-                            onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); runNotionSearch() } }}
-                          />
-                          <button
-                            className="v2-settings-btn"
-                            onClick={runNotionSearch}
-                            disabled={notionSearching || !notionSearchQuery.trim()}
-                          >
-                            {notionSearching ? 'Searching…' : 'Search'}
+                    {statuses.notion?.mcpHealth?.needsReauth && (
+                      <div className="v2-integrations-warn">
+                        <span>⚠️ MCP connection expired. Quokka + Knowledge Base won't work until reconnected.</span>
+                        <div className="v2-integrations-actions">
+                          <button className="v2-settings-btn" onClick={reconnectNotionMCP} disabled={notionReconnecting}>
+                            {notionReconnecting ? 'Reconnecting…' : 'Reconnect'}
+                          </button>
+                          <button className="v2-settings-btn v2-settings-btn-danger" onClick={disconnectNotionMCP}>
+                            Disconnect
                           </button>
                         </div>
-                        {notionSearchError && <div className="v2-integrations-error">{notionSearchError}</div>}
-                        {notionSearchResults && notionSearchResults.length > 0 && (
-                          <ul className="v2-weather-results">
-                            {notionSearchResults.map(page => (
-                              <li key={page.id}>
-                                <button className="v2-weather-result" onClick={() => pickNotionParent(page)}>
-                                  {page.title}
-                                </button>
-                              </li>
-                            ))}
-                          </ul>
+                      </div>
+                    )}
+                    {statuses.notion?.connected && !statuses.notion?.mcpHealth?.needsReauth && (
+                      <>
+                        {/* Parent page config */}
+                        {settings.notion_sync_parent_id ? (
+                          <div className="v2-weather-current">
+                            <div className="v2-weather-current-label">
+                              📄 Syncing from <strong>{settings.notion_sync_parent_title || 'Selected page'}</strong>
+                              {notionChildCount != null && (
+                                <span className="v2-integrations-hint" style={{ display: 'block', marginTop: 4 }}>
+                                  {notionChildCount} child page{notionChildCount === 1 ? '' : 's'} discovered
+                                  {settings.notion_last_sync ? ` · last synced ${new Date(settings.notion_last_sync).toLocaleString()}` : ''}
+                                </span>
+                              )}
+                            </div>
+                            <button className="v2-settings-btn" onClick={clearNotionParent}>Change page</button>
+                          </div>
+                        ) : (
+                          <>
+                            <div className="v2-integrations-hint">
+                              Pick a parent Notion page — its child pages get pulled as tasks.
+                            </div>
+                            <div className="v2-weather-search">
+                              <input
+                                type="text"
+                                className="v2-form-input"
+                                placeholder="Search Notion pages…"
+                                value={notionSearchQuery}
+                                onChange={e => setNotionSearchQuery(e.target.value)}
+                                onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); runNotionSearch() } }}
+                              />
+                              <button
+                                className="v2-settings-btn"
+                                onClick={runNotionSearch}
+                                disabled={notionSearching || !notionSearchQuery.trim()}
+                              >
+                                {notionSearching ? 'Searching…' : 'Search'}
+                              </button>
+                            </div>
+                            {notionSearchError && <div className="v2-integrations-error">{notionSearchError}</div>}
+                            {notionSearchResults && notionSearchResults.length > 0 && (
+                              <ul className="v2-weather-results">
+                                {notionSearchResults.map(page => (
+                                  <li key={page.id}>
+                                    <button className="v2-weather-result" onClick={() => pickNotionParent(page)}>
+                                      {page.title}
+                                    </button>
+                                  </li>
+                                ))}
+                              </ul>
+                            )}
+                            {notionSearchResults && notionSearchResults.length === 0 && (
+                              <div className="v2-integrations-hint">No pages found.</div>
+                            )}
+                          </>
                         )}
-                        {notionSearchResults && notionSearchResults.length === 0 && (
-                          <div className="v2-integrations-hint">No pages found.</div>
-                        )}
+                        {/* Knowledge base */}
+                        <div className="v2-integrations-kb">
+                          <div className="v2-form-label">Knowledge base</div>
+                          <div className="v2-integrations-hint">
+                            Stash long-term reference (where you keep things, decisions you've made,
+                            people, how-tos) as Notion pages Quokka can search. One database in your
+                            Notion workspace, kept in sync automatically.
+                          </div>
+                          {kbStatus?.configured ? (
+                            <>
+                              <div className="v2-integrations-status-line">
+                                ✓ Connected
+                                {kbStatus.database_url && (
+                                  <> · <a href={kbStatus.database_url} target="_blank" rel="noreferrer">Open in Notion</a></>
+                                )}
+                                {kbStatus.last_sync && (
+                                  <span className="v2-integrations-hint" style={{ display: 'block', marginTop: 4 }}>
+                                    Last synced {new Date(kbStatus.last_sync).toLocaleString()}
+                                  </span>
+                                )}
+                              </div>
+                              <button className="v2-settings-btn" onClick={runKnowledgeRefresh}>
+                                Sync now
+                              </button>
+                            </>
+                          ) : (
+                            <button
+                              className="v2-settings-btn"
+                              onClick={runKnowledgeSetup}
+                              disabled={kbSetupBusy || !settings.notion_sync_parent_id}
+                            >
+                              {kbSetupBusy ? 'Setting up…' : 'Set up Knowledge Base'}
+                            </button>
+                          )}
+                          {!settings.notion_sync_parent_id && !kbStatus?.configured && (
+                            <div className="v2-integrations-hint">
+                              Pick a parent page above first — the knowledge database is created underneath it.
+                            </div>
+                          )}
+                          {kbError && <div className="v2-integrations-error">{kbError}</div>}
+                        </div>
+                        {/* Disconnect */}
+                        <button className="v2-settings-btn v2-settings-btn-danger" onClick={disconnectNotionMCP}>
+                          Disconnect Notion
+                        </button>
                       </>
                     )}
-                    <div className="v2-integrations-kb">
-                      <div className="v2-form-label">Knowledge base</div>
-                      <div className="v2-integrations-hint">
-                        Stash long-term reference (where you keep things, decisions you've made,
-                        people, how-tos) as Notion pages Quokka can search. One database in your
-                        Notion workspace, kept in sync automatically.
-                      </div>
-                      {kbStatus?.configured ? (
-                        <>
-                          <div className="v2-integrations-status-line">
-                            ✓ Connected
-                            {kbStatus.database_url && (
-                              <> · <a href={kbStatus.database_url} target="_blank" rel="noreferrer">Open in Notion</a></>
-                            )}
-                            {kbStatus.last_sync && (
-                              <span className="v2-integrations-hint" style={{ display: 'block', marginTop: 4 }}>
-                                Last synced {new Date(kbStatus.last_sync).toLocaleString()}
-                              </span>
-                            )}
-                          </div>
-                          <button className="v2-settings-btn" onClick={runKnowledgeRefresh}>
-                            Sync now
-                          </button>
-                        </>
-                      ) : (
-                        <button
-                          className="v2-settings-btn"
-                          onClick={runKnowledgeSetup}
-                          disabled={kbSetupBusy || !settings.notion_sync_parent_id}
-                        >
-                          {kbSetupBusy ? 'Setting up…' : 'Set up Knowledge Base'}
-                        </button>
-                      )}
-                      {!settings.notion_sync_parent_id && !kbStatus?.configured && (
-                        <div className="v2-integrations-hint">
-                          Pick a parent page above first — the knowledge database is created underneath it.
-                        </div>
-                      )}
-                      {kbError && <div className="v2-integrations-error">{kbError}</div>}
-                    </div>
                   </div>
                 )}
                 {int.inline === 'trello-connect' && (

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,11 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-23
 
+- fix(ui): full Notion connect/disconnect/reconnect in v2 Settings + bottom gap [M]
+  - **Notion controls.** v2 Settings had NO connect, disconnect, or reconnect buttons for Notion — all of that was v1-only. Now the Notion integration section renders a full lifecycle: "Connect via MCP" when not connected, page search + KB setup + "Disconnect" when connected, and a warning banner with "Reconnect" + "Disconnect" when MCP needs reauth. The `inline` section always renders regardless of connection state.
+  - **Bottom gap.** Root cause: body background `var(--bg)` = `#F5F5F7` (v1 light grey) vs v2 app `var(--v2-bg)` = `#FFFFFF`. Any sub-pixel gap between the fixed container and the screen edge exposed the mismatch. Fix: `:root[data-ui="v2"] body { background: var(--v2-bg) }` makes the gap invisible. Reverted `min-height` approach back to `bottom: auto; height: 100dvh` for the keyboard fix.
+  - Modified: `src/v2/components/SettingsModal.jsx`, `src/v2/components/SettingsModal.css`, `src/v2/AppV2.css`
+
 - fix(notion): MCP auto-reconnect + expired connection UI warning [M]
   - **Root cause.** MCP SDK v1.29 calls `provider.prepareTokenRequest()` for token refresh, but `NotionMCPProvider` didn't implement it. Auto-reconnect always failed.
   - Added `prepareTokenRequest()` returning `grant_type=refresh_token`. 5-min retry loop on failure. Transport reset on reconnect. `needsReauth` + `error` in status. Orange dot + warning banner + Reconnect button in Settings.


### PR DESCRIPTION
## What was broken

### Notion
v2 Settings had NO connect, disconnect, or reconnect buttons. The entire inline section was gated on `statuses.notion?.connected` — if Notion was broken, nothing rendered. User had to go back to v1 Settings to manage the connection, and v1 state changes didn't propagate to v2.

### Bottom gap
Body background was `var(--bg)` (#F5F5F7 v1 light grey). v2 app was `var(--v2-bg)` (#FFFFFF). Any sub-pixel gap between the fixed container and screen edge exposed grey.

## Fixes

### Notion — full lifecycle in v2
The inline section now always renders (`inline: 'notion-full'`) with three states:
- **Not connected**: "Connect via MCP" button
- **Connected**: parent page search + KB setup + "Disconnect Notion" button
- **Needs reauth**: orange warning banner + "Reconnect" + "Disconnect" buttons

Added `disconnectNotionMCP()` handler that calls the API and resets local state.

### Bottom gap — body-bg match
`:root[data-ui="v2"] body { background: var(--v2-bg) }` makes any gap invisible. Reverted to `bottom: auto; height: 100dvh` for the keyboard fix since the color match handles cold-start gaps.

## Test plan
- [ ] Settings → Notion: Connect button visible when not connected
- [ ] After connecting: page search + KB setup + Disconnect all visible
- [ ] Disconnect works from v2 — status updates immediately
- [ ] If MCP needs reauth: orange warning + Reconnect + Disconnect visible
- [ ] No grey strip below BottomTabs in light mode

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmpfJaWEpmFxNg4yJbepdP)_