### PR TITLE
fix(ui): WeekStrip inline desktop only — restore mobile layout

### DIFF
--- a/src/v2/AppV2.jsx
+++ b/src/v2/AppV2.jsx
@@ -865,7 +865,7 @@ export default function AppV2() {
                   tasks={tasks}
                   dailyTaskGoal={settingsForRings.daily_task_goal || 3}
                   easterEggWins={settingsForRings.easter_egg_wins}
-                  inline
+                  inline={isDesktop}
                 />
               )}
             </div>


### PR DESCRIPTION
inline prop was hardcoded true — broke mobile. Now `inline={isDesktop}`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V1M3jStNM9RUw7vuEEVpYh)_