### PR TITLE
fix(ui): desktop stats spacing + detail panel label/value gap

### DIFF
--- a/src/v2/AppV2.css
+++ b/src/v2/AppV2.css
@@ -57,13 +57,10 @@
   align-items: center;
   justify-content: center;
   gap: 6px 10px;
-  padding: 14px 0 10px;
+  padding: 6px 16px 4px;
   font: 500 13px/1.2 var(--v2-font-body);
   color: var(--v2-text-meta);
   text-align: center;
-  max-width: 600px;
-  margin-left: auto;
-  margin-right: auto;
 }
 
 /* Tappable streak + today buttons — same inline treatment as the date
@@ -91,9 +88,9 @@
 /* Inline detail panel — slides below the home stats line for streak
  * or today progress. Hairline-list aesthetic, centered like stats. */
 .v2-stats-detail {
-  max-width: 320px;
+  max-width: 360px;
   margin: 0 auto 8px;
-  padding: 10px 16px;
+  padding: 10px 20px;
   background: var(--v2-surface);
   border: 1px solid var(--v2-hairline);
   border-radius: var(--v2-radius-card, 12px);
@@ -105,6 +102,7 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: 16px;
   padding: 5px 0;
 }
 

--- a/src/v2/components/WeekStrip.css
+++ b/src/v2/components/WeekStrip.css
@@ -10,11 +10,9 @@
  */
 
 .v2-week-strip {
-  margin: 0 -8px 16px;
-  padding: 0 8px;
-  max-width: 600px;
-  margin-left: auto;
-  margin-right: auto;
+  margin: 0 auto 12px;
+  padding: 0 16px;
+  max-width: 480px;
 }
 
 .v2-week-strip-head {

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,12 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-25
 
+- fix(ui): desktop stats strip spacing + detail panel label/value gap [XS]
+  - **Stats strip.** Removed max-width constraint and excess padding — no more dead space flanking the centered stats.
+  - **Detail panels.** Added 16px gap so "Current streak" and "20 days" don't run together. Widened to 360px.
+  - **WeekStrip.** Tightened to 480px max-width with less vertical whitespace.
+  - Modified: `src/v2/AppV2.css`, `src/v2/components/WeekStrip.css`
+
 - fix(ui): date picker unclickable on desktop Chrome [XS]
   - **Bug.** Desktop Chrome only opens the date picker via the calendar indicator icon, not the full input area. The overlay trick (opacity:0 input covering the display span) worked on iOS Safari but not Chrome — only the far-right calendar icon was clickable.
   - **Fix.** Stretched `::-webkit-calendar-picker-indicator` to fill the entire input with `position: absolute; inset: 0; width/height: 100%`.


### PR DESCRIPTION
Fixes desktop stats strip dead space, label/value cramming in detail panels, and WeekStrip width.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V1M3jStNM9RUw7vuEEVpYh)_