### PR TITLE
fix(quokka): poll fallback when SSE stream dies on iOS

### DIFF
--- a/server.js
+++ b/server.js
@@ -3111,12 +3111,22 @@ app.post('/api/adviser/abort', (req, res) => {
   abortSession(sessionId)
   const ctrl = adviserAbortMap.get(sessionId)
   if (ctrl) ctrl.abort()
-  // Abort also drops any queued follow-ups — user is explicitly stopping
-  // the conversation, queued messages would be confusing to resume.
   const session = getSession(sessionId)
   if (session) session.queue = []
   clearSession(sessionId)
   res.json({ ok: true })
+})
+
+// Poll endpoint for when SSE streaming fails (iOS PWA drops SSE connections).
+// Returns the session's buffered events so the client can catch up without SSE.
+app.get('/api/adviser/session/:id/events', (req, res) => {
+  const session = getSession(req.params.id)
+  if (!session) return res.status(404).json({ error: 'Session not found' })
+  res.json({
+    runnerState: session.runnerState || 'idle',
+    events: session.events || [],
+    plan: session.plan || [],
+  })
 })
 
 app.get('/api/adviser/tools', (_req, res) => {

--- a/src/hooks/useAdviser.js
+++ b/src/hooks/useAdviser.js
@@ -285,26 +285,32 @@ export function useAdviser() {
       chatId,
       onEvent: handler,
       onError: (err) => {
-        console.warn('[Quokka] stream error, retrying subscribe-only:', err.message || err)
-        // The server runner continues in the background even when the
-        // SSE stream drops ("Load failed" on iOS). Retry by re-attaching
-        // to the same session with subscribeOnly — the server replays
-        // buffered events so we catch up.
-        setTimeout(() => {
-          if (streamRef.current) return // already reconnected
-          streamRef.current = adviserChat({
-            sessionId,
-            chatId,
-            subscribeOnly: true,
-            onEvent: handler,
-            onError: (retryErr) => {
-              console.error('[Quokka] subscribe-only retry also failed:', retryErr)
-              setLastError(retryErr.message || String(retryErr))
-              setStatus('error')
-            },
-            onDone: () => { streamRef.current = null },
-          })
-        }, 1500)
+        console.warn('[Quokka] stream error, falling back to polling:', err.message || err)
+        // iOS PWA kills SSE connections immediately. The server runner
+        // continues in the background. Poll the session events endpoint
+        // until the runner finishes, then process all buffered events.
+        const pollSessionId = sessionId
+        const pollInterval = setInterval(async () => {
+          try {
+            const res = await fetch(`/api/adviser/session/${pollSessionId}/events`)
+            if (!res.ok) { clearInterval(pollInterval); return }
+            const data = await res.json()
+            // Replay all buffered events through the handler
+            for (const evt of data.events || []) {
+              handler(evt.type || 'message', evt.data || evt)
+            }
+            // If runner is done, stop polling
+            if (data.runnerState === 'idle' || data.runnerState === 'awaiting_confirm' || data.runnerState === 'committed' || data.runnerState === 'errored') {
+              clearInterval(pollInterval)
+              streamRef.current = null
+            }
+          } catch {
+            clearInterval(pollInterval)
+            setLastError('Connection lost')
+            setStatus('error')
+          }
+        }, 2000)
+        streamRef.current = { abort: () => clearInterval(pollInterval) }
       },
       onDone: () => {
         streamRef.current = null


### PR DESCRIPTION
iOS PWA kills SSE connections immediately. The retry via subscribeOnly also dies before the runner finishes. The response never reaches the client.

Fix: when the initial SSE stream fails, fall back to polling `GET /api/adviser/session/:id/events` every 2s. Replays buffered events through the same event handler. Stops when the runner finishes.

New endpoint: `GET /api/adviser/session/:id/events` returns `{ runnerState, events, plan }`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmpfJaWEpmFxNg4yJbepdP)_