### PR TITLE
feat(ui): Wallaby design language + Habits surface (wired into app)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -971,6 +971,62 @@ The Boomerang wordmark popover (Analytics + Done, top-left) was already in place
 
 The whole thing was designed so either pivot is cheap. Don't make it expensive by piling on more terminal-only features without revisiting whether they should be terminal-only.
 
+### Wallaby Theme + IA Remap (2026-06-06, in progress)
+
+A deep-navy, **heatmap-first dashboard** design language modeled on
+[loggd.life](https://loggd.life) (reference screenshots: per-color habit
+contribution grids, segmented Single/Week/Month controls, semantic action
+buttons, colorful FABs, a profile year-grid). This is a **full IA remap** in
+progress — Boomerang's surfaces are being rebuilt to match the loggd structure,
+not just re-skinned. Concept mapping: **routines → habits**, **projects →
+goals**, tasks → tasks, plus a **profile/dashboard**. (Named Wallaby — another
+Australian marsupial, sibling to the Quokka adviser. The earlier "Loggd"-named
+attempt was torn out and reset; do not reintroduce that name.)
+
+**Theme model (4 palettes).** Settings → General → Theme is a **family** toggle
+(Standard / Terminal / **Wallaby**) × a Light/Dark mode → `wallaby-dark`
+(flagship) and `wallaby-light`. Like the built-in dark theme, Wallaby OVERRIDES
+the shared `--v2-*` tokens; Wallaby-specific structural tokens are namespaced
+`--wb-*`. All of it lives in **`src/v2/wallaby/`**.
+
+**Theme registration — three sync points (keep in lockstep):** `index.html`
+(pre-paint map), `AppV2.jsx` (mount effect map), `SettingsModal.jsx` (picker +
+`setTheme`). A base `:root[data-ui="v2"]` block in `palette.css` defines `--wb-*`
+defaults for *every* v2 theme so the Wallaby surfaces always resolve their
+tokens even if reached from a non-Wallaby theme.
+
+**`src/v2/wallaby/`:**
+- `palette.css` — base `--wb-*` defaults + `wallaby-dark` / `wallaby-light`
+  (card surfaces, per-habit accents blue/purple/green/orange/pink, heatmap
+  cells, semantic action colors orange=primary/green=complete/yellow=pause/
+  red=delete/slate=secondary, FAB colors). Imported via `AppV2.css`.
+- `ContributionHeatmap.{jsx,css}` — GitHub-style grid (weeks × 7 days,
+  local-time bucketing, per-color intensity). Theme-agnostic; sizes off inline
+  `--wb-cell`/`--wb-gap` props.
+- `heatmapUtils.js` — `historyByDay`, `WALLABY_COLORS`/color cycling,
+  `currentStreak`, `weekStart`/`addDays`/`fmtMonthDay`.
+- `HabitsView.{jsx,css}` — the **Habits** screen. Routines (filtered to
+  non-paused) as habit cards: color icon tile + title + streak/count badges +
+  the grid. Single (full heatmap) / Week (7 day-cells + date stepper) / Month
+  (calendar grid). Distinct per-habit color by list index. Purple FAB.
+
+**How Habits is reached (interim).** Mounted as a full-screen overlay
+(`.v2-habits-overlay` in `AppV2.css`) via **Spaces → Habits** (`onOpenHabits`
+row in `SpacesHub`, `showHabits` state + escape-stack entry in `AppV2`). The
+full remap promotes it to a top-level **bottom-nav tab** (Home/Habits/Tasks/
+Goals/Profile) — not yet built.
+
+**Dev-only render harness.** `wallaby-preview.html` + `src/wallaby-preview.jsx`
+mount `HabitsView` in isolation (mock or API-injected routines) for
+screenshot verification. NOT imported by `index.html`, so it never ships to
+prod or affects the running app. Verified via a headless-Chromium (puppeteer)
+screenshot loop — render before claiming a surface works.
+
+**Remaining surfaces (not built):** 5-tab bottom nav, Tasks (segmented
+Upcoming/Backlog, pink checkboxes, nested subtasks, green FAB), Goals (project
+detail with metric + semantic buttons), Profile (avatar + stat pills + activity
+year-grid), Home dashboard.
+
 ## Additional Notes
 - Single developer (ryakel) — no PR review process needed.
 

--- a/index.html
+++ b/index.html
@@ -32,7 +32,9 @@
           light: '#FFFFFF',
           dark: '#0B0B0F',
           'terminal-dark': '#0D1117',
