### PR TITLE
release: detail panel + WeekStrip padding + overflow fix

### DIFF
--- a/src/v2/AppV2.css
+++ b/src/v2/AppV2.css
@@ -24,6 +24,7 @@
 .v2-main {
   flex: 1;
   overflow-y: auto;
+  overflow-x: hidden;
   display: flex;
   flex-direction: column;
   align-items: stretch;

--- a/src/v2/AppV2.css
+++ b/src/v2/AppV2.css
@@ -89,7 +89,7 @@
 /* Inline detail panel — slides below the home stats line for streak
  * or today progress. Hairline-list aesthetic, centered like stats. */
 .v2-stats-detail {
-  margin: 0 auto 8px;
+  margin: 0 8px 8px;
   padding: 10px 16px;
   background: var(--v2-surface);
   border: 1px solid var(--v2-hairline);

--- a/src/v2/AppV2.css
+++ b/src/v2/AppV2.css
@@ -89,7 +89,6 @@
 /* Inline detail panel — slides below the home stats line for streak
  * or today progress. Hairline-list aesthetic, centered like stats. */
 .v2-stats-detail {
-  max-width: 320px;
   margin: 0 auto 8px;
   padding: 10px 16px;
   background: var(--v2-surface);

--- a/src/v2/components/WeekStrip.css
+++ b/src/v2/components/WeekStrip.css
@@ -10,8 +10,8 @@
  */
 
 .v2-week-strip {
-  margin: 0 -8px 16px;
-  padding: 0 8px;
+  margin: 0 0 16px;
+  padding: 0 4px;
 }
 
 .v2-week-strip-head {


### PR DESCRIPTION
Detail panel stretches to match stats width. WeekStrip edge cells no longer clipped. Horizontal scroll fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V1M3jStNM9RUw7vuEEVpYh)_