### PR TITLE
fix(quokka): 5s timeout + 3s heartbeat + message logging

### DIFF
--- a/server.js
+++ b/server.js
@@ -3038,7 +3038,7 @@ app.post('/api/adviser/chat', async (req, res) => {
       res.write(': heartbeat\n\n')
       if (typeof res.flush === 'function') res.flush()
     } catch { /* client gone */ }
-  }, 15000)
+  }, 3000)
 
   req.on('close', () => {
     clearInterval(heartbeat)

--- a/src/api.js
+++ b/src/api.js
@@ -1391,8 +1391,8 @@ export function adviserChat({ message, history, sessionId, chatId, subscribeOnly
       let buffer = ''
       // iOS PWA kills TCP connections silently — reader.read() hangs
       // forever without resolving or rejecting. The server sends
-      // heartbeats every 15s, so if we get nothing for 20s, assume dead.
-      const READ_TIMEOUT_MS = 20000
+      // Server heartbeats every 3s. If nothing for 5s, connection is dead.
+      const READ_TIMEOUT_MS = 5000
       while (true) {
         let readResult
         try {

--- a/src/hooks/useAdviser.js
+++ b/src/hooks/useAdviser.js
@@ -158,6 +158,7 @@ export function useAdviser() {
           ensurePlaceholder()
           break
         case 'message': {
+          quokkaLog('message event, text length=' + (data.text?.length || 0), 'hasPlaceholder=' + !!pendingAssistantRef.current)
           ensurePlaceholder()
           const t = data.text || ''
           if (!pendingAssistantRef.current) break


### PR DESCRIPTION
Heartbeat 15s→3s, read timeout 20s→5s. Total delay before GET fallback: ~5s instead of ~20s. Added message event logging to diagnose blank response.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmpfJaWEpmFxNg4yJbepdP)_