### PR TITLE
fix(notion): MCP connect button works on iOS + error feedback

### DIFF
--- a/src/v2/components/SettingsModal.jsx
+++ b/src/v2/components/SettingsModal.jsx
@@ -473,6 +473,12 @@ function IntegrationsPanel({
           const s = await api.gcalStatus()
           setStatuses(prev => ({ ...prev, gcal: s }))
         } catch { /* swallow */ }
+      } else if (event.data?.type === 'notion-mcp-connected') {
+        try {
+          const api = await import('../../api')
+          const s = await api.notionStatus()
+          setStatuses(prev => ({ ...prev, notion: s }))
+        } catch { /* swallow */ }
       } else if (event.data?.type === 'gmail-connected') {
         try {
           const api = await import('../../api')
@@ -520,19 +526,30 @@ function IntegrationsPanel({
     setNotionChildCount(null)
   }
 
+  const [notionConnectError, setNotionConnectError] = useState(null)
+
   const reconnectNotionMCP = async () => {
     setNotionReconnecting(true)
+    setNotionConnectError(null)
+    const popup = window.open('about:blank', 'notion-mcp-auth', 'width=600,height=700')
     try {
       const api = await import('../../api')
       const result = await api.notionMCPConnect()
       if (result.alreadyAuthorized) {
+        if (popup) popup.close()
         const s = await api.notionStatus()
         setStatuses(prev => ({ ...prev, notion: s }))
       } else if (result.authUrl) {
-        window.open(result.authUrl, 'notion-mcp-auth', 'width=600,height=700')
+        if (popup) { popup.location = result.authUrl } else { window.open(result.authUrl, 'notion-mcp-auth', 'width=600,height=700') }
+      } else {
+        if (popup) popup.close()
       }
-    } catch { /* swallow */ }
-    finally { setNotionReconnecting(false) }
+    } catch (e) {
+      if (popup) popup.close()
+      setNotionConnectError(e?.message || 'Connection failed')
+    } finally {
+      setNotionReconnecting(false)
+    }
   }
 
   const disconnectNotionMCP = async () => {
@@ -800,6 +817,7 @@ function IntegrationsPanel({
                   <div className="v2-integrations-inline">
                     {/* Connection controls — always visible */}
                     {!statuses.notion?.connected && !statuses.notion?.mcpHealth?.needsReauth && (
+                    <>
                       <div className="v2-integrations-actions">
                         <button
                           className="v2-settings-btn"
@@ -809,6 +827,8 @@ function IntegrationsPanel({
                           {notionReconnecting ? 'Connecting…' : 'Connect via MCP'}
                         </button>
                       </div>
+                      {notionConnectError && <div className="v2-integrations-error" style={{ marginTop: 8 }}>{notionConnectError}</div>}
+                    </>
                     )}
                     {statuses.notion?.mcpHealth?.needsReauth && (
                       <div className="v2-integrations-warn">

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,11 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-23
 
+- fix(notion): MCP connect button works on iOS + error feedback [XS]
+  - **Bug.** "Connect via MCP" button did nothing. Two causes: (1) iOS blocks `window.open()` inside async callbacks — by the time the API response arrived, the user gesture had expired. (2) Errors were silently swallowed.
+  - **Fix.** Open a blank popup synchronously on tap, then redirect it after the API responds. Show error text if the call fails. Added `notion-mcp-connected` postMessage handler so the v2 status refreshes when the OAuth popup completes.
+  - Modified: `src/v2/components/SettingsModal.jsx`
+
 - chore(ui): purge all v1 references from v2 Settings [S]
   - Removed broken "Manage in v1" / "Connect in v1" fallback buttons (Notion showed "Open undefined in v1")
   - Removed `switchToV1` function + prop threading through IntegrationsPanel


### PR DESCRIPTION
## Bug
"Connect via MCP" button did nothing on iOS.

**Cause 1:** `window.open()` was inside an async callback — iOS blocks popups when the user gesture expires during the `await`.

**Cause 2:** Errors were silently swallowed by `catch { /* swallow */ }`.

**Cause 3:** No `notion-mcp-connected` postMessage handler — v2 status never refreshed after OAuth completed (only GCal and Gmail had handlers).

## Fix
- Open blank popup synchronously on tap, redirect it after API responds
- Show error text inline if the call fails
- Add `notion-mcp-connected` postMessage handler to refresh status

## Test plan
- [ ] Tap "Connect via MCP" → popup opens immediately, redirects to Notion OAuth
- [ ] Complete OAuth → popup says "Connected!", v2 Settings shows green dot
- [ ] If API fails → error text appears below the button

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmpfJaWEpmFxNg4yJbepdP)_