### PR TITLE
feat(ui): port v1-only settings + date inference to v2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -905,7 +905,7 @@ The Boomerang wordmark popover (Analytics + Done, top-left) was already in place
 
 **User opt-in.** Settings → Beta tab → "Use v2 interface" toggle. The Beta tab is reserved for future opt-in experiments too.
 
-**Legacy toggle (`v1_disabled` setting).** Settings → Legacy tab → "Disable v1" toggle. When ON: (1) App.jsx blocks v1 UI rendering regardless of `?ui=v1` or localStorage, logs the block to Activity Log. (2) Server returns 410 Gone on `GET/PUT/POST /api/data` (legacy bulk sync endpoints), logged to server logs + Activity Log. Per-record APIs (`/api/tasks/:id`, `/api/routines/:id`, etc.) are unaffected, so v2 task/routine CRUD still works — only the bulk sync path breaks. The "Switch to v1" toggle is greyed out while v1 is disabled. Purpose: test what breaks before fully removing v1 code.
+**Legacy toggle (`v1_disabled` setting).** Settings → Legacy tab → "Disable v1" toggle. When ON: App.jsx blocks v1 UI rendering regardless of `?ui=v1` or localStorage, logs the block to Activity Log. The "Switch to v1" toggle is greyed out while v1 is disabled. All v1-only settings (Notion DB sync, page template, Pushover deep-link URL) have been ported to v2 — deleting v1 code will not lose any configuration surface. Purpose: test what breaks before fully removing v1 code.
 
 **Global error logging.** `window.onerror` + `unhandledrejection` handlers log errors to the Activity Log as `error` entries. React ErrorBoundary render crashes also logged. Activity Log has an "Errors" filter tab. `logSystemError(message, detail)` in store.js is the shared function.
 

--- a/src/hooks/useTaskForm.js
+++ b/src/hooks/useTaskForm.js
@@ -135,6 +135,19 @@ export function useTaskForm(initial = {}) {
     return cl
   }
 
