### PR TITLE
fix: poll dedup + REST API version + KB tags parsing

### DIFF
--- a/knowledgeSync.js
+++ b/knowledgeSync.js
@@ -145,7 +145,8 @@ export async function refreshKnowledgeIndex({ getData, setData }) {
         notion_page_id: page.id,
         title: page.properties?.Name?.title?.map(t => t.plain_text).join('') || 'Untitled',
         type: page.properties?.Type?.select?.name || null,
-        tags: (page.properties?.Tags?.multi_select || []).map(t => t.name),
+        tags: (page.properties?.Tags?.rich_text?.map(t => t.plain_text).join('') || '')
+          .split(/[,\s]+/).map(s => s.trim()).filter(Boolean),
         summary: '',
         confidence: page.properties?.Confidence?.select?.name || null,
         related_task_ids: (page.properties?.['Related tasks']?.rich_text?.map(t => t.plain_text).join('') || '')

--- a/notionMCPProxy.js
+++ b/notionMCPProxy.js
@@ -27,7 +27,7 @@ function restHeaders() {
   if (!token) return null
   return {
     'Authorization': `Bearer ${token}`,
-    'Notion-Version': '2025-09-03',
+    'Notion-Version': '2022-06-28',
     'Content-Type': 'application/json',
   }
 }

--- a/server.js
+++ b/server.js
@@ -3030,7 +3030,8 @@ app.post('/api/adviser/chat', async (req, res) => {
   // Always send the session id as the first event (idempotent — if the
   // session was new, no events buffered yet, so this is the only thing).
   // Re-subscribers also benefit: confirms which session they joined.
-  res.write(`event: session\ndata: ${JSON.stringify({ sessionId, runnerState: getSession(sessionId)?.runnerState || 'idle' })}\n\n`)
+  const sess = getSession(sessionId)
+  res.write(`event: session\ndata: ${JSON.stringify({ sessionId, runnerState: sess?.runnerState || 'idle', eventCount: sess?.events?.length || 0 })}\n\n`)
   if (typeof res.flush === 'function') res.flush()
 
   const heartbeat = setInterval(() => {

--- a/src/hooks/useAdviser.js
+++ b/src/hooks/useAdviser.js
@@ -302,15 +302,14 @@ export function useAdviser() {
       chatId,
       onEvent: (event, data) => {
         handler(event, data)
-        // As soon as we receive the session event with a sessionId,
-        // abort the SSE stream and switch to GET polling. iOS kills
-        // ReadableStream connections silently — polling is reliable.
         if (event === 'session' && data.sessionId) {
           const sid = data.sessionId
-          quokkaLog('got sessionId, aborting stream and switching to poll, sid=' + sid)
           if (streamRef.current?.abort) streamRef.current.abort()
           streamRef.current = null
-          let lastIdx = 0
+          // Start from current event count — skip events from prior turns
+          const startFrom = (data.eventCount || 0)
+          quokkaLog('switching to poll, sid=' + sid, 'startFrom=' + startFrom)
+          let lastIdx = startFrom
           const pollForResult = async () => {
             for (let attempt = 0; attempt < 30; attempt++) {
               await new Promise(r => setTimeout(r, 1500))


### PR DESCRIPTION
1. **Poll dedup**: server sends eventCount in session event; client starts polling from that index, skipping events from prior turns
2. **REST 400 fix**: Notion-Version reverted to 2022-06-28 (2025-09-03 caused all REST queries to fail)
3. **KB Tags parsing**: updated to parse rich_text format after the MULTI_SELECT→RICH_TEXT migration

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmpfJaWEpmFxNg4yJbepdP)_