### PR TITLE
fix(routines): done-today label wrong for yesterday completions

### DIFF
--- a/src/v2/components/RoutinesModal.jsx
+++ b/src/v2/components/RoutinesModal.jsx
@@ -32,7 +32,10 @@ function formatNextDue(routine) {
 function formatLastDone(routine) {
   if (!routine.completed_history?.length) return 'never done'
   const last = new Date(routine.completed_history[routine.completed_history.length - 1])
-  const days = Math.floor((Date.now() - last.getTime()) / 86400000)
+  const now = new Date()
+  const lastDay = new Date(last.getFullYear(), last.getMonth(), last.getDate())
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate())
+  const days = Math.round((today - lastDay) / 86400000)
   if (days === 0) return 'done today'
   if (days === 1) return 'done yesterday'
   return `done ${days}d ago`

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,11 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-25
 
+- fix(routines): "done today" label showing for yesterday's completions [XS]
+  - **Bug.** `formatLastDone` compared raw millisecond deltas (`Math.floor(diff / 86400000)`), which doesn't cross calendar day boundaries. A routine completed at 11pm yesterday would show "done today" at 8am the next day because the elapsed time is under 24h.
+  - **Fix.** Compare calendar dates (midnight-truncated) instead of raw deltas.
+  - Modified: `src/v2/components/RoutinesModal.jsx`
+
 - feat(ui): port remaining v1-only settings + date inference to v2 [M]
   - **Notion database sync** — database ID/URL input, verify via `notionQueryDatabase`, display connected title, disconnect button. Integrations → Notion → Database sync section.
   - **Notion page template** — collapsible textarea editor for the markdown template used when syncing pages to Notion. Reset-to-default button.


### PR DESCRIPTION
## Summary
- "done today" label on routines was showing for yesterday's completions because `formatLastDone` used raw millisecond deltas instead of calendar day comparison

## Test plan
- [ ] Complete a routine late in the evening → check label next morning → should say "done yesterday"

---
_Generated by [Claude Code](https://claude.ai/code/session_01V1M3jStNM9RUw7vuEEVpYh)_