### PR TITLE
feat(ui): Wallaby Profile/dashboard surface

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1013,14 +1013,20 @@ tokens even if reached from a non-Wallaby theme.
   tasks grouped (Overdue/Today/Upcoming/Anytime), pink square checkboxes
   (orange for high-pri), label chips from `tags`, nested checklist items as
   circular sub-checkboxes, search filter, green FAB.
+- `ProfileView.{jsx,css}` — the **Profile/Dashboard** screen. Gradient avatar +
+  "Your year" header, scrollable colorful stat pills (streak / points / done /
+  best streak / lifetime), an Activity 53-week year-grid (Tasks/Points toggle,
+  from `/api/analytics/history`), and per-habit grids. Stat values passed from
+  AppV2; year history fetched internally.
 
 **How the surfaces are reached (interim).** Each mounts as a full-screen overlay
-(`.v2-habits-overlay` in `AppV2.css`) via the **Spaces hub**: Habits
-(`onOpenHabits`/`showHabits`) and Tasks (`onOpenTasks`/`showTasks`), each with a
-back button and an escape-stack entry in `AppV2`. Tasks checkbox →
-`handleComplete`; subtask toggle → `updateTask({ checklists })`; row →
-`EditTaskModal`. The full remap promotes these to top-level **bottom-nav tabs**
-(Home/Habits/Tasks/Goals/Profile) — not yet built.
+(`.v2-habits-overlay` in `AppV2.css`) via the **Spaces hub**: Dashboard
+(`onOpenProfile`/`showProfile`), Habits (`onOpenHabits`/`showHabits`), Tasks
+(`onOpenTasks`/`showTasks`), each with a back button and an escape-stack entry in
+`AppV2`. Tasks checkbox → `handleComplete`; subtask toggle →
+`updateTask({ checklists })`; row → `EditTaskModal`. The full remap promotes
+these to top-level **bottom-nav tabs** (Home/Habits/Tasks/Goals/Profile) — not
+yet built.
 
 **Dev-only render harness.** `wallaby-preview.html` + `src/wallaby-preview.jsx`
 mount `HabitsView` in isolation (mock or API-injected routines) for
@@ -1029,8 +1035,7 @@ prod or affects the running app. Verified via a headless-Chromium (puppeteer)
 screenshot loop — render before claiming a surface works.
 
 **Remaining surfaces (not built):** 5-tab bottom nav, Goals (project detail
-with metric + semantic buttons), Profile (avatar + stat pills + activity
-year-grid), Home dashboard.
+with metric + semantic buttons), Home dashboard.
 
 ## Additional Notes
 - Single developer (ryakel) — no PR review process needed.

--- a/src/v2/AppV2.jsx
+++ b/src/v2/AppV2.jsx
@@ -20,6 +20,7 @@ import ActivityLog from './components/ActivityLog'
 import RoutinesModal from './components/RoutinesModal'
 import HabitsView from './wallaby/HabitsView'
 import TasksView from './wallaby/TasksView'
+import ProfileView from './wallaby/ProfileView'
 import SuggestionsModal from './components/SuggestionsModal'
 import PackagesModal from './components/PackagesModal'
 import AdviserModal from './components/AdviserModal'
