### PR TITLE
fix(ui): remove useless active-tab highlight from bottom bar

### DIFF
--- a/src/v2/components/BottomTabs.css
+++ b/src/v2/components/BottomTabs.css
@@ -32,8 +32,8 @@
 
 /* === Base tab button ================================================= */
 
-/* All buttons always show their color. Active state is distinguished
- * by the filled pill behind the icon. */
+/* All buttons always show their color. No active-state distinction —
+ * Today is always home, the other three are action triggers. */
 .v2-bottom-tab {
   flex: 1;
   display: flex;
@@ -69,11 +69,6 @@
 
 .v2-bottom-tab-icon {
   display: block;
-}
-
-/* Active tab gets a soft-tinted pill behind the icon. */
-.v2-bottom-tab.is-active .v2-bottom-tab-icon-wrap {
-  background: color-mix(in srgb, var(--tab-color) 14%, transparent);
 }
 
 /* === Quick-add input bar ============================================= */

--- a/src/v2/components/BottomTabs.jsx
+++ b/src/v2/components/BottomTabs.jsx
@@ -4,7 +4,7 @@ import './BottomTabs.css'
 
 const LONG_PRESS_MS = 500
 
-export default function BottomTabs({ activeTab, onTabChange, onQuickAdd, onAddLongPress, onWhatNow }) {
+export default function BottomTabs({ onTabChange, onQuickAdd, onAddLongPress, onWhatNow }) {
   const [quickAddOpen, setQuickAddOpen] = useState(false)
   const [draft, setDraft] = useState('')
   const inputRef = useRef(null)
@@ -101,9 +101,7 @@ export default function BottomTabs({ activeTab, onTabChange, onQuickAdd, onAddLo
       <div className="v2-bottom-tabs-row">
         <button
           type="button"
-          role="tab"
-          aria-selected={activeTab === 'today'}
-          className={`v2-bottom-tab v2-bottom-tab--today${activeTab === 'today' ? ' is-active' : ''}`}
+          className="v2-bottom-tab v2-bottom-tab--today"
           onClick={() => onTabChange('today')}
         >
           <span className="v2-bottom-tab-icon-wrap">
@@ -140,9 +138,7 @@ export default function BottomTabs({ activeTab, onTabChange, onQuickAdd, onAddLo
         </button>
         <button
           type="button"
-          role="tab"
-          aria-selected={activeTab === 'spaces'}
-          className={`v2-bottom-tab v2-bottom-tab--spaces${activeTab === 'spaces' ? ' is-active' : ''}`}
+          className="v2-bottom-tab v2-bottom-tab--spaces"
           onClick={() => onTabChange('spaces')}
         >
           <span className="v2-bottom-tab-icon-wrap">

--- a/src/v2/terminal/tabs.css
+++ b/src/v2/terminal/tabs.css
@@ -68,13 +68,10 @@
   text-shadow: none;
 }
 
-/* All tabs use per-button color + glow in terminal. Active gets bold. */
+/* All tabs use per-button color + glow in terminal. */
 :root[data-ui="v2"][data-theme^="terminal"] .v2-bottom-tab .v2-bottom-tab-label {
   color: var(--tab-color);
   text-shadow: 0 0 6px var(--tab-color);
-}
-:root[data-ui="v2"][data-theme^="terminal"] .v2-bottom-tab.is-active .v2-bottom-tab-label {
-  font-weight: 700;
 }
 
 /* Quick-add input in terminal mode. */


### PR DESCRIPTION
## Summary

- Remove the active-tab pill highlight from the bottom bar. Today is always the home tab and the other three are action triggers that open modals — the highlight was only ever visible on Today and served no purpose. All four buttons now render identically with just their own color.

https://claude.ai/code/session_01TbgxMRsYwTtMf2FaNGvxVe

---
_Generated by [Claude Code](https://claude.ai/code/session_01TbgxMRsYwTtMf2FaNGvxVe)_