### PR TITLE
fix: full revert WeekStrip + stats to v1.21.18 baseline

### DIFF
--- a/src/v2/AppV2.css
+++ b/src/v2/AppV2.css
@@ -63,14 +63,6 @@
   text-align: center;
 }
 
-@media (min-width: 769px) {
-  .v2-home-stats {
-    justify-content: flex-start;
-    padding: 6px 16px 4px;
-    text-align: left;
-  }
-}
-
 /* Tappable streak + today buttons — same inline treatment as the date
  * toggle: stripped button chrome, accent on active/hover. */
 .v2-thx-btn {
@@ -96,9 +88,9 @@
 /* Inline detail panel — slides below the home stats line for streak
  * or today progress. Hairline-list aesthetic, centered like stats. */
 .v2-stats-detail {
-  max-width: 360px;
+  max-width: 320px;
   margin: 0 auto 8px;
-  padding: 10px 20px;
+  padding: 10px 16px;
   background: var(--v2-surface);
   border: 1px solid var(--v2-hairline);
   border-radius: var(--v2-radius-card, 12px);
@@ -110,7 +102,6 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 16px;
   padding: 5px 0;
 }
 

--- a/src/v2/AppV2.jsx
+++ b/src/v2/AppV2.jsx
@@ -860,15 +860,14 @@ export default function AppV2() {
               >
                 ✓ {dailyStats.tasksToday}/{settingsForRings.daily_task_goal || 3} today
               </button>
-              {weekStripShown && (
-                <WeekStrip
-                  tasks={tasks}
-                  dailyTaskGoal={settingsForRings.daily_task_goal || 3}
-                  easterEggWins={settingsForRings.easter_egg_wins}
-                  inline={isDesktop}
-                />
-              )}
             </div>
+            {weekStripShown && (
+              <WeekStrip
+                tasks={tasks}
+                dailyTaskGoal={settingsForRings.daily_task_goal || 3}
+                easterEggWins={settingsForRings.easter_egg_wins}
+              />
+            )}
             {statsDetail === 'streak' && (() => {
               const bestStreak = Math.max(streak, records.longestStreak)
               return (

--- a/src/v2/components/WeekStrip.css
+++ b/src/v2/components/WeekStrip.css
@@ -212,50 +212,6 @@
   font-size: 12px;
 }
 
-/* === Inline mode (desktop: day cells sit in the stats bar flex row) == */
-
-@media (min-width: 769px) {
-  .v2-week-strip-inline {
-    margin: 0;
-    padding: 0;
-    max-width: none;
-    display: contents;
-  }
-  .v2-week-strip-inline .v2-week-strip-row {
-    display: flex;
-    gap: 8px;
-    margin: 0;
-    padding: 0;
-  }
-  .v2-week-strip-inline .v2-week-strip-day {
-    min-width: 48px;
-    padding: 4px 8px;
-    border-radius: 8px;
-  }
-  .v2-week-strip-inline .v2-week-strip-day-btn {
-    padding: 4px 2px;
-    min-height: 0;
-  }
-  .v2-week-strip-inline .v2-week-strip-head {
-    flex-basis: 100%;
-    margin-top: 4px;
-    justify-content: flex-start;
-    gap: 8px;
-  }
-  .v2-week-strip-inline .v2-week-strip-detail {
-    flex-basis: 100%;
-    margin-top: 8px;
-  }
-}
-
-/* Below 769px, inline class is ignored — full stacked layout */
-@media (max-width: 768px) {
-  .v2-week-strip-inline {
-    margin: 0 0 12px;
-    padding: 0 16px;
-  }
-}
-
 /* === Terminal mode override =========================================
  * Drop the card chrome — bare row of day cells. Each day's number gets
  * a `*` prefix when it's today. Intensity bar becomes a block character

--- a/src/v2/components/WeekStrip.jsx
+++ b/src/v2/components/WeekStrip.jsx
@@ -14,7 +14,7 @@ function startOfWeekSunday(date) {
   return d
 }
 
-export default function WeekStrip({ tasks, dailyTaskGoal, easterEggWins, inline }) {
+export default function WeekStrip({ tasks, dailyTaskGoal, easterEggWins }) {
   const [weekOffset, setWeekOffset] = useState(0)
   const [selectedDate, setSelectedDate] = useState(null)
 
@@ -80,33 +80,29 @@ export default function WeekStrip({ tasks, dailyTaskGoal, easterEggWins, inline 
       items.push({ id: '__egg__', title: 'Daily Bonus', points: 1 })
     }
     return items
-  }, [selectedDate, completionsByDate, easterEggWins])
-
-  const navRow = (
-    <div className="v2-week-strip-head">
-      <button
-        className="v2-week-strip-nav"
-        onClick={() => { setWeekOffset(o => o - 1); setSelectedDate(null) }}
-        aria-label="Previous week"
-      >
-        <ChevronLeft size={14} strokeWidth={2} />
-      </button>
-      <span className="v2-week-strip-range">
-        <span className="v2-week-strip-range-label">{rangeLabel}</span>
-      </span>
-      <button
-        className="v2-week-strip-nav"
-        onClick={() => { setWeekOffset(o => o + 1); setSelectedDate(null) }}
-        aria-label="Next week"
-      >
-        <ChevronRight size={14} strokeWidth={2} />
-      </button>
-    </div>
-  )
+  }, [selectedDate, completionsByDate])
 
   return (
-    <div className={`v2-week-strip${inline ? ' v2-week-strip-inline' : ''}`}>
-      {!inline && navRow}
+    <div className="v2-week-strip">
+      <div className="v2-week-strip-head">
+        <button
+          className="v2-week-strip-nav"
+          onClick={() => { setWeekOffset(o => o - 1); setSelectedDate(null) }}
+          aria-label="Previous week"
+        >
+          <ChevronLeft size={14} strokeWidth={2} />
+        </button>
+        <span className="v2-week-strip-range">
+          <span className="v2-week-strip-range-label">{rangeLabel}</span>
+        </span>
+        <button
+          className="v2-week-strip-nav"
+          onClick={() => { setWeekOffset(o => o + 1); setSelectedDate(null) }}
+          aria-label="Next week"
+        >
+          <ChevronRight size={14} strokeWidth={2} />
+        </button>
+      </div>
       <ol id="v2-week-strip-days" className="v2-week-strip-row">
         {days.map(d => (
           <li
@@ -155,7 +151,6 @@ export default function WeekStrip({ tasks, dailyTaskGoal, easterEggWins, inline 
           )}
         </div>
       )}
-      {inline && navRow}
     </div>
   )
 }


### PR DESCRIPTION
Full revert of WeekStrip.css, WeekStrip.jsx, and AppV2.css to v1.21.18 exact content. Only addition: easterEggWins prop (real bug fix). All desktop inline/left-align/auto-shrink experiments removed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V1M3jStNM9RUw7vuEEVpYh)_