+  const [dateInferring, setDateInferring] = useState(false)
+  const handleInferDate = async (e) => {
+    e.stopPropagation()
+    e.preventDefault()
+    if (!title.trim()) return
+    setDateInferring(true)
+    try {
+      const inferred = await inferDate(title, notes)
+      if (inferred) setDueDate(inferred)
+    } catch { /* ignore */ }
+    finally { setDateInferring(false) }
+  }
+
   const handleInferSize = async (e) => {
     e.stopPropagation()
     e.preventDefault()
@@ -257,6 +270,9 @@ export function useTaskForm(initial = {}) {
     polishing, polishError, handlePolish,
     polishApplied, setPolishApplied,
     suggestedChecklist, consumeSuggestedChecklist,
+
+    // Date inference
+    dateInferring, handleInferDate,
 
     // Size/energy inference
     sizing, handleInferSize,

--- a/src/v2/components/EditTaskModal.jsx
+++ b/src/v2/components/EditTaskModal.jsx
@@ -587,7 +587,20 @@ export default function EditTaskModal({
       <div className="v2-form-row">
         <div className="v2-form-field">
           <label className="v2-form-label">Due</label>
-          <DateField value={form.dueDate} onChange={form.setDueDate} min={today} />
+          <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+            <DateField value={form.dueDate} onChange={form.setDueDate} min={today} />
+            {!form.dueDate && (
+              <button
+                className="v2-form-ai-pill v2-form-ai-pill-inline"
+                onClick={form.handleInferDate}
+                disabled={form.dateInferring || !form.title.trim()}
+                title="Ask AI to extract a due date from the title and notes"
+              >
+                {form.dateInferring ? <span className="v2-spinner-tiny" /> : <Sparkles size={12} strokeWidth={1.75} />}
+                {form.dateInferring ? 'Inferring…' : 'Infer'}
+              </button>
+            )}
+          </div>
         </div>
         <div className="v2-form-field">
           <label className="v2-form-label">Priority</label>

--- a/src/v2/components/SettingsModal.css
+++ b/src/v2/components/SettingsModal.css
@@ -1192,6 +1192,26 @@
   color: var(--v2-text);
 }
 
+.v2-integrations-toggle-btn {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  background: none;
+  border: none;
+  padding: 0;
+  font: 500 13px/1 var(--v2-font-body);
+  color: var(--v2-text-meta);
+  cursor: pointer;
+}
+
+.v2-integrations-toggle-btn:hover {
+  color: var(--v2-text);
+}
+
+.v2-chevron-open {
+  transform: rotate(90deg);
+}
+
 .v2-integrations-sub-settings {
   padding: 8px 0 4px 12px;
   border-left: 2px solid var(--v2-hairline);

--- a/src/v2/components/SettingsModal.jsx
+++ b/src/v2/components/SettingsModal.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
-import { Trash2, Download, Upload, RefreshCw, Copy, FileText, ArrowUp, ArrowDown, Plus } from 'lucide-react'
+import { Trash2, Download, Upload, RefreshCw, Copy, FileText, ArrowUp, ArrowDown, Plus, ChevronRight } from 'lucide-react'
 import {
   loadSettings, saveSettings, loadTasks, saveTasks,
   loadRoutines, saveRoutines, loadLabels, saveLabels,
@@ -331,6 +331,10 @@ function IntegrationsPanel({
   const [notionSearchError, setNotionSearchError] = useState(null)
   const [notionReconnecting, setNotionReconnecting] = useState(false)
   const [notionChildCount, setNotionChildCount] = useState(null)
+  const [notionDbInput, setNotionDbInput] = useState('')
+  const [notionDbVerifying, setNotionDbVerifying] = useState(false)
+  const [notionDbError, setNotionDbError] = useState(null)
+  const [showNotionTemplate, setShowNotionTemplate] = useState(false)
   // Knowledge base setup state — separate from sync-parent so the two
   // Notion features stay independent.
   const [kbStatus, setKbStatus] = useState(null) // { configured, database_id, database_url, last_sync }
@@ -589,6 +593,31 @@ function IntegrationsPanel({
       setNotionConnectError(e?.message || 'Connection failed — check server logs for details')
     } finally {
       setNotionReconnecting(false)
+    }
+  }
+
+  const handleConnectDatabase = async () => {
+    const input = notionDbInput.trim()
+    if (!input) return
+    setNotionDbVerifying(true)
+    setNotionDbError(null)
+    try {
+      const api = await import('../../api')
+      let dbId = input
+      const urlMatch = input.match(/([a-f0-9]{32})/)
+      if (urlMatch) dbId = urlMatch[1]
+      if (dbId.length === 32 && !dbId.includes('-')) {
+        dbId = `${dbId.slice(0,8)}-${dbId.slice(8,12)}-${dbId.slice(12,16)}-${dbId.slice(16,20)}-${dbId.slice(20)}`
+      }
+      const result = await api.notionQueryDatabase(dbId)
+      const title = result.pages?.[0]?.title ? `Database (${result.pages.length} rows)` : 'Connected database'
+      update('notion_db_id', dbId)
+      update('notion_db_title', title)
+      setNotionDbInput('')
+    } catch (err) {
+      setNotionDbError(err.message || 'Could not connect to database. Check the ID and permissions.')
+    } finally {
+      setNotionDbVerifying(false)
     }
   }
 
@@ -946,6 +975,51 @@ function IntegrationsPanel({
                           <div className="v2-integrations-hint">Pick a sync parent first.</div>
                         )}
                         {kbError && <div className="v2-integrations-error">{kbError}</div>}
+
+                        {/* Database Sync */}
+                        <label className="v2-form-label" style={{ marginTop: 12 }}>Database sync</label>
+                        {settings.notion_db_id ? (
+                          <>
+                            <div className="v2-integrations-toggle-row">
+                              <span>📊 {settings.notion_db_title || 'Connected'}</span>
+                              <button className="v2-settings-btn" onClick={() => { update('notion_db_id', ''); update('notion_db_title', '') }}>Disconnect</button>
+                            </div>
+                          </>
+                        ) : (
+                          <>
+                            <div className="v2-integrations-hint" style={{ marginBottom: 4 }}>Paste a Notion database ID or URL to sync its rows as tasks.</div>
+                            <div className="v2-weather-search">
+                              <input type="text" className="v2-form-input" placeholder="Database ID or URL…" value={notionDbInput} onChange={e => { setNotionDbInput(e.target.value); setNotionDbError(null) }} onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); handleConnectDatabase() } }} />
+                              <button className="v2-settings-btn" onClick={handleConnectDatabase} disabled={notionDbVerifying || !notionDbInput.trim()}>
+                                {notionDbVerifying ? 'Verifying…' : 'Connect'}
+                              </button>
+                            </div>
+                            {notionDbError && <div className="v2-integrations-error">{notionDbError}</div>}
+                          </>
+                        )}
+
+                        {/* Page Template */}
+                        <button className="v2-integrations-toggle-btn" onClick={() => setShowNotionTemplate(s => !s)} style={{ marginTop: 12 }}>
+                          <ChevronRight size={12} className={showNotionTemplate ? 'v2-chevron-open' : ''} />
+                          Page template
+                        </button>
+                        {showNotionTemplate && (
+                          <div style={{ marginTop: 6 }}>
+                            <div className="v2-integrations-hint" style={{ marginBottom: 4 }}>
+                              Structure for synced Notion pages. Use ## for headings, - [ ] for tasks, &gt; for callouts.
+                            </div>
+                            <textarea
+                              className="v2-form-input"
+                              value={settings.notion_page_template ?? ''}
+                              onChange={e => update('notion_page_template', e.target.value)}
+                              rows={8}
+                              style={{ fontFamily: 'var(--v2-font-mono, monospace)', fontSize: 12 }}
+                            />
+                            <button className="v2-settings-btn" style={{ marginTop: 4 }} onClick={() => update('notion_page_template', null)}>
+                              Reset to default
+                            </button>
+                          </div>
+                        )}
                       </>
                     )}
                   </div>
@@ -1383,6 +1457,17 @@ function IntegrationsPanel({
                     {pushoverEmer.status === 'error' && pushoverEmer.error && (
                       <div className="v2-integrations-error">{pushoverEmer.error}</div>
                     )}
+                    <label className="v2-form-label" style={{ marginTop: 8 }}>Public app URL (for deep links)</label>
+                    <input
+                      type="text"
+                      className="v2-form-input"
+                      placeholder="https://boomerang.example.com"
+                      value={settings.public_app_url || ''}
+                      onChange={e => update('public_app_url', e.target.value)}
+                    />
+                    <div className="v2-integrations-hint" style={{ marginTop: 4 }}>
+                      When set, notifications include a tappable link to the relevant task. Required for Pushover deep links.
+                    </div>
                     <div className="v2-integrations-hint" style={{ marginTop: 6 }}>
                       Configure which notification types fire over Pushover in the Notifications tab.
                     </div>

--- a/src/v2/terminal/init.css
+++ b/src/v2/terminal/init.css
@@ -1471,6 +1471,10 @@
 }
 
 /* --- Settings subviews ------------------------------------------- */
+:root[data-ui="v2"][data-theme^="terminal"] .v2-integrations-toggle-btn {
+  font-family: var(--v2-font-mono);
+}
+
 :root[data-ui="v2"][data-theme^="terminal"] .v2-integrations-toggle-row,
 :root[data-ui="v2"][data-theme^="terminal"] .v2-notif-test-row,
 :root[data-ui="v2"][data-theme^="terminal"] .v2-settings-log-row,

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,14 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-25
 
+- feat(ui): port remaining v1-only settings + date inference to v2 [M]
+  - **Notion database sync** — database ID/URL input, verify via `notionQueryDatabase`, display connected title, disconnect button. Integrations → Notion → Database sync section.
+  - **Notion page template** — collapsible textarea editor for the markdown template used when syncing pages to Notion. Reset-to-default button.
+  - **Pushover deep-link URL** (`public_app_url`) — text input in the Pushover section for tappable notification links.
+  - **Date inference button** — "Infer" AI pill on the Due date field in EditTaskModal. Calls `inferDate()` to extract a date from the title and notes. Only shows when no date is set. `handleInferDate` + `dateInferring` added to `useTaskForm` hook.
+  - **v1 deprecation status:** All v1-only settings are now available in v2. Deleting v1 code will not lose any configuration surface.
+  - Modified: `src/hooks/useTaskForm.js`, `src/v2/components/EditTaskModal.jsx`, `src/v2/components/SettingsModal.jsx`, `src/v2/components/SettingsModal.css`
+
 - fix(ui): logs copy button copies filtered view, not all logs [XS]
   - **Bug.** "Copy all" in Settings → Logs copied the entire unfiltered log buffer regardless of which filter tab was active.
   - **Fix.** `handleCopy` now uses `filtered` instead of `logs`. Button label shows count when a filter is active (e.g. "Copy 12").


### PR DESCRIPTION
## Summary
Closes all v1 settings gaps so v1 can be deleted without losing any configuration surface.

- **Notion database sync** — ID/URL input, verify via query, display title, disconnect
- **Notion page template** — collapsible textarea, reset-to-default
- **Pushover deep-link URL** (`public_app_url`) — text input in Pushover section
- **Date inference button** — "Infer" AI pill on Due date field in EditTaskModal

## Test plan
- [ ] Settings → Integrations → Notion (connected) → verify Database sync section appears
- [ ] Paste a database URL → Connect → verify it validates and shows title
- [ ] Expand Page template → edit → Reset to default
- [ ] Settings → Integrations → Pushover → verify Public app URL input appears
- [ ] EditTaskModal → clear due date → verify "Infer" button appears → tap it

---
_Generated by [Claude Code](https://claude.ai/code/session_01V1M3jStNM9RUw7vuEEVpYh)_