### PR TITLE
feat(ui): Wallaby Tasks surface (wired into app)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1009,12 +1009,18 @@ tokens even if reached from a non-Wallaby theme.
   non-paused) as habit cards: color icon tile + title + streak/count badges +
   the grid. Single (full heatmap) / Week (7 day-cells + date stepper) / Month
   (calendar grid). Distinct per-habit color by list index. Purple FAB.
+- `TasksView.{jsx,css}` — the **Tasks** screen. Segmented Upcoming/Backlog,
+  tasks grouped (Overdue/Today/Upcoming/Anytime), pink square checkboxes
+  (orange for high-pri), label chips from `tags`, nested checklist items as
+  circular sub-checkboxes, search filter, green FAB.
 
-**How Habits is reached (interim).** Mounted as a full-screen overlay
-(`.v2-habits-overlay` in `AppV2.css`) via **Spaces → Habits** (`onOpenHabits`
-row in `SpacesHub`, `showHabits` state + escape-stack entry in `AppV2`). The
-full remap promotes it to a top-level **bottom-nav tab** (Home/Habits/Tasks/
-Goals/Profile) — not yet built.
+**How the surfaces are reached (interim).** Each mounts as a full-screen overlay
+(`.v2-habits-overlay` in `AppV2.css`) via the **Spaces hub**: Habits
+(`onOpenHabits`/`showHabits`) and Tasks (`onOpenTasks`/`showTasks`), each with a
+back button and an escape-stack entry in `AppV2`. Tasks checkbox →
+`handleComplete`; subtask toggle → `updateTask({ checklists })`; row →
+`EditTaskModal`. The full remap promotes these to top-level **bottom-nav tabs**
+(Home/Habits/Tasks/Goals/Profile) — not yet built.
 
 **Dev-only render harness.** `wallaby-preview.html` + `src/wallaby-preview.jsx`
 mount `HabitsView` in isolation (mock or API-injected routines) for
@@ -1022,9 +1028,8 @@ screenshot verification. NOT imported by `index.html`, so it never ships to
 prod or affects the running app. Verified via a headless-Chromium (puppeteer)
 screenshot loop — render before claiming a surface works.
 
