### PR TITLE
feat(scoring+ui): waiting counts as progress + bottom bar actions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,8 @@ AI-inferred energy tagging on every task — no manual fields to fill in.
 - An XL⚡⚡⚡ task = 20 × 2.0 × speedMult = up to 80 points
 - This rewards tackling hard tasks — one high-drain task can crush the daily goal
 
+**Waiting = Progress:** Moving a task from not_started or doing to waiting awards +1 task and +1 point for the daily count. Reflects real effort (sent the email, made the call) even though the task isn't done. Tracked via `waiting_at` timestamp (migration 032); cleared when leaving waiting status. Counts toward streak and WeekStrip intensity.
+
 **Nagging Boost:** Avoidance-prone types (confrontation, errand) get more frequent notifications.
 - Avoidance type: interval / 1.3 (30% more frequent)
 - High drain (level 3): additional / 1.2
@@ -888,14 +890,14 @@ Each PR is independently mergeable. v2 currently renders the calm header + a rea
 - `Header` — calm 4-affordance header. Props: `onOpenAdviser`, `onOpenPackages`, `onOpenSystemMenu`, `systemMenuOpen`. Logo + wordmark left, three icon buttons right (sparkle / package / ⚙). The legacy `MoreVertical` ⋯ slot was replaced by the ⚙ Settings glyph that toggles the `SystemMenu` popover (2026-05-22).
 - `SectionLabel` — `--type-section` ALL-CAPS label with sparkle bullet + optional count chip.
 - `TaskCard` — v2 list card. Status economy: only overdue + high-pri get a colored left border; stale → inline meta; low-pri → opacity 0.78. Energy as a single chip (lucide icon + N small Zap glyphs in the type color).
-- `BottomTabs` — mobile-only bottom navigation. Two tabs: Today (current task list) and Spaces (opens SpacesHub). Hidden on desktop (≥769px) by both AppV2 render gate AND a CSS @media — desktop keeps Kanban + side drawer.
+- `BottomTabs` — mobile-only bottom navigation. Four buttons: Today | New | What now | Spaces. Today + Spaces are navigation tabs; New and What now are action triggers (open AddTaskModal and WhatNowModal respectively). Hidden on desktop (≥769px) by both AppV2 render gate AND a CSS @media — desktop keeps Kanban + side drawer + FloatingCapture FABs.
 - `SystemMenu` — anchored popover off the ⚙ icon. Hosts low-frequency system surfaces: Settings, Analytics, Done, Suggestions, Activity log. Same row treatment as the brand popover so the two header popovers feel like siblings.
 - `SpacesHub` — modal-sheet picker for Projects / Routines / Knowledge. Tapping a row closes the hub and launches the existing dedicated modal. Future C-upgrade swaps the picker rows for live preview cards (session counts, last-edited timestamps) without changing the launcher contract.
 
 The first five primitives are the v2 task-surface language. The last three (added 2026-05-22) are the v2 mobile-navigation language. Every subsequent v2 surface uses them — never reach for a one-off chrome.
 
 **Mobile navigation model (2026-05-22).** The legacy ⋯ More menu (8 items, single sheet) was retired in favor of three separate surfaces, each sized to its frequency:
-1. **BottomTabs (mobile only)** — Today + Spaces. Persistent across the app; one tap to switch contexts.
+1. **BottomTabs (mobile only)** — Today | New | What now | Spaces. Persistent across the app; one tap to switch contexts or trigger actions. FloatingCapture (inline quick-add + time-picker FABs) is desktop-only now that these actions live in the bottom bar.
 2. **SystemMenu (popover off ⚙)** — Settings, Analytics, Done, Suggestions, Activity log. Low-frequency system stuff.
 3. **SpacesHub (modal from Spaces tab)** — Projects, Routines, Knowledge. Each row launches the existing dedicated modal.
 

--- a/db.js
+++ b/db.js
@@ -256,6 +256,7 @@ function taskToRow(task) {
     snooze_indefinite: task.snooze_indefinite ? 1 : 0,
     blocked_by_json: JSON.stringify(task.blocked_by || []),
     knowledge_page_ids_json: JSON.stringify(task.knowledge_page_ids || []),
+    waiting_at: task.waiting_at || null,
   }
 }
 