@@ -95,6 +96,8 @@ export default function AppV2() {
   const [showHabits, setShowHabits] = useState(false)
   // Wallaby Tasks surface — loggd-style task list (segmented + subtasks).
   const [showTasks, setShowTasks] = useState(false)
+  // Wallaby Profile/dashboard — stat pills + activity year-grid + habit grids.
+  const [showProfile, setShowProfile] = useState(false)
   const [editRoutineId, setEditRoutineId] = useState(null)
   const [showPackages, setShowPackages] = useState(false)
   const [showAdviser, setShowAdviser] = useState(false)
@@ -487,6 +490,7 @@ export default function AppV2() {
     if (showActivityLog) { setShowActivityLog(false); return }
     if (showHabits) { setShowHabits(false); return }
     if (showTasks) { setShowTasks(false); return }
+    if (showProfile) { setShowProfile(false); return }
     if (showRoutines) { setShowRoutines(false); return }
     if (showPackages) { setShowPackages(false); return }
     if (showAdviser) { setShowAdviser(false); return }
@@ -495,7 +499,7 @@ export default function AppV2() {
     if (spacesHubOpen) { setSpacesHubOpen(false); setActiveTab('today'); return }
     if (systemMenuOpen) { setSystemMenuOpen(false); return }
     if (searchOpen) { handleCloseSearch(); return }
-  }, [snoozeTarget, reframeTarget, editTarget, showAdd, showWhatNow, showSettings, showProjects, showDone, showActivityLog, showHabits, showTasks, showRoutines, showPackages, showAdviser, showAnalytics, showSuggestions, spacesHubOpen, systemMenuOpen, searchOpen, handleCloseSearch])
+  }, [snoozeTarget, reframeTarget, editTarget, showAdd, showWhatNow, showSettings, showProjects, showDone, showActivityLog, showHabits, showTasks, showProfile, showRoutines, showPackages, showAdviser, showAnalytics, showSuggestions, spacesHubOpen, systemMenuOpen, searchOpen, handleCloseSearch])
 
   const focusSearchInput = useCallback(() => {
     setSearchOpen(true)
@@ -1164,6 +1168,7 @@ export default function AppV2() {
         onOpenRoutines={() => setShowRoutines(true)}
         onOpenHabits={() => setShowHabits(true)}
         onOpenTasks={() => setShowTasks(true)}
+        onOpenProfile={() => setShowProfile(true)}
         onOpenKnowledge={() => {
           setAdviserDraftSeed("What's in my knowledge base?")
           setShowAdviser(true)
@@ -1193,6 +1198,18 @@ export default function AppV2() {
             onOpenTask={(task) => { setShowTasks(false); setEditTarget(task) }}
             onAdd={() => { setShowTasks(false); setShowAdd(true) }}
             onClose={() => setShowTasks(false)}
+          />
+        </div>
+      )}
+      {showProfile && (
+        <div className="v2-habits-overlay">
+          <ProfileView
+            dailyStats={dailyStats}
+            streak={streak}
+            records={records}
+            lifetimeDone={tasks.filter(t => t.status === 'done').length}
+            routines={routines}
+            onClose={() => setShowProfile(false)}
           />
         </div>
       )}

--- a/src/v2/components/SpacesHub.jsx
+++ b/src/v2/components/SpacesHub.jsx
@@ -1,4 +1,4 @@
-import { FolderKanban, RotateCw, BookOpen, Activity, ListTodo, ChevronRight } from 'lucide-react'
+import { FolderKanban, RotateCw, BookOpen, Activity, ListTodo, LayoutDashboard, ChevronRight } from 'lucide-react'
 import ModalShell from './ModalShell'
 import './SpacesHub.css'
 
@@ -13,9 +13,18 @@ import './SpacesHub.css'
 // the same hub a richer data shape.
 export default function SpacesHub({
   open, onClose,
-  onOpenProjects, onOpenRoutines, onOpenHabits, onOpenTasks, onOpenKnowledge,
+  onOpenProjects, onOpenRoutines, onOpenHabits, onOpenTasks, onOpenProfile, onOpenKnowledge,
 }) {
   const rows = [
+    {
+      key: 'dashboard',
+      icon: LayoutDashboard,
+      tint: 'projects',
+      label: 'Dashboard',
+      subtitle: 'Stats + your activity year',
+      terminalCmd: '> dashboard',
+      onClick: onOpenProfile,
+    },
     {
       key: 'habits',
       icon: Activity,

--- a/src/v2/wallaby/ContributionHeatmap.css
+++ b/src/v2/wallaby/ContributionHeatmap.css
@@ -35,7 +35,6 @@
   width: 100%;
   aspect-ratio: 1 / 1;
   min-width: 0;
-  height: var(--wb-cell, 12px);
   border-radius: var(--wb-radius, 2px);
   background: var(--wb-heat-empty, #1B2235);
   box-shadow: inset 0 0 0 1px var(--wb-heat-border, transparent);

--- a/src/v2/wallaby/ContributionHeatmap.jsx
+++ b/src/v2/wallaby/ContributionHeatmap.jsx
@@ -65,7 +65,7 @@ export default function ContributionHeatmap({
             <span
               key={i}
               className="wb-heat-month"
-              style={{ left: `calc(${m.index} * (var(--wb-cell) + var(--wb-gap)))` }}
+              style={{ left: `${(m.index / weeks) * 100}%` }}
             >{m.label}</span>
           ))}
         </div>

--- a/src/v2/wallaby/ProfileView.css
+++ b/src/v2/wallaby/ProfileView.css
@@ -1,0 +1,158 @@
+/* Wallaby "Profile" / dashboard surface. Avatar + colorful stat pills + the
+ * Activity year-grid + per-habit grids. Shares the navy canvas + segmented
+ * control + heatmap language with the other Wallaby surfaces. */
+
+.wb-profile {
+  min-height: 100vh;
+  background: var(--wb-bg);
+  color: var(--wb-text);
+  padding: 16px 16px 120px;
+  font-family: var(--v2-font-body);
+  -webkit-font-smoothing: antialiased;
+}
+
+/* ── Header (avatar + name + bio) ─────────────────────────────────────────── */
+.wb-profile-head {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  padding: 8px 0 18px;
+}
+.wb-profile-back { position: absolute; left: 0; top: 0; }
+.wb-profile-avatar {
+  display: grid;
+  place-items: center;
+  width: 72px;
+  height: 72px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--wb-cat-purple), var(--wb-cat-blue));
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+  margin-bottom: 12px;
+}
+.wb-profile-name {
+  margin: 0;
+  font-family: var(--v2-font-display);
+  font-size: 24px;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+}
+.wb-profile-bio {
+  margin: 4px 0 0;
+  font-size: 13px;
+  color: var(--wb-text-meta);
+}
+
+/* ── Stat pills (horizontal scroll row) ───────────────────────────────────── */
+.wb-profile-pills {
+  display: flex;
+  gap: 10px;
+  overflow-x: auto;
+  padding-bottom: 6px;
+  margin: 0 -16px 20px;
+  padding-left: 16px;
+  padding-right: 16px;
+  scrollbar-width: none;
+}
+.wb-profile-pills::-webkit-scrollbar { display: none; }
+.wb-profile-pill {
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  min-width: 92px;
+  padding: 14px 12px;
+  background: var(--wb-card);
+  border: 1px solid var(--wb-hairline);
+  border-radius: 16px;
+  box-shadow: var(--wb-shadow);
+}
+.wb-profile-pill-icon {
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  color: #fff;
+  background: var(--pill, var(--v2-accent));
+  margin-bottom: 2px;
+}
+.wb-profile-pill-value {
+  font-family: var(--v2-font-display);
+  font-size: 22px;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+}
+.wb-profile-pill-label {
+  font-size: 10.5px;
+  font-weight: 600;
+  color: var(--wb-text-meta);
+  text-align: center;
+  white-space: nowrap;
+}
+
+/* ── Sections ─────────────────────────────────────────────────────────────── */
+.wb-profile-section { margin-bottom: 22px; }
+.wb-profile-section-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 10px;
+}
+.wb-profile-section-title {
+  margin: 0 0 10px;
+  font-family: var(--v2-font-display);
+  font-size: 17px;
+  font-weight: 700;
+}
+.wb-profile-section-head .wb-profile-section-title { margin-bottom: 0; }
+
+/* Segmented control (reused) */
+.wb-profile .wb-seg {
+  display: inline-flex;
+  background: var(--wb-card-2);
+  border: 1px solid var(--wb-hairline);
+  border-radius: 999px;
+  padding: 3px;
+  gap: 2px;
+}
+.wb-profile .wb-seg-btn {
+  appearance: none;
+  border: none;
+  background: transparent;
+  color: var(--wb-text-meta);
+  font: 600 12px/1 var(--v2-font-body);
+  padding: 6px 12px;
+  border-radius: 999px;
+  cursor: pointer;
+}
+.wb-profile .wb-seg-btn.is-active {
+  background: var(--wb-card-3);
+  color: var(--wb-text);
+}
+
+.wb-profile-card {
+  background: var(--wb-card);
+  border: 1px solid var(--wb-hairline);
+  border-radius: 16px;
+  padding: 14px;
+  box-shadow: var(--wb-shadow);
+  margin-bottom: 10px;
+}
+.wb-profile-habit-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+.wb-profile-habit-title { font-size: 14px; font-weight: 650; }
+.wb-profile-habit-count {
+  font-size: 11.5px;
+  font-weight: 700;
+  color: var(--wb-text-meta);
+  background: var(--wb-card-2);
+  border-radius: 999px;
+  padding: 2px 8px;
+}

--- a/src/v2/wallaby/ProfileView.jsx
+++ b/src/v2/wallaby/ProfileView.jsx
@@ -1,0 +1,119 @@
+import { useEffect, useMemo, useState } from 'react'
+import { ArrowLeft, Flame, Zap, CheckCircle2, Trophy, Star, TrendingUp } from 'lucide-react'
+import ContributionHeatmap from './ContributionHeatmap'
+import { WALLABY_COLORS, historyByDay } from './heatmapUtils'
+import './ProfileView.css'
+
+// Wallaby "Profile" / dashboard surface (loggd IMG_1574): avatar + stat pills +
+// the big Activity year-grid heatmap + per-habit grids. Stat values come in as
+// props (computed by AppV2); the 365-day daily history is fetched here (or
+// injected via window/prop for the preview harness).
+export default function ProfileView({
+  dailyStats = {}, streak = 0, records = {}, lifetimeDone = 0,
+  routines = [], dailyHistory, onClose,
+}) {
+  const [history, setHistory] = useState(dailyHistory || null)
+  const [metric, setMetric] = useState('tasks')
+
+  useEffect(() => {
+    if (dailyHistory) { setHistory(dailyHistory); return }
+    if (typeof window !== 'undefined' && window.__WALLABY_HISTORY__) { setHistory(window.__WALLABY_HISTORY__); return }
+    fetch('/api/analytics/history?days=365')
+      .then(r => r.ok ? r.json() : null)
+      .then(d => { if (d) setHistory(d.daily) })
+      .catch(() => {})
+  }, [dailyHistory])
+
+  const valueByDay = useMemo(() => {
+    const m = {}
+    for (const d of (history || [])) m[d.day] = metric === 'points' ? d.points : d.tasks
+    return m
+  }, [history, metric])
+
+  const totalContrib = useMemo(
+    () => (history || []).reduce((n, d) => n + (metric === 'points' ? d.points : d.tasks), 0),
+    [history, metric],
+  )
+  const activeDays = useMemo(
+    () => (history || []).filter(d => (metric === 'points' ? d.points : d.tasks) > 0).length,
+    [history, metric],
+  )
+
+  const bestStreak = Math.max(streak, records?.longestStreak || 0)
+  const pills = [
+    { icon: Flame, label: 'Day streak', value: streak, color: 'var(--wb-cat-orange)' },
+    { icon: Zap, label: 'Points today', value: dailyStats?.pointsToday ?? 0, color: 'var(--wb-cat-purple)' },
+    { icon: CheckCircle2, label: 'Done today', value: dailyStats?.tasksToday ?? 0, color: 'var(--wb-cat-green)' },
+    { icon: Trophy, label: 'Best streak', value: bestStreak, color: 'var(--wb-cat-blue)' },
+    { icon: Star, label: 'Lifetime done', value: lifetimeDone, color: 'var(--wb-cat-pink)' },
+  ]
+
+  const habits = (routines || []).filter(r => (r.completed_history?.length || 0) > 0)
+
+  return (
+    <div className="wb-profile">
+      <header className="wb-profile-head">
+        {onClose && (
+          <button className="wb-back wb-profile-back" onClick={onClose} aria-label="Back">
+            <ArrowLeft size={20} strokeWidth={2.25} />
+          </button>
+        )}
+        <div className="wb-profile-avatar"><TrendingUp size={30} strokeWidth={2.25} color="#fff" /></div>
+        <h1 className="wb-profile-name">Your year</h1>
+        <p className="wb-profile-bio">{totalContrib} contributions · {activeDays} active day{activeDays === 1 ? '' : 's'}</p>
+      </header>
+
+      <div className="wb-profile-pills">
+        {pills.map(p => {
+          const Icon = p.icon
+          return (
+            <div key={p.label} className="wb-profile-pill" style={{ '--pill': p.color }}>
+              <span className="wb-profile-pill-icon"><Icon size={16} strokeWidth={2.25} /></span>
+              <span className="wb-profile-pill-value">{p.value}</span>
+              <span className="wb-profile-pill-label">{p.label}</span>
+            </div>
+          )
+        })}
+      </div>
+
+      <section className="wb-profile-section">
+        <div className="wb-profile-section-head">
+          <h2 className="wb-profile-section-title">Activity</h2>
+          <div className="wb-seg">
+            {[{ id: 'tasks', label: 'Tasks' }, { id: 'points', label: 'Points' }].map(m => (
+              <button
+                key={m.id}
+                className={`wb-seg-btn${metric === m.id ? ' is-active' : ''}`}
+                onClick={() => setMetric(m.id)}
+              >{m.label}</button>
+            ))}
+          </div>
+        </div>
+        <div className="wb-profile-card">
+          <ContributionHeatmap valueByDay={valueByDay} color="var(--wb-cat-green)" weeks={53} cellSize={9} gap={2} showMonths />
+        </div>
+      </section>
+
+      {habits.length > 0 && (
+        <section className="wb-profile-section">
+          <h2 className="wb-profile-section-title">Habits</h2>
+          {habits.map((r, i) => (
+            <div key={r.id} className="wb-profile-card wb-profile-habit">
+              <div className="wb-profile-habit-head">
+                <span className="wb-profile-habit-title">{r.title}</span>
+                <span className="wb-profile-habit-count">{r.completed_history.length}×</span>
+              </div>
+              <ContributionHeatmap
+                valueByDay={historyByDay(r.completed_history)}
+                color={WALLABY_COLORS[i % WALLABY_COLORS.length]}
+                weeks={30}
+                cellSize={9}
+                gap={2}
+              />
+            </div>
+          ))}
+        </section>
+      )}
+    </div>
+  )
+}

--- a/src/wallaby-preview.jsx
+++ b/src/wallaby-preview.jsx
@@ -7,6 +7,7 @@ import './v2/tokens.css'
 import './v2/wallaby/palette.css'
 import HabitsView from './v2/wallaby/HabitsView'
 import TasksView from './v2/wallaby/TasksView'
+import ProfileView from './v2/wallaby/ProfileView'
 
 document.documentElement.setAttribute('data-ui', 'v2')
 document.documentElement.setAttribute('data-theme', new URLSearchParams(location.search).get('theme') || 'wallaby-dark')
@@ -54,6 +55,17 @@ if (surface === 'tasks') {
       onToggleComplete={() => {}}
       onToggleItem={() => {}}
       onAdd={() => {}}
+    />,
+  )
+} else if (surface === 'profile') {
+  root.render(
+    <ProfileView
+      dailyStats={{ pointsToday: 14, tasksToday: 3 }}
+      streak={6}
+      records={{ longestStreak: 21, bestTasks: 9, bestPoints: 64 }}
+      lifetimeDone={(window.__WALLABY_TASKS__ || []).filter(t => t.status === 'done').length || 142}
+      routines={data}
+      dailyHistory={window.__WALLABY_HISTORY__ || null}
     />,
   )
 } else {

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,12 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-06
 
+- feat(ui): Wallaby Profile/dashboard surface + heatmap fit-to-width [M]
+  - **What.** Third Wallaby surface (loggd `IMG_1574`): `src/v2/wallaby/ProfileView.{jsx,css}`. Gradient avatar + "Your year" header with contribution count, a horizontally-scrollable row of **colorful stat pills** (day streak / points today / done today / best streak / lifetime done), an **Activity year-grid** (53-week contribution heatmap, Tasks/Points toggle, fed by `/api/analytics/history?days=365`), and per-habit grids below.
+  - **Heatmap fix.** `ContributionHeatmap` now fits its container width (cells size purely by `width:100% + aspect-ratio`, fixed `height` dropped) and month labels position by `index/weeks %` — so the full 53-week year fits without horizontal scroll and labels stay aligned at any week count. Improves the Habits heatmaps too.
+  - **Wiring.** Reachable via **Spaces → Dashboard** (`onOpenProfile` row in `SpacesHub`, `showProfile` overlay + escape-stack entry in `AppV2`). Stat values come from AppV2 (`dailyStats`, `streak`, `records`, `lifetimeDone`, `routines`); the year history is fetched inside `ProfileView`.
+  - **Verification.** Driven through the real app (Spaces → Dashboard in wallaby-dark renders live stats + the year-grid + per-habit grids).
+
 - feat(ui): Wallaby Tasks surface, wired into the app [M]
   - **What.** Second Wallaby surface (loggd `IMG_1575`): `src/v2/wallaby/TasksView.{jsx,css}`. Segmented **Upcoming / Backlog**, tasks grouped (Overdue / Today / Upcoming / Anytime), **pink square checkboxes** (orange for high-priority), colored label chips resolved from `tags` → labels, overdue/today due meta, **nested checklist items** as circular sub-checkboxes (completed = filled green + strikethrough), search filter, green FAB.
   - **Wiring.** Reachable via **Spaces → Tasks** (`onOpenTasks` row in `SpacesHub`, `showTasks` overlay + escape-stack entry in `AppV2`). Checkbox → `handleComplete`; subtask toggle → `updateTask({ checklists })`; row tap → `EditTaskModal`; FAB → AddTaskModal. Fed by live `tasks` + `labels`.


### PR DESCRIPTION
Third Wallaby surface — the **Profile / dashboard** from loggd `IMG_1574`.

## What's here
`src/v2/wallaby/ProfileView.{jsx,css}`:
- Gradient avatar + "Your year" header with live contribution count
- Scrollable row of **colorful stat pills** — day streak / points today / done today / best streak / lifetime done
- **Activity year-grid** — 53-week contribution heatmap, Tasks/Points toggle, fed by `/api/analytics/history?days=365`
- Per-habit grids below

## Heatmap fix (also improves Habits)
`ContributionHeatmap` now fits its container width (cells size by `width:100% + aspect-ratio`, fixed `height` dropped) and month labels position by `index/weeks %`. The full 53-week year fits without horizontal scroll and labels stay aligned at any week count.

## Wiring
Reachable via **Spaces → Dashboard** (interim). Stat values from AppV2 (`dailyStats`, `streak`, `records`, `lifetimeDone`, `routines`); year history fetched inside `ProfileView`.

## Verification
- `npm run build` green, `npm run lint` 0 errors.
- Driven through the real app (headless Chromium): Spaces → Dashboard in wallaby-dark renders live stats, the full-width year-grid (month labels aligned), and per-habit grids.

## Next
Goals (project detail + metric + semantic buttons), then the **5-tab bottom nav** to unify Home/Habits/Tasks/Goals/Profile and retire the interim Spaces entries.

https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk)_