### PR TITLE
fix(notion): persist refreshed token AFTER listTools

### DIFF
--- a/notionMCP.js
+++ b/notionMCP.js
@@ -115,12 +115,6 @@ async function ensureClient() {
   try {
     await client.connect(transport)
     clientConnected = true
-    // Force-persist whatever token the SDK used to connect — it may have
-    // refreshed in-memory without calling saveTokens() on our provider.
-    const currentTokens = provider.tokens()
-    if (currentTokens?.access_token) {
-      await provider.saveTokens(currentTokens)
-    }
     return client
   } catch (err) {
     throw err
@@ -201,6 +195,17 @@ export async function autoReconnect() {
     transport = makeTransport()
     await ensureClient()
     await refreshToolCache()
+    // Force-persist the token AFTER tool calls — the SDK refreshes
+    // during listTools(), not during connect(). Reading provider.tokens()
+    // now should return the refreshed token.
+    const freshTokens = provider.tokens()
+    if (freshTokens?.access_token) {
+      const stored = deps.getData(TOKENS_KEY)
+      if (!stored || stored.access_token !== freshTokens.access_token) {
+        await provider.saveTokens(freshTokens)
+        console.log('[NotionMCP] persisted refreshed token for REST API use')
+      }
+    }
     lastError = null
     if (reconnectTimer) { clearInterval(reconnectTimer); reconnectTimer = null }
     console.log('[NotionMCP] reconnected successfully')


### PR DESCRIPTION
KB setup still 401 after removing the env var. The force-persist was running during `connect()` — too early. The SDK refreshes tokens during `listTools()`, not `connect()`. Moved the persist to `autoReconnect()` after `refreshToolCache()`, only when the token actually changed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmpfJaWEpmFxNg4yJbepdP)_