-**Remaining surfaces (not built):** 5-tab bottom nav, Tasks (segmented
-Upcoming/Backlog, pink checkboxes, nested subtasks, green FAB), Goals (project
-detail with metric + semantic buttons), Profile (avatar + stat pills + activity
+**Remaining surfaces (not built):** 5-tab bottom nav, Goals (project detail
+with metric + semantic buttons), Profile (avatar + stat pills + activity
 year-grid), Home dashboard.
 
 ## Additional Notes

--- a/src/v2/AppV2.jsx
+++ b/src/v2/AppV2.jsx
@@ -19,6 +19,7 @@ import DoneList from './components/DoneList'
 import ActivityLog from './components/ActivityLog'
 import RoutinesModal from './components/RoutinesModal'
 import HabitsView from './wallaby/HabitsView'
+import TasksView from './wallaby/TasksView'
 import SuggestionsModal from './components/SuggestionsModal'
 import PackagesModal from './components/PackagesModal'
 import AdviserModal from './components/AdviserModal'
@@ -92,6 +93,8 @@ export default function AppV2() {
   // Wallaby Habits surface — routines rendered as loggd-style heatmap cards.
   // Reachable from the Spaces hub; full-screen overlay above the app.
   const [showHabits, setShowHabits] = useState(false)
+  // Wallaby Tasks surface — loggd-style task list (segmented + subtasks).
+  const [showTasks, setShowTasks] = useState(false)
   const [editRoutineId, setEditRoutineId] = useState(null)
   const [showPackages, setShowPackages] = useState(false)
   const [showAdviser, setShowAdviser] = useState(false)
@@ -483,6 +486,7 @@ export default function AppV2() {
     if (showDone) { setShowDone(false); return }
     if (showActivityLog) { setShowActivityLog(false); return }
     if (showHabits) { setShowHabits(false); return }
+    if (showTasks) { setShowTasks(false); return }
     if (showRoutines) { setShowRoutines(false); return }
     if (showPackages) { setShowPackages(false); return }
     if (showAdviser) { setShowAdviser(false); return }
@@ -491,7 +495,7 @@ export default function AppV2() {
     if (spacesHubOpen) { setSpacesHubOpen(false); setActiveTab('today'); return }
     if (systemMenuOpen) { setSystemMenuOpen(false); return }
     if (searchOpen) { handleCloseSearch(); return }
-  }, [snoozeTarget, reframeTarget, editTarget, showAdd, showWhatNow, showSettings, showProjects, showDone, showActivityLog, showHabits, showRoutines, showPackages, showAdviser, showAnalytics, showSuggestions, spacesHubOpen, systemMenuOpen, searchOpen, handleCloseSearch])
+  }, [snoozeTarget, reframeTarget, editTarget, showAdd, showWhatNow, showSettings, showProjects, showDone, showActivityLog, showHabits, showTasks, showRoutines, showPackages, showAdviser, showAnalytics, showSuggestions, spacesHubOpen, systemMenuOpen, searchOpen, handleCloseSearch])
 
   const focusSearchInput = useCallback(() => {
     setSearchOpen(true)
@@ -1159,6 +1163,7 @@ export default function AppV2() {
         onOpenProjects={() => setShowProjects(true)}
         onOpenRoutines={() => setShowRoutines(true)}
         onOpenHabits={() => setShowHabits(true)}
+        onOpenTasks={() => setShowTasks(true)}
         onOpenKnowledge={() => {
           setAdviserDraftSeed("What's in my knowledge base?")
           setShowAdviser(true)
@@ -1170,6 +1175,24 @@ export default function AppV2() {
             routines={routines}
             onAdd={() => { setShowHabits(false); setShowRoutines(true) }}
             onClose={() => setShowHabits(false)}
+          />
+        </div>
+      )}
+      {showTasks && (
+        <div className="v2-habits-overlay">
+          <TasksView
+            tasks={tasks}
+            labels={labels}
+            onToggleComplete={(task) => handleComplete(task.id)}
+            onToggleItem={(task, clId, itemId) => {
+              const checklists = (task.checklists || []).map(cl =>
+                cl.id !== clId ? cl : { ...cl, items: (cl.items || []).map(it => it.id === itemId ? { ...it, completed: !it.completed } : it) },
+              )
+              updateTask(task.id, { checklists })
+            }}
+            onOpenTask={(task) => { setShowTasks(false); setEditTarget(task) }}
+            onAdd={() => { setShowTasks(false); setShowAdd(true) }}
+            onClose={() => setShowTasks(false)}
           />
         </div>
       )}

--- a/src/v2/components/SpacesHub.jsx
+++ b/src/v2/components/SpacesHub.jsx
@@ -1,4 +1,4 @@
-import { FolderKanban, RotateCw, BookOpen, Activity, ChevronRight } from 'lucide-react'
+import { FolderKanban, RotateCw, BookOpen, Activity, ListTodo, ChevronRight } from 'lucide-react'
 import ModalShell from './ModalShell'
 import './SpacesHub.css'
 
@@ -13,7 +13,7 @@ import './SpacesHub.css'
 // the same hub a richer data shape.
 export default function SpacesHub({
   open, onClose,
-  onOpenProjects, onOpenRoutines, onOpenHabits, onOpenKnowledge,
+  onOpenProjects, onOpenRoutines, onOpenHabits, onOpenTasks, onOpenKnowledge,
 }) {
   const rows = [
     {
@@ -24,6 +24,15 @@ export default function SpacesHub({
       subtitle: 'Routines as contribution heatmaps',
       terminalCmd: '> habits',
       onClick: onOpenHabits,
+    },
+    {
+      key: 'tasks',
+      icon: ListTodo,
+      tint: 'projects',
+      label: 'Tasks',
+      subtitle: 'Upcoming + backlog · subtasks',
+      terminalCmd: '> tasks',
+      onClick: onOpenTasks,
     },
     {
       key: 'projects',

--- a/src/v2/wallaby/TasksView.css
+++ b/src/v2/wallaby/TasksView.css
@@ -1,0 +1,210 @@
+/* Wallaby "Tasks" surface. Pink square checkboxes, nested checklist sub-rows,
+ * colored label chips, green FAB. Shares the navy canvas + segmented control
+ * language with HabitsView. */
+
+.wb-tasks {
+  min-height: 100vh;
+  background: var(--wb-bg);
+  color: var(--wb-text);
+  padding: 16px 16px 120px;
+  font-family: var(--v2-font-body);
+  -webkit-font-smoothing: antialiased;
+}
+
+.wb-tasks-head { margin-bottom: 14px; }
+.wb-tasks-titlerow {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 14px;
+}
+.wb-tasks-title {
+  margin: 0 auto 0 0;
+  font-family: var(--v2-font-display);
+  font-size: 28px;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+}
+.wb-icon-btn {
+  display: grid;
+  place-items: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 10px;
+  border: 1px solid var(--wb-hairline);
+  background: var(--wb-card);
+  color: var(--wb-text-meta);
+  cursor: pointer;
+  flex: 0 0 auto;
+}
+.wb-icon-btn.is-active { color: var(--wb-text); border-color: var(--wb-hairline-strong); }
+
+/* Segmented control — full width on Tasks */
+.wb-tasks .wb-seg {
+  display: flex;
+  width: 100%;
+  background: var(--wb-card-2);
+  border: 1px solid var(--wb-hairline);
+  border-radius: 999px;
+  padding: 3px;
+  gap: 2px;
+}
+.wb-tasks .wb-seg-btn {
+  flex: 1 1 0;
+  appearance: none;
+  border: none;
+  background: transparent;
+  color: var(--wb-text-meta);
+  font: 600 13px/1 var(--v2-font-body);
+  padding: 9px 13px;
+  border-radius: 999px;
+  cursor: pointer;
+}
+.wb-tasks .wb-seg-btn.is-active {
+  background: var(--wb-card-3);
+  color: var(--wb-text);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
+}
+
+.wb-tasks-search {
+  width: 100%;
+  margin-top: 10px;
+  padding: 11px 14px;
+  border-radius: 12px;
+  border: 1px solid var(--wb-hairline);
+  background: var(--wb-card);
+  color: var(--wb-text);
+  font-size: 14px;
+}
+.wb-tasks-search::placeholder { color: var(--wb-text-meta); }
+
+/* ── List ────────────────────────────────────────────────────────────────── */
+.wb-tasks-empty { color: var(--wb-text-meta); text-align: center; padding: 40px 0; }
+
+.wb-tasks-section { margin-bottom: 18px; }
+.wb-tasks-section-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0 4px 8px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--wb-text-meta);
+}
+.wb-tasks-count {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--wb-text-meta);
+  background: var(--wb-card-2);
+  border-radius: 999px;
+  padding: 1px 7px;
+}
+
+.wb-task {
+  background: var(--wb-card);
+  border: 1px solid var(--wb-hairline);
+  border-radius: 14px;
+  padding: 13px 14px;
+  margin-bottom: 8px;
+}
+.wb-task-main {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+/* Pink square checkbox */
+.wb-check {
+  flex: 0 0 auto;
+  width: 22px;
+  height: 22px;
+  margin-top: 1px;
+  border-radius: 6px;
+  border: 2px solid var(--wb-cat-pink);
+  background: transparent;
+  cursor: pointer;
+  transition: background 120ms ease;
+}
+.wb-check:hover { background: color-mix(in srgb, var(--wb-cat-pink) 22%, transparent); }
+.wb-check-hi { border-color: var(--wb-action-primary); }
+
+.wb-task-body {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  background: none;
+  border: none;
+  padding: 0;
+  text-align: left;
+  cursor: pointer;
+}
+.wb-task-title {
+  font-size: 15px;
+  font-weight: 550;
+  color: var(--wb-text);
+  line-height: 1.3;
+}
+.wb-task-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+}
+.wb-task-due {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--wb-text-meta);
+}
+.wb-task-due-overdue { color: var(--wb-action-delete); }
+.wb-task-due-today { color: var(--wb-action-primary); }
+.wb-task-tag {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--tag, var(--wb-text-meta));
+  background: color-mix(in srgb, var(--tag, #888) 18%, transparent);
+  border-radius: 999px;
+  padding: 2px 9px;
+}
+
+/* Nested checklist sub-rows */
+.wb-subtasks {
+  list-style: none;
+  margin: 10px 0 0;
+  padding: 0 0 0 34px;
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+}
+.wb-subtask {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+}
+.wb-subcheck {
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: 1.5px solid var(--wb-hairline-strong);
+  background: transparent;
+  color: #fff;
+  cursor: pointer;
+}
+.wb-subcheck.is-done {
+  background: var(--wb-action-complete);
+  border-color: var(--wb-action-complete);
+}
+.wb-subtask-text {
+  font-size: 13.5px;
+  color: var(--wb-text-meta);
+}
+.wb-subtask-text.is-done {
+  text-decoration: line-through;
+  opacity: 0.6;
+}

--- a/src/v2/wallaby/TasksView.jsx
+++ b/src/v2/wallaby/TasksView.jsx
@@ -1,0 +1,190 @@
+import { useMemo, useState } from 'react'
+import { ArrowLeft, Search, Plus, Check } from 'lucide-react'
+import { localYMD } from './heatmapUtils'
+import './TasksView.css'
+
+const ACTIVE = ['not_started', 'doing', 'waiting', 'in_progress']
+
+// Wallaby "Tasks" surface — loggd-style task list. Segmented Upcoming / Backlog,
+// pink square checkboxes, nested checklist items as circular sub-checkboxes,
+// colored label chips, green FAB. Reads Boomerang's task + label shape directly.
+export default function TasksView({
+  tasks = [], labels = [],
+  onToggleComplete, onToggleItem, onAdd, onClose, onOpenTask,
+}) {
+  const [tab, setTab] = useState('upcoming')
+  const [query, setQuery] = useState('')
+  const [searchOpen, setSearchOpen] = useState(false)
+
+  const labelsById = useMemo(() => {
+    const m = {}
+    for (const l of labels) m[l.id] = l
+    return m
+  }, [labels])
+
+  const visible = useMemo(() => {
+    const q = query.trim().toLowerCase()
+    return tasks.filter(t => {
+      if (t.gmail_pending) return false
+      if (t.parent_id) return false
+      if (tab === 'backlog' ? t.status !== 'backlog' : !ACTIVE.includes(t.status)) return false
+      if (q && !t.title.toLowerCase().includes(q)) return false
+      return true
+    })
+  }, [tasks, tab, query])
+
+  const sections = useMemo(() => groupTasks(visible, tab), [visible, tab])
+
+  return (
+    <div className="wb-tasks">
+      <header className="wb-tasks-head">
+        <div className="wb-tasks-titlerow">
+          {onClose && (
+            <button className="wb-back" onClick={onClose} aria-label="Back">
+              <ArrowLeft size={20} strokeWidth={2.25} />
+            </button>
+          )}
+          <h1 className="wb-tasks-title">Tasks</h1>
+          <button
+            className={`wb-icon-btn${searchOpen ? ' is-active' : ''}`}
+            onClick={() => { setSearchOpen(o => !o); if (searchOpen) setQuery('') }}
+            aria-label="Search tasks"
+          >
+            <Search size={18} strokeWidth={2} />
+          </button>
+        </div>
+
+        <div className="wb-seg" role="tablist" aria-label="Task list">
+          {[{ id: 'upcoming', label: 'Upcoming' }, { id: 'backlog', label: 'Backlog' }].map(t => (
+            <button
+              key={t.id}
+              role="tab"
+              aria-selected={tab === t.id}
+              className={`wb-seg-btn${tab === t.id ? ' is-active' : ''}`}
+              onClick={() => setTab(t.id)}
+            >{t.label}</button>
+          ))}
+        </div>
+
+        {searchOpen && (
+          <input
+            className="wb-tasks-search"
+            placeholder="Search tasks…"
+            value={query}
+            onChange={e => setQuery(e.target.value)}
+            autoFocus
+          />
+        )}
+      </header>
+
+      <div className="wb-tasks-list">
+        {sections.length === 0 && (
+          <p className="wb-tasks-empty">Nothing here.</p>
+        )}
+        {sections.map(sec => (
+          <section key={sec.key} className="wb-tasks-section">
+            <h2 className="wb-tasks-section-label">{sec.label} <span className="wb-tasks-count">{sec.items.length}</span></h2>
+            {sec.items.map(task => (
+              <TaskRow
+                key={task.id}
+                task={task}
+                labelsById={labelsById}
+                onToggleComplete={onToggleComplete}
+                onToggleItem={onToggleItem}
+                onOpenTask={onOpenTask}
+              />
+            ))}
+          </section>
+        ))}
+      </div>
+
+      <button className="wb-fab wb-fab-tasks" onClick={onAdd} aria-label="New task">
+        <Plus size={26} strokeWidth={2.5} />
+      </button>
+    </div>
+  )
+}
+
+function TaskRow({ task, labelsById, onToggleComplete, onToggleItem, onOpenTask }) {
+  const items = (Array.isArray(task.checklists) ? task.checklists : []).flatMap(cl =>
+    (cl.items || []).map(it => ({ ...it, clId: cl.id })),
+  )
+  const due = dueMeta(task.due_date)
+  const tagChips = (task.tags || []).map(id => labelsById[id]).filter(Boolean)
+
+  return (
+    <div className="wb-task">
+      <div className="wb-task-main">
+        <button
+          className={`wb-check${task.high_priority ? ' wb-check-hi' : ''}`}
+          onClick={() => onToggleComplete?.(task)}
+          aria-label="Complete task"
+        />
+        <button className="wb-task-body" onClick={() => onOpenTask?.(task)}>
+          <span className="wb-task-title">{task.title}</span>
+          {(tagChips.length > 0 || due) && (
+            <span className="wb-task-meta">
+              {due && <span className={`wb-task-due${due.tone ? ` wb-task-due-${due.tone}` : ''}`}>{due.label}</span>}
+              {tagChips.map(l => (
+                <span key={l.id} className="wb-task-tag" style={{ '--tag': l.color }}>{l.name}</span>
+              ))}
+            </span>
+          )}
+        </button>
+      </div>
+      {items.length > 0 && (
+        <ul className="wb-subtasks">
+          {items.map(it => (
+            <li key={it.id} className="wb-subtask">
+              <button
+                className={`wb-subcheck${it.completed ? ' is-done' : ''}`}
+                onClick={() => onToggleItem?.(task, it.clId, it.id)}
+                aria-label={it.completed ? 'Uncheck' : 'Check'}
+              >
+                {it.completed && <Check size={11} strokeWidth={3} />}
+              </button>
+              <span className={`wb-subtask-text${it.completed ? ' is-done' : ''}`}>{it.text}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}
+
+function dueMeta(due) {
+  if (!due) return null
+  const today = localYMD(new Date())
+  const d = localYMD(due)
+  if (!d) return null
+  const t = new Date(); t.setHours(0, 0, 0, 0)
+  const dd = new Date(due); dd.setHours(0, 0, 0, 0)
+  const diff = Math.round((dd - t) / 86400000)
+  if (d < today) return { label: `${Math.abs(diff)}d overdue`, tone: 'overdue' }
+  if (diff === 0) return { label: 'Today', tone: 'today' }
+  if (diff === 1) return { label: 'Tomorrow' }
+  if (diff < 7) return { label: dd.toLocaleDateString('en-US', { weekday: 'short' }) }
+  return { label: dd.toLocaleDateString('en-US', { month: 'short', day: 'numeric' }) }
+}
+
+function groupTasks(list, tab) {
+  if (tab === 'backlog') {
+    return list.length ? [{ key: 'backlog', label: 'Backlog', items: list }] : []
+  }
+  const today = localYMD(new Date())
+  const buckets = { overdue: [], today: [], soon: [], anytime: [] }
+  for (const t of list) {
+    if (!t.due_date) { buckets.anytime.push(t); continue }
+    const d = localYMD(t.due_date)
+    if (d < today) buckets.overdue.push(t)
+    else if (d === today) buckets.today.push(t)
+    else buckets.soon.push(t)
+  }
+  const byDue = (a, b) => (a.due_date || '').localeCompare(b.due_date || '')
+  const out = []
+  if (buckets.overdue.length) out.push({ key: 'overdue', label: 'Overdue', items: buckets.overdue.sort(byDue) })
+  if (buckets.today.length) out.push({ key: 'today', label: 'Today', items: buckets.today })
+  if (buckets.soon.length) out.push({ key: 'soon', label: 'Upcoming', items: buckets.soon.sort(byDue) })
+  if (buckets.anytime.length) out.push({ key: 'anytime', label: 'Anytime', items: buckets.anytime })
+  return out
+}

--- a/src/wallaby-preview.jsx
+++ b/src/wallaby-preview.jsx
@@ -6,6 +6,7 @@ import './index.css'
 import './v2/tokens.css'
 import './v2/wallaby/palette.css'
 import HabitsView from './v2/wallaby/HabitsView'
+import TasksView from './v2/wallaby/TasksView'
 
 document.documentElement.setAttribute('data-ui', 'v2')
 document.documentElement.setAttribute('data-theme', new URLSearchParams(location.search).get('theme') || 'wallaby-dark')
@@ -42,6 +43,19 @@ const data = window.__WALLABY_ROUTINES__ && window.__WALLABY_ROUTINES__.length
   ? window.__WALLABY_ROUTINES__
   : routines
 
-createRoot(document.getElementById('root')).render(
-  <HabitsView routines={data} onAdd={() => {}} />,
-)
+const surface = new URLSearchParams(location.search).get('surface') || 'habits'
+const root = createRoot(document.getElementById('root'))
+
+if (surface === 'tasks') {
+  root.render(
+    <TasksView
+      tasks={window.__WALLABY_TASKS__ || []}
+      labels={window.__WALLABY_LABELS__ || []}
+      onToggleComplete={() => {}}
+      onToggleItem={() => {}}
+      onAdd={() => {}}
+    />,
+  )
+} else {
+  root.render(<HabitsView routines={data} onAdd={() => {}} />)
+}

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,11 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-06
 
+- feat(ui): Wallaby Tasks surface, wired into the app [M]
+  - **What.** Second Wallaby surface (loggd `IMG_1575`): `src/v2/wallaby/TasksView.{jsx,css}`. Segmented **Upcoming / Backlog**, tasks grouped (Overdue / Today / Upcoming / Anytime), **pink square checkboxes** (orange for high-priority), colored label chips resolved from `tags` → labels, overdue/today due meta, **nested checklist items** as circular sub-checkboxes (completed = filled green + strikethrough), search filter, green FAB.
+  - **Wiring.** Reachable via **Spaces → Tasks** (`onOpenTasks` row in `SpacesHub`, `showTasks` overlay + escape-stack entry in `AppV2`). Checkbox → `handleComplete`; subtask toggle → `updateTask({ checklists })`; row tap → `EditTaskModal`; FAB → AddTaskModal. Fed by live `tasks` + `labels`.
+  - **Verification.** Screenshot-driven through the real app (Spaces → Tasks in wallaby-dark renders 42 live tasks with correct grouping, chips, and nested checklist toggles). New file under `src/`, ships via Vite bundle — no Dockerfile change.
+
 - feat(ui): Wallaby design language — Habits surface, wired into the app [L]
   - **What.** First surface of a full IA remap toward the loggd.life reference: a deep-navy, heatmap-first dashboard language named **Wallaby**. Adds the theme + the **Habits** screen (Boomerang routines rendered as loggd-style habit cards), selectable via Settings → General → Theme → **Wallaby**, reachable via **Spaces → Habits**.
   - **Integration.** `wallaby-dark` / `wallaby-light` registered in the three theme sync points (`index.html` pre-paint, `AppV2.jsx` mount effect, `SettingsModal` picker — now a Standard/Terminal/**Wallaby** family toggle). `palette.css` imported via `AppV2.css`. `HabitsView` mounts as a full-screen overlay (`.v2-habits-overlay`, back button) fed by live `useRoutines` routines; new `onOpenHabits` row in `SpacesHub`; `showHabits` added to the escape stack. Base `--wb-*` defaults defined for every v2 theme so the surface always resolves its tokens.


### PR DESCRIPTION
Second Wallaby surface — the **Tasks** screen from loggd `IMG_1575`.

## What's here
`src/v2/wallaby/TasksView.{jsx,css}`:
- Segmented **Upcoming / Backlog**; Upcoming grouped into Overdue / Today / Upcoming / Anytime
- **Pink square checkboxes** (orange for high-priority) → complete the task
- Colored **label chips** resolved from `tags` → labels
- Overdue/Today **due meta**
- **Nested checklist items** as circular sub-checkboxes (completed = filled green + strikethrough) → toggle saves via `updateTask`
- Search filter, green FAB

## Wiring
Reachable via **Spaces → Tasks** (interim, like Habits — both promote to bottom-nav tabs in the full remap). Checkbox → `handleComplete`; row tap → `EditTaskModal`; FAB → AddTaskModal. Fed by live `tasks` + `labels`.

## Verification
- `npm run build` green, `npm run lint` 0 errors.
- Driven through the real built app (headless Chromium): Spaces → Tasks in wallaby-dark renders 42 live tasks with correct grouping, chips, and the nested checklist toggle styling (verified against a task with a 5-item checklist).
- New file under `src/` → ships via Vite bundle, no Dockerfile change.

## Next
Goals (project detail + semantic buttons), Profile (stat pills + year-grid), then the 5-tab bottom nav to unify Home/Habits/Tasks/Goals/Profile.

https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk)_