### PR TITLE
fix: pages array wrapper + hide duplicate New button

### DIFF
--- a/notionMCPProxy.js
+++ b/notionMCPProxy.js
@@ -142,12 +142,12 @@ export async function search(query) {
 }
 
 export async function createPage({ parentId, title, content }) {
-  const args = {
+  const page = {
     parent: { page_id: parentId },
     properties: { title: { title: [{ text: { content: title } }] } },
   }
-  if (content) args.children = content.split('\n').filter(Boolean)
-  const raw = await callMCP('notion-create-pages', args)
+  if (content) page.children = content.split('\n').filter(Boolean)
+  const raw = await callMCP('notion-create-pages', { pages: [page] })
   const json = tryParseJSON(raw)
   if (json?.id) return { id: json.id, url: json.url }
   const id = extractIdFromUrl(raw)
@@ -159,9 +159,9 @@ export async function createPageInDatabase({ databaseId, properties, content }) 
   let propsObj = properties
   if (typeof properties === 'string') propsObj = textToNotionProperties(properties)
   else if (properties && !properties.Name?.title && !properties.title?.title) propsObj = simpleMapToNotionProperties(properties)
-  const args = { parent: { database_id: databaseId }, properties: propsObj }
-  if (content) args.children = content.split('\n').filter(Boolean)
-  const raw = await callMCP('notion-create-pages', args)
+  const page = { parent: { database_id: databaseId }, properties: propsObj }
+  if (content) page.children = content.split('\n').filter(Boolean)
+  const raw = await callMCP('notion-create-pages', { pages: [page] })
   const json = tryParseJSON(raw)
   if (json?.id) return { id: json.id, url: json.url }
   const id = extractIdFromUrl(raw)

--- a/src/v2/components/AdviserModal.jsx
+++ b/src/v2/components/AdviserModal.jsx
@@ -264,12 +264,14 @@ export default function AdviserModal({ open, adviser, onClose, onAfterCommit, on
         >
           <History size={14} strokeWidth={1.75} /> {chats.length > 0 ? `${chats.length} chat${chats.length !== 1 ? 's' : ''}` : 'Chats'}
         </button>
-        <button
-          className="v2-adviser-tool-btn v2-adviser-tool-btn-primary"
-          onClick={handleNewChat}
-        >
-          <Plus size={14} strokeWidth={2} /> New chat
-        </button>
+        {!showHistory && (
+          <button
+            className="v2-adviser-tool-btn v2-adviser-tool-btn-primary"
+            onClick={handleNewChat}
+          >
+            <Plus size={14} strokeWidth={2} /> New chat
+          </button>
+        )}
       </div>
 
       {showHistory ? (


### PR DESCRIPTION
1. `notion-create-pages` expects `{ pages: [page] }` wrapper — was passing page object directly
2. Duplicate "+ New" button hidden when chat history is showing

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmpfJaWEpmFxNg4yJbepdP)_