### PR TITLE
feat(ui): inline WeekStrip in desktop stats bar

### DIFF
--- a/src/v2/AppV2.jsx
+++ b/src/v2/AppV2.jsx
@@ -860,14 +860,15 @@ export default function AppV2() {
               >
                 ✓ {dailyStats.tasksToday}/{settingsForRings.daily_task_goal || 3} today
               </button>
+              {weekStripShown && (
+                <WeekStrip
+                  tasks={tasks}
+                  dailyTaskGoal={settingsForRings.daily_task_goal || 3}
+                  easterEggWins={settingsForRings.easter_egg_wins}
+                  inline
+                />
+              )}
             </div>
-            {weekStripShown && (
-              <WeekStrip
-                tasks={tasks}
-                dailyTaskGoal={settingsForRings.daily_task_goal || 3}
-                easterEggWins={settingsForRings.easter_egg_wins}
-              />
-            )}
             {statsDetail === 'streak' && (() => {
               const bestStreak = Math.max(streak, records.longestStreak)
               return (

--- a/src/v2/components/WeekStrip.css
+++ b/src/v2/components/WeekStrip.css
@@ -213,6 +213,47 @@
   font-size: 12px;
 }
 
+/* === Inline mode (desktop: day cells sit in the stats bar flex row) == */
+
+@media (min-width: 769px) {
+  .v2-week-strip-inline {
+    margin: 0;
+    padding: 0;
+    max-width: none;
+    display: contents;
+  }
+  .v2-week-strip-inline .v2-week-strip-head {
+    display: none;
+  }
+  .v2-week-strip-inline .v2-week-strip-row {
+    display: flex;
+    gap: 4px;
+    margin: 0;
+    padding: 0;
+  }
+  .v2-week-strip-inline .v2-week-strip-day {
+    min-width: 44px;
+    padding: 4px 6px;
+    border-radius: 8px;
+  }
+  .v2-week-strip-inline .v2-week-strip-day-btn {
+    padding: 4px 2px;
+    min-height: 0;
+  }
+  .v2-week-strip-inline .v2-week-strip-detail {
+    flex-basis: 100%;
+    margin-top: 8px;
+  }
+}
+
+/* Below 769px, inline class is ignored — full stacked layout */
+@media (max-width: 768px) {
+  .v2-week-strip-inline {
+    margin: 0 0 12px;
+    padding: 0 16px;
+  }
+}
+
 /* === Terminal mode override =========================================
  * Drop the card chrome — bare row of day cells. Each day's number gets
  * a `*` prefix when it's today. Intensity bar becomes a block character

--- a/src/v2/components/WeekStrip.jsx
+++ b/src/v2/components/WeekStrip.jsx
@@ -14,7 +14,7 @@ function startOfWeekSunday(date) {
   return d
 }
 
-export default function WeekStrip({ tasks, dailyTaskGoal, easterEggWins }) {
+export default function WeekStrip({ tasks, dailyTaskGoal, easterEggWins, inline }) {
   const [weekOffset, setWeekOffset] = useState(0)
   const [selectedDate, setSelectedDate] = useState(null)
 
@@ -83,7 +83,7 @@ export default function WeekStrip({ tasks, dailyTaskGoal, easterEggWins }) {
   }, [selectedDate, completionsByDate, easterEggWins])
 
   return (
-    <div className="v2-week-strip">
+    <div className={`v2-week-strip${inline ? ' v2-week-strip-inline' : ''}`}>
       <div className="v2-week-strip-head">
         <button
           className="v2-week-strip-nav"

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,11 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-25
 
+- feat(ui): inline WeekStrip in desktop stats bar [S]
+  - **Desktop (≥769px).** WeekStrip day cells render inline after the date/streak/today buttons in the same flex row. Nav arrows and range label hidden — the date button already shows the date. Detail panel wraps below full-width when a day is clicked. `display: contents` on the strip wrapper lets its children participate in the parent flex.
+  - **Mobile (<769px).** Falls back to the existing stacked layout below the stats line — no change.
+  - Modified: `src/v2/AppV2.jsx`, `src/v2/components/WeekStrip.jsx`, `src/v2/components/WeekStrip.css`
+
 - style(ui): left-align stats strip, detail panels, and WeekStrip on desktop [XS]
   - Stats, streak/today detail, and WeekStrip now start from the left edge instead of floating centered. Reads naturally left-to-right and aligns with the Kanban columns below.
   - Modified: `src/v2/AppV2.css`, `src/v2/components/WeekStrip.css`


### PR DESCRIPTION
Desktop: WeekStrip day cells inline in the stats bar. Nav arrows hidden. Detail drops below. Mobile: unchanged stacked layout.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V1M3jStNM9RUw7vuEEVpYh)_