### PR TITLE
fix(ui): restore WeekStrip 7-column grid on dev

### DIFF
--- a/src/v2/components/WeekStrip.css
+++ b/src/v2/components/WeekStrip.css
@@ -58,8 +58,8 @@
   margin: 0;
   padding: 0;
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(48px, 1fr));
-  gap: 8px;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 4px;
 }
 
 .v2-week-strip-day {


### PR DESCRIPTION
Same grid fix as main — repeat(7, 1fr) instead of auto-fit.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V1M3jStNM9RUw7vuEEVpYh)_