### PR TITLE
fix: restore mobile layout

### DIFF
--- a/src/v2/AppV2.css
+++ b/src/v2/AppV2.css
@@ -55,10 +55,20 @@
   display: flex;
   flex-wrap: wrap;
   align-items: center;
+  justify-content: center;
   gap: 6px 10px;
-  padding: 6px 16px 4px;
+  padding: 14px 0 10px;
   font: 500 13px/1.2 var(--v2-font-body);
   color: var(--v2-text-meta);
+  text-align: center;
+}
+
+@media (min-width: 769px) {
+  .v2-home-stats {
+    justify-content: flex-start;
+    padding: 6px 16px 4px;
+    text-align: left;
+  }
 }
 
 /* Tappable streak + today buttons — same inline treatment as the date
@@ -87,7 +97,7 @@
  * or today progress. Hairline-list aesthetic, centered like stats. */
 .v2-stats-detail {
   max-width: 360px;
-  margin: 0 0 8px 16px;
+  margin: 0 auto 8px;
   padding: 10px 20px;
   background: var(--v2-surface);
   border: 1px solid var(--v2-hairline);

--- a/src/v2/components/WeekStrip.css
+++ b/src/v2/components/WeekStrip.css
@@ -10,9 +10,8 @@
  */
 
 .v2-week-strip {
-  margin: 0 0 12px;
-  padding: 0 16px;
-  max-width: 900px;
+  margin: 0 -8px 16px;
+  padding: 0 8px;
 }
 
 .v2-week-strip-head {

--- a/src/v2/components/WeekStrip.css
+++ b/src/v2/components/WeekStrip.css
@@ -58,8 +58,8 @@
   margin: 0;
   padding: 0;
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(48px, 1fr));
-  gap: 8px;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 4px;
 }
 
 .v2-week-strip-day {


### PR DESCRIPTION
Restores mobile stats + WeekStrip to v1.21.18 baseline. Desktop overrides via @media only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V1M3jStNM9RUw7vuEEVpYh)_