### PR TITLE
fix(packages): wire v2 Packages modal track + carrier detection

### DIFF
--- a/src/v2/components/PackagesModal.jsx
+++ b/src/v2/components/PackagesModal.jsx
@@ -174,11 +174,8 @@ export default function PackagesModal({
     if (!tracking) return
     setAdding(true)
     try {
-      await onAdd({
-        tracking_number: tracking,
-        label: labelInput.trim() || null,
-        carrier: detectedCarrier?.carrier || 'other',
-      })
+      // addPackage takes positional args (trackingNumber, label, carrier) — same as v1.
+      await onAdd(tracking, labelInput.trim() || null, detectedCarrier?.code || 'other')
       setTrackingInput('')
       setLabelInput('')
       setShowAddForm(false)
@@ -229,8 +226,8 @@ export default function PackagesModal({
           />
           {detectedCarrier && (
             <div className="v2-package-detected">
-              <CarrierLogo carrier={detectedCarrier.carrier} size={18} />
-              <span>Detected: <strong>{detectedCarrier.label}</strong></span>
+              <CarrierLogo carrier={detectedCarrier.code} size={18} />
+              <span>Detected: <strong>{detectedCarrier.name}</strong></span>
             </div>
           )}
           <button

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -4,6 +4,18 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ---
 
+## 2026-06-01
+
+- fix(packages): v2 Packages modal — Track button + carrier detection both broken [S]
+  - **Symptom.** In the v2 Packages modal, adding a tracking number did nothing ("Track doesn't work") and the "Detected:" line rendered blank even for an obvious UPS `1Z…` number.
+  - **Cause.** Two property/signature mismatches in `src/v2/components/PackagesModal.jsx` (v1 was unaffected):
+    1. `handleAdd` called `onAdd({ tracking_number, label, carrier })` with a single object, but `addPackage`/`createPackage` are **positional** `(trackingNumber, label, carrier)` — so the object itself was sent as the tracking number and the create request was malformed.
+    2. The detection result from `detectCarrier()` is shaped `{ code, name, icon, trackUrl }`, but the modal read `.carrier` / `.label` (undefined) → blank "Detected:" label and carrier always fell back to `'other'`.
+  - **Fix.** Call `onAdd(tracking, label || null, detectedCarrier?.code || 'other')` positionally; render `detectedCarrier.code` (CarrierLogo) and `detectedCarrier.name` (label).
+  - File: `src/v2/components/PackagesModal.jsx`.
+
+---
+
 ## 2026-05-31
 
 - feat(routines): Stacks — one routine that fans out into several independent tasks, with a clear bonus [L]


### PR DESCRIPTION
## What
Fixes "Track doesn't work" in the **v2** Packages modal (v1 was unaffected).

## Root cause
Two mismatches in `src/v2/components/PackagesModal.jsx`:

1. **Track broken.** `handleAdd` called `onAdd({ tracking_number, label, carrier })` with a single object, but `addPackage` → `createPackage` are **positional** `(trackingNumber, label, carrier)`. The object got passed as the tracking number → malformed create request → nothing tracked.
2. **"Detected:" blank.** `detectCarrier()` returns `{ code, name, icon, trackUrl }`, but the modal read `.carrier` / `.label` (both `undefined`) → empty detected label, and carrier always defaulted to `'other'`.

## Fix
- Call `onAdd(tracking, label || null, detectedCarrier?.code || 'other')` positionally.
- Render `detectedCarrier.code` (CarrierLogo) and `detectedCarrier.name` (label text).

## Test
- eslint clean.
- Manual: open Packages, enter a `1Z…` UPS number → "Detected: **UPS**" now shows; Track package creates the package.

Docs: Version-History entry added under 2026-06-01.

https://claude.ai/code/session_014k2Xk1NMQAkgBfc7q689Hn

---
_Generated by [Claude Code](https://claude.ai/code/session_014k2Xk1NMQAkgBfc7q689Hn)_