### PR TITLE
fix(ui): prevent horizontal scroll from WeekStrip overflow

### DIFF
--- a/src/v2/AppV2.css
+++ b/src/v2/AppV2.css
@@ -24,6 +24,7 @@
 .v2-main {
   flex: 1;
   overflow-y: auto;
+  overflow-x: hidden;
   display: flex;
   flex-direction: column;
   align-items: stretch;


### PR DESCRIPTION
WeekStrip negative margins caused horizontal scroll. Added `overflow-x: hidden` on `.v2-main`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V1M3jStNM9RUw7vuEEVpYh)_