### PR TITLE
release: desktop design + mobile WeekStrip fix

### DIFF
--- a/src/v2/AppV2.css
+++ b/src/v2/AppV2.css
@@ -55,12 +55,10 @@
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  justify-content: center;
   gap: 6px 10px;
   padding: 6px 16px 4px;
   font: 500 13px/1.2 var(--v2-font-body);
   color: var(--v2-text-meta);
-  text-align: center;
 }
 
 /* Tappable streak + today buttons — same inline treatment as the date
@@ -89,7 +87,7 @@
  * or today progress. Hairline-list aesthetic, centered like stats. */
 .v2-stats-detail {
   max-width: 360px;
-  margin: 0 auto 8px;
+  margin: 0 0 8px 16px;
   padding: 10px 20px;
   background: var(--v2-surface);
   border: 1px solid var(--v2-hairline);

--- a/src/v2/AppV2.jsx
+++ b/src/v2/AppV2.jsx
@@ -865,7 +865,7 @@ export default function AppV2() {
                   tasks={tasks}
                   dailyTaskGoal={settingsForRings.daily_task_goal || 3}
                   easterEggWins={settingsForRings.easter_egg_wins}
-                  inline
+                  inline={isDesktop}
                 />
               )}
             </div>

--- a/src/v2/AppV2.jsx
+++ b/src/v2/AppV2.jsx
@@ -860,14 +860,15 @@ export default function AppV2() {
               >
                 ✓ {dailyStats.tasksToday}/{settingsForRings.daily_task_goal || 3} today
               </button>
+              {weekStripShown && (
+                <WeekStrip
+                  tasks={tasks}
+                  dailyTaskGoal={settingsForRings.daily_task_goal || 3}
+                  easterEggWins={settingsForRings.easter_egg_wins}
+                  inline
+                />
+              )}
             </div>
-            {weekStripShown && (
-              <WeekStrip
-                tasks={tasks}
-                dailyTaskGoal={settingsForRings.daily_task_goal || 3}
-                easterEggWins={settingsForRings.easter_egg_wins}
-              />
-            )}
             {statsDetail === 'streak' && (() => {
               const bestStreak = Math.max(streak, records.longestStreak)
               return (

--- a/src/v2/components/KanbanBoard.css
+++ b/src/v2/components/KanbanBoard.css
@@ -2,7 +2,7 @@
 
 .v2-kanban {
   display: flex;
-  flex-direction: row;
+  flex-wrap: wrap;
   gap: 12px;
   padding: 12px 16px 24px;
   overflow-x: auto;

--- a/src/v2/components/WeekStrip.css
+++ b/src/v2/components/WeekStrip.css
@@ -213,6 +213,47 @@
   font-size: 12px;
 }
 
+/* === Inline mode (desktop: day cells sit in the stats bar flex row) == */
+
+@media (min-width: 769px) {
+  .v2-week-strip-inline {
+    margin: 0;
+    padding: 0;
+    max-width: none;
+    display: contents;
+  }
+  .v2-week-strip-inline .v2-week-strip-head {
+    display: none;
+  }
+  .v2-week-strip-inline .v2-week-strip-row {
+    display: flex;
+    gap: 4px;
+    margin: 0;
+    padding: 0;
+  }
+  .v2-week-strip-inline .v2-week-strip-day {
+    min-width: 44px;
+    padding: 4px 6px;
+    border-radius: 8px;
+  }
+  .v2-week-strip-inline .v2-week-strip-day-btn {
+    padding: 4px 2px;
+    min-height: 0;
+  }
+  .v2-week-strip-inline .v2-week-strip-detail {
+    flex-basis: 100%;
+    margin-top: 8px;
+  }
+}
+
+/* Below 769px, inline class is ignored — full stacked layout */
+@media (max-width: 768px) {
+  .v2-week-strip-inline {
+    margin: 0 0 12px;
+    padding: 0 16px;
+  }
+}
+
 /* === Terminal mode override =========================================
  * Drop the card chrome — bare row of day cells. Each day's number gets
  * a `*` prefix when it's today. Intensity bar becomes a block character

--- a/src/v2/components/WeekStrip.css
+++ b/src/v2/components/WeekStrip.css
@@ -12,7 +12,7 @@
 .v2-week-strip {
   margin: 0 auto 12px;
   padding: 0 16px;
-  max-width: 480px;
+  max-width: 900px;
 }
 
 .v2-week-strip-head {

--- a/src/v2/components/WeekStrip.css
+++ b/src/v2/components/WeekStrip.css
@@ -58,8 +58,8 @@
   margin: 0;
   padding: 0;
   display: grid;
-  grid-template-columns: repeat(7, 1fr);
-  gap: 4px;
+  grid-template-columns: repeat(auto-fit, minmax(48px, 1fr));
+  gap: 8px;
 }
 
 .v2-week-strip-day {
@@ -222,23 +222,26 @@
     max-width: none;
     display: contents;
   }
-  .v2-week-strip-inline .v2-week-strip-head {
-    display: none;
-  }
   .v2-week-strip-inline .v2-week-strip-row {
     display: flex;
-    gap: 4px;
+    gap: 8px;
     margin: 0;
     padding: 0;
   }
   .v2-week-strip-inline .v2-week-strip-day {
-    min-width: 44px;
-    padding: 4px 6px;
+    min-width: 48px;
+    padding: 4px 8px;
     border-radius: 8px;
   }
   .v2-week-strip-inline .v2-week-strip-day-btn {
     padding: 4px 2px;
     min-height: 0;
+  }
+  .v2-week-strip-inline .v2-week-strip-head {
+    flex-basis: 100%;
+    margin-top: 4px;
+    justify-content: flex-start;
+    gap: 8px;
   }
   .v2-week-strip-inline .v2-week-strip-detail {
     flex-basis: 100%;

--- a/src/v2/components/WeekStrip.css
+++ b/src/v2/components/WeekStrip.css
@@ -10,7 +10,7 @@
  */
 
 .v2-week-strip {
-  margin: 0 auto 12px;
+  margin: 0 0 12px;
   padding: 0 16px;
   max-width: 900px;
 }

--- a/src/v2/components/WeekStrip.jsx
+++ b/src/v2/components/WeekStrip.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useMemo, useState } from 'react'
 import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { localYMD } from '../../store'
 import { calculateTaskPoints } from '../../scoring'
@@ -14,30 +14,9 @@ function startOfWeekSunday(date) {
   return d
 }
 
-const DAY_CELL_MIN = 56
-
 export default function WeekStrip({ tasks, dailyTaskGoal, easterEggWins, inline }) {
   const [weekOffset, setWeekOffset] = useState(0)
   const [selectedDate, setSelectedDate] = useState(null)
-  const rowRef = useRef(null)
-  const [maxDays, setMaxDays] = useState(7)
-
-  const measureFit = useCallback(() => {
-    if (!inline || !rowRef.current) { setMaxDays(7); return }
-    const parent = rowRef.current.parentElement
-    if (!parent) return
-    const statsWidth = Array.from(parent.children)
-      .filter(el => el !== rowRef.current && !el.classList.contains('v2-week-strip-inline'))
-      .reduce((w, el) => w + el.offsetWidth, 0)
-    const available = parent.offsetWidth - statsWidth - 40
-    setMaxDays(Math.max(3, Math.min(7, Math.floor(available / DAY_CELL_MIN))))
-  }, [inline])
-
-  useEffect(() => {
-    measureFit()
-    window.addEventListener('resize', measureFit)
-    return () => window.removeEventListener('resize', measureFit)
-  }, [measureFit])
 
   const completionsByDate = useMemo(() => {
     const map = {}
@@ -82,19 +61,9 @@ export default function WeekStrip({ tasks, dailyTaskGoal, easterEggWins, inline 
     return out
   }, [completionsByDate, weekOffset, dailyTaskGoal])
 
-  const displayDays = useMemo(() => {
-    if (maxDays >= 7) return days
-    const todayIdx = days.findIndex(d => d.isToday)
-    const center = todayIdx >= 0 ? todayIdx : Math.floor(days.length / 2)
-    const half = Math.floor(maxDays / 2)
-    let s = Math.max(0, center - half)
-    if (s + maxDays > days.length) s = Math.max(0, days.length - maxDays)
-    return days.slice(s, s + maxDays)
-  }, [days, maxDays])
-
   const rangeLabel = useMemo(() => {
-    const first = displayDays[0].date
-    const last = displayDays[displayDays.length - 1].date
+    const first = days[0].date
+    const last = days[6].date
     const firstMonth = first.toLocaleString('en', { month: 'short' })
     const lastMonth = last.toLocaleString('en', { month: 'short' })
     if (firstMonth === lastMonth) {
@@ -138,8 +107,8 @@ export default function WeekStrip({ tasks, dailyTaskGoal, easterEggWins, inline 
   return (
     <div className={`v2-week-strip${inline ? ' v2-week-strip-inline' : ''}`}>
       {!inline && navRow}
-      <ol ref={rowRef} id="v2-week-strip-days" className="v2-week-strip-row">
-        {displayDays.map(d => (
+      <ol id="v2-week-strip-days" className="v2-week-strip-row">
+        {days.map(d => (
           <li
             key={d.key}
             className={[

--- a/src/v2/components/WeekStrip.jsx
+++ b/src/v2/components/WeekStrip.jsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { localYMD } from '../../store'
 import { calculateTaskPoints } from '../../scoring'
@@ -14,9 +14,30 @@ function startOfWeekSunday(date) {
   return d
 }
 
+const DAY_CELL_MIN = 56
+
 export default function WeekStrip({ tasks, dailyTaskGoal, easterEggWins, inline }) {
   const [weekOffset, setWeekOffset] = useState(0)
   const [selectedDate, setSelectedDate] = useState(null)
+  const rowRef = useRef(null)
+  const [maxDays, setMaxDays] = useState(7)
+
+  const measureFit = useCallback(() => {
+    if (!inline || !rowRef.current) { setMaxDays(7); return }
+    const parent = rowRef.current.parentElement
+    if (!parent) return
+    const statsWidth = Array.from(parent.children)
+      .filter(el => el !== rowRef.current && !el.classList.contains('v2-week-strip-inline'))
+      .reduce((w, el) => w + el.offsetWidth, 0)
+    const available = parent.offsetWidth - statsWidth - 40
+    setMaxDays(Math.max(3, Math.min(7, Math.floor(available / DAY_CELL_MIN))))
+  }, [inline])
+
+  useEffect(() => {
+    measureFit()
+    window.addEventListener('resize', measureFit)
+    return () => window.removeEventListener('resize', measureFit)
+  }, [measureFit])
 
   const completionsByDate = useMemo(() => {
     const map = {}
@@ -61,9 +82,19 @@ export default function WeekStrip({ tasks, dailyTaskGoal, easterEggWins, inline 
     return out
   }, [completionsByDate, weekOffset, dailyTaskGoal])
 
+  const displayDays = useMemo(() => {
+    if (maxDays >= 7) return days
+    const todayIdx = days.findIndex(d => d.isToday)
+    const center = todayIdx >= 0 ? todayIdx : Math.floor(days.length / 2)
+    const half = Math.floor(maxDays / 2)
+    let s = Math.max(0, center - half)
+    if (s + maxDays > days.length) s = Math.max(0, days.length - maxDays)
+    return days.slice(s, s + maxDays)
+  }, [days, maxDays])
+
   const rangeLabel = useMemo(() => {
-    const first = days[0].date
-    const last = days[6].date
+    const first = displayDays[0].date
+    const last = displayDays[displayDays.length - 1].date
     const firstMonth = first.toLocaleString('en', { month: 'short' })
     const lastMonth = last.toLocaleString('en', { month: 'short' })
     if (firstMonth === lastMonth) {
@@ -82,29 +113,33 @@ export default function WeekStrip({ tasks, dailyTaskGoal, easterEggWins, inline 
     return items
   }, [selectedDate, completionsByDate, easterEggWins])
 
+  const navRow = (
+    <div className="v2-week-strip-head">
+      <button
+        className="v2-week-strip-nav"
+        onClick={() => { setWeekOffset(o => o - 1); setSelectedDate(null) }}
+        aria-label="Previous week"
+      >
+        <ChevronLeft size={14} strokeWidth={2} />
+      </button>
+      <span className="v2-week-strip-range">
+        <span className="v2-week-strip-range-label">{rangeLabel}</span>
+      </span>
+      <button
+        className="v2-week-strip-nav"
+        onClick={() => { setWeekOffset(o => o + 1); setSelectedDate(null) }}
+        aria-label="Next week"
+      >
+        <ChevronRight size={14} strokeWidth={2} />
+      </button>
+    </div>
+  )
+
   return (
     <div className={`v2-week-strip${inline ? ' v2-week-strip-inline' : ''}`}>
-      <div className="v2-week-strip-head">
-        <button
-          className="v2-week-strip-nav"
-          onClick={() => { setWeekOffset(o => o - 1); setSelectedDate(null) }}
-          aria-label="Previous week"
-        >
-          <ChevronLeft size={14} strokeWidth={2} />
-        </button>
-        <span className="v2-week-strip-range">
-          <span className="v2-week-strip-range-label">{rangeLabel}</span>
-        </span>
-        <button
-          className="v2-week-strip-nav"
-          onClick={() => { setWeekOffset(o => o + 1); setSelectedDate(null) }}
-          aria-label="Next week"
-        >
-          <ChevronRight size={14} strokeWidth={2} />
-        </button>
-      </div>
-      <ol id="v2-week-strip-days" className="v2-week-strip-row">
-        {days.map(d => (
+      {!inline && navRow}
+      <ol ref={rowRef} id="v2-week-strip-days" className="v2-week-strip-row">
+        {displayDays.map(d => (
           <li
             key={d.key}
             className={[
@@ -151,6 +186,7 @@ export default function WeekStrip({ tasks, dailyTaskGoal, easterEggWins, inline 
           )}
         </div>
       )}
+      {inline && navRow}
     </div>
   )
 }

--- a/src/v2/components/WeekStrip.jsx
+++ b/src/v2/components/WeekStrip.jsx
@@ -14,7 +14,7 @@ function startOfWeekSunday(date) {
   return d
 }
 
-export default function WeekStrip({ tasks, dailyTaskGoal, easterEggWins }) {
+export default function WeekStrip({ tasks, dailyTaskGoal, easterEggWins, inline }) {
   const [weekOffset, setWeekOffset] = useState(0)
   const [selectedDate, setSelectedDate] = useState(null)
 
@@ -83,7 +83,7 @@ export default function WeekStrip({ tasks, dailyTaskGoal, easterEggWins }) {
   }, [selectedDate, completionsByDate, easterEggWins])
 
   return (
-    <div className="v2-week-strip">
+    <div className={`v2-week-strip${inline ? ' v2-week-strip-inline' : ''}`}>
       <div className="v2-week-strip-head">
         <button
           className="v2-week-strip-nav"

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,11 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-25
 
+- fix(ui): WeekStrip full-width on desktop + Kanban columns wrap on narrow viewports [XS]
+  - **WeekStrip.** max-width 480px → 900px so it fills the desktop content area instead of looking tiny.
+  - **Kanban wrap.** `flex-wrap: wrap` so columns stack into rows when the viewport can't fit them side-by-side, instead of requiring horizontal scroll.
+  - Modified: `src/v2/components/WeekStrip.css`, `src/v2/components/KanbanBoard.css`
+
 - fix(ui): Kanban columns dynamically resize with viewport [XS]
   - **Bug.** Columns were fixed at 260px — dead space on wide screens, cut off on narrow ones.
   - **Fix.** `flex: 1 0 220px; max-width: 400px` — columns grow to fill available space, cap at 400px, scroll horizontally below 220px each.

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,10 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-25
 
+- style(ui): left-align stats strip, detail panels, and WeekStrip on desktop [XS]
+  - Stats, streak/today detail, and WeekStrip now start from the left edge instead of floating centered. Reads naturally left-to-right and aligns with the Kanban columns below.
+  - Modified: `src/v2/AppV2.css`, `src/v2/components/WeekStrip.css`
+
 - fix(ui): WeekStrip full-width on desktop + Kanban columns wrap on narrow viewports [XS]
   - **WeekStrip.** max-width 480px → 900px so it fills the desktop content area instead of looking tiny.
   - **Kanban wrap.** `flex-wrap: wrap` so columns stack into rows when the viewport can't fit them side-by-side, instead of requiring horizontal scroll.

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,11 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-25
 
+- feat(ui): inline WeekStrip in desktop stats bar [S]
+  - **Desktop (≥769px).** WeekStrip day cells render inline after the date/streak/today buttons in the same flex row. Nav arrows and range label hidden — the date button already shows the date. Detail panel wraps below full-width when a day is clicked. `display: contents` on the strip wrapper lets its children participate in the parent flex.
+  - **Mobile (<769px).** Falls back to the existing stacked layout below the stats line — no change.
+  - Modified: `src/v2/AppV2.jsx`, `src/v2/components/WeekStrip.jsx`, `src/v2/components/WeekStrip.css`
+
 - style(ui): left-align stats strip, detail panels, and WeekStrip on desktop [XS]
   - Stats, streak/today detail, and WeekStrip now start from the left edge instead of floating centered. Reads naturally left-to-right and aligns with the Kanban columns below.
   - Modified: `src/v2/AppV2.css`, `src/v2/components/WeekStrip.css`

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,12 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-25
 
+- feat(ui): WeekStrip nav below stats + breathing room + auto-shrink [S]
+  - **Nav row below.** Date range selector (< May 24-30 >) renders below the stats+days row in inline mode, not above. Always visible when strip is open.
+  - **Breathing room.** Day cell gap 4px → 8px, min-width 48px with 8px padding.
+  - **Auto-shrink.** Measures available width and shows 3-7 days centered on today. ResizeObserver re-measures on viewport change.
+  - Modified: `src/v2/components/WeekStrip.jsx`, `src/v2/components/WeekStrip.css`
+
 - feat(ui): inline WeekStrip in desktop stats bar [S]
   - **Desktop (≥769px).** WeekStrip day cells render inline after the date/streak/today buttons in the same flex row. Nav arrows and range label hidden — the date button already shows the date. Detail panel wraps below full-width when a day is clicked. `display: contents` on the strip wrapper lets its children participate in the parent flex.
   - **Mobile (<769px).** Falls back to the existing stacked layout below the stats line — no change.


### PR DESCRIPTION
Full dev → main promotion. Includes all desktop design work (inline WeekStrip, nav below, dynamic Kanban columns, stats spacing) with mobile fix (inline={isDesktop}).

---
_Generated by [Claude Code](https://claude.ai/code/session_01V1M3jStNM9RUw7vuEEVpYh)_