### PR TITLE
release: v2 carrier-site link

### DIFF
--- a/src/v2/components/PackagesModal.css
+++ b/src/v2/components/PackagesModal.css
@@ -228,6 +228,7 @@
   border: 1px solid var(--v2-hairline);
   font: 500 12px/1 var(--v2-font-body);
   cursor: pointer;
+  text-decoration: none;
   transition: background var(--v2-dur-quick) var(--v2-ease-standard),
               color var(--v2-dur-quick) var(--v2-ease-standard);
 }

--- a/src/v2/components/PackagesModal.jsx
+++ b/src/v2/components/PackagesModal.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useMemo } from 'react'
-import { Plus, Package as PackageIcon, RefreshCw, Trash2 } from 'lucide-react'
+import { Plus, Package as PackageIcon, RefreshCw, Trash2, ExternalLink } from 'lucide-react'
 import CarrierLogo from '../../components/CarrierLogo'
-import { detectCarrier } from '../../utils/carrierDetect'
+import { detectCarrier, getTrackingUrl } from '../../utils/carrierDetect'
 import ModalShell from './ModalShell'
 import EmptyState from './EmptyState'
 import './PackagesModal.css'
@@ -42,6 +42,7 @@ function PackageRow({ pkg, expanded, onToggleExpand, onRefresh, onDelete }) {
 
   const meta = STATUS_META[pkg.status] || STATUS_META.pending
   const events = pkg.events || []
+  const trackUrl = getTrackingUrl(pkg.carrier, pkg.tracking_number)
 
   const handleRefresh = async (e) => {
     e.stopPropagation()
@@ -114,6 +115,17 @@ function PackageRow({ pkg, expanded, onToggleExpand, onRefresh, onDelete }) {
               <RefreshCw size={14} strokeWidth={1.75} className={refreshing ? 'v2-package-spin' : ''} />
               {refreshing ? 'Refreshing…' : 'Refresh'}
             </button>
+            {trackUrl && (
+              <a
+                className="v2-package-action"
+                href={trackUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={e => { e.preventDefault(); e.stopPropagation(); window.open(trackUrl, '_blank', 'noopener,noreferrer') }}
+              >
+                <ExternalLink size={14} strokeWidth={1.75} /> Carrier site
+              </a>
+            )}
             {!confirmDelete ? (
               <button
                 className="v2-package-action v2-package-action-danger"

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,10 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-01
 
+- feat(packages): v2 Packages modal — "Carrier site" link to the provider's tracking page [XS]
+  - The v2 Packages modal never exposed a link out to the carrier's own tracking page (v1's `PackageCard`/`PackageDetailModal` both had one via `getTrackingUrl()`). Added a "Carrier site" action in the expanded package row that opens the provider page (UPS/FedEx/USPS/DHL/Amazon/OnTrac/LaserShip) in a new tab. Only renders when `getTrackingUrl()` resolves a URL for the package's carrier.
+  - Files: `src/v2/components/PackagesModal.{jsx,css}` (import `getTrackingUrl` + `ExternalLink`, compute `trackUrl` per row, `text-decoration: none` so the anchor matches the other pill actions).
+
 - fix(packages): v2 Packages modal — Track button + carrier detection both broken [S]
   - **Symptom.** In the v2 Packages modal, adding a tracking number did nothing ("Track doesn't work") and the "Detected:" line rendered blank even for an obvious UPS `1Z…` number.
   - **Cause.** Two property/signature mismatches in `src/v2/components/PackagesModal.jsx` (v1 was unaffected):


### PR DESCRIPTION
Promotes the v2 carrier-site link to production.

- **feat(packages):** v2 Packages modal — "Carrier site" link to the provider's tracking page (#384). Opens the carrier's own page in a new tab from the expanded package row; renders only when a tracking URL resolves.

Merge with `merge_method: "merge"`.

https://claude.ai/code/session_014k2Xk1NMQAkgBfc7q689Hn

---
_Generated by [Claude Code](https://claude.ai/code/session_014k2Xk1NMQAkgBfc7q689Hn)_