### PR TITLE
feat(ui): Loggd full-dashboard layer — stat band, category tiles, semantic actions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -998,6 +998,24 @@ mode change?" is one directory grep.
    stripped from all call sites. (Dead `[data-theme^="terminal"]` CSS blocks
    in component CSS are inert — no theme matches them — and get swept per-file
    as each component's CSS is next touched.)
+   - **Full-dashboard layer (2026-06-06):** the structural touches above were
+     too timid — Loggd read as a navy recolor of the calm Wheneri list. The
+     dashboard character is now wired into the surfaces you actually look at,
+     all still Loggd-gated in `structure.css` (Standard untouched):
+     (a) a **home stat band** — 4 colorful stat tiles (streak / points / done
+     / date) with big grotesk numbers at the top of the main list. The band
+     markup lives in `AppV2.jsx` for every theme but is `display:none` outside
+     Loggd, where it replaces the calm `.v2-home-stats` inline line; both drive
+     the same `statsDetail`/`weekStrip` state so the expandable detail panels
+     work in both. (b) **filled category tiles** — the card energy chip becomes
+     a colored rounded square with a white glyph (fill = the per-energy
+     `--lg-stripe` color, inline lucide color attrs overridden). (c) **semantic
+     action buttons** — green Done (`--lg-action-complete`), yellow Snooze
+     (new `.v2-card-action-snooze` class), orange Save (`--lg-action-primary`),
+     red Delete/confirm (`--lg-action-delete`). (d) **contained segmented
+     toolbar** (`.v2-toolbar-pills` gets a card-surface container) + heavier
+     card titles. The rich `--lg-*` action/category tokens were defined in
+     Phase 1 but only consumed by heatmaps until this layer.
 3. ✅ Heatmaps — reusable `ContributionHeatmap` (theme-agnostic, consumes
    `--lg-heat-*` with Standard fallbacks; helpers in `heatmapUtils.js`).
    Routine cards render a per-habit contribution grid (color cycled by

--- a/src/v2/AppV2.jsx
+++ b/src/v2/AppV2.jsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { ListChecks } from 'lucide-react'
+import { ListChecks, Flame, Zap, CheckCircle2, CalendarDays } from 'lucide-react'
 import Header from './components/Header'
 import ModalShell from './components/ModalShell'
 import BottomTabs from './components/BottomTabs'
@@ -909,6 +909,53 @@ export default function AppV2() {
           * Date → WeekStrip. Streak → streak detail. Today → daily detail. */}
         {!searchOpen && (totalActive > 0 || sortedSnoozed.length > 0 || backlogTasks.length > 0 || projectTasks.length > 0) && (
           <>
+            {/* Loggd dashboard stat band — rendered in markup for every theme
+              * but shown only in Loggd (CSS-gated); the calm .v2-home-stats
+              * line takes over in Standard. Drives the SAME statsDetail /
+              * weekStrip state, so the detail panels below work in both. */}
+            <div className="v2-loggd-band" role="group" aria-label="Today at a glance">
+              <button
+                type="button"
+                className={`v2-loggd-stat v2-loggd-stat-streak${statsDetail === 'streak' ? ' is-active' : ''}`}
+                onClick={() => { setStatsDetail(v => v === 'streak' ? null : 'streak'); setWeekStripShown(false) }}
+                aria-expanded={statsDetail === 'streak'}
+              >
+                <Flame size={18} strokeWidth={2} className="v2-loggd-stat-icon" />
+                <span className="v2-loggd-stat-value">{streak}</span>
+                <span className="v2-loggd-stat-label">streak</span>
+              </button>
+              <button
+                type="button"
+                className={`v2-loggd-stat v2-loggd-stat-points${statsDetail === 'today' ? ' is-active' : ''}`}
+                onClick={() => { setStatsDetail(v => v === 'today' ? null : 'today'); setWeekStripShown(false) }}
+                aria-expanded={statsDetail === 'today'}
+              >
+                <Zap size={18} strokeWidth={2} className="v2-loggd-stat-icon" />
+                <span className="v2-loggd-stat-value">{dailyStats.pointsToday}</span>
+                <span className="v2-loggd-stat-label">points</span>
+              </button>
+              <button
+                type="button"
+                className={`v2-loggd-stat v2-loggd-stat-done${statsDetail === 'today' ? ' is-active' : ''}`}
+                onClick={() => { setStatsDetail(v => v === 'today' ? null : 'today'); setWeekStripShown(false) }}
+                aria-expanded={statsDetail === 'today'}
+              >
+                <CheckCircle2 size={18} strokeWidth={2} className="v2-loggd-stat-icon" />
+                <span className="v2-loggd-stat-value">{dailyStats.tasksToday}</span>
+                <span className="v2-loggd-stat-label">done</span>
+              </button>
+              <button
+                type="button"
+                className={`v2-loggd-stat v2-loggd-stat-date${weekStripShown ? ' is-active' : ''}`}
+                onClick={() => { setWeekStripShown(v => !v); setStatsDetail(null) }}
+                aria-expanded={weekStripShown}
+                aria-controls="v2-week-strip-days"
+              >
+                <CalendarDays size={18} strokeWidth={2} className="v2-loggd-stat-icon" />
+                <span className="v2-loggd-stat-value">{new Date().getDate()}</span>
+                <span className="v2-loggd-stat-label">{new Date().toLocaleDateString('en-US', { weekday: 'short' })}</span>
+              </button>
+            </div>
             <div className="v2-home-stats" aria-hidden="false">
               <button
                 type="button"

--- a/src/v2/components/TaskCard.jsx
+++ b/src/v2/components/TaskCard.jsx
@@ -275,7 +275,7 @@ function TaskCard({ task, expanded, onToggleExpand, onComplete, onEdit, onSnooze
               </button>
             )}
             <button
-              className="v2-card-action"
+              className="v2-card-action v2-card-action-snooze"
               onClick={() => onSnooze(task)}
               aria-label="Snooze"
             >

--- a/src/v2/loggd/structure.css
+++ b/src/v2/loggd/structure.css
@@ -89,3 +89,121 @@
 [data-theme^="loggd"] .v2-header-icon:hover {
   border-color: var(--lg-border-strong);
 }
+
+/* ════════════════════════════════════════════════════════════════════════
+ * Full-dashboard layer — the moves that make Loggd read as a dashboard, not
+ * a navy recolor of the calm list. All Loggd-gated; Standard is untouched.
+ * ════════════════════════════════════════════════════════════════════════ */
+
+/* ── Home stat band: colorful stat tiles (streak / points / done / date) ──
+ * The band is in the markup for every theme but hidden by default; Loggd
+ * shows it and hides the calm inline `.v2-home-stats` line. Both drive the
+ * same statsDetail state, so the expandable detail panels still work. */
+.v2-loggd-band { display: none; }
+
+[data-theme^="loggd"] .v2-home-stats { display: none; }
+
+[data-theme^="loggd"] .v2-loggd-band {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 10px;
+  margin: 2px 0 16px;
+}
+[data-theme^="loggd"] .v2-loggd-stat {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 3px;
+  padding: 13px 14px;
+  background: var(--lg-card-2);
+  border: 1px solid var(--v2-hairline);
+  border-radius: 14px;
+  box-shadow: var(--lg-shadow);
+  cursor: pointer;
+  text-align: left;
+  min-width: 0;
+  transition: border-color var(--v2-dur-quick) var(--v2-ease-standard),
+              transform var(--v2-dur-quick) var(--v2-ease-standard);
+}
+[data-theme^="loggd"] .v2-loggd-stat:hover { transform: translateY(-1px); }
+[data-theme^="loggd"] .v2-loggd-stat.is-active { border-color: var(--stat-color, var(--v2-accent)); }
+[data-theme^="loggd"] .v2-loggd-stat-icon { color: var(--stat-color, var(--v2-accent)); }
+[data-theme^="loggd"] .v2-loggd-stat-value {
+  font: 800 24px/1 var(--v2-font-display);
+  color: var(--v2-text);
+  letter-spacing: -0.02em;
+}
+[data-theme^="loggd"] .v2-loggd-stat-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--v2-text-meta);
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+[data-theme^="loggd"] .v2-loggd-stat-streak { --stat-color: var(--lg-orange); }
+[data-theme^="loggd"] .v2-loggd-stat-points { --stat-color: var(--lg-purple); }
+[data-theme^="loggd"] .v2-loggd-stat-done   { --stat-color: var(--lg-green); }
+[data-theme^="loggd"] .v2-loggd-stat-date   { --stat-color: var(--lg-blue); }
+
+@media (max-width: 520px) {
+  [data-theme^="loggd"] .v2-loggd-band { gap: 7px; }
+  [data-theme^="loggd"] .v2-loggd-stat { padding: 10px; border-radius: 12px; }
+  [data-theme^="loggd"] .v2-loggd-stat-value { font-size: 20px; }
+}
+
+/* ── Cards: energy chip → filled colored category tile (white glyph). The
+ * per-energy color rides on --lg-stripe (set in the card-stripe block above);
+ * reuse it as the tile fill. Inline lucide color attrs are overridden. ──── */
+[data-theme^="loggd"] .v2-card-energy {
+  flex-direction: column;
+  gap: 3px;
+  align-self: center;
+  padding: 7px;
+  border-radius: 10px;
+  background: var(--lg-stripe, var(--lg-card-2));
+}
+[data-theme^="loggd"] .v2-card-energy > svg { color: #fff !important; }
+[data-theme^="loggd"] .v2-card-energy-bolts svg {
+  color: rgba(255, 255, 255, 0.92) !important;
+  fill: rgba(255, 255, 255, 0.92) !important;
+}
+
+/* Heavier card titles — dashboard weight, not airy list weight. */
+[data-theme^="loggd"] .v2-card-title { font-weight: 650; }
+
+/* ── Semantic action buttons (green done / yellow snooze / orange save /
+ * red delete) — the Loggd goal-detail button language. ─────────────────── */
+[data-theme^="loggd"] .v2-card-action-primary {
+  background: var(--lg-action-complete);
+  border-color: var(--lg-action-complete);
+  color: #fff;
+}
+[data-theme^="loggd"] .v2-card-action-snooze {
+  color: var(--lg-action-pause);
+  border-color: color-mix(in srgb, var(--lg-action-pause) 55%, transparent);
+}
+[data-theme^="loggd"] .v2-edit-action-primary {
+  background: var(--lg-action-primary);
+  border-color: var(--lg-action-primary);
+  color: #fff;
+}
+[data-theme^="loggd"] .v2-edit-action-danger {
+  color: var(--lg-action-delete);
+  border-color: color-mix(in srgb, var(--lg-action-delete) 55%, transparent);
+}
+[data-theme^="loggd"] .v2-edit-action-confirm-yes {
+  background: var(--lg-action-delete);
+  border-color: var(--lg-action-delete);
+  color: #fff;
+}
+
+/* ── Filter toolbar → contained segmented control (active pill = accent
+ * fill, already set in the toolbar-pill block above). ──────────────────── */
+[data-theme^="loggd"] .v2-toolbar-pills {
+  background: var(--lg-card-2);
+  border: 1px solid var(--v2-hairline);
+  border-radius: var(--v2-radius-pill);
+  padding: 4px;
+}

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,10 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-05
 
+- feat(ui): Loggd full-dashboard layer — stat band, category tiles, semantic actions [M]
+  - The Phase-2 structural touches read as a navy recolor, not a reskin. Wired the dashboard character into the surfaces you actually look at, all Loggd-gated (Standard untouched): a home **stat band** of 4 colorful tiles (streak / points / done / date) with big grotesk numbers, driving the same `statsDetail` state as the calm line it replaces; **filled category tiles** for the card energy chip (colored square + white glyph from the per-energy `--lg-stripe`); **semantic action buttons** (green Done / yellow Snooze / orange Save / red Delete); a **contained segmented toolbar**; heavier card titles. The rich `--lg-action-*` / category tokens defined in Phase 1 were previously only consumed by heatmaps.
+  - Files: `src/v2/AppV2.jsx` (band markup + lucide imports), `src/v2/components/TaskCard.jsx` (snooze class), `src/v2/loggd/structure.css` (the dashboard layer), `CLAUDE.md`.
+
 - chore(ui): strip inert terminal props + Loggd header icon pills [S]
   - Removed every now-inert `terminalTitle` / `terminalCommand` / `terminalCmd` / `data-terminal-cmd` / `data-terminal-label` prop+attr from all v2 call sites (ModalShell/EmptyState/ConfirmDialog stopped reading them in the teardown — they were dead strings). 20 files touched, no behavior change. Added a Loggd-gated header touch: contained surface-pill icon buttons so the header glyphs read as buttons against the navy canvas. Dead `[data-theme^="terminal"]` CSS blocks remain inert (no theme matches) and get swept per-file later.
   - Files: 20 v2 components + `src/v2/AppV2.jsx`, `src/v2/loggd/structure.css`, `CLAUDE.md`.


### PR DESCRIPTION
The Phase-2 structural touches read as a navy recolor, not a reskin. This wires the dashboard character into the surfaces you actually look at — all Loggd-gated in `structure.css`, Standard untouched.

## What changed
- **Home stat band** — 4 colorful stat tiles (streak / points / done / date) with big grotesk numbers at the top of the main list. Markup lives in `AppV2.jsx` for every theme but is `display:none` outside Loggd, where it replaces the calm `.v2-home-stats` inline line. Both drive the **same** `statsDetail`/`weekStrip` state, so the expandable detail panels still work in both presentations.
- **Filled category tiles** — the card energy chip becomes a colored rounded square with a white glyph (fill = the per-energy `--lg-stripe` color; inline lucide color attrs overridden).
- **Semantic action buttons** — green Done (`--lg-action-complete`), yellow Snooze (new `.v2-card-action-snooze` class), orange Save (`--lg-action-primary`), red Delete/confirm (`--lg-action-delete`).
- **Contained segmented toolbar** (`.v2-toolbar-pills` gets a card-surface container) + heavier card titles.

The rich `--lg-action-*` / category tokens were defined in Phase 1 but only consumed by heatmaps until now.

## Files
- `src/v2/AppV2.jsx` — band markup + lucide imports
- `src/v2/components/TaskCard.jsx` — snooze action class
- `src/v2/loggd/structure.css` — the dashboard layer (all gated on `[data-theme^="loggd"]`)
- `CLAUDE.md`, `wiki/Version-History.md` — docs

## Verification
- `npm run build` green, `npm run lint` 0 errors
- Standard themes get zero visual change (band hidden, every rule Loggd-gated)

https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk)_