### PR TITLE
fix(notion): dynamic search tool name + force-persist token

### DIFF
--- a/notionMCP.js
+++ b/notionMCP.js
@@ -115,9 +115,14 @@ async function ensureClient() {
   try {
     await client.connect(transport)
     clientConnected = true
+    // Force-persist whatever token the SDK used to connect — it may have
+    // refreshed in-memory without calling saveTokens() on our provider.
+    const currentTokens = provider.tokens()
+    if (currentTokens?.access_token) {
+      await provider.saveTokens(currentTokens)
+    }
     return client
   } catch (err) {
-    // UnauthorizedError or network — caller handles
     throw err
   }
 }
@@ -126,6 +131,7 @@ async function refreshToolCache() {
   if (!clientConnected) return []
   const res = await client.listTools()
   toolCache = res.tools || []
+  console.log(`[NotionMCP] ${toolCache.length} tools available: ${toolCache.map(t => t.name).join(', ')}`)
   try { registerMCPToolsInQuokka(toolCache) } catch (e) { console.warn('[NotionMCP] tool registration failed:', e?.message) }
   return toolCache
 }

--- a/server.js
+++ b/server.js
@@ -636,8 +636,11 @@ function parseContentToBlocks(content) {
 
 async function mcpSearchPages(queryText) {
   if (!notionMCP.getStatus().connected) return null
+  const tools = notionMCP.getCachedTools()
+  const searchTool = tools.find(t => /search/i.test(t.name))
+  if (!searchTool) { console.warn('[Notion] No search tool found in MCP tools:', tools.map(t => t.name).join(', ')); return null }
   try {
-    const result = await notionMCP.callTool('search', { query: queryText })
+    const result = await notionMCP.callTool(searchTool.name, { query: queryText })
     if (result?.isError) {
       const errText = (result.content || []).map(c => c.text || '').join(' ')
       console.warn('[Notion] MCP search tool error:', errText)


### PR DESCRIPTION
From logs: `Tool search not found` (wrong name) + `401 API token is invalid` (stale stored token).

1. **Dynamic tool name** — finds search tool via `/search/i` regex on cached tool list instead of hardcoded `'search'`. Logs all tool names on connect.
2. **Force-persist token** — after successful `client.connect()`, reads `provider.tokens()` and saves them. The SDK refreshes in-memory but may not call `saveTokens()` on our provider.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmpfJaWEpmFxNg4yJbepdP)_