### PR TITLE
fix(ui): stats detail panel matches stats line width

### DIFF
--- a/src/v2/AppV2.css
+++ b/src/v2/AppV2.css
@@ -89,7 +89,6 @@
 /* Inline detail panel — slides below the home stats line for streak
  * or today progress. Hairline-list aesthetic, centered like stats. */
 .v2-stats-detail {
-  max-width: 320px;
   margin: 0 auto 8px;
   padding: 10px 16px;
   background: var(--v2-surface);


### PR DESCRIPTION
Removed max-width: 320px so detail panel matches stats line width.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V1M3jStNM9RUw7vuEEVpYh)_