### PR TITLE
fix(notion): create-database uses SQL DDL schema format

### DIFF
--- a/server.js
+++ b/server.js
@@ -1539,17 +1539,17 @@ app.post('/api/knowledge/setup', async (req, res) => {
     const tools = notionMCP.getCachedTools()
     const createDbTool = tools.find(t => t.name === 'notion-create-database')
     if (!createDbTool) throw new Error('notion-create-database tool not available')
-    // Log the schema so we know what this tool actually expects
-    console.log('[Knowledge] notion-create-database inputSchema:', JSON.stringify(createDbTool.inputSchema))
 
-    const schema = `Name: title
-Type: select [Location, How-to, Decision, Person]
-Tags: multi_select
-Related tasks: rich_text
-Confidence: select [Certain, Fuzzy]`
+    const schema = `CREATE TABLE (
+  "Name" TITLE,
+  "Type" SELECT('Location':blue, 'How-to':green, 'Decision':purple, 'Person':pink),
+  "Tags" MULTI_SELECT,
+  "Related tasks" RICH_TEXT,
+  "Confidence" SELECT('Certain':green, 'Fuzzy':yellow)
+)`
 
     const result = await notionMCP.callTool('notion-create-database', {
-      parent_page_id: parentPageId,
+      parent: { page_id: parentPageId },
       title: 'Boomerang Knowledge',
       schema,
     })


### PR DESCRIPTION
The Notion MCP `notion-create-database` tool expects SQL DDL, not JSON or plain text.

```sql
CREATE TABLE (
  "Name" TITLE,
  "Type" SELECT('Location':blue, 'How-to':green, 'Decision':purple, 'Person':pink),
  "Tags" MULTI_SELECT,
  "Related tasks" RICH_TEXT,
  "Confidence" SELECT('Certain':green, 'Fuzzy':yellow)
)
```

Parent passed as `{ page_id }` object per the tool's documented schema.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmpfJaWEpmFxNg4yJbepdP)_