### PR TITLE
fix(ui): all bottom bar buttons show their color

### DIFF
--- a/src/v2/components/BottomTabs.css
+++ b/src/v2/components/BottomTabs.css
@@ -32,6 +32,8 @@
 
 /* === Base tab button ================================================= */
 
+/* All buttons always show their color. Active state is distinguished
+ * by the filled pill behind the icon. */
 .v2-bottom-tab {
   flex: 1;
   display: flex;
@@ -44,7 +46,7 @@
   background: transparent;
   border: none;
   cursor: pointer;
-  color: var(--v2-text-meta);
+  color: var(--tab-color);
   font: 500 11px/1 var(--v2-font-body);
   transition: color var(--v2-dur-quick) var(--v2-ease-standard);
   -webkit-touch-callout: none;
@@ -69,24 +71,9 @@
   display: block;
 }
 
-/* Active nav tab — uses its own color. */
-.v2-bottom-tab.is-active {
-  color: var(--tab-color);
-}
-
+/* Active tab gets a soft-tinted pill behind the icon. */
 .v2-bottom-tab.is-active .v2-bottom-tab-icon-wrap {
   background: color-mix(in srgb, var(--tab-color) 14%, transparent);
-}
-
-/* Action buttons always show their color (not navigation state). */
-.v2-bottom-tab--new,
-.v2-bottom-tab--whatnow {
-  color: var(--tab-color);
-}
-
-.v2-bottom-tab--new .v2-bottom-tab-icon-wrap,
-.v2-bottom-tab--whatnow .v2-bottom-tab-icon-wrap {
-  background: color-mix(in srgb, var(--tab-color) 10%, transparent);
 }
 
 /* === Quick-add input bar ============================================= */

--- a/src/v2/terminal/tabs.css
+++ b/src/v2/terminal/tabs.css
@@ -68,24 +68,12 @@
   text-shadow: none;
 }
 
-/* Action tabs (New, What now) use the per-button color + glow. */
-:root[data-ui="v2"][data-theme^="terminal"] .v2-bottom-tab--new,
-:root[data-ui="v2"][data-theme^="terminal"] .v2-bottom-tab--whatnow {
-  color: var(--tab-color);
-}
-:root[data-ui="v2"][data-theme^="terminal"] .v2-bottom-tab--new .v2-bottom-tab-label,
-:root[data-ui="v2"][data-theme^="terminal"] .v2-bottom-tab--whatnow .v2-bottom-tab-label {
+/* All tabs use per-button color + glow in terminal. Active gets bold. */
+:root[data-ui="v2"][data-theme^="terminal"] .v2-bottom-tab .v2-bottom-tab-label {
   color: var(--tab-color);
   text-shadow: 0 0 6px var(--tab-color);
-}
-
-/* Active nav tabs in terminal also use per-button color. */
-:root[data-ui="v2"][data-theme^="terminal"] .v2-bottom-tab.is-active {
-  color: var(--tab-color);
 }
 :root[data-ui="v2"][data-theme^="terminal"] .v2-bottom-tab.is-active .v2-bottom-tab-label {
-  color: var(--tab-color);
-  text-shadow: 0 0 6px var(--tab-color);
   font-weight: 700;
 }
 


### PR DESCRIPTION
## Summary

- All four bottom bar buttons now always show their color (Today=blue, New=green, What now=orange, Spaces=purple). Previously only the active nav tab and the action buttons showed color — inactive Spaces was grey.
- Active tab distinguished by the soft-tinted pill behind the icon, not by color appearing/disappearing.

https://claude.ai/code/session_01TbgxMRsYwTtMf2FaNGvxVe

---
_Generated by [Claude Code](https://claude.ai/code/session_01TbgxMRsYwTtMf2FaNGvxVe)_