-          'terminal-light': '#FFFFFF'
+          'terminal-light': '#FFFFFF',
+          'wallaby-dark': '#0E1322',
+          'wallaby-light': '#F4F6FB'
         }
         if (s && themeColors[s.theme]) {
           document.documentElement.setAttribute('data-theme', s.theme)

--- a/src/v2/AppV2.css
+++ b/src/v2/AppV2.css
@@ -1,5 +1,16 @@
 @import './tokens.css';
 @import './terminal/index.css';
+@import './wallaby/palette.css';
+
+/* Wallaby "Habits" surface mounts as a full-screen overlay above the app. */
+.v2-habits-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 70;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  background: var(--wb-bg, var(--v2-bg));
+}
 
 /* Match body bg to v2 app bg so any sub-pixel gap between the fixed
  * container and the screen edge is invisible. The v1 body uses --bg

--- a/src/v2/AppV2.jsx
+++ b/src/v2/AppV2.jsx
@@ -18,6 +18,7 @@ import ProjectsView from './components/ProjectsView'
 import DoneList from './components/DoneList'
 import ActivityLog from './components/ActivityLog'
 import RoutinesModal from './components/RoutinesModal'
+import HabitsView from './wallaby/HabitsView'
 import SuggestionsModal from './components/SuggestionsModal'
 import PackagesModal from './components/PackagesModal'
 import AdviserModal from './components/AdviserModal'
@@ -88,6 +89,9 @@ export default function AppV2() {
   // picker rows with rich preview cards but keeps the contract.
   const [spacesHubOpen, setSpacesHubOpen] = useState(false)
   const [showRoutines, setShowRoutines] = useState(false)
+  // Wallaby Habits surface — routines rendered as loggd-style heatmap cards.
+  // Reachable from the Spaces hub; full-screen overlay above the app.
+  const [showHabits, setShowHabits] = useState(false)
   const [editRoutineId, setEditRoutineId] = useState(null)
   const [showPackages, setShowPackages] = useState(false)
   const [showAdviser, setShowAdviser] = useState(false)
@@ -177,6 +181,8 @@ export default function AppV2() {
       dark: '#0B0B0F',
       'terminal-dark': '#0D1117',
       'terminal-light': '#FFFFFF',
+      'wallaby-dark': '#0E1322',
+      'wallaby-light': '#F4F6FB',
     }
     if (themeColors[theme]) {
       document.documentElement.setAttribute('data-theme', theme)
@@ -476,6 +482,7 @@ export default function AppV2() {
     if (showProjects) { setShowProjects(false); return }
     if (showDone) { setShowDone(false); return }
     if (showActivityLog) { setShowActivityLog(false); return }
+    if (showHabits) { setShowHabits(false); return }
     if (showRoutines) { setShowRoutines(false); return }
     if (showPackages) { setShowPackages(false); return }
     if (showAdviser) { setShowAdviser(false); return }
@@ -484,7 +491,7 @@ export default function AppV2() {
     if (spacesHubOpen) { setSpacesHubOpen(false); setActiveTab('today'); return }
     if (systemMenuOpen) { setSystemMenuOpen(false); return }
     if (searchOpen) { handleCloseSearch(); return }
-  }, [snoozeTarget, reframeTarget, editTarget, showAdd, showWhatNow, showSettings, showProjects, showDone, showActivityLog, showRoutines, showPackages, showAdviser, showAnalytics, showSuggestions, spacesHubOpen, systemMenuOpen, searchOpen, handleCloseSearch])
+  }, [snoozeTarget, reframeTarget, editTarget, showAdd, showWhatNow, showSettings, showProjects, showDone, showActivityLog, showHabits, showRoutines, showPackages, showAdviser, showAnalytics, showSuggestions, spacesHubOpen, systemMenuOpen, searchOpen, handleCloseSearch])
 
   const focusSearchInput = useCallback(() => {
     setSearchOpen(true)
@@ -1151,11 +1158,21 @@ export default function AppV2() {
         }}
         onOpenProjects={() => setShowProjects(true)}
         onOpenRoutines={() => setShowRoutines(true)}
+        onOpenHabits={() => setShowHabits(true)}
         onOpenKnowledge={() => {
           setAdviserDraftSeed("What's in my knowledge base?")
           setShowAdviser(true)
         }}
       />
+      {showHabits && (
+        <div className="v2-habits-overlay">
+          <HabitsView
+            routines={routines}
+            onAdd={() => { setShowHabits(false); setShowRoutines(true) }}
+            onClose={() => setShowHabits(false)}
+          />
+        </div>
+      )}
 
       {snoozeTarget && (
         <SnoozeModal

--- a/src/v2/components/SettingsModal.jsx
+++ b/src/v2/components/SettingsModal.jsx
@@ -2433,16 +2433,21 @@ export default function SettingsModal({
                 dark: '#0B0B0F',
                 'terminal-light': '#FFFFFF',
                 'terminal-dark': '#0D1117',
+                'wallaby-light': '#F4F6FB',
+                'wallaby-dark': '#0E1322',
               }
               const currentTheme = settings.theme || 'light'
               const isTerminal = currentTheme.startsWith('terminal')
-              const isDark = currentTheme === 'dark' || currentTheme === 'terminal-dark'
-              const family = isTerminal ? 'terminal' : 'standard'
+              const isWallaby = currentTheme.startsWith('wallaby')
+              const isDark = currentTheme === 'dark' || currentTheme === 'terminal-dark' || currentTheme === 'wallaby-dark'
+              const family = isTerminal ? 'terminal' : isWallaby ? 'wallaby' : 'standard'
               const mode = isDark ? 'dark' : 'light'
               const setTheme = (nextFamily, nextMode) => {
                 const value = nextFamily === 'terminal'
                   ? (nextMode === 'dark' ? 'terminal-dark' : 'terminal-light')
-                  : (nextMode === 'dark' ? 'dark' : 'light')
+                  : nextFamily === 'wallaby'
+                    ? (nextMode === 'dark' ? 'wallaby-dark' : 'wallaby-light')
+                    : (nextMode === 'dark' ? 'dark' : 'light')
                 update('theme', value)
                 document.documentElement.setAttribute('data-theme', value)
                 const meta = document.querySelector('meta[name="theme-color"]')
@@ -2453,12 +2458,13 @@ export default function SettingsModal({
                   <div className="v2-settings-row v2-settings-row-stacked">
                     <div className="v2-settings-row-text">
                       <div className="v2-settings-row-label">Theme</div>
-                      <div className="v2-settings-row-hint">Standard is the calm Wheneri-flavored UI. Terminal is monospace + ASCII flourishes — init-style on a GitHub palette.</div>
+                      <div className="v2-settings-row-hint">Standard is the calm Wheneri-flavored UI. Terminal is monospace + ASCII flourishes. Wallaby is a deep-navy, heatmap-first dashboard.</div>
                     </div>
                     <div className="v2-settings-segment" role="radiogroup" aria-label="Theme family">
                       {[
                         { value: 'standard', label: 'Standard' },
                         { value: 'terminal', label: 'Terminal' },
+                        { value: 'wallaby', label: 'Wallaby' },
                       ].map(opt => (
                         <button
                           key={opt.value}

--- a/src/v2/components/SpacesHub.jsx
+++ b/src/v2/components/SpacesHub.jsx
@@ -1,4 +1,4 @@
-import { FolderKanban, RotateCw, BookOpen, ChevronRight } from 'lucide-react'
+import { FolderKanban, RotateCw, BookOpen, Activity, ChevronRight } from 'lucide-react'
 import ModalShell from './ModalShell'
 import './SpacesHub.css'
 
@@ -13,9 +13,18 @@ import './SpacesHub.css'
 // the same hub a richer data shape.
 export default function SpacesHub({
   open, onClose,
-  onOpenProjects, onOpenRoutines, onOpenKnowledge,
+  onOpenProjects, onOpenRoutines, onOpenHabits, onOpenKnowledge,
 }) {
   const rows = [
+    {
+      key: 'habits',
+      icon: Activity,
+      tint: 'routines',
+      label: 'Habits',
+      subtitle: 'Routines as contribution heatmaps',
+      terminalCmd: '> habits',
+      onClick: onOpenHabits,
+    },
     {
       key: 'projects',
       icon: FolderKanban,

--- a/src/v2/wallaby/ContributionHeatmap.css
+++ b/src/v2/wallaby/ContributionHeatmap.css
@@ -1,0 +1,46 @@
+/* Wallaby contribution heatmap — see ContributionHeatmap.jsx. Cells size off
+ * the --wb-cell / --wb-gap custom props passed inline so one component serves
+ * the big card heatmap and the smaller profile/year grids. */
+
+.wb-heat {
+  position: relative;
+  width: 100%;
+}
+
+.wb-heat-months {
+  position: relative;
+  height: 14px;
+  margin-bottom: 4px;
+}
+.wb-heat-month {
+  position: absolute;
+  top: 0;
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--wb-text-meta, var(--v2-text-meta));
+  white-space: nowrap;
+}
+
+.wb-heat-grid {
+  display: flex;
+  gap: var(--wb-gap, 3px);
+}
+.wb-heat-col {
+  display: flex;
+  flex-direction: column;
+  gap: var(--wb-gap, 3px);
+  flex: 1 1 0;
+}
+.wb-heat-cell {
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  min-width: 0;
+  height: var(--wb-cell, 12px);
+  border-radius: var(--wb-radius, 2px);
+  background: var(--wb-heat-empty, #1B2235);
+  box-shadow: inset 0 0 0 1px var(--wb-heat-border, transparent);
+}
+.wb-heat-cell-future {
+  background: transparent;
+  box-shadow: none;
+}

--- a/src/v2/wallaby/ContributionHeatmap.jsx
+++ b/src/v2/wallaby/ContributionHeatmap.jsx
@@ -1,0 +1,91 @@
+import { useMemo } from 'react'
+import { localYMD } from './heatmapUtils'
+import './ContributionHeatmap.css'
+
+const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+
+// GitHub-style contribution grid. Columns = weeks (Monday-anchored), rows =
+// days (Mon..Sun, top to bottom). Theme-agnostic: empty cells use
+// --wb-heat-empty, filled cells use the per-habit `color` at an intensity
+// scaled to the busiest day in the window. The signature Wallaby visual.
+export default function ContributionHeatmap({
+  valueByDay = {},
+  color = '#4F8DF5',
+  weeks = 24,
+  cellSize = 12,
+  gap = 3,
+  showMonths = false,
+  radius = 2,
+}) {
+  const { cols, months } = useMemo(() => {
+    const today = new Date()
+    today.setHours(0, 0, 0, 0)
+    // End on the Sunday closing the current (Monday-anchored) week.
+    const dow = (today.getDay() + 6) % 7
+    const end = new Date(today)
+    end.setDate(end.getDate() + (6 - dow))
+    const start = new Date(end)
+    start.setDate(start.getDate() - weeks * 7 + 1)
+
+    let max = 1
+    const cols = []
+    const months = []
+    let lastMonth = -1
+    for (let w = 0; w < weeks; w++) {
+      const col = []
+      for (let d = 0; d < 7; d++) {
+        const cur = new Date(start)
+        cur.setDate(start.getDate() + w * 7 + d)
+        const key = localYMD(cur)
+        const value = valueByDay[key] || 0
+        if (value > max) max = value
+        col.push({ key, value, future: cur > today, date: cur })
+      }
+      // Month label when the first day of a column crosses into a new month.
+      const firstReal = col.find(c => !c.future) || col[0]
+      const m = firstReal.date.getMonth()
+      if (m !== lastMonth) { months.push({ index: w, label: MONTHS[m] }); lastMonth = m }
+      cols.push(col)
+    }
+    // attach intensity now that max is known
+    for (const col of cols) for (const c of col) {
+      c.intensity = c.value === 0 ? 0 : Math.min(1, 0.32 + 0.68 * (c.value / max))
+    }
+    return { cols, months }
+  }, [valueByDay, weeks])
+
+  return (
+    <div
+      className="wb-heat"
+      style={{ '--wb-cell': `${cellSize}px`, '--wb-gap': `${gap}px`, '--wb-radius': `${radius}px` }}
+    >
+      {showMonths && (
+        <div className="wb-heat-months">
+          {months.map((m, i) => (
+            <span
+              key={i}
+              className="wb-heat-month"
+              style={{ left: `calc(${m.index} * (var(--wb-cell) + var(--wb-gap)))` }}
+            >{m.label}</span>
+          ))}
+        </div>
+      )}
+      <div className="wb-heat-grid" role="img" aria-label="Activity heatmap">
+        {cols.map((col, ci) => (
+          <div key={ci} className="wb-heat-col">
+            {col.map(c => (
+              <div
+                key={c.key}
+                className={`wb-heat-cell${c.future ? ' wb-heat-cell-future' : ''}`}
+                title={`${c.key}: ${c.value}`}
+                style={c.value > 0 && !c.future
+                  ? { background: color, opacity: c.intensity }
+                  : undefined}
+              />
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/v2/wallaby/HabitsView.css
+++ b/src/v2/wallaby/HabitsView.css
@@ -15,9 +15,21 @@
 .wb-habits-titlerow {
   display: flex;
   align-items: center;
-  justify-content: space-between;
   gap: 12px;
 }
+.wb-back {
+  display: grid;
+  place-items: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 10px;
+  border: 1px solid var(--wb-hairline);
+  background: var(--wb-card);
+  color: var(--wb-text);
+  cursor: pointer;
+  flex: 0 0 auto;
+}
+.wb-habits-title { margin-right: auto; }
 .wb-habits-title {
   margin: 0;
   font-family: var(--v2-font-display);

--- a/src/v2/wallaby/HabitsView.css
+++ b/src/v2/wallaby/HabitsView.css
@@ -1,0 +1,222 @@
+/* Wallaby "Habits" surface. Navy canvas, habit cards each carrying a per-color
+ * contribution grid. Mobile-first; widths flex so the heatmap fills the card. */
+
+.wb-habits {
+  min-height: 100vh;
+  background: var(--wb-bg);
+  color: var(--wb-text);
+  padding: 16px 16px 120px;
+  font-family: var(--v2-font-body);
+  -webkit-font-smoothing: antialiased;
+}
+
+/* ── Header ──────────────────────────────────────────────────────────────── */
+.wb-habits-head { margin-bottom: 16px; }
+.wb-habits-titlerow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+.wb-habits-title {
+  margin: 0;
+  font-family: var(--v2-font-display);
+  font-size: 28px;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  color: var(--wb-text);
+}
+
+/* Segmented pill control */
+.wb-seg {
+  display: inline-flex;
+  background: var(--wb-card-2);
+  border: 1px solid var(--wb-hairline);
+  border-radius: 999px;
+  padding: 3px;
+  gap: 2px;
+}
+.wb-seg-btn {
+  appearance: none;
+  border: none;
+  background: transparent;
+  color: var(--wb-text-meta);
+  font: 600 12.5px/1 var(--v2-font-body);
+  padding: 7px 13px;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background 140ms ease, color 140ms ease;
+}
+.wb-seg-btn.is-active {
+  background: var(--wb-card-3);
+  color: var(--wb-text);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
+}
+
+/* Date stepper (week / month) */
+.wb-stepper {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 14px;
+  background: var(--wb-card);
+  border: 1px solid var(--wb-hairline);
+  border-radius: 12px;
+  padding: 6px 8px;
+}
+.wb-stepper-label {
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--wb-text);
+}
+.wb-stepper-btn {
+  display: grid;
+  place-items: center;
+  width: 30px;
+  height: 30px;
+  border-radius: 8px;
+  border: none;
+  background: var(--wb-card-2);
+  color: var(--wb-text);
+  cursor: pointer;
+}
+.wb-stepper-btn:disabled { opacity: 0.35; cursor: default; }
+
+/* ── Habit cards ─────────────────────────────────────────────────────────── */
+.wb-habits-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.wb-card {
+  background: var(--wb-card);
+  border: 1px solid var(--wb-hairline);
+  border-radius: 16px;
+  padding: 14px 15px 16px;
+  box-shadow: var(--wb-shadow);
+}
+.wb-card-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 13px;
+}
+.wb-card-icon {
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
+  flex: 0 0 auto;
+}
+.wb-card-title {
+  font-family: var(--v2-font-display);
+  font-size: 15px;
+  font-weight: 650;
+  color: var(--wb-text);
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.wb-card-stats {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex: 0 0 auto;
+}
+.wb-stat {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  font-size: 11.5px;
+  font-weight: 700;
+  padding: 3px 8px;
+  border-radius: 999px;
+  background: var(--wb-card-2);
+  color: var(--wb-text-meta);
+}
+.wb-stat-streak { color: #F0973E; }
+
+/* Single-view heatmap body */
+.wb-card-body { width: 100%; }
+
+/* Week view — 7 day cells */
+.wb-week {
+  display: flex;
+  gap: 7px;
+}
+.wb-week-day {
+  flex: 1 1 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+.wb-week-dow {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--wb-text-meta);
+}
+.wb-week-cell {
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  display: grid;
+  place-items: center;
+  border-radius: 10px;
+  border: 1.5px solid var(--wb-hairline);
+  background: var(--wb-heat-empty);
+  color: var(--wb-text-meta);
+  font-size: 13px;
+  font-weight: 700;
+}
+.wb-week-cell.is-done { color: #fff; }
+.wb-week-day.is-today .wb-week-cell { border-color: var(--habit); }
+
+/* Month view — calendar grid */
+.wb-month {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 5px;
+}
+.wb-month-dow {
+  text-align: center;
+  font-size: 10px;
+  font-weight: 700;
+  color: var(--wb-text-meta);
+  padding-bottom: 2px;
+}
+.wb-month-cell {
+  aspect-ratio: 1 / 1;
+  display: grid;
+  place-items: center;
+  border-radius: 7px;
+  border: 1px solid var(--wb-hairline);
+  background: var(--wb-heat-empty);
+  color: var(--wb-text-meta);
+  font-size: 11px;
+  font-weight: 600;
+}
+.wb-month-cell.is-done { color: #fff; }
+.wb-month-cell-blank { background: transparent; border-color: transparent; }
+
+/* ── FAB ─────────────────────────────────────────────────────────────────── */
+.wb-fab {
+  position: fixed;
+  right: 18px;
+  bottom: 92px;
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  border: none;
+  display: grid;
+  place-items: center;
+  color: #fff;
+  cursor: pointer;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.45);
+  z-index: 20;
+}
+.wb-fab-habits { background: var(--wb-fab-habits); }
+.wb-fab-tasks { background: var(--wb-fab-tasks); }

--- a/src/v2/wallaby/HabitsView.jsx
+++ b/src/v2/wallaby/HabitsView.jsx
@@ -1,0 +1,196 @@
+import { useMemo, useState } from 'react'
+import {
+  Plus, Flame, ChevronLeft, ChevronRight,
+  Monitor, Users, MapPin, Palette, Dumbbell, Repeat,
+} from 'lucide-react'
+import ContributionHeatmap from './ContributionHeatmap'
+import {
+  WALLABY_COLORS, historyByDay, currentStreak,
+  weekStart, addDays, fmtMonthDay, localYMD,
+} from './heatmapUtils'
+import './HabitsView.css'
+
+const ENERGY_ICONS = { desk: Monitor, people: Users, errand: MapPin, creative: Palette, physical: Dumbbell }
+const DOW = ['M', 'T', 'W', 'T', 'F', 'S', 'S']
+const MODES = [
+  { id: 'single', label: 'Single' },
+  { id: 'week', label: 'Week' },
+  { id: 'month', label: 'Month' },
+]
+
+// Wallaby "Habits" surface — Boomerang routines rendered as loggd-style habit
+// cards. Each routine gets a stable per-habit color and a GitHub contribution
+// grid built from its completed_history. Three views: Single (full heatmap),
+// Week (7 day-cells with a date stepper), Month (calendar grid).
+export default function HabitsView({ routines = [], onAdd }) {
+  const [mode, setMode] = useState('single')
+  const [weekOffset, setWeekOffset] = useState(0)
+  const [monthOffset, setMonthOffset] = useState(0)
+
+  const habits = useMemo(() => routines.filter(r => !r.paused), [routines])
+
+  const wkStart = weekStart(new Date(), weekOffset)
+  const wkEnd = addDays(wkStart, 6)
+
+  const monthRef = useMemo(() => {
+    const d = new Date(); d.setDate(1); d.setMonth(d.getMonth() + monthOffset); d.setHours(0, 0, 0, 0)
+    return d
+  }, [monthOffset])
+
+  return (
+    <div className="wb-habits">
+      <header className="wb-habits-head">
+        <div className="wb-habits-titlerow">
+          <h1 className="wb-habits-title">Habits</h1>
+          <div className="wb-seg" role="tablist" aria-label="Heatmap range">
+            {MODES.map(m => (
+              <button
+                key={m.id}
+                role="tab"
+                aria-selected={mode === m.id}
+                className={`wb-seg-btn${mode === m.id ? ' is-active' : ''}`}
+                onClick={() => setMode(m.id)}
+              >{m.label}</button>
+            ))}
+          </div>
+        </div>
+
+        {mode === 'week' && (
+          <div className="wb-stepper">
+            <button className="wb-stepper-btn" onClick={() => setWeekOffset(o => o - 1)} aria-label="Previous week">
+              <ChevronLeft size={18} strokeWidth={2.25} />
+            </button>
+            <span className="wb-stepper-label">{fmtMonthDay(wkStart)} – {fmtMonthDay(wkEnd)}, {wkEnd.getFullYear()}</span>
+            <button
+              className="wb-stepper-btn"
+              onClick={() => setWeekOffset(o => Math.min(0, o + 1))}
+              disabled={weekOffset >= 0}
+              aria-label="Next week"
+            >
+              <ChevronRight size={18} strokeWidth={2.25} />
+            </button>
+          </div>
+        )}
+        {mode === 'month' && (
+          <div className="wb-stepper">
+            <button className="wb-stepper-btn" onClick={() => setMonthOffset(o => o - 1)} aria-label="Previous month">
+              <ChevronLeft size={18} strokeWidth={2.25} />
+            </button>
+            <span className="wb-stepper-label">
+              {monthRef.toLocaleDateString('en-US', { month: 'long', year: 'numeric' })}
+            </span>
+            <button
+              className="wb-stepper-btn"
+              onClick={() => setMonthOffset(o => Math.min(0, o + 1))}
+              disabled={monthOffset >= 0}
+              aria-label="Next month"
+            >
+              <ChevronRight size={18} strokeWidth={2.25} />
+            </button>
+          </div>
+        )}
+      </header>
+
+      <div className="wb-habits-list">
+        {habits.map((r, i) => (
+          <HabitCard
+            key={r.id}
+            routine={r}
+            color={WALLABY_COLORS[i % WALLABY_COLORS.length]}
+            mode={mode}
+            wkStart={wkStart}
+            monthRef={monthRef}
+          />
+        ))}
+      </div>
+
+      <button className="wb-fab wb-fab-habits" onClick={onAdd} aria-label="New habit">
+        <Plus size={26} strokeWidth={2.5} />
+      </button>
+    </div>
+  )
+}
+
+function HabitCard({ routine, color, mode, wkStart, monthRef }) {
+  const Icon = ENERGY_ICONS[routine.energy] || Repeat
+  const valueByDay = useMemo(() => historyByDay(routine.completed_history), [routine.completed_history])
+  const total = routine.completed_history?.length || 0
+  const streak = useMemo(() => currentStreak(valueByDay), [valueByDay])
+
+  return (
+    <article className="wb-card" style={{ '--habit': color }}>
+      <div className="wb-card-head">
+        <span className="wb-card-icon" style={{ background: color }}>
+          <Icon size={16} strokeWidth={2} color="#fff" />
+        </span>
+        <span className="wb-card-title">{routine.title}</span>
+        <span className="wb-card-stats">
+          {streak > 0 && (
+            <span className="wb-stat wb-stat-streak"><Flame size={12} strokeWidth={2.25} /> {streak}</span>
+          )}
+          <span className="wb-stat wb-stat-total">{total}×</span>
+        </span>
+      </div>
+
+      {mode === 'single' && (
+        <div className="wb-card-body">
+          <ContributionHeatmap valueByDay={valueByDay} color={color} weeks={22} cellSize={13} gap={3} />
+        </div>
+      )}
+
+      {mode === 'week' && (
+        <div className="wb-week">
+          {Array.from({ length: 7 }, (_, i) => {
+            const day = addDays(wkStart, i)
+            const key = localYMD(day)
+            const done = (valueByDay[key] || 0) > 0
+            const isToday = key === localYMD(new Date())
+            return (
+              <div key={key} className={`wb-week-day${isToday ? ' is-today' : ''}`}>
+                <span className="wb-week-dow">{DOW[i]}</span>
+                <span
+                  className={`wb-week-cell${done ? ' is-done' : ''}`}
+                  style={done ? { background: color, borderColor: color } : undefined}
+                >{day.getDate()}</span>
+              </div>
+            )
+          })}
+        </div>
+      )}
+
+      {mode === 'month' && (
+        <MonthGrid monthRef={monthRef} valueByDay={valueByDay} color={color} />
+      )}
+    </article>
+  )
+}
+
+function MonthGrid({ monthRef, valueByDay, color }) {
+  const cells = useMemo(() => {
+    const first = new Date(monthRef)
+    const startPad = (first.getDay() + 6) % 7 // Monday-anchored leading blanks
+    const daysInMonth = new Date(first.getFullYear(), first.getMonth() + 1, 0).getDate()
+    const out = []
+    for (let i = 0; i < startPad; i++) out.push(null)
+    for (let d = 1; d <= daysInMonth; d++) {
+      const day = new Date(first.getFullYear(), first.getMonth(), d)
+      out.push({ d, key: localYMD(day), done: (valueByDay[localYMD(day)] || 0) > 0 })
+    }
+    return out
+  }, [monthRef, valueByDay])
+
+  return (
+    <div className="wb-month">
+      {DOW.map((d, i) => <span key={`h${i}`} className="wb-month-dow">{d}</span>)}
+      {cells.map((c, i) => c === null
+        ? <span key={`b${i}`} className="wb-month-cell wb-month-cell-blank" />
+        : (
+          <span
+            key={c.key}
+            className={`wb-month-cell${c.done ? ' is-done' : ''}`}
+            style={c.done ? { background: color, borderColor: color } : undefined}
+          >{c.d}</span>
+        ))}
+    </div>
+  )
+}

--- a/src/v2/wallaby/HabitsView.jsx
+++ b/src/v2/wallaby/HabitsView.jsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react'
 import {
-  Plus, Flame, ChevronLeft, ChevronRight,
+  Plus, Flame, ChevronLeft, ChevronRight, ArrowLeft,
   Monitor, Users, MapPin, Palette, Dumbbell, Repeat,
 } from 'lucide-react'
 import ContributionHeatmap from './ContributionHeatmap'
@@ -22,7 +22,7 @@ const MODES = [
 // cards. Each routine gets a stable per-habit color and a GitHub contribution
 // grid built from its completed_history. Three views: Single (full heatmap),
 // Week (7 day-cells with a date stepper), Month (calendar grid).
-export default function HabitsView({ routines = [], onAdd }) {
+export default function HabitsView({ routines = [], onAdd, onClose }) {
   const [mode, setMode] = useState('single')
   const [weekOffset, setWeekOffset] = useState(0)
   const [monthOffset, setMonthOffset] = useState(0)
@@ -41,6 +41,11 @@ export default function HabitsView({ routines = [], onAdd }) {
     <div className="wb-habits">
       <header className="wb-habits-head">
         <div className="wb-habits-titlerow">
+          {onClose && (
+            <button className="wb-back" onClick={onClose} aria-label="Back">
+              <ArrowLeft size={20} strokeWidth={2.25} />
+            </button>
+          )}
           <h1 className="wb-habits-title">Habits</h1>
           <div className="wb-seg" role="tablist" aria-label="Heatmap range">
             {MODES.map(m => (

--- a/src/v2/wallaby/heatmapUtils.js
+++ b/src/v2/wallaby/heatmapUtils.js
@@ -1,0 +1,67 @@
+// Wallaby heatmap helpers — local-time day bucketing + per-habit color cycling.
+// Shared by ContributionHeatmap and HabitsView so the grid math lives in one
+// place. All bucketing is LOCAL time (not UTC) so "today" lines up with what
+// the user sees on their device.
+
+export const WALLABY_COLORS = ['#4F8DF5', '#8C7CF0', '#41C083', '#F0973E', '#EA6C9D']
+
+// Deterministic per-habit color from an id. Stable across reloads so a routine
+// keeps the same color (matches the loggd per-habit color identity).
+export function habitColor(id) {
+  const s = String(id ?? '')
+  let h = 0
+  for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) >>> 0
+  return WALLABY_COLORS[h % WALLABY_COLORS.length]
+}
+
+export function localYMD(d) {
+  const x = new Date(d)
+  if (Number.isNaN(x.getTime())) return null
+  return `${x.getFullYear()}-${String(x.getMonth() + 1).padStart(2, '0')}-${String(x.getDate()).padStart(2, '0')}`
+}
+
+// completed_history (array of ISO timestamps) → { 'YYYY-MM-DD': count }
+export function historyByDay(history) {
+  const m = {}
+  for (const ts of (history || [])) {
+    const k = localYMD(ts)
+    if (k) m[k] = (m[k] || 0) + 1
+  }
+  return m
+}
+
+// Consecutive-day streak ending today (today optional — if today has no entry
+// we still count a streak that ran up to yesterday, the conventional rule).
+export function currentStreak(valueByDay) {
+  const d = new Date()
+  d.setHours(0, 0, 0, 0)
+  // If today is empty, start counting from yesterday so an unlogged "today"
+  // doesn't read as a broken streak mid-day.
+  if (!valueByDay[localYMD(d)]) d.setDate(d.getDate() - 1)
+  let streak = 0
+  for (;;) {
+    if (valueByDay[localYMD(d)]) { streak++; d.setDate(d.getDate() - 1) }
+    else break
+  }
+  return streak
+}
+
+// Monday-anchored start of the week containing `ref` (+ weekOffset weeks).
+export function weekStart(ref, weekOffset = 0) {
+  const d = new Date(ref)
+  d.setHours(0, 0, 0, 0)
+  const dow = (d.getDay() + 6) % 7 // 0 = Monday
+  d.setDate(d.getDate() - dow + weekOffset * 7)
+  return d
+}
+
+export function addDays(d, n) {
+  const x = new Date(d)
+  x.setDate(x.getDate() + n)
+  return x
+}
+
+const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+export function fmtMonthDay(d) {
+  return `${MONTHS[d.getMonth()]} ${d.getDate()}`
+}

--- a/src/v2/wallaby/palette.css
+++ b/src/v2/wallaby/palette.css
@@ -1,0 +1,107 @@
+/* ════════════════════════════════════════════════════════════════════════
+ * Wallaby theme — deep-navy, heatmap-first dashboard design language.
+ * Modeled on the loggd.life reference: navy canvas, slightly-lighter card
+ * surfaces, GitHub contribution heatmaps as the signature visual, per-habit
+ * color accents (blue/purple/green/orange/pink), heavy grotesk titles, pill
+ * segmented controls, colorful FABs, and semantic action buttons
+ * (orange=primary, green=complete, yellow=pause, red=delete, slate=secondary).
+ *
+ * Two palettes: wallaby-dark (flagship) and wallaby-light. Like the built-in
+ * dark theme, Wallaby OVERRIDES the shared --v2-* tokens so every existing
+ * token-consuming component re-skins for free. Wallaby-specific STRUCTURAL
+ * tokens are namespaced --wb-* and consumed by the heatmap / habit cards /
+ * stat pills / semantic buttons.
+ * ════════════════════════════════════════════════════════════════════════ */
+
+/* ── Wallaby dark (flagship) ─────────────────────────────────────────────── */
+:root[data-ui="v2"][data-theme="wallaby-dark"] {
+  /* Clean grotesk over Syne for the dashboard register */
+  --v2-font-display: 'Inter', system-ui, -apple-system, 'Segoe UI', sans-serif;
+  --v2-font-body: 'Inter', system-ui, -apple-system, 'Segoe UI', sans-serif;
+
+  /* Canvas + surfaces (navy) */
+  --v2-bg: #0E1322;
+  --v2-surface: #161C2D;
+  --v2-text: #EAEEF7;
+  --v2-text-rgb: 234, 238, 247;
+  --v2-text-meta: rgba(234, 238, 247, 0.56);
+  --v2-text-faint: rgba(234, 238, 247, 0.34);
+  --v2-hairline: rgba(255, 255, 255, 0.07);
+  --v2-accent: #7C5CF0;
+
+  /* Wallaby structural tokens */
+  --wb-bg: #0E1322;
+  --wb-card: #161C2D;
+  --wb-card-2: #1E2638;          /* elevated: segmented track, stat pills */
+  --wb-card-3: #232C42;          /* hover / pressed */
+  --wb-hairline: rgba(255, 255, 255, 0.08);
+  --wb-hairline-strong: rgba(255, 255, 255, 0.14);
+  --wb-text: #EAEEF7;
+  --wb-text-meta: rgba(234, 238, 247, 0.56);
+  --wb-shadow: 0 1px 2px rgba(0, 0, 0, 0.4), 0 8px 24px rgba(0, 0, 0, 0.28);
+
+  /* Per-category / per-habit accents */
+  --wb-cat-blue: #4F8DF5;
+  --wb-cat-purple: #8C7CF0;
+  --wb-cat-green: #41C083;
+  --wb-cat-orange: #F0973E;
+  --wb-cat-pink: #EA6C9D;
+
+  /* Heatmap */
+  --wb-heat-empty: #1B2235;      /* cell at value 0 */
+  --wb-heat-border: rgba(255, 255, 255, 0.03);
+
+  /* Semantic action colors */
+  --wb-action-primary: #F0853A;   /* orange — Update / primary CTA */
+  --wb-action-complete: #34C27E;  /* green — Complete / Done */
+  --wb-action-pause: #E6B43E;     /* yellow — Pause */
+  --wb-action-delete: #E5564B;    /* red — Delete */
+  --wb-action-secondary: #2A3348; /* slate — Edit / secondary */
+
+  /* FABs */
+  --wb-fab-habits: #7C5CF0;       /* purple */
+  --wb-fab-tasks: #34C27E;        /* green */
+}
+
+/* ── Wallaby light ───────────────────────────────────────────────────────── */
+:root[data-ui="v2"][data-theme="wallaby-light"] {
+  --v2-font-display: 'Inter', system-ui, -apple-system, 'Segoe UI', sans-serif;
+  --v2-font-body: 'Inter', system-ui, -apple-system, 'Segoe UI', sans-serif;
+
+  --v2-bg: #F4F6FB;
+  --v2-surface: #FFFFFF;
+  --v2-text: #18203A;
+  --v2-text-rgb: 24, 32, 58;
+  --v2-text-meta: rgba(24, 32, 58, 0.58);
+  --v2-text-faint: rgba(24, 32, 58, 0.34);
+  --v2-hairline: rgba(24, 32, 58, 0.10);
+  --v2-accent: #7C5CF0;
+
+  --wb-bg: #F4F6FB;
+  --wb-card: #FFFFFF;
+  --wb-card-2: #EEF1F8;
+  --wb-card-3: #E4E9F4;
+  --wb-hairline: rgba(24, 32, 58, 0.10);
+  --wb-hairline-strong: rgba(24, 32, 58, 0.18);
+  --wb-text: #18203A;
+  --wb-text-meta: rgba(24, 32, 58, 0.58);
+  --wb-shadow: 0 1px 2px rgba(24, 32, 58, 0.06), 0 8px 24px rgba(24, 32, 58, 0.08);
+
+  --wb-cat-blue: #3B7BE8;
+  --wb-cat-purple: #7C5CF0;
+  --wb-cat-green: #2BA56B;
+  --wb-cat-orange: #E07E26;
+  --wb-cat-pink: #DB5690;
+
+  --wb-heat-empty: #E7EBF4;
+  --wb-heat-border: rgba(24, 32, 58, 0.04);
+
+  --wb-action-primary: #E97A2C;
+  --wb-action-complete: #2BA56B;
+  --wb-action-pause: #D9A21F;
+  --wb-action-delete: #DC4A40;
+  --wb-action-secondary: #DDE3F0;
+
+  --wb-fab-habits: #7C5CF0;
+  --wb-fab-tasks: #2BA56B;
+}

--- a/src/v2/wallaby/palette.css
+++ b/src/v2/wallaby/palette.css
@@ -13,6 +13,37 @@
  * stat pills / semantic buttons.
  * ════════════════════════════════════════════════════════════════════════ */
 
+/* ── Base --wb-* defaults ────────────────────────────────────────────────────
+ * Defined for EVERY v2 theme so the Wallaby surfaces (Habits heatmaps) always
+ * resolve their structural tokens — even if reached from a non-Wallaby theme,
+ * the surface renders in the intended navy rather than unstyled. The
+ * wallaby-dark / wallaby-light blocks below override where they differ. */
+:root[data-ui="v2"] {
+  --wb-bg: #0E1322;
+  --wb-card: #161C2D;
+  --wb-card-2: #1E2638;
+  --wb-card-3: #232C42;
+  --wb-hairline: rgba(255, 255, 255, 0.08);
+  --wb-hairline-strong: rgba(255, 255, 255, 0.14);
+  --wb-text: #EAEEF7;
+  --wb-text-meta: rgba(234, 238, 247, 0.56);
+  --wb-shadow: 0 1px 2px rgba(0, 0, 0, 0.4), 0 8px 24px rgba(0, 0, 0, 0.28);
+  --wb-cat-blue: #4F8DF5;
+  --wb-cat-purple: #8C7CF0;
+  --wb-cat-green: #41C083;
+  --wb-cat-orange: #F0973E;
+  --wb-cat-pink: #EA6C9D;
+  --wb-heat-empty: #1B2235;
+  --wb-heat-border: rgba(255, 255, 255, 0.03);
+  --wb-action-primary: #F0853A;
+  --wb-action-complete: #34C27E;
+  --wb-action-pause: #E6B43E;
+  --wb-action-delete: #E5564B;
+  --wb-action-secondary: #2A3348;
+  --wb-fab-habits: #7C5CF0;
+  --wb-fab-tasks: #34C27E;
+}
+
 /* ── Wallaby dark (flagship) ─────────────────────────────────────────────── */
 :root[data-ui="v2"][data-theme="wallaby-dark"] {
   /* Clean grotesk over Syne for the dashboard register */

--- a/src/wallaby-preview.jsx
+++ b/src/wallaby-preview.jsx
@@ -1,0 +1,41 @@
+// Isolated render harness for the Wallaby Habits surface. Mounts the real
+// HabitsView with mock routine data so the look can be verified via the
+// screenshot harness WITHOUT touching AppV2. Dev-only; not shipped.
+import { createRoot } from 'react-dom/client'
+import './index.css'
+import './v2/tokens.css'
+import './v2/wallaby/palette.css'
+import HabitsView from './v2/wallaby/HabitsView'
+
+document.documentElement.setAttribute('data-ui', 'v2')
+document.documentElement.setAttribute('data-theme', new URLSearchParams(location.search).get('theme') || 'wallaby-dark')
+
+// Deterministic-ish completed_history generator over the past ~200 days.
+function gen(seed, density, days = 200) {
+  let s = seed
+  const rand = () => { s = (s * 1103515245 + 12345) & 0x7fffffff; return s / 0x7fffffff }
+  const out = []
+  const now = Date.now()
+  for (let i = 0; i < days; i++) {
+    if (rand() < density) {
+      const d = new Date(now - i * 86400000)
+      d.setHours(9, 0, 0, 0)
+      out.push(d.toISOString())
+      if (rand() < density * 0.4) out.push(new Date(d.getTime() + 3600000).toISOString())
+    }
+  }
+  return out
+}
+
+const routines = [
+  { id: 'threads', title: 'Post on Threads', energy: 'desk', completed_history: gen(7, 0.55) },
+  { id: 'saas', title: 'SaaS Work', energy: 'creative', completed_history: gen(19, 0.42) },
+  { id: 'github', title: 'GitHub Activity', energy: 'desk', completed_history: gen(3, 0.72) },
+  { id: 'reddit', title: 'Post on Reddit', energy: 'people', completed_history: gen(31, 0.24) },
+  { id: 'cycling', title: 'Cycling', energy: 'physical', completed_history: gen(11, 0.35) },
+  { id: 'reading', title: 'Read 20 pages', energy: 'creative', completed_history: gen(23, 0.5) },
+]
+
+createRoot(document.getElementById('root')).render(
+  <HabitsView routines={routines} onAdd={() => {}} />,
+)

--- a/src/wallaby-preview.jsx
+++ b/src/wallaby-preview.jsx
@@ -36,6 +36,12 @@ const routines = [
   { id: 'reading', title: 'Read 20 pages', energy: 'creative', completed_history: gen(23, 0.5) },
 ]
 
+// When the screenshot harness injects real routine rows from the dev API
+// (window.__WALLABY_ROUTINES__), render those; otherwise fall back to mock.
+const data = window.__WALLABY_ROUTINES__ && window.__WALLABY_ROUTINES__.length
+  ? window.__WALLABY_ROUTINES__
+  : routines
+
 createRoot(document.getElementById('root')).render(
-  <HabitsView routines={routines} onAdd={() => {}} />,
+  <HabitsView routines={data} onAdd={() => {}} />,
 )

--- a/wallaby-preview.html
+++ b/wallaby-preview.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <title>Wallaby preview</title>
+    <style>html,body{margin:0;padding:0;background:#0E1322}</style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/wallaby-preview.jsx"></script>
+  </body>
+</html>

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,11 +6,13 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-06
 
-- feat(ui): Wallaby design language — Habits surface (WIP, not yet wired into app) [L]
-  - **What.** First surface of a full IA remap toward the loggd.life reference: a deep-navy, heatmap-first dashboard language named **Wallaby**. This commit adds the theme + the **Habits** screen (Boomerang routines rendered as loggd-style habit cards).
+- feat(ui): Wallaby design language — Habits surface, wired into the app [L]
+  - **What.** First surface of a full IA remap toward the loggd.life reference: a deep-navy, heatmap-first dashboard language named **Wallaby**. Adds the theme + the **Habits** screen (Boomerang routines rendered as loggd-style habit cards), selectable via Settings → General → Theme → **Wallaby**, reachable via **Spaces → Habits**.
+  - **Integration.** `wallaby-dark` / `wallaby-light` registered in the three theme sync points (`index.html` pre-paint, `AppV2.jsx` mount effect, `SettingsModal` picker — now a Standard/Terminal/**Wallaby** family toggle). `palette.css` imported via `AppV2.css`. `HabitsView` mounts as a full-screen overlay (`.v2-habits-overlay`, back button) fed by live `useRoutines` routines; new `onOpenHabits` row in `SpacesHub`; `showHabits` added to the escape stack. Base `--wb-*` defaults defined for every v2 theme so the surface always resolves its tokens.
   - **New `src/v2/wallaby/`.** `palette.css` — two palettes (`wallaby-dark` flagship + `wallaby-light`) that override the shared `--v2-*` tokens and add structural `--wb-*` tokens (card surfaces, per-habit category accents blue/purple/green/orange/pink, heatmap cells, semantic action colors orange=primary/green=complete/yellow=pause/red=delete/slate=secondary, colorful FABs). `ContributionHeatmap.{jsx,css}` — GitHub-style grid (weeks × 7 days, local-time bucketing, per-color intensity). `heatmapUtils.js` — day bucketing, per-habit color cycling, streak, week/month helpers. `HabitsView.{jsx,css}` — the screen: heavy grotesk "Habits" title, Single/Week/Month segmented control, week + month date steppers, habit cards (color icon tile + title + streak/count badges + the grid), purple FAB. Each habit gets a distinct color by list index.
   - **Verification.** Rendered in isolation via `wallaby-preview.html` + `src/wallaby-preview.jsx` (dev-only harness, mock routine data) and screenshot-checked against IMG_1573 (Single) / IMG_1577 (Week). Not imported by `index.html`, so it does not affect the running app or ship to prod.
-  - **Status.** WIP pushed to a feature branch for preservation; not merged to `dev`. Next: 5-tab bottom nav (Home/Habits/Tasks/Goals/Profile) wiring HabitsView to live routines, then Tasks/Goals/Profile/Home surfaces.
+  - **Verification.** Built + screenshot-driven through the real app (Spaces → Habits in wallaby-dark renders the live seeded routines, paused ones filtered, weekly-cadence routines showing as single clean rows). Shipped to `dev` so it can be exercised against real routine data on `boomerang-dev:3002`.
+  - **Next.** Full IA remap continues: 5-tab bottom nav (Home/Habits/Tasks/Goals/Profile) promoting Habits from the Spaces hub to a top-level tab, then Tasks/Goals/Profile/Home surfaces.
 
 ## 2026-06-04
 

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -4,6 +4,14 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ---
 
+## 2026-06-06
+
+- feat(ui): Wallaby design language — Habits surface (WIP, not yet wired into app) [L]
+  - **What.** First surface of a full IA remap toward the loggd.life reference: a deep-navy, heatmap-first dashboard language named **Wallaby**. This commit adds the theme + the **Habits** screen (Boomerang routines rendered as loggd-style habit cards).
+  - **New `src/v2/wallaby/`.** `palette.css` — two palettes (`wallaby-dark` flagship + `wallaby-light`) that override the shared `--v2-*` tokens and add structural `--wb-*` tokens (card surfaces, per-habit category accents blue/purple/green/orange/pink, heatmap cells, semantic action colors orange=primary/green=complete/yellow=pause/red=delete/slate=secondary, colorful FABs). `ContributionHeatmap.{jsx,css}` — GitHub-style grid (weeks × 7 days, local-time bucketing, per-color intensity). `heatmapUtils.js` — day bucketing, per-habit color cycling, streak, week/month helpers. `HabitsView.{jsx,css}` — the screen: heavy grotesk "Habits" title, Single/Week/Month segmented control, week + month date steppers, habit cards (color icon tile + title + streak/count badges + the grid), purple FAB. Each habit gets a distinct color by list index.
+  - **Verification.** Rendered in isolation via `wallaby-preview.html` + `src/wallaby-preview.jsx` (dev-only harness, mock routine data) and screenshot-checked against IMG_1573 (Single) / IMG_1577 (Week). Not imported by `index.html`, so it does not affect the running app or ship to prod.
+  - **Status.** WIP pushed to a feature branch for preservation; not merged to `dev`. Next: 5-tab bottom nav (Home/Habits/Tasks/Goals/Profile) wiring HabitsView to live routines, then Tasks/Goals/Profile/Home surfaces.
+
 ## 2026-06-04
 
 - fix(ui): tic-tac-toe text/labels actually follow the active theme [XS]


### PR DESCRIPTION
Ships the first surface of the Wallaby IA remap so it can be exercised against real routine data on `boomerang-dev:3002`.

## What's here
- **Wallaby design language** (`src/v2/wallaby/`): `palette.css` (wallaby-dark flagship + wallaby-light, overriding `--v2-*`, adding `--wb-*`), `ContributionHeatmap`, `heatmapUtils`, `HabitsView` (Single/Week/Month).
- **Habits surface** — Boomerang routines rendered as loggd-style per-color contribution heatmap cards (paused routines filtered, weekly-cadence routines read as clean single rows).
- **Wired into the app**: theme registered in all three sync points (`index.html`, `AppV2`, `SettingsModal` — now a Standard/Terminal/**Wallaby** family toggle); Habits reachable via **Spaces → Habits** as a full-screen overlay with a back button; `showHabits` in the escape stack; base `--wb-*` defaults so the surface resolves in any theme.

## How to see it
Settings → General → Theme → **Wallaby** (+ Dark), then **Spaces → Habits**.

## Verification
- `npm run build` green, `npm run lint` 0 errors.
- Screenshot-driven through the real app (headless Chromium): Spaces → Habits in wallaby-dark renders the live seeded routines with correct per-habit colors, totals, and weekly-cadence rows.
- New runtime files live under `src/`, so they ship via the Vite bundle — no Dockerfile change. The `wallaby-preview.*` harness is dev-only (not imported by `index.html`), so it doesn't ship to prod.

## Not in scope (next)
Full IA remap continues: 5-tab bottom nav promoting Habits to a top-level tab, then Tasks / Goals / Profile / Home surfaces.

https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk)_