### PR TITLE
fix(quokka): registerNotionTools was async — tools never registered

### DIFF
--- a/adviserToolsIntegrations.js
+++ b/adviserToolsIntegrations.js
@@ -6,6 +6,7 @@
 // - delete → cannot perfectly restore (logs a warning; external deletes are final)
 
 import { registerTool } from './adviserTools.js'
+import * as notionProxy from './notionMCPProxy.js'
 
 const GCAL_BASE = 'https://www.googleapis.com/calendar/v3'
 const TRELLO_BASE = 'https://api.trello.com/1'
@@ -203,8 +204,7 @@ export function registerGCalTools() {
 // ============================================================
 
 
-export async function registerNotionTools() {
-  const notionProxy = await import('./notionMCPProxy.js')
+export function registerNotionTools() {
 
   registerTool({
     name: 'notion_query_database',


### PR DESCRIPTION
`registerNotionTools()` was changed to `async` for a dynamic `import()`, but called without `await` at server startup. Tools never registered properly. Made the import static at module top level, function back to sync.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmpfJaWEpmFxNg4yJbepdP)_