### PR TITLE
chore(ui): purge all v1 references from v2 Settings (v2)

### DIFF
--- a/src/v2/components/SettingsModal.jsx
+++ b/src/v2/components/SettingsModal.jsx
@@ -175,8 +175,6 @@ const STORAGE_KEY = 'ui_version'
 const TABS = ['General', 'AI', 'Labels', 'Integrations', 'Notifications', 'Data', 'Logs', 'Legacy']
 
 // All Settings tabs now have v2 implementations.
-const PLACEHOLDER_TABS = new Set()
-const PLACEHOLDER_BODY = {}
 
 // Notification types (excluding high priority which has its own escalation
 // section) + their channel-specific setting key suffixes. Same scheme v1
@@ -201,7 +199,7 @@ const NOTIF_PACKAGE_TYPES = [
   { key: 'package_exception', label: 'Package exception', desc: 'Delivery issue or routing problem reported by carrier.' },
 ]
 
-// Integrations panel — status summary + "Configure in v1" CTAs for the
+// Integrations panel — status summary + inline config for each
 // OAuth-heavy ones. Inline credential entry for simple key-only integrations
 // (Anthropic, 17track) since those are one-field forms.
 // Anthropic key entry + status check. Lives in the AI tab; the
@@ -309,7 +307,7 @@ function AnthropicKeyBlock({ settings, update, embedded = false }) {
 }
 
 function IntegrationsPanel({
-  settings, update, switchToV1, setActiveTab,
+  settings, update, setActiveTab,
   onTrelloSync, trelloSyncing, onNotionSync, notionSyncing, onGCalSync, gcalSyncing,
 }) {
   const [envKeys, setEnvKeys] = useState({ anthropic: false, notion: false, trello: false, tracking: false })
@@ -717,7 +715,6 @@ function IntegrationsPanel({
       label: '17track (packages)',
       hint: 'Server-side polling for delivery status across most major carriers.',
       connected: envKeys.tracking || !!settings.tracking_api_key,
-      v1Section: 'Integrations → Package Tracking',
       inline: 'api-key',
       keyName: 'tracking_api_key',
       envFlag: envKeys.tracking,
@@ -735,7 +732,6 @@ function IntegrationsPanel({
       label: 'Pushover',
       hint: 'iOS-friendly transport that bypasses Safari throttling. One-time $5 app required.',
       connected: !!statuses.pushover?.configured,
-      v1Section: 'Integrations → Pushover',
       inline: 'pushover',
       appTokenFromEnv: !!statuses.pushover?.app_token_from_env,
     },
@@ -768,7 +764,7 @@ function IntegrationsPanel({
         <div className="v2-form-label">Status</div>
         <div className="v2-settings-row-hint">
           Connect, configure, and disconnect every integration inline. Tokens are shared
-          across v1 and v2 — you only have to connect once.
+          Tokens persist across reloads — you only connect once.
         </div>
         <ul className="v2-integrations-list">
           {integrations.map(int => (
@@ -1291,24 +1287,14 @@ function IntegrationsPanel({
                     {int.sync.busy ? 'Syncing…' : 'Sync now'}
                   </button>
                 )}
-                {!['api-key', 'pushover', 'weather', 'trello-config', 'trello-connect', 'gcal-config', 'gcal-connect', 'gmail-config', 'gmail-connect', 'notion-config', 'anthropic'].includes(int.inline) && (
-                  int.manageInTab ? (
-                    <button
-                      className="v2-settings-btn"
-                      onClick={() => setActiveTab(int.manageInTab)}
-                      title={`Open ${int.manageInTab} tab`}
-                    >
-                      Configure in {int.manageInTab}
-                    </button>
-                  ) : (
-                    <button
-                      className="v2-settings-btn"
-                      onClick={switchToV1}
-                      title={`Open ${int.v1Section} in v1`}
-                    >
-                      {int.connected ? 'Manage in v1' : 'Connect in v1'}
-                    </button>
-                  )
+                {int.manageInTab && (
+                  <button
+                    className="v2-settings-btn"
+                    onClick={() => setActiveTab(int.manageInTab)}
+                    title={`Open ${int.manageInTab} tab`}
+                  >
+                    Configure in {int.manageInTab}
+                  </button>
                 )}
               </div>
             </li>
@@ -1346,7 +1332,7 @@ function NotificationsPanel({ settings, update }) {
   const masters = [
     { key: 'push_notifications_enabled', label: 'Web push', hint: 'Browser-native notifications. Per-device subscription.' },
     { key: 'email_notifications_enabled', label: 'Email', hint: 'Server-side SMTP. Address comes from `email_address` setting or NOTIFICATION_EMAIL env.' },
-    { key: 'pushover_notifications_enabled', label: 'Pushover', hint: 'iOS-friendly transport via the Pushover app. Credentials in v1 → Integrations.' },
+    { key: 'pushover_notifications_enabled', label: 'Pushover', hint: 'iOS-friendly transport via the Pushover app. Credentials in Integrations tab.' },
   ]
 
   // Web push needs a per-device subscribe step (browser permission +
@@ -2187,11 +2173,6 @@ export default function SettingsModal({
     URL.revokeObjectURL(url)
   }
 
-  const switchToV1 = () => {
-    localStorage.setItem(STORAGE_KEY, 'v1')
-    window.location.reload()
-  }
-
   return (
     <ModalShell
       open={open}
@@ -2214,14 +2195,6 @@ export default function SettingsModal({
       </div>
 
       <div className="v2-settings-content">
-        {PLACEHOLDER_TABS.has(activeTab) && (
-          <EmptyState
-            title={`${activeTab} settings`}
-            body={`${PLACEHOLDER_BODY[activeTab]} Use v1 → Settings → ${activeTab} to configure for now.`}
-            cta="Open v1"
-            ctaOnClick={switchToV1}
-          />
-        )}
 
         {activeTab === 'General' && (
           <div className="v2-settings-form">
@@ -2545,7 +2518,6 @@ export default function SettingsModal({
           <IntegrationsPanel
             settings={settings}
             update={update}
-            switchToV1={switchToV1}
             setActiveTab={setActiveTab}
             onTrelloSync={onTrelloSync}
             trelloSyncing={trelloSyncing}

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,17 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-23
 
+- chore(ui): purge all v1 references from v2 Settings [S]
+  - Removed broken "Manage in v1" / "Connect in v1" fallback buttons (Notion showed "Open undefined in v1")
+  - Removed `switchToV1` function + prop threading through IntegrationsPanel
+  - Removed dead `PLACEHOLDER_TABS` / `PLACEHOLDER_BODY` code + "Open v1" EmptyState
+  - Removed stale `v1Section` props from tracking + pushover integrations
+  - Fixed Pushover hint "Credentials in v1 → Integrations" → "Credentials in Integrations tab"
+  - Fixed "across v1 and v2" → "Tokens persist across reloads"
+  - Fixed stale comment "Configure in v1 CTAs"
+  - Only v1 reference remaining: the intentional Legacy tab toggle for opting back to v1 UI
+  - Modified: `src/v2/components/SettingsModal.jsx`
+
 - fix(ui): full Notion connect/disconnect/reconnect in v2 Settings + bottom gap [M]
   - **Notion controls.** v2 Settings had NO connect, disconnect, or reconnect buttons for Notion — all of that was v1-only. Now the Notion integration section renders a full lifecycle: "Connect via MCP" when not connected, page search + KB setup + "Disconnect" when connected, and a warning banner with "Reconnect" + "Disconnect" when MCP needs reauth. The `inline` section always renders regardless of connection state.
   - **Bottom gap.** Root cause: body background `var(--bg)` = `#F5F5F7` (v1 light grey) vs v2 app `var(--v2-bg)` = `#FFFFFF`. Any sub-pixel gap between the fixed container and the screen edge exposed the mismatch. Fix: `:root[data-ui="v2"] body { background: var(--v2-bg) }` makes the gap invisible. Reverted `min-height` approach back to `bottom: auto; height: 100dvh` for the keyboard fix.


### PR DESCRIPTION
Re-push of PR #236 — the v1 cleanup commit never made it to the remote branch. This time it's correct.

Purges all v1 references: broken "Manage in v1" buttons, switchToV1(), PLACEHOLDER_TABS, stale v1Section props, v1 text references. Also includes body-bg fix for bottom gap.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmpfJaWEpmFxNg4yJbepdP)_