### PR TITLE
fix(server): remove v1 guard from shared /api/data endpoints

### DIFF
--- a/server.js
+++ b/server.js
@@ -258,30 +258,8 @@ app.get('/api/events', (req, res) => {
   })
 })
 
-// --- Legacy v1 endpoint guard ---
-// When v1_disabled setting is true, block legacy bulk data endpoints and log.
-function isV1Disabled() {
-  try {
-    const settings = getData('settings') || {}
-    return !!settings.v1_disabled
-  } catch { return false }
-}
-
-function guardV1Disabled(req, res) {
-  if (!isV1Disabled()) return false
-  const msg = `[Legacy] BLOCKED ${req.method} ${req.path} — v1_disabled is ON`
-  console.warn(msg)
-  res.status(410).json({
-    ok: false,
-    error: 'v1_disabled',
-    message: 'v1 legacy endpoints are disabled. Toggle off in Settings → Legacy to re-enable.',
-  })
-  return true
-}
-
 // --- Data routes ---
 app.get('/api/data', (req, res) => {
-  if (guardV1Disabled(req, res)) return
   const data = getAllData()
   data._version = getVersion()
   res.json(data)
@@ -350,7 +328,6 @@ function handleWeatherSettingsChange(prevSettings, nextSettings) {
 }
 
 app.put('/api/data', (req, res) => {
-  if (guardV1Disabled(req, res)) return
   if (guardStaleClient(req, res)) return
   if (guardBulkBlobOnly(req, res)) return
   const clientId = req.body._clientId
@@ -369,7 +346,6 @@ app.put('/api/data', (req, res) => {
 
 // POST does the same as PUT — needed because navigator.sendBeacon only sends POST
 app.post('/api/data', (req, res) => {
-  if (guardV1Disabled(req, res)) return
   if (guardStaleClient(req, res)) return
   if (guardBulkBlobOnly(req, res)) return
   const clientId = req.body._clientId

--- a/src/hooks/useServerSync.js
+++ b/src/hooks/useServerSync.js
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
-import { saveTasks, saveRoutines, saveSettings, saveLabels, loadSettings, uuid, logSystemError } from '../store'
+import { saveTasks, saveRoutines, saveSettings, saveLabels, loadSettings, uuid } from '../store'
 import { serverCreateTask, serverUpdateTask, serverDeleteTask,
   serverCreateRoutine, serverUpdateRoutine, serverDeleteRoutine } from '../api'
 
@@ -109,11 +109,6 @@ export function useServerSync(tasks, routines, onHydrate, onVersionMismatch) {
       body: JSON.stringify(payload),
     })
       .then(res => {
-        if (res.status === 410) {
-          logSystemError('PUT /api/data blocked (v1 legacy disabled)', 'Bulk write endpoint returned 410. Settings/labels not synced server-side. Disable the Legacy toggle in Settings to restore.')
-          setSyncStatus('offline')
-          return
-        }
         if (!res.ok) {
           remoteLog('push: server responded', res.status)
           setSyncStatus('offline')
@@ -297,10 +292,6 @@ export function useServerSync(tasks, routines, onHydrate, onVersionMismatch) {
     remoteLog(`${reason}: fetching /api/data`)
     return fetch('/api/data')
       .then(res => {
-        if (res.status === 410) {
-          logSystemError('GET /api/data blocked (v1 legacy disabled)', 'Bulk data endpoint returned 410. Per-record APIs still work. Disable the Legacy toggle in Settings to restore.')
-          throw new Error('v1_disabled: GET /api/data blocked')
-        }
         if (!res.ok) throw new Error(`fetch failed: ${res.status}`)
         return res.json()
       })


### PR DESCRIPTION
## Summary
- Removed `guardV1Disabled` from `GET/PUT/POST /api/data` — these are shared infrastructure used by both v1 and v2 via `useServerSync`, not v1-only endpoints
- Removed the unused `guardV1Disabled` and `isV1Disabled` functions (lint error)
- Reverted the 410-handling code in `useServerSync.js`
- Legacy toggle still blocks the v1 **UI** from rendering (App.jsx) — just no longer blocks shared API endpoints

---
_Generated by [Claude Code](https://claude.ai/code/session_01V1M3jStNM9RUw7vuEEVpYh)_