### PR TITLE
style(ui): left-align stats + WeekStrip on desktop

### DIFF
--- a/src/v2/AppV2.css
+++ b/src/v2/AppV2.css
@@ -55,12 +55,10 @@
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  justify-content: center;
   gap: 6px 10px;
   padding: 6px 16px 4px;
   font: 500 13px/1.2 var(--v2-font-body);
   color: var(--v2-text-meta);
-  text-align: center;
 }
 
 /* Tappable streak + today buttons — same inline treatment as the date
@@ -89,7 +87,7 @@
  * or today progress. Hairline-list aesthetic, centered like stats. */
 .v2-stats-detail {
   max-width: 360px;
-  margin: 0 auto 8px;
+  margin: 0 0 8px 16px;
   padding: 10px 20px;
   background: var(--v2-surface);
   border: 1px solid var(--v2-hairline);

--- a/src/v2/components/WeekStrip.css
+++ b/src/v2/components/WeekStrip.css
@@ -10,7 +10,7 @@
  */
 
 .v2-week-strip {
-  margin: 0 auto 12px;
+  margin: 0 0 12px;
   padding: 0 16px;
   max-width: 900px;
 }

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,10 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-25
 
+- style(ui): left-align stats strip, detail panels, and WeekStrip on desktop [XS]
+  - Stats, streak/today detail, and WeekStrip now start from the left edge instead of floating centered. Reads naturally left-to-right and aligns with the Kanban columns below.
+  - Modified: `src/v2/AppV2.css`, `src/v2/components/WeekStrip.css`
+
 - fix(ui): WeekStrip full-width on desktop + Kanban columns wrap on narrow viewports [XS]
   - **WeekStrip.** max-width 480px → 900px so it fills the desktop content area instead of looking tiny.
   - **Kanban wrap.** `flex-wrap: wrap` so columns stack into rows when the viewport can't fit them side-by-side, instead of requiring horizontal scroll.


### PR DESCRIPTION
Left-align stats strip, detail panels, and WeekStrip on desktop. Builds left-to-right instead of floating centered.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V1M3jStNM9RUw7vuEEVpYh)_