### PR TITLE
fix: restore mobile WeekStrip 7-column grid

### DIFF
--- a/src/v2/components/WeekStrip.css
+++ b/src/v2/components/WeekStrip.css
@@ -58,8 +58,8 @@
   margin: 0;
   padding: 0;
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(48px, 1fr));
-  gap: 8px;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 4px;
 }
 
 .v2-week-strip-day {


### PR DESCRIPTION
Restores repeat(7, 1fr) grid for mobile WeekStrip. auto-fit was wrapping cells into rows.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V1M3jStNM9RUw7vuEEVpYh)_