### PR TITLE
fix(quokka): GET-based session fetch — no more SSE resubscribe

### DIFF
--- a/server.js
+++ b/server.js
@@ -3118,6 +3118,19 @@ app.post('/api/adviser/abort', (req, res) => {
 })
 
 
+// Non-streaming session state fetch. iOS PWA kills SSE/ReadableStream
+// connections, so the client falls back to this after the initial POST
+// stream dies. Returns buffered events + runner state as plain JSON.
+app.get('/api/adviser/session/:id', (req, res) => {
+  const session = getSession(req.params.id)
+  if (!session) return res.status(404).json({ error: 'Session not found' })
+  res.json({
+    runnerState: session.runnerState || 'idle',
+    events: session.events || [],
+    plan: session.plan || [],
+  })
+})
+
 app.get('/api/adviser/tools', (_req, res) => {
   // Diagnostic: list registered tool names
   res.json({ tools: listToolSchemas().map(t => ({ name: t.name, description: t.description })) })

--- a/src/hooks/useAdviser.js
+++ b/src/hooks/useAdviser.js
@@ -305,8 +305,33 @@ export function useAdviser() {
         quokkaLog('stream error:', err.message || err, 'sessionId=' + (sid || 'null'))
         streamRef.current = null
         if (sid) {
-          quokkaLog('auto-resubscribe in 2s, sessionId=' + sid)
-          setTimeout(() => tryResubscribe(sid), 2000)
+          // iOS kills SSE/ReadableStream connections — resubscribe via SSE
+          // also dies instantly. Use a plain GET to fetch buffered events.
+          quokkaLog('fetching session state via GET, sessionId=' + sid)
+          const pollForResult = async () => {
+            for (let attempt = 0; attempt < 15; attempt++) {
+              await new Promise(r => setTimeout(r, 2000))
+              try {
+                const res = await fetch(`/api/adviser/session/${sid}`)
+                if (!res.ok) break
+                const data = await res.json()
+                quokkaLog('poll attempt', attempt + 1, 'runnerState=' + data.runnerState, 'events=' + (data.events?.length || 0))
+                for (const evt of data.events || []) {
+                  handler(evt.type || 'message', evt.data || evt)
+                }
+                if (data.runnerState !== 'running') {
+                  quokkaLog('poll complete, runnerState=' + data.runnerState)
+                  return
+                }
+              } catch (e) {
+                quokkaLog('poll error:', e.message)
+                break
+              }
+            }
+            setLastError('Could not retrieve response')
+            setStatus('error')
+          }
+          pollForResult()
         } else {
           setLastError(err.message || String(err))
           setStatus('error')


### PR DESCRIPTION
iOS kills every SSE/ReadableStream connection — both the initial POST and the resubscribe die instantly. The server replays events but iOS kills the TCP before the client reads them.

Fix: on stream timeout, fetch session state via plain `GET /api/adviser/session/:id` (normal JSON, no streaming). Poll every 2s until runner finishes. Replay events through the same handler. No ReadableStream involved — iOS can't kill a completed JSON response.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmpfJaWEpmFxNg4yJbepdP)_