### PR TITLE
fix(ui): modal min-height prevents shrink during search

### DIFF
--- a/src/v2/components/DoneList.css
+++ b/src/v2/components/DoneList.css
@@ -9,6 +9,7 @@
   border: 1px solid var(--v2-hairline);
   margin-bottom: 16px;
   transition: border-color var(--v2-dur-quick) var(--v2-ease-standard);
+  flex: 0 0 auto;
 }
 
 .v2-smart-search:focus-within {

--- a/src/v2/components/ModalShell.css
+++ b/src/v2/components/ModalShell.css
@@ -18,6 +18,7 @@
   background: var(--v2-surface);
   color: var(--v2-text);
   width: 100%;
+  min-height: 60dvh;
   max-height: 92dvh;
   overflow-y: auto;
   border-radius: var(--v2-radius-modal) var(--v2-radius-modal) 0 0;

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,11 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-25
 
+- fix(ui): modal bottom-sheet min-height prevents shrinking during search [XS]
+  - **Bug.** On mobile, the Done modal (and any ModalShell) shrank to fit content when search filtered results down to a few items, causing the search bar to jump down the screen.
+  - **Fix.** Added `min-height: 60dvh` to `.v2-modal` so the bottom sheet maintains a stable height regardless of content.
+  - Modified: `src/v2/components/ModalShell.css`, `src/v2/components/DoneList.css`
+
 - fix(routines): "done today" label showing for yesterday's completions [XS]
   - **Bug.** `formatLastDone` compared raw millisecond deltas (`Math.floor(diff / 86400000)`), which doesn't cross calendar day boundaries. A routine completed at 11pm yesterday would show "done today" at 8am the next day because the elapsed time is under 24h.
   - **Fix.** Compare calendar dates (midnight-truncated) instead of raw deltas.


### PR DESCRIPTION
## Summary
- Bottom-sheet modals shrank when search filtered results down to a few items, making the search bar jump
- Added `min-height: 60dvh` to `.v2-modal` so the sheet stays stable

## Test plan
- [ ] Open Done → search with few results → modal should not shrink

---
_Generated by [Claude Code](https://claude.ai/code/session_01V1M3jStNM9RUw7vuEEVpYh)_