### PR TITLE
release: package ETA on card + dev catch-up

### DIFF
--- a/src/v2/components/PackagesModal.css
+++ b/src/v2/components/PackagesModal.css
@@ -123,6 +123,12 @@
   margin-top: 2px;
 }
 
+.v2-package-summary-eta {
+  font: 500 12px/1.3 var(--v2-font-body);
+  color: var(--v2-text-meta);
+  margin-top: 3px;
+}
+
 .v2-package-status {
   flex: 0 0 auto;
   font: 600 10px/1 var(--v2-font-body);

--- a/src/v2/components/PackagesModal.jsx
+++ b/src/v2/components/PackagesModal.jsx
@@ -43,6 +43,9 @@ function PackageRow({ pkg, expanded, onToggleExpand, onRefresh, onDelete }) {
   const meta = STATUS_META[pkg.status] || STATUS_META.pending
   const events = pkg.events || []
   const trackUrl = getTrackingUrl(pkg.carrier, pkg.tracking_number)
+  const summaryEta = pkg.status === 'delivered'
+    ? (pkg.delivered_at ? `Delivered ${timeAgo(pkg.delivered_at)}` : null)
+    : (pkg.eta ? `ETA ${formatEta(pkg.eta)}` : null)
 
   const handleRefresh = async (e) => {
     e.stopPropagation()
@@ -62,6 +65,9 @@ function PackageRow({ pkg, expanded, onToggleExpand, onRefresh, onDelete }) {
           <div className="v2-package-label">{pkg.label || pkg.tracking_number}</div>
           {pkg.label && (
             <div className="v2-package-tracking">{pkg.tracking_number}</div>
+          )}
+          {summaryEta && (
+            <div className="v2-package-summary-eta">{summaryEta}</div>
           )}
         </div>
         <span className={`v2-package-status v2-package-status-${meta.tone}`}>{meta.label}</span>

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -82,6 +82,10 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-05-26
 
+- feat(packages): show ETA on the package row without expanding [XS]
+  - **Glanceability.** Each package card now shows `ETA <date>` (or `Delivered <Nd ago>` once delivered) directly under the tracking number, so you don't have to tap into the row to see when it's coming.
+  - Modified: `src/v2/components/PackagesModal.jsx`, `src/v2/components/PackagesModal.css`
+
 - fix(sync): break infinite sync loop between multi-client auto-roll routine updates [M]
   - **Root cause.** Auto-roll routines called `updateTask` with a new `last_touched` timestamp on every hydration, even when `due_date` was already today. Two clients would ping-pong: Client A rolls → SSE → Client B hydrates + re-rolls with new timestamp → SSE → Client A repeats. Version counter incremented ~1/second indefinitely.
   - **Fix 1 (primary).** `spawnDueTasks` in `useRoutines.js` now checks whether the active instance's `due_date` is already today and has no stale snooze before emitting a roll update. No-op rolls are skipped entirely.


### PR DESCRIPTION
Promotes the latest `dev` to `main`. Includes the inline package ETA on the row plus everything else accumulated on dev since the last main promotion.

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3Y9oke3pugERTJ88nwexg)_