### PR TITLE
fix: projects excluded from stale + MCP create-pages params

### DIFF
--- a/emailNotifications.js
+++ b/emailNotifications.js
@@ -226,6 +226,7 @@ function isOverdue(task) {
 }
 
 function isStale(task, staleDays) {
+  if (task.status === 'project') return false
   if (task.snoozed_until && new Date(task.snoozed_until) > new Date()) return false
   const elapsed = Date.now() - new Date(task.last_touched).getTime()
   return elapsed > (task.staleness_days || staleDays || 2) * 86400000

--- a/notionMCPProxy.js
+++ b/notionMCPProxy.js
@@ -134,9 +134,9 @@ export async function getChildPages(parentId) {
 
 export async function createPage({ parentId, title, content }) {
   const raw = await call('notion-create-pages', {
-    parent_id: parentId,
-    title,
-    content: content || '',
+    parent: { page_id: parentId },
+    properties: `Name: ${title}`,
+    children: content || undefined,
   })
   const id = extractIdFromUrl(raw)
   const url = extractUrlFromText(raw)
@@ -147,11 +147,24 @@ export async function createPage({ parentId, title, content }) {
 // --- Create page in a database ---
 
 export async function createPageInDatabase({ databaseId, properties, content }) {
-  const raw = await call('notion-create-pages', {
-    database_id: databaseId,
-    properties: typeof properties === 'string' ? properties : formatProperties(properties),
-    content: content || '',
-  })
+  const propsText = typeof properties === 'string' ? properties : formatProperties(properties)
+  // Try with both parent shapes — v2.0.0 prefers data_source_id
+  let raw
+  try {
+    raw = await call('notion-create-pages', {
+      parent: { data_source_id: databaseId },
+      properties: propsText,
+      children: content || undefined,
+    })
+  } catch (e1) {
+    // Fall back to database_id if data_source_id fails
+    console.warn('[Notion:MCP] create-pages with data_source_id failed, trying database_id:', e1?.message?.slice(0, 150))
+    raw = await call('notion-create-pages', {
+      parent: { database_id: databaseId },
+      properties: propsText,
+      children: content || undefined,
+    })
+  }
   const id = extractIdFromUrl(raw)
   const url = extractUrlFromText(raw)
   if (!id) throw new Error('Could not parse page ID from MCP response')

--- a/pushNotifications.js
+++ b/pushNotifications.js
@@ -121,6 +121,7 @@ function isOverdue(task) {
 }
 
 function isStale(task, staleDays) {
+  if (task.status === 'project') return false
   if (task.snoozed_until && new Date(task.snoozed_until) > new Date()) return false
   const elapsed = Date.now() - new Date(task.last_touched).getTime()
   return elapsed > (task.staleness_days || staleDays || 2) * 86400000

--- a/pushoverNotifications.js
+++ b/pushoverNotifications.js
@@ -217,6 +217,7 @@ function isOverdue(task) {
 }
 
 function isStale(task, staleDays) {
+  if (task.status === 'project') return false
   if (task.snoozed_until && new Date(task.snoozed_until) > new Date()) return false
   const elapsed = Date.now() - new Date(task.last_touched).getTime()
   return elapsed > (task.staleness_days || staleDays || 2) * 86400000


### PR DESCRIPTION
1. **Projects excluded from stale** — `isStale()` now returns false for `status === 'project'` in all three notification engines. Projects are containers, not tasks.

2. **MCP create-pages params** — pass `parent` as object `{ page_id }` or `{ data_source_id }`, properties as text, `children` for content. Tries `data_source_id` first (Notion MCP v2.0.0), falls back to `database_id`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmpfJaWEpmFxNg4yJbepdP)_