### PR TITLE
fix(ui): Kanban columns scroll not crush + constrain stats width

### DIFF
--- a/src/v2/AppV2.css
+++ b/src/v2/AppV2.css
@@ -61,6 +61,9 @@
   font: 500 13px/1.2 var(--v2-font-body);
   color: var(--v2-text-meta);
   text-align: center;
+  max-width: 600px;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 /* Tappable streak + today buttons — same inline treatment as the date

--- a/src/v2/components/KanbanBoard.css
+++ b/src/v2/components/KanbanBoard.css
@@ -11,9 +11,7 @@
 }
 
 .v2-kanban-col {
-  flex: 1 1 0;
-  min-width: 200px;
-  max-width: 360px;
+  flex: 0 0 260px;
   background: rgba(var(--v2-text-rgb), 0.02);
   border: 1px solid var(--v2-hairline);
   border-radius: 14px;

--- a/src/v2/components/WeekStrip.css
+++ b/src/v2/components/WeekStrip.css
@@ -12,6 +12,9 @@
 .v2-week-strip {
   margin: 0 -8px 16px;
   padding: 0 8px;
+  max-width: 600px;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .v2-week-strip-head {

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -16,6 +16,11 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
   - **Fix.** Added `min-height: 60dvh` to `.v2-modal` so the bottom sheet maintains a stable height regardless of content.
   - Modified: `src/v2/components/ModalShell.css`, `src/v2/components/DoneList.css`
 
+- fix(ui): desktop Kanban columns scroll instead of crush + constrain stats/WeekStrip width [XS]
+  - **Kanban.** Reverted flex-grow columns back to fixed 260px — with 7 columns the grow approach smushed them into unreadable oblivion. Horizontal scroll via `overflow-x: auto` is the correct pattern.
+  - **Stats strip + WeekStrip.** Added `max-width: 600px` + auto margins so they don't span the full widescreen width.
+  - Modified: `src/v2/components/KanbanBoard.css`, `src/v2/AppV2.css`, `src/v2/components/WeekStrip.css`
+
 - fix(routines): "done today" label showing for yesterday's completions [XS]
   - **Bug.** `formatLastDone` compared raw millisecond deltas (`Math.floor(diff / 86400000)`), which doesn't cross calendar day boundaries. A routine completed at 11pm yesterday would show "done today" at 8am the next day because the elapsed time is under 24h.
   - **Fix.** Compare calendar dates (midnight-truncated) instead of raw deltas.


### PR DESCRIPTION
## Summary
- Kanban columns back to fixed 260px with horizontal scroll — flex-grow with 7 columns crushed them into unreadable mush
- Stats strip + WeekStrip constrained to max-width 600px so they don't span full widescreen

## Test plan
- [ ] Desktop → columns readable, horizontal scroll when needed
- [ ] Stats strip + WeekStrip centered, not spanning full width
- [ ] Day click on WeekStrip still shows task detail

---
_Generated by [Claude Code](https://claude.ai/code/session_01V1M3jStNM9RUw7vuEEVpYh)_