### PR TITLE
fix(notion): robust title extraction + KB reset button

### DIFF
--- a/notionMCPProxy.js
+++ b/notionMCPProxy.js
@@ -74,12 +74,35 @@ function extractUrlFromText(text) {
 
 function extractTitleFromProperties(properties) {
   if (!properties) return null
-  for (const val of Object.values(properties)) {
+  for (const [key, val] of Object.entries(properties)) {
+    // Standard Notion API format
     if (val?.type === 'title' && val.title?.length) {
       return val.title.map(t => t.plain_text || t.text?.content || '').join('')
     }
+    // 2025 API may nest differently
+    if (val?.title?.length && Array.isArray(val.title)) {
+      return val.title.map(t => t.plain_text || t.text?.content || '').join('')
+    }
+    // Simple string value for title-type properties
+    if (key.toLowerCase() === 'title' && typeof val === 'string') return val
+    if (key === 'Name' && typeof val === 'string') return val
   }
   return null
+}
+
+function extractTitleFromPage(page) {
+  if (!page) return 'Untitled'
+  // Try properties first
+  const fromProps = extractTitleFromProperties(page.properties)
+  if (fromProps) return fromProps
+  // Direct title field (some API responses)
+  if (page.title) {
+    if (typeof page.title === 'string') return page.title
+    if (Array.isArray(page.title)) return page.title.map(t => t.plain_text || t.text?.content || '').join('')
+  }
+  // child_page block format
+  if (page.child_page?.title) return page.child_page.title
+  return 'Untitled'
 }
 
 function extractPagesFromText(raw) {
@@ -107,9 +130,10 @@ export async function search(query) {
   const raw = await callMCP('notion-search', { query })
   const json = tryParseJSON(raw)
   if (json?.results) {
+    if (json.results[0]) console.log('[Notion:MCP] search result sample keys:', Object.keys(json.results[0]).join(', '))
     return json.results.map(p => ({
       id: p.id,
-      title: extractTitleFromProperties(p.properties) || 'Untitled',
+      title: extractTitleFromPage(p),
       url: p.url,
       last_edited: p.last_edited_time,
     }))
@@ -183,12 +207,12 @@ export async function getPage(pageId) {
     try {
       console.log(`[Notion:REST] GET pages/${pageId}`)
       const data = await restJson(`${NOTION_BASE}/pages/${pageId}`, {}, 'get page')
-      return { id: data.id, title: extractTitleFromProperties(data.properties), url: data.url, properties: data.properties }
+      return { id: data.id, title: extractTitleFromPage(data), url: data.url, properties: data.properties }
     } catch (err) { console.warn('[Notion:REST] get page failed:', err.message) }
   }
   const raw = await callMCP('notion-fetch', { id: pageId })
   const json = tryParseJSON(raw)
-  if (json?.id) return { id: json.id, title: extractTitleFromProperties(json.properties), url: json.url, properties: json.properties }
+  if (json?.id) return { id: json.id, title: extractTitleFromPage(json), url: json.url, properties: json.properties }
   return { id: pageId, title: 'Untitled', url: extractUrlFromText(raw) }
 }
 

--- a/server.js
+++ b/server.js
@@ -676,12 +676,21 @@ app.post('/api/notion/databases/:id/query', async (req, res) => {
 })
 
 function extractTitle(page) {
-  const props = page.properties || {}
-  for (const val of Object.values(props)) {
-    if (val.type === 'title' && val.title?.length > 0) {
-      return val.title.map(t => t.plain_text).join('')
-    }
+  if (page.title) {
+    if (typeof page.title === 'string') return page.title
+    if (Array.isArray(page.title)) return page.title.map(t => t.plain_text || t.text?.content || '').join('')
   }
+  const props = page.properties || {}
+  for (const [key, val] of Object.entries(props)) {
+    if (val?.type === 'title' && val.title?.length > 0) {
+      return val.title.map(t => t.plain_text || '').join('')
+    }
+    if (val?.title?.length && Array.isArray(val.title)) {
+      return val.title.map(t => t.plain_text || '').join('')
+    }
+    if (key === 'Name' && typeof val === 'string') return val
+  }
+  if (page.child_page?.title) return page.child_page.title
   return 'Untitled'
 }
 
@@ -1242,6 +1251,14 @@ app.post('/api/knowledge/setup', async (req, res) => {
     console.error('[Knowledge] setup failed:', err?.message)
     res.status(500).json({ error: err.message || 'Knowledge setup failed' })
   }
+})
+
+app.post('/api/knowledge/reset', (req, res) => {
+  setData('notion_knowledge_db_id', null)
+  setData('notion_knowledge_db_url', null)
+  setData('notion_knowledge_last_sync', null)
+  console.log('[Knowledge] Reset — cleared stored DB ID')
+  res.json({ ok: true })
 })
 
 app.post('/api/knowledge/refresh', async (req, res) => {

--- a/src/v2/components/SettingsModal.jsx
+++ b/src/v2/components/SettingsModal.jsx
@@ -919,13 +919,23 @@ function IntegrationsPanel({
                         )}
                         <label className="v2-form-label" style={{ marginTop: 12 }}>Knowledge base</label>
                         {kbStatus?.configured ? (
-                          <div className="v2-integrations-toggle-row">
-                            <span>
-                              ✓ Connected
-                              {kbStatus.database_url && <> · <a href={kbStatus.database_url} target="_blank" rel="noreferrer">Open in Notion</a></>}
-                            </span>
-                            <button className="v2-settings-btn" onClick={runKnowledgeRefresh}>Sync now</button>
-                          </div>
+                          <>
+                            <div className="v2-integrations-toggle-row">
+                              <span>
+                                ✓ Connected
+                                {kbStatus.database_url && <> · <a href={kbStatus.database_url} target="_blank" rel="noreferrer">Open in Notion</a></>}
+                              </span>
+                              <button className="v2-settings-btn" onClick={runKnowledgeRefresh}>Sync now</button>
+                            </div>
+                            <div className="v2-integrations-actions" style={{ marginTop: 4 }}>
+                              <button className="v2-settings-btn v2-settings-btn-danger" onClick={async () => {
+                                try {
+                                  await fetch('/api/knowledge/reset', { method: 'POST' })
+                                  setKbStatus(null)
+                                } catch { /* swallow */ }
+                              }}>Reset KB</button>
+                            </div>
+                          </>
                         ) : (
                           <button className="v2-settings-btn" onClick={runKnowledgeSetup} disabled={kbSetupBusy || !settings.notion_sync_parent_id}>
                             {kbSetupBusy ? 'Setting up…' : 'Set up Knowledge Base'}


### PR DESCRIPTION
1. **Title extraction broken** — MCP search returned pages but all showed "Untitled". The 2025 API returns titles in different formats (page.title, properties.Name as string, child_page.title). Added `extractTitleFromPage()` that tries all known shapes. Also logs first search result keys for diagnostics.

2. **KB reset** — No way to clear a stale KB database ID from the UI. Added "Reset KB" button + `POST /api/knowledge/reset` endpoint that clears the stored DB ID/URL/sync timestamp.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmpfJaWEpmFxNg4yJbepdP)_