### PR TITLE
fix(notion): v2 recognizes MCP connected state

### DIFF
--- a/src/v2/AppV2.css
+++ b/src/v2/AppV2.css
@@ -21,18 +21,6 @@
   overflow: hidden;
 }
 
-/* iOS PWA keyboard fix (issue #213). After keyboard show/hide,
- * `inset: 0` can anchor to a stale layout viewport. `100dvh` tracks
- * the live visual viewport. `bottom: auto` lets height win over the
- * bottom anchor. The body-bg match above hides any sub-pixel gap on
- * cold starts where dvh reports a fractionally short value. */
-@supports (height: 100dvh) {
-  .v2-app {
-    bottom: auto;
-    height: 100dvh;
-  }
-}
-
 .v2-main {
   flex: 1;
   overflow-y: auto;

--- a/src/v2/components/SettingsModal.jsx
+++ b/src/v2/components/SettingsModal.jsx
@@ -735,7 +735,7 @@ function IntegrationsPanel({
       hint: statuses.notion?.mcpHealth?.needsReauth
         ? 'MCP connection expired — reconnect to restore Quokka + Knowledge Base.'
         : 'Pull pages as tasks, sync edits both ways. MCP-based connection (recommended).',
-      connected: statuses.notion?.mcpHealth?.needsReauth ? 'warn' : !!statuses.notion?.connected,
+      connected: statuses.notion?.mcpHealth?.needsReauth ? 'warn' : !!(statuses.notion?.connected || statuses.notion?.mcpHealth?.connected),
       sync: onNotionSync && settings.notion_sync_parent_id ? { fn: onNotionSync, busy: notionSyncing } : null,
       inline: 'notion-full',
     },
@@ -853,9 +853,15 @@ function IntegrationsPanel({
                 )}
                 {int.inline === 'notion-full' && (
                   <div className="v2-integrations-inline">
-                    {/* Connection controls — always visible */}
-                    {!statuses.notion?.connected && !statuses.notion?.mcpHealth?.needsReauth && (
-                    <>
+                    {/* Error + fallback link — always visible regardless of connection state */}
+                    {notionConnectError && <div className="v2-integrations-warn" style={{ marginBottom: 8 }}>⚠️ {notionConnectError}</div>}
+                    {notionAuthUrl && (
+                      <div className="v2-integrations-hint" style={{ marginBottom: 8 }}>
+                        Popup blocked — <a href={notionAuthUrl} target="_blank" rel="noreferrer">click here to connect</a>
+                      </div>
+                    )}
+                    {/* Not connected — show Connect button */}
+                    {!statuses.notion?.connected && !statuses.notion?.mcpHealth?.connected && !statuses.notion?.mcpHealth?.needsReauth && (
                       <div className="v2-integrations-actions">
                         <button
                           className="v2-settings-btn"
@@ -865,13 +871,6 @@ function IntegrationsPanel({
                           {notionReconnecting ? 'Connecting…' : 'Connect via MCP'}
                         </button>
                       </div>
-                      {notionConnectError && <div className="v2-integrations-error" style={{ marginTop: 8 }}>{notionConnectError}</div>}
-                      {notionAuthUrl && (
-                        <div className="v2-integrations-hint" style={{ marginTop: 8 }}>
-                          Popup blocked — <a href={notionAuthUrl} target="_blank" rel="noreferrer">click here to connect</a>
-                        </div>
-                      )}
-                    </>
                     )}
                     {statuses.notion?.mcpHealth?.needsReauth && (
                       <div className="v2-integrations-warn">
@@ -886,7 +885,7 @@ function IntegrationsPanel({
                         </div>
                       </div>
                     )}
-                    {statuses.notion?.connected && !statuses.notion?.mcpHealth?.needsReauth && (
+                    {(statuses.notion?.connected || statuses.notion?.mcpHealth?.connected) && !statuses.notion?.mcpHealth?.needsReauth && (
                       <>
                         {/* Parent page config */}
                         {settings.notion_sync_parent_id ? (

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,11 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-23
 
+- fix(ui): kill 100dvh — pure inset:0 for bottom gap + Notion error always visible [XS]
+  - **Bottom gap.** `bottom: auto; height: 100dvh` was returning a genuinely wrong value on iOS PWA — the gap was 100+ pixels, not sub-pixel. Removed the entire `@supports (height: 100dvh)` block. Pure `position: fixed; inset: 0` + body-bg match. If the keyboard issue (#213) recurs, we'll solve it with JS, not CSS hacks.
+  - **Notion error.** Error text was inside the `!connected && !needsReauth` conditional — if the status was in any other state, errors were invisible. Moved error + fallback-link rendering outside all conditionals so they always show.
+  - Modified: `src/v2/AppV2.css`, `src/v2/components/SettingsModal.jsx`
+
 - feat(ui): port all missing v1 settings to v2 + fix Notion connect popup [L]
   - **Notion connect fix.** Removed about:blank pre-open approach — now opens the popup directly with the auth URL, falls back to a clickable link if popup is blocked. Error text visible inline. Added `notion-mcp-connected` postMessage handler so v2 status refreshes after OAuth.
   - **GCal** (+7 controls): bulk delete events, status filter checkboxes, AI-timed events toggle, fallback time + duration inputs, remove-on-complete toggle, event buffer toggle, pull filter text input, last sync timestamp.


### PR DESCRIPTION
v2 checks `/api/notion/status` (REST token test) but ignores `mcpHealth.connected` from the MCP client. When the MCP SDK refreshes the token asynchronously, v1 sees "Connected — 14 tools" via `/api/notion/mcp/status` while v2 still shows grey dot + Connect button.

Fix: v2 now considers `mcpHealth.connected` as a valid connected state for the dot, the inline section gating, and the connect/config conditional blocks.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmpfJaWEpmFxNg4yJbepdP)_