### PR TITLE
fix(ios): PWA standalone bottom gap — min-height hack

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -48,6 +48,16 @@ html, body, #root {
   overflow: hidden;
 }
 
+/* iOS PWA standalone hack: in standalone mode, Safari shifts the
+ * document up by the status bar height (safe-area-inset-top) but
+ * doesn't extend the viewport down to compensate — leaving a white
+ * bar at the bottom. Adding the top inset to min-height fills it. */
+@media (display-mode: standalone) {
+  html {
+    min-height: calc(100% + env(safe-area-inset-top));
+  }
+}
+
 body {
   font-family: var(--font-body);
   font-weight: 400;


### PR DESCRIPTION
## Root cause (researched, not guessed)
iOS PWA standalone mode shifts the document up by `env(safe-area-inset-top)` (the status bar area) but doesn't extend the viewport downward to compensate. This leaves a white bar at the bottom equal to the status bar height. This is a [documented iOS quirk since iOS 12](https://gist.github.com/cvan/6c022ff9b14cf8840e9d28730f75fc14) that Apple has never fixed.

## Fix
```css
@media (display-mode: standalone) {
  html {
    min-height: calc(100% + env(safe-area-inset-top));
  }
}
```

Only applies in PWA standalone mode — no effect in regular Safari or desktop.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmpfJaWEpmFxNg4yJbepdP)_