### PR TITLE
fix(notion): upgrade REST to API v2025-09-03 + data_sources

### DIFF
--- a/knowledgeSync.js
+++ b/knowledgeSync.js
@@ -61,7 +61,7 @@ async function verifyRestAccess(databaseId) {
     const res = await fetch(`${NOTION_BASE}/databases/${databaseId}`, {
       headers: {
         'Authorization': `Bearer ${token}`,
-        'Notion-Version': '2022-06-28',
+        'Notion-Version': '2025-09-03',
       },
     })
     if (res.ok) {

--- a/notionMCPProxy.js
+++ b/notionMCPProxy.js
@@ -27,7 +27,7 @@ function restHeaders() {
   if (!token) return null
   return {
     'Authorization': `Bearer ${token}`,
-    'Notion-Version': '2022-06-28',
+    'Notion-Version': '2025-09-03',
     'Content-Type': 'application/json',
   }
 }
@@ -237,13 +237,13 @@ export async function queryDatabase(databaseId) {
   const headers = restHeaders()
   if (headers) {
     try {
-      console.log(`[Notion:REST] POST databases/${databaseId}/query`)
+      console.log(`[Notion:REST] POST data_sources/${databaseId}/query`)
       const allResults = []
       let cursor = undefined
       do {
         const body = { page_size: 100 }
         if (cursor) body.start_cursor = cursor
-        const data = await restJson(`${NOTION_BASE}/databases/${databaseId}/query`, {
+        const data = await restJson(`${NOTION_BASE}/data_sources/${databaseId}/query`, {
           method: 'POST', body: JSON.stringify(body),
         }, 'query database')
         allResults.push(...(data.results || []))
@@ -260,8 +260,8 @@ export async function getDatabase(databaseId) {
   const headers = restHeaders()
   if (headers) {
     try {
-      console.log(`[Notion:REST] GET databases/${databaseId}`)
-      const data = await restJson(`${NOTION_BASE}/databases/${databaseId}`, {}, 'get database')
+      console.log(`[Notion:REST] GET data_sources/${databaseId}`)
+      const data = await restJson(`${NOTION_BASE}/data_sources/${databaseId}`, {}, 'get data source')
       return { id: data.id, archived: !!data.archived, url: data.url, raw: JSON.stringify(data) }
     } catch (err) { console.warn('[Notion:REST] get database failed:', err.message) }
   }

--- a/server.js
+++ b/server.js
@@ -578,7 +578,7 @@ const NOTION_BASE = 'https://api.notion.com/v1'
 function makeNotionHeaders(token) {
   return {
     'Authorization': `Bearer ${token}`,
-    'Notion-Version': '2022-06-28',
+    'Notion-Version': '2025-09-03',
     'Content-Type': 'application/json',
   }
 }
@@ -759,7 +759,7 @@ app.post('/api/notion/file-uploads', async (req, res) => {
       method: 'POST',
       headers: {
         'Authorization': `Bearer ${token}`,
-        'Notion-Version': '2022-06-28',
+        'Notion-Version': '2025-09-03',
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({ filename, content_type }),
@@ -786,7 +786,7 @@ app.post('/api/notion/file-uploads/:id/send', async (req, res) => {
       method: 'POST',
       headers: {
         'Authorization': `Bearer ${token}`,
-        'Notion-Version': '2022-06-28',
+        'Notion-Version': '2025-09-03',
       },
       body: formData,
     })


### PR DESCRIPTION
KB database was created via MCP `notion-create-database` → `POST /v1/data_sources` (2025 API). REST was querying `/v1/databases/{id}/query` with `Notion-Version: 2022-06-28` → 404 because the old API can't see data sources.

Fix: `Notion-Version: 2025-09-03` everywhere + `/v1/data_sources/{id}/query` for database operations.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmpfJaWEpmFxNg4yJbepdP)_