### PR TITLE
fix(knowledge): Tags to RICH_TEXT for freeform tags

### DIFF
--- a/knowledgeSync.js
+++ b/knowledgeSync.js
@@ -17,7 +17,7 @@ const KNOWLEDGE_LAST_SYNC_KEY = 'notion_knowledge_last_sync'
 const KB_SCHEMA = `CREATE TABLE (
   "Name" TITLE,
   "Type" SELECT('Location':blue, 'How-to':green, 'Decision':purple, 'Person':pink),
-  "Tags" MULTI_SELECT,
+  "Tags" RICH_TEXT,
   "Related tasks" RICH_TEXT,
   "Confidence" SELECT('Certain':green, 'Fuzzy':yellow)
 )`
@@ -87,6 +87,13 @@ export async function ensureKnowledgeDatabase({ parentPageId, getData, setData }
     try {
       const db = await notion.getDatabase(existing)
       if (db && !db.archived) {
+        if (!getData('knowledge_tags_migrated')) {
+          try {
+            await notion.updateDataSource({ dataSourceId: existing, statements: 'ALTER COLUMN "Tags" SET RICH_TEXT' })
+            setData('knowledge_tags_migrated', true)
+            console.log('[Knowledge] Migrated Tags from MULTI_SELECT to RICH_TEXT')
+          } catch (e) { console.warn('[Knowledge] Tags migration skipped:', e.message) }
+        }
         return { database_id: existing, url: db.url || getData(KNOWLEDGE_DB_URL_KEY), created: false }
       }
     } catch {

--- a/notionMCPProxy.js
+++ b/notionMCPProxy.js
@@ -174,6 +174,10 @@ export async function createPageInDatabase({ databaseId, properties, content }) 
   return { id, url: extractUrlFromText(raw) }
 }
 
+export async function updateDataSource({ dataSourceId, statements }) {
+  return await callMCP('notion-update-data-source', { data_source_id: dataSourceId, statements })
+}
+
 export async function updatePage({ pageId, properties, archived }) {
   const args = { page_id: pageId }
   if (properties) {


### PR DESCRIPTION
Notion MULTI_SELECT requires pre-defined options. Tags are freeform — changed to RICH_TEXT. One-time migration alters existing DB on next access.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmpfJaWEpmFxNg4yJbepdP)_