### PR TITLE
fix(quokka): read timeout on SSE stream — iOS hangs reader.read()

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -1389,11 +1389,26 @@ export function adviserChat({ message, history, sessionId, chatId, subscribeOnly
       const reader = res.body.getReader()
       const decoder = new TextDecoder()
       let buffer = ''
+      // iOS PWA kills TCP connections silently — reader.read() hangs
+      // forever without resolving or rejecting. The server sends
+      // heartbeats every 15s, so if we get nothing for 20s, assume dead.
+      const READ_TIMEOUT_MS = 20000
       while (true) {
-        const { done, value } = await reader.read()
+        let readResult
+        try {
+          readResult = await Promise.race([
+            reader.read(),
+            new Promise((_, reject) =>
+              setTimeout(() => reject(new Error('Stream read timeout — no data for 20s')), READ_TIMEOUT_MS)
+            ),
+          ])
+        } catch (timeoutErr) {
+          reader.cancel().catch(() => {})
+          throw timeoutErr
+        }
+        const { done, value } = readResult
         if (done) break
         buffer += decoder.decode(value, { stream: true })
-        // Split on double-newline (SSE event boundary)
         let idx
         while ((idx = buffer.indexOf('\n\n')) !== -1) {
           const raw = buffer.slice(0, idx)


### PR DESCRIPTION
## The actual bug (from client-side logging)
```
11:37:15.419  [Quokka] stream connected      ← client received session event
11:37:15.406  subscriber dropped              ← server says connection died
              (no [Quokka] stream error)      ← onError NEVER fired
              (no auto-resubscribe)           ← no recovery
```

iOS kills the TCP connection silently. WebKit's ReadableStream `reader.read()` hangs as an unresolved Promise — no `done`, no error, no rejection. The UI shows "thinking..." forever.

## Fix
Race `reader.read()` against a 20-second timeout. Server sends heartbeats every 15s, so silence for 20s means dead. The timeout throws → `onError` fires → auto-resubscribe kicks in.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmpfJaWEpmFxNg4yJbepdP)_