### PR TITLE
release: fix infinite sync loop

### DIFF
--- a/src/hooks/useRoutines.js
+++ b/src/hooks/useRoutines.js
@@ -166,19 +166,16 @@ export function useRoutines() {
           t => t.routine_id === routine.id && !TERMINAL_FOR_ROLL.has(t.status),
         )
         if (activeInstance) {
+          const needsDateBump = activeInstance.due_date !== today
+          const hasStaleSnooze = activeInstance.snoozed_until &&
+            new Date(activeInstance.snoozed_until) <= new Date()
+          if (!needsDateBump && !hasStaleSnooze) return
+
           const updates = {
             due_date: today,
             last_touched: new Date().toISOString(),
           }
-          // Clear snoozed_until only if it's already in the past — a
-          // forward-looking snooze ("don't bother me until 8pm tonight")
-          // is the user's explicit signal and auto-roll shouldn't override
-          // it. Past snoozes are stale and would otherwise leave the
-          // newly-rolled task hidden.
-          if (
-            activeInstance.snoozed_until &&
-            new Date(activeInstance.snoozed_until) <= new Date()
-          ) {
+          if (hasStaleSnooze) {
             updates.snoozed_until = null
           }
           rolled.push({ taskId: activeInstance.id, updates })

--- a/src/hooks/useServerSync.js
+++ b/src/hooks/useServerSync.js
@@ -58,7 +58,7 @@ export function useServerSync(tasks, routines, onHydrate, onVersionMismatch) {
   const clientId = useRef(uuid()).current
   const debounceTimer = useRef(null)
   const hydrated = useRef(false)
-  const skipNextPush = useRef(false)
+  const skipPushUntil = useRef(0)
   const latestState = useRef({ tasks, routines })
   const serverVersion = useRef(0)
   const [syncStatus, setSyncStatus] = useState(null) // null | 'saving' | 'saved' | 'offline'
@@ -299,7 +299,7 @@ export function useServerSync(tasks, routines, onHydrate, onVersionMismatch) {
         if (data && Object.keys(data).length > 0) {
           serverVersion.current = data._version || 0
           remoteLog(`${reason}: got v${serverVersion.current}, tasks=${taskSummary(data.tasks)}`)
-          skipNextPush.current = true
+          skipPushUntil.current = Date.now() + 2000
           onHydrate(data)
           if (data.tasks) saveTasks(data.tasks)
           if (data.routines) saveRoutines(data.routines)
@@ -426,8 +426,7 @@ export function useServerSync(tasks, routines, onHydrate, onVersionMismatch) {
   // Debounced per-record push whenever tasks or routines change
   useEffect(() => {
     if (!hydrated.current) return
-    if (skipNextPush.current) {
-      skipNextPush.current = false
+    if (Date.now() < skipPushUntil.current) {
       return
     }
 

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,12 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-26
 
+- fix(sync): break infinite sync loop between multi-client auto-roll routine updates [M]
+  - **Root cause.** Auto-roll routines called `updateTask` with a new `last_touched` timestamp on every hydration, even when `due_date` was already today. Two clients would ping-pong: Client A rolls → SSE → Client B hydrates + re-rolls with new timestamp → SSE → Client A repeats. Version counter incremented ~1/second indefinitely.
+  - **Fix 1 (primary).** `spawnDueTasks` in `useRoutines.js` now checks whether the active instance's `due_date` is already today and has no stale snooze before emitting a roll update. No-op rolls are skipped entirely.
+  - **Fix 2 (defense-in-depth).** `skipNextPush` in `useServerSync.js` replaced with a 2-second `skipPushUntil` suppression window. The old boolean flag was consumed on the first state change after hydration, leaving subsequent state changes (like auto-roll `updateTask`) unprotected.
+  - Modified: `src/hooks/useRoutines.js`, `src/hooks/useServerSync.js`
+
 - feat(scoring): award 1 point for moving tasks to waiting status [S]
   - **Motivation boost.** Moving a task from not_started/doing to waiting (e.g. sent an email, made a call) now counts as +1 task and +1 point in the daily stats. Reflects real work done even when the task isn't fully complete.
   - **New column.** `waiting_at` timestamp (migration 032) records when the task entered waiting status. Cleared when leaving waiting.


### PR DESCRIPTION
Hotfix: breaks the infinite sync loop caused by auto-roll routines ping-ponging between clients. Version counter was climbing ~1/second indefinitely.

See PR #364 for details.

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3Y9oke3pugERTJ88nwexg)_