### PR TITLE
fix(ui): kill 100dvh + Notion error visibility + deps bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "lucide-react": "^1.7.0",
         "mobile-drag-drop": "^3.0.0-rc.0",
         "nodemailer": "^8.0.5",
+        "qs": "^6.15.2",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "sql.js": "^1.11.0",
@@ -4664,9 +4665,10 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
@@ -6018,9 +6020,10 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
       },

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "lucide-react": "^1.7.0",
     "mobile-drag-drop": "^3.0.0-rc.0",
     "nodemailer": "^8.0.5",
+    "qs": "^6.15.2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "sql.js": "^1.11.0",

--- a/src/v2/AppV2.css
+++ b/src/v2/AppV2.css
@@ -21,18 +21,6 @@
   overflow: hidden;
 }
 
-/* iOS PWA keyboard fix (issue #213). After keyboard show/hide,
- * `inset: 0` can anchor to a stale layout viewport. `100dvh` tracks
- * the live visual viewport. `bottom: auto` lets height win over the
- * bottom anchor. The body-bg match above hides any sub-pixel gap on
- * cold starts where dvh reports a fractionally short value. */
-@supports (height: 100dvh) {
-  .v2-app {
-    bottom: auto;
-    height: 100dvh;
-  }
-}
-
 .v2-main {
   flex: 1;
   overflow-y: auto;

--- a/src/v2/components/SettingsModal.jsx
+++ b/src/v2/components/SettingsModal.jsx
@@ -853,9 +853,15 @@ function IntegrationsPanel({
                 )}
                 {int.inline === 'notion-full' && (
                   <div className="v2-integrations-inline">
-                    {/* Connection controls — always visible */}
+                    {/* Error + fallback link — always visible regardless of connection state */}
+                    {notionConnectError && <div className="v2-integrations-warn" style={{ marginBottom: 8 }}>⚠️ {notionConnectError}</div>}
+                    {notionAuthUrl && (
+                      <div className="v2-integrations-hint" style={{ marginBottom: 8 }}>
+                        Popup blocked — <a href={notionAuthUrl} target="_blank" rel="noreferrer">click here to connect</a>
+                      </div>
+                    )}
+                    {/* Not connected — show Connect button */}
                     {!statuses.notion?.connected && !statuses.notion?.mcpHealth?.needsReauth && (
-                    <>
                       <div className="v2-integrations-actions">
                         <button
                           className="v2-settings-btn"
@@ -865,13 +871,6 @@ function IntegrationsPanel({
                           {notionReconnecting ? 'Connecting…' : 'Connect via MCP'}
                         </button>
                       </div>
-                      {notionConnectError && <div className="v2-integrations-error" style={{ marginTop: 8 }}>{notionConnectError}</div>}
-                      {notionAuthUrl && (
-                        <div className="v2-integrations-hint" style={{ marginTop: 8 }}>
-                          Popup blocked — <a href={notionAuthUrl} target="_blank" rel="noreferrer">click here to connect</a>
-                        </div>
-                      )}
-                    </>
                     )}
                     {statuses.notion?.mcpHealth?.needsReauth && (
                       <div className="v2-integrations-warn">

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,11 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-23
 
+- fix(ui): kill 100dvh — pure inset:0 for bottom gap + Notion error always visible [XS]
+  - **Bottom gap.** `bottom: auto; height: 100dvh` was returning a genuinely wrong value on iOS PWA — the gap was 100+ pixels, not sub-pixel. Removed the entire `@supports (height: 100dvh)` block. Pure `position: fixed; inset: 0` + body-bg match. If the keyboard issue (#213) recurs, we'll solve it with JS, not CSS hacks.
+  - **Notion error.** Error text was inside the `!connected && !needsReauth` conditional — if the status was in any other state, errors were invisible. Moved error + fallback-link rendering outside all conditionals so they always show.
+  - Modified: `src/v2/AppV2.css`, `src/v2/components/SettingsModal.jsx`
+
 - feat(ui): port all missing v1 settings to v2 + fix Notion connect popup [L]
   - **Notion connect fix.** Removed about:blank pre-open approach — now opens the popup directly with the auth URL, falls back to a clickable link if popup is blocked. Error text visible inline. Added `notion-mcp-connected` postMessage handler so v2 status refreshes after OAuth.
   - **GCal** (+7 controls): bulk delete events, status filter checkboxes, AI-timed events toggle, fallback time + duration inputs, remove-on-complete toggle, event buffer toggle, pull filter text input, last sync timestamp.


### PR DESCRIPTION
## Bottom gap
`100dvh` was returning a genuinely wrong value on iOS PWA — 100+ pixel gap, not sub-pixel. Killed the entire `@supports (height: 100dvh)` block. Pure `position: fixed; inset: 0` + body-bg match. If the keyboard bug (#213) recurs, we'll solve it with JS.

## Notion error visibility
Error text was gated inside `!connected && !needsReauth` — invisible in any other state. Moved error + fallback link above all conditionals.

Also includes the deps bump (qs 6.15.2 + brace-expansion fix, 0 audit vulns).

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmpfJaWEpmFxNg4yJbepdP)_