### PR TITLE
feat(ui): responsive Kanban columns + desktop stats strip

### DIFF
--- a/src/v2/AppV2.jsx
+++ b/src/v2/AppV2.jsx
@@ -826,83 +826,10 @@ export default function AppV2() {
             ))}
           </div>
         )}
-        {searchOpen ? (
-          <div className="v2-list">
-            {searchResults === null ? (
-              <EmptyState
-                icon={ListChecks}
-                title="Type to search"
-                body="Searches every task — active, done, backlog, or project."
-                terminalCommand="// type a query — searches active, done, backlog, projects"
-              />
-            ) : searchResults.length === 0 ? (
-              <EmptyState
-                icon={ListChecks}
-                title="No matches"
-                body={`Nothing matches "${searchQuery}". Try a different keyword.`}
-                terminalCommand={`// no matches for "${searchQuery}"`}
-              />
-            ) : (
-              <>
-                <SectionLabel count={searchResults.length}>
-                  {searchResults.length} result{searchResults.length === 1 ? '' : 's'}
-                </SectionLabel>
-                {searchResults.map(t => (
-                  <TaskCard
-                    key={t.id}
-                    task={t}
-                    expanded={expandedTaskId === t.id}
-                    onToggleExpand={setExpandedTaskId}
-                    onComplete={handleComplete}
-                    onEdit={handleEdit}
-                    onSnooze={handleSnooze}
-                    onSkipAdvance={handleSkipAdvance}
-                    weatherByDate={weather.enabled ? weather.byDate : null}
-                    routineStreaks={routineStreaks}
-                  />
-                ))}
-              </>
-            )}
-          </div>
-        ) : totalActive === 0 && sortedSnoozed.length === 0 && backlogTasks.length === 0 && projectTasks.length === 0 ? (
-          <EmptyState
-            icon={ListChecks}
-            title={activeFilter !== 'all' ? 'No tasks match this filter' : 'Nothing on your plate'}
-            body={activeFilter !== 'all' ? 'Tap All above to clear the filter.' : 'No active tasks right now. Tap the + above to add one.'}
-            cta={activeFilter !== 'all' ? 'Show all' : 'Add task'}
-            ctaOnClick={activeFilter !== 'all' ? () => setActiveFilter('all') : () => setShowAdd(true)}
-            terminalCommand={activeFilter !== 'all'
-              ? '// no matches under this filter — clear it to see everything'
-              : '// no active tasks. that\'s either bold or concerning. press + to add.'}
-          />
-        ) : isDesktop ? (
-          <KanbanBoard
-            doingTasks={sortedDoing}
-            staleTasks={sortedStale}
-            upNextTasks={sortedUpNext}
-            waitingTasks={sortedWaiting}
-            snoozedTasks={sortedSnoozed}
-            backlogTasks={backlogTasks}
-            projectTasks={projectTasks}
-            onAddTask={(title, status) => {
-              const taskId = addTask({ title })
-              if (status !== 'not_started') changeStatus(taskId, status)
-            }}
-            onStatusChange={handleStatusChange}
-            expandedTaskId={expandedTaskId}
-            onToggleExpand={setExpandedTaskId}
-            onComplete={handleComplete}
-            onEdit={handleEdit}
-            onSnooze={handleSnooze}
-            onSkipAdvance={handleSkipAdvance}
-            weatherByDate={weather.enabled ? weather.byDate : null}
-            selectedTaskId={selectedTaskId}
-            routineStreaks={routineStreaks}
-          />
-        ) : (
-          <div className="v2-list">
-            {/* Home stats line — every segment is tappable.
-              * Date → WeekStrip. Streak → streak detail. Today → daily detail. */}
+        {/* Home stats line — renders on both mobile and desktop.
+          * Date → WeekStrip. Streak → streak detail. Today → daily detail. */}
+        {!searchOpen && (totalActive > 0 || sortedSnoozed.length > 0 || backlogTasks.length > 0 || projectTasks.length > 0) && (
+          <>
             <div className="v2-home-stats" aria-hidden="false">
               <button
                 type="button"
@@ -999,6 +926,83 @@ export default function AppV2() {
                 </div>
               )
             })()}
+          </>
+        )}
+        {searchOpen ? (
+          <div className="v2-list">
+            {searchResults === null ? (
+              <EmptyState
+                icon={ListChecks}
+                title="Type to search"
+                body="Searches every task — active, done, backlog, or project."
+                terminalCommand="// type a query — searches active, done, backlog, projects"
+              />
+            ) : searchResults.length === 0 ? (
+              <EmptyState
+                icon={ListChecks}
+                title="No matches"
+                body={`Nothing matches "${searchQuery}". Try a different keyword.`}
+                terminalCommand={`// no matches for "${searchQuery}"`}
+              />
+            ) : (
+              <>
+                <SectionLabel count={searchResults.length}>
+                  {searchResults.length} result{searchResults.length === 1 ? '' : 's'}
+                </SectionLabel>
+                {searchResults.map(t => (
+                  <TaskCard
+                    key={t.id}
+                    task={t}
+                    expanded={expandedTaskId === t.id}
+                    onToggleExpand={setExpandedTaskId}
+                    onComplete={handleComplete}
+                    onEdit={handleEdit}
+                    onSnooze={handleSnooze}
+                    onSkipAdvance={handleSkipAdvance}
+                    weatherByDate={weather.enabled ? weather.byDate : null}
+                    routineStreaks={routineStreaks}
+                  />
+                ))}
+              </>
+            )}
+          </div>
+        ) : totalActive === 0 && sortedSnoozed.length === 0 && backlogTasks.length === 0 && projectTasks.length === 0 ? (
+          <EmptyState
+            icon={ListChecks}
+            title={activeFilter !== 'all' ? 'No tasks match this filter' : 'Nothing on your plate'}
+            body={activeFilter !== 'all' ? 'Tap All above to clear the filter.' : 'No active tasks right now. Tap the + above to add one.'}
+            cta={activeFilter !== 'all' ? 'Show all' : 'Add task'}
+            ctaOnClick={activeFilter !== 'all' ? () => setActiveFilter('all') : () => setShowAdd(true)}
+            terminalCommand={activeFilter !== 'all'
+              ? '// no matches under this filter — clear it to see everything'
+              : '// no active tasks. that\'s either bold or concerning. press + to add.'}
+          />
+        ) : isDesktop ? (
+          <KanbanBoard
+            doingTasks={sortedDoing}
+            staleTasks={sortedStale}
+            upNextTasks={sortedUpNext}
+            waitingTasks={sortedWaiting}
+            snoozedTasks={sortedSnoozed}
+            backlogTasks={backlogTasks}
+            projectTasks={projectTasks}
+            onAddTask={(title, status) => {
+              const taskId = addTask({ title })
+              if (status !== 'not_started') changeStatus(taskId, status)
+            }}
+            onStatusChange={handleStatusChange}
+            expandedTaskId={expandedTaskId}
+            onToggleExpand={setExpandedTaskId}
+            onComplete={handleComplete}
+            onEdit={handleEdit}
+            onSnooze={handleSnooze}
+            onSkipAdvance={handleSkipAdvance}
+            weatherByDate={weather.enabled ? weather.byDate : null}
+            selectedTaskId={selectedTaskId}
+            routineStreaks={routineStreaks}
+          />
+        ) : (
+          <div className="v2-list">
             <ProjectPinnedSection
               projects={pinnedProjects}
               activeChildren={activeChildrenOfPinned}

--- a/src/v2/components/KanbanBoard.css
+++ b/src/v2/components/KanbanBoard.css
@@ -11,7 +11,9 @@
 }
 
 .v2-kanban-col {
-  flex: 0 0 280px;
+  flex: 1 1 0;
+  min-width: 200px;
+  max-width: 360px;
   background: rgba(var(--v2-text-rgb), 0.02);
   border: 1px solid var(--v2-hairline);
   border-radius: 14px;

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,11 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-25
 
+- feat(ui): desktop Kanban responsive columns + stats strip [M]
+  - **Resize bug.** Kanban columns were fixed at 280px (`flex: 0 0 280px`) and never grew or shrank with the viewport. Changed to `flex: 1 1 0` with `min-width: 200px` / `max-width: 360px` so columns fill available space and shrink gracefully.
+  - **Stats strip on desktop.** The date/streak/today-count header + expandable WeekStrip were mobile-only. Lifted them out of the mobile list branch into the shared layout so they render above both Kanban and mobile views. Hidden during search.
+  - Modified: `src/v2/AppV2.jsx`, `src/v2/components/KanbanBoard.css`
+
 - fix(ui): modal bottom-sheet min-height prevents shrinking during search [XS]
   - **Bug.** On mobile, the Done modal (and any ModalShell) shrank to fit content when search filtered results down to a few items, causing the search bar to jump down the screen.
   - **Fix.** Added `min-height: 60dvh` to `.v2-modal` so the bottom sheet maintains a stable height regardless of content.


### PR DESCRIPTION
## Summary
- **Kanban columns responsive** — changed from fixed 280px to flex grow/shrink (min 200px, max 360px). Columns fill the viewport and resize dynamically.
- **Stats strip on desktop** — date, streak, today count + expandable WeekStrip now render above the Kanban, not just on mobile.

## Test plan
- [ ] Resize browser window wide → columns should stretch to fill
- [ ] Resize narrow → columns should shrink, then scroll horizontally below 200px each
- [ ] Stats strip visible above Kanban with working date/streak/today toggles
- [ ] Mobile layout unchanged

---
_Generated by [Claude Code](https://claude.ai/code/session_01V1M3jStNM9RUw7vuEEVpYh)_