### PR TITLE
fix(ui): date picker unclickable on desktop Chrome

### DIFF
--- a/src/v2/components/DateField.css
+++ b/src/v2/components/DateField.css
@@ -80,9 +80,17 @@
 }
 
 /* Strip default appearance on iOS Safari so the input's space is just
- * a tap target. */
+ * a tap target. On desktop Chrome the picker only opens via the calendar
+ * indicator icon — stretch it to fill the entire input area. */
 .v2-form-date-input::-webkit-date-and-time-value { text-align: left; }
-.v2-form-date-input::-webkit-calendar-picker-indicator { opacity: 0; }
+.v2-form-date-input::-webkit-calendar-picker-indicator {
+  opacity: 0;
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  cursor: pointer;
+}
 
 .v2-form-date-clear {
   background: transparent;

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,11 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-25
 
+- fix(ui): date picker unclickable on desktop Chrome [XS]
+  - **Bug.** Desktop Chrome only opens the date picker via the calendar indicator icon, not the full input area. The overlay trick (opacity:0 input covering the display span) worked on iOS Safari but not Chrome — only the far-right calendar icon was clickable.
+  - **Fix.** Stretched `::-webkit-calendar-picker-indicator` to fill the entire input with `position: absolute; inset: 0; width/height: 100%`.
+  - Modified: `src/v2/components/DateField.css`
+
 - fix(ui): WeekStrip missing Easter egg bonus + desktop layout fixes [S]
   - **Easter egg bug.** WeekStrip day count and detail panel only counted done tasks, not the Easter egg bonus. Stats line "3/3 today" included it but WeekStrip showed "2/3" with no "Daily Bonus" entry. Fixed by passing `easterEggWins` to WeekStrip.
   - **Kanban columns.** Reverted flex-grow back to fixed 260px with horizontal scroll — 7 columns with flex-grow smushed into unreadable mush.


### PR DESCRIPTION
## Summary
Desktop Chrome only opens date picker via the tiny calendar icon on the far right. Stretched `::-webkit-calendar-picker-indicator` to fill the entire input.

## Test plan
- [ ] Desktop Chrome: click anywhere on date field → picker opens
- [ ] Mobile Safari: still works

---
_Generated by [Claude Code](https://claude.ai/code/session_01V1M3jStNM9RUw7vuEEVpYh)_