### PR TITLE
fix(notion): notion-fetch param is 'id' not 'resource_uri'

### DIFF
--- a/notionMCPProxy.js
+++ b/notionMCPProxy.js
@@ -186,7 +186,7 @@ export async function getPage(pageId) {
       return { id: data.id, title: extractTitleFromProperties(data.properties), url: data.url, properties: data.properties }
     } catch (err) { console.warn('[Notion:REST] get page failed:', err.message) }
   }
-  const raw = await callMCP('notion-fetch', { resource_uri: `notion://page/${pageId}` })
+  const raw = await callMCP('notion-fetch', { id: pageId })
   const json = tryParseJSON(raw)
   if (json?.id) return { id: json.id, title: extractTitleFromProperties(json.properties), url: json.url, properties: json.properties }
   return { id: pageId, title: 'Untitled', url: extractUrlFromText(raw) }
@@ -220,7 +220,7 @@ export async function getBlockChildren(blockId) {
       return { raw: plainText, blocks: allBlocks }
     } catch (err) { console.warn('[Notion:REST] get blocks failed:', err.message) }
   }
-  const raw = await callMCP('notion-fetch', { resource_uri: `notion://block/${blockId}/children` })
+  const raw = await callMCP('notion-fetch', { id: blockId })
   return { raw, blocks: tryParseJSON(raw)?.results || [] }
 }
 
@@ -252,7 +252,7 @@ export async function queryDatabase(databaseId) {
       return { raw: JSON.stringify({ results: allResults }), json: { results: allResults } }
     } catch (err) { console.warn('[Notion:REST] query database failed:', err.message) }
   }
-  const raw = await callMCP('notion-fetch', { resource_uri: `notion://database/${databaseId}` })
+  const raw = await callMCP('notion-fetch', { id: databaseId })
   return { raw, json: tryParseJSON(raw) }
 }
 
@@ -265,7 +265,7 @@ export async function getDatabase(databaseId) {
       return { id: data.id, archived: !!data.archived, url: data.url, raw: JSON.stringify(data) }
     } catch (err) { console.warn('[Notion:REST] get database failed:', err.message) }
   }
-  const raw = await callMCP('notion-fetch', { resource_uri: `notion://database/${databaseId}` })
+  const raw = await callMCP('notion-fetch', { id: databaseId })
   const json = tryParseJSON(raw)
   return { id: databaseId, archived: json?.archived || false, url: json?.url || extractUrlFromText(raw), raw }
 }

--- a/wiki/Notion-Integration.md
+++ b/wiki/Notion-Integration.md
@@ -50,7 +50,7 @@ Derived from the OpenAPI spec at `@notionhq/notion-mcp-server/scripts/notion-ope
 | MCP Tool | API Operation | Custom? | Notes |
 |---|---|---|---|
 | `notion-search` | `POST /v1/search` | No | `{ query }` param |
-| `notion-fetch` | multiple GETs | **Yes** | Bundles page/block/database fetches via `resource_uri` param |
+| `notion-fetch` | multiple GETs | **Yes** | Bundles page/block/database fetches via `id` param (UUID string) |
 | `notion-create-pages` | `POST /v1/pages` | No | `{ parent, properties, children? }` — properties are Notion API objects |
 | `notion-update-page` | `PATCH /v1/pages/{id}` | No | `{ page_id, properties?, archived? }` — NO children support |
 | `notion-create-database` | `POST /v1/data_sources` | **Yes** | Accepts `{ parent, title, schema }` where schema is SQL DDL |


### PR DESCRIPTION
From logs: `notion-fetch` expects `{ id: "uuid" }` not `{ resource_uri: "notion://..." }`. Fixed all 4 call sites. The `resource_uri` param was an assumption — the actual error confirmed `id` is the required param.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmpfJaWEpmFxNg4yJbepdP)_