@@ -308,6 +309,7 @@ function rowToTask(row) {
     snooze_indefinite: !!row.snooze_indefinite,
     blocked_by: safeJsonParse(row.blocked_by_json, []),
     knowledge_page_ids: safeJsonParse(row.knowledge_page_ids_json, []),
+    waiting_at: row.waiting_at || null,
   }
 }
 

--- a/migrations/032_waiting_at.sql
+++ b/migrations/032_waiting_at.sql
@@ -1,0 +1,1 @@
+ALTER TABLE tasks ADD COLUMN waiting_at TEXT;

--- a/src/hooks/useTasks.js
+++ b/src/hooks/useTasks.js
@@ -197,6 +197,10 @@ export function useTasks() {
         const updates = { status: newStatus, last_touched: new Date().toISOString() }
         if (newStatus === 'done') updates.completed_at = new Date().toISOString()
         if (t.status === 'done' && newStatus !== 'done') updates.completed_at = null
+        if (newStatus === 'waiting' && (t.status === 'not_started' || t.status === 'doing')) {
+          updates.waiting_at = new Date().toISOString()
+        }
+        if (t.status === 'waiting' && newStatus !== 'waiting') updates.waiting_at = null
         return { ...t, ...updates }
       })
     })

--- a/src/scoring.js
+++ b/src/scoring.js
@@ -70,12 +70,14 @@ export function computeDailyStats(tasks, settings = null) {
     points += calculateTaskPoints(t)
   }
 
+  const waitingToday = tasks.filter(t => t.status === 'waiting' && t.waiting_at && new Date(t.waiting_at).toDateString() === todayStr)
+
   const sessions = computeSessionStatsToday(tasks)
   const eggBonus = settings?.easter_egg_wins?.[todayIso] ? 1 : 0
 
   return {
-    tasksToday: todayTasks.length + sessions.count + eggBonus,
-    pointsToday: points + sessions.points + eggBonus,
+    tasksToday: todayTasks.length + waitingToday.length + sessions.count + eggBonus,
+    pointsToday: points + waitingToday.length + sessions.points + eggBonus,
   }
 }
 

--- a/src/store.js
+++ b/src/store.js
@@ -678,6 +678,9 @@ export function computeStreak(tasks, settings) {
     if (t.status === 'done' && t.completed_at) {
       completionDates.add(new Date(t.completed_at).toDateString())
     }
+    if (t.status === 'waiting' && t.waiting_at) {
+      completionDates.add(new Date(t.waiting_at).toDateString())
+    }
     if (t.status === 'project' && Array.isArray(t.session_log)) {
       for (const entry of t.session_log) {
         if (entry?.timestamp) completionDates.add(new Date(entry.timestamp).toDateString())

--- a/src/v2/AppV2.jsx
+++ b/src/v2/AppV2.jsx
@@ -1047,6 +1047,8 @@ export default function AppV2() {
               setSpacesHubOpen(true)
             }
           }}
+          onAdd={() => setShowAdd(true)}
+          onWhatNow={() => setShowWhatNow(true)}
         />
       )}
 
@@ -1275,18 +1277,20 @@ export default function AppV2() {
         onClose={() => setShowAnalytics(false)}
       />
 
-      <FloatingCapture
-        onAddTask={(title) => {
-          const id = addTask({ title })
-          if (id) {
-            // Quick-add lands a task with the configured default due-date,
-            // M size, and the size-auto-infer hook will refine energy on
-            // the next render tick. No EditTaskModal opens — the user is
-            // doing rapid-fire capture, not careful curation.
-          }
-        }}
-        onOpenWhatNow={() => setShowWhatNow(true)}
-      />
+      {isDesktop && (
+        <FloatingCapture
+          onAddTask={(title) => {
+            const id = addTask({ title })
+            if (id) {
+              // Quick-add lands a task with the configured default due-date,
+              // M size, and the size-auto-infer hook will refine energy on
+              // the next render tick. No EditTaskModal opens — the user is
+              // doing rapid-fire capture, not careful curation.
+            }
+          }}
+          onOpenWhatNow={() => setShowWhatNow(true)}
+        />
+      )}
 
       <ConfirmDialog
         open={!!chainConfirm}

--- a/src/v2/components/BottomTabs.css
+++ b/src/v2/components/BottomTabs.css
@@ -1,6 +1,9 @@
 /* Bottom tab bar — mobile only. The .v2-app flex column hosts header +
  * scrollable main + this strip. iOS safe-area inset is respected via
- * padding-bottom so the home-bar gesture doesn't overlap the labels. */
+ * padding-bottom so the home-bar gesture doesn't overlap the labels.
+ *
+ * Four buttons: Today | New | What now | Spaces.
+ * Today + Spaces are navigation tabs; New + What now are action triggers. */
 
 .v2-bottom-tabs {
   display: flex;
@@ -51,9 +54,17 @@
 }
 
 .v2-bottom-tab.is-active .v2-bottom-tab-icon-wrap {
-  /* Soft accent-tinted pill behind the icon. Same convention as v2
-   * SuggestionsModal / PackagesModal — hardcoded rgba(255,98,64,x). */
   background: rgba(255, 98, 64, 0.14);
+}
+
+/* Action buttons (New, What now) get accent-tinted icon pills to
+ * distinguish them from the navigation tabs visually. */
+.v2-bottom-tab-action-icon {
+  background: rgba(255, 98, 64, 0.10);
+}
+
+.v2-bottom-tab-action {
+  color: var(--v2-accent);
 }
 
 /* Hide on desktop — the v2 Kanban + side drawer already covers the

--- a/src/v2/components/BottomTabs.jsx
+++ b/src/v2/components/BottomTabs.jsx
@@ -1,13 +1,7 @@
-import { ListChecks, FolderKanban } from 'lucide-react'
+import { ListChecks, FolderKanban, Plus, Compass } from 'lucide-react'
 import './BottomTabs.css'
 
-// Mobile-only bottom tab bar. Two tabs: Today (default) and Spaces.
-// Desktop intentionally skipped — it has the Kanban + side drawer
-// pattern, doesn't need bottom chrome eating screen height.
-//
-// Terminal-theme styling lives in src/v2/terminal/tabs.css — lucide
-// SVGs hide, labels become `[ today ]` bracketed mono.
-export default function BottomTabs({ activeTab, onTabChange }) {
+export default function BottomTabs({ activeTab, onTabChange, onAdd, onWhatNow }) {
   return (
     <nav className="v2-bottom-tabs" role="tablist" aria-label="Primary navigation">
       <button
@@ -21,6 +15,28 @@ export default function BottomTabs({ activeTab, onTabChange }) {
           <ListChecks size={22} strokeWidth={1.75} className="v2-bottom-tab-icon" aria-hidden="true" />
         </span>
         <span className="v2-bottom-tab-label" data-terminal-label="today">Today</span>
+      </button>
+      <button
+        type="button"
+        className="v2-bottom-tab v2-bottom-tab-action"
+        onClick={onAdd}
+        aria-label="New task"
+      >
+        <span className="v2-bottom-tab-icon-wrap v2-bottom-tab-action-icon">
+          <Plus size={22} strokeWidth={2} className="v2-bottom-tab-icon" aria-hidden="true" />
+        </span>
+        <span className="v2-bottom-tab-label" data-terminal-label="new">New</span>
+      </button>
+      <button
+        type="button"
+        className="v2-bottom-tab v2-bottom-tab-action"
+        onClick={onWhatNow}
+        aria-label="What can I do now?"
+      >
+        <span className="v2-bottom-tab-icon-wrap v2-bottom-tab-action-icon">
+          <Compass size={22} strokeWidth={1.75} className="v2-bottom-tab-icon" aria-hidden="true" />
+        </span>
+        <span className="v2-bottom-tab-label" data-terminal-label="what now">What now</span>
       </button>
       <button
         type="button"

--- a/src/v2/components/WeekStrip.jsx
+++ b/src/v2/components/WeekStrip.jsx
@@ -21,10 +21,15 @@ export default function WeekStrip({ tasks, dailyTaskGoal, easterEggWins }) {
   const completionsByDate = useMemo(() => {
     const map = {}
     for (const t of tasks) {
-      if (t.status !== 'done' || !t.completed_at) continue
-      const key = ymd(new Date(t.completed_at))
-      if (!map[key]) map[key] = []
-      map[key].push(t)
+      if (t.status === 'done' && t.completed_at) {
+        const key = ymd(new Date(t.completed_at))
+        if (!map[key]) map[key] = []
+        map[key].push(t)
+      } else if (t.status === 'waiting' && t.waiting_at) {
+        const key = ymd(new Date(t.waiting_at))
+        if (!map[key]) map[key] = []
+        map[key].push(t)
+      }
     }
     return map
   }, [tasks])

--- a/src/v2/terminal/tabs.css
+++ b/src/v2/terminal/tabs.css
@@ -68,6 +68,19 @@
   text-shadow: none;
 }
 
+/* Action tabs (New, What now) use the same bracketed mono treatment
+ * but always show accent color (they're not navigation state). */
+:root[data-ui="v2"][data-theme^="terminal"] .v2-bottom-tab-action {
+  color: var(--v2-accent);
+}
+:root[data-ui="v2"][data-theme^="terminal"] .v2-bottom-tab-action .v2-bottom-tab-label {
+  color: var(--v2-accent);
+  text-shadow: var(--v2-glow);
+}
+:root[data-ui="v2"][data-theme^="terminal"] .v2-bottom-tab-action .v2-bottom-tab-action-icon {
+  background: transparent;
+}
+
 
 /* === SystemMenu ===================================================== */
 

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -4,6 +4,23 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ---
 
+## 2026-05-26
+
+- feat(scoring): award 1 point for moving tasks to waiting status [S]
+  - **Motivation boost.** Moving a task from not_started/doing to waiting (e.g. sent an email, made a call) now counts as +1 task and +1 point in the daily stats. Reflects real work done even when the task isn't fully complete.
+  - **New column.** `waiting_at` timestamp (migration 032) records when the task entered waiting status. Cleared when leaving waiting.
+  - **Daily stats.** `computeDailyStats` counts waiting tasks stamped today alongside completions.
+  - **Streak.** `computeStreak` counts waiting transitions as completion days.
+  - **WeekStrip.** Waiting tasks show in the weekly heat strip alongside completions.
+  - Modified: `db.js`, `src/scoring.js`, `src/store.js`, `src/hooks/useTasks.js`, `src/v2/components/WeekStrip.jsx`
+  - Added: `migrations/032_waiting_at.sql`
+
+- feat(ui): move New + What Now buttons to mobile bottom tab bar [S]
+  - **Bottom bar.** Four buttons: Today | New | What now | Spaces. The two action buttons (+ and compass) live alongside the navigation tabs for easy thumb reach.
+  - **FloatingCapture.** Now desktop-only — mobile gets the bottom bar actions instead of floating FABs.
+  - **Terminal theme.** Action tabs styled with accent glow, matching existing bracketed-mono idiom.
+  - Modified: `src/v2/components/BottomTabs.jsx`, `src/v2/components/BottomTabs.css`, `src/v2/AppV2.jsx`, `src/v2/terminal/tabs.css`
+
 ## 2026-05-25
 
 - feat(ui): WeekStrip nav below stats + breathing room + auto-shrink [S]


### PR DESCRIPTION
## Summary

- **Waiting = progress.** Moving a task from not_started/doing → waiting now awards +1 task and +1 point in the daily stats. New `waiting_at` column (migration 032) tracks the transition; cleared when leaving waiting. Counts toward streak and WeekStrip intensity. Keeps motivation flowing for real work done (sent the email, made the call) even when the task isn't fully complete.
- **Bottom bar actions.** New and What Now buttons moved from floating FABs into the mobile bottom tab bar: Today | New | What now | Spaces. FloatingCapture is now desktop-only. Terminal theme updated for the new action tabs.

## Test plan

- [ ] Move a task from "doing" to "waiting" — daily task count and points should increment by 1
- [ ] Move a task from "not started" to "waiting" — same +1/+1 behavior
- [ ] Move a task from "waiting" back to "doing" — the waiting credit should clear
- [ ] Check streak still counts days with only waiting transitions
- [ ] WeekStrip shows waiting tasks in the day intensity
- [ ] Mobile: bottom bar shows 4 buttons (Today, New, What now, Spaces)
- [ ] Mobile: tapping New opens AddTaskModal
- [ ] Mobile: tapping What now opens WhatNowModal
- [ ] Desktop: FloatingCapture FABs still render (bottom bar hidden)
- [ ] Terminal theme: new action tabs styled with accent glow

https://claude.ai/code/session_01TbgxMRsYwTtMf2FaNGvxVe

---
_Generated by [Claude Code](https://claude.ai/code/session_01TbgxMRsYwTtMf2FaNGvxVe)_