### PR TITLE
fix(ui): detail panel stretch + WeekStrip edge padding

### DIFF
--- a/src/v2/AppV2.css
+++ b/src/v2/AppV2.css
@@ -89,7 +89,7 @@
 /* Inline detail panel — slides below the home stats line for streak
  * or today progress. Hairline-list aesthetic, centered like stats. */
 .v2-stats-detail {
-  margin: 0 auto 8px;
+  margin: 0 8px 8px;
   padding: 10px 16px;
   background: var(--v2-surface);
   border: 1px solid var(--v2-hairline);

--- a/src/v2/components/WeekStrip.css
+++ b/src/v2/components/WeekStrip.css
@@ -10,8 +10,8 @@
  */
 
 .v2-week-strip {
-  margin: 0 -8px 16px;
-  padding: 0 8px;
+  margin: 0 0 16px;
+  padding: 0 4px;
 }
 
 .v2-week-strip-head {


### PR DESCRIPTION
Detail panel: margin 8px sides to stretch. WeekStrip: removed negative margins, 4px padding so edge cells aren't clipped.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V1M3jStNM9RUw7vuEEVpYh)_