### PR TITLE
feat(ui): Wallaby Goals surface (projects as goals)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1018,13 +1018,20 @@ tokens even if reached from a non-Wallaby theme.
   best streak / lifetime), an Activity 53-week year-grid (Tasks/Points toggle,
   from `/api/analytics/history`), and per-habit grids. Stat values passed from
   AppV2; year history fetched internally.
+- `GoalsView.{jsx,css}` — the **Goals** screen (projects as goals). List of goal
+  cards + a detail with a metric card (child-step `done/total` or
+  `session_count`, progress bar, `computeProjectBudget`), a "Why this matters"
+  notes block, and semantic action buttons (orange Log session / slate Edit /
+  green Complete / yellow Set aside / red Delete, two-tap confirm).
 
 **How the surfaces are reached (interim).** Each mounts as a full-screen overlay
 (`.v2-habits-overlay` in `AppV2.css`) via the **Spaces hub**: Dashboard
 (`onOpenProfile`/`showProfile`), Habits (`onOpenHabits`/`showHabits`), Tasks
-(`onOpenTasks`/`showTasks`), each with a back button and an escape-stack entry in
-`AppV2`. Tasks checkbox → `handleComplete`; subtask toggle →
-`updateTask({ checklists })`; row → `EditTaskModal`. The full remap promotes
+(`onOpenTasks`/`showTasks`), Goals (`onOpenGoals`/`showGoals`), each with a back
+button and an escape-stack entry in `AppV2`. Tasks checkbox → `handleComplete`;
+subtask toggle → `updateTask({ checklists })`; row → `EditTaskModal`. Goals: Log
+session → `logProjectSession`, Complete → `handleComplete`, Set aside →
+`updateTask({status:'backlog'})`, Delete → `deleteTask`. The full remap promotes
 these to top-level **bottom-nav tabs** (Home/Habits/Tasks/Goals/Profile) — not
 yet built.
 
@@ -1034,8 +1041,8 @@ screenshot verification. NOT imported by `index.html`, so it never ships to
 prod or affects the running app. Verified via a headless-Chromium (puppeteer)
 screenshot loop — render before claiming a surface works.
 
-**Remaining surfaces (not built):** 5-tab bottom nav, Goals (project detail
-with metric + semantic buttons), Home dashboard.
+**Remaining surfaces (not built):** 5-tab bottom nav (Home/Habits/Tasks/Goals/
+Profile) to retire the interim Spaces entries, and a Home dashboard.
 
 ## Additional Notes
 - Single developer (ryakel) — no PR review process needed.

--- a/src/v2/AppV2.jsx
+++ b/src/v2/AppV2.jsx
@@ -21,6 +21,7 @@ import RoutinesModal from './components/RoutinesModal'
 import HabitsView from './wallaby/HabitsView'
 import TasksView from './wallaby/TasksView'
 import ProfileView from './wallaby/ProfileView'
+import GoalsView from './wallaby/GoalsView'
 import SuggestionsModal from './components/SuggestionsModal'
 import PackagesModal from './components/PackagesModal'
 import AdviserModal from './components/AdviserModal'
@@ -98,6 +99,8 @@ export default function AppV2() {
   const [showTasks, setShowTasks] = useState(false)
   // Wallaby Profile/dashboard — stat pills + activity year-grid + habit grids.
   const [showProfile, setShowProfile] = useState(false)
+  // Wallaby Goals surface — projects as loggd-style goals (list + detail).
+  const [showGoals, setShowGoals] = useState(false)
   const [editRoutineId, setEditRoutineId] = useState(null)
   const [showPackages, setShowPackages] = useState(false)
   const [showAdviser, setShowAdviser] = useState(false)
@@ -491,6 +494,7 @@ export default function AppV2() {
     if (showHabits) { setShowHabits(false); return }
     if (showTasks) { setShowTasks(false); return }
     if (showProfile) { setShowProfile(false); return }
+    if (showGoals) { setShowGoals(false); return }
     if (showRoutines) { setShowRoutines(false); return }
     if (showPackages) { setShowPackages(false); return }
     if (showAdviser) { setShowAdviser(false); return }
@@ -499,7 +503,7 @@ export default function AppV2() {
     if (spacesHubOpen) { setSpacesHubOpen(false); setActiveTab('today'); return }
     if (systemMenuOpen) { setSystemMenuOpen(false); return }
     if (searchOpen) { handleCloseSearch(); return }
-  }, [snoozeTarget, reframeTarget, editTarget, showAdd, showWhatNow, showSettings, showProjects, showDone, showActivityLog, showHabits, showTasks, showProfile, showRoutines, showPackages, showAdviser, showAnalytics, showSuggestions, spacesHubOpen, systemMenuOpen, searchOpen, handleCloseSearch])
+  }, [snoozeTarget, reframeTarget, editTarget, showAdd, showWhatNow, showSettings, showProjects, showDone, showActivityLog, showHabits, showTasks, showProfile, showGoals, showRoutines, showPackages, showAdviser, showAnalytics, showSuggestions, spacesHubOpen, systemMenuOpen, searchOpen, handleCloseSearch])
 
   const focusSearchInput = useCallback(() => {
     setSearchOpen(true)
@@ -1169,6 +1173,7 @@ export default function AppV2() {
         onOpenHabits={() => setShowHabits(true)}
         onOpenTasks={() => setShowTasks(true)}
         onOpenProfile={() => setShowProfile(true)}
+        onOpenGoals={() => setShowGoals(true)}
         onOpenKnowledge={() => {
           setAdviserDraftSeed("What's in my knowledge base?")
           setShowAdviser(true)
@@ -1210,6 +1215,22 @@ export default function AppV2() {
             lifetimeDone={tasks.filter(t => t.status === 'done').length}
             routines={routines}
             onClose={() => setShowProfile(false)}
+          />
+        </div>
+      )}
+      {showGoals && (
+        <div className="v2-habits-overlay">
+          <GoalsView
+            projects={projectTasks}
+            tasks={tasks}
+            labels={labels}
+            onLogSession={(p) => logProjectSession(p.id)}
+            onComplete={(p) => handleComplete(p.id)}
+            onEdit={(p) => { setShowGoals(false); setEditTarget(p) }}
+            onSetAside={(p) => updateTask(p.id, { status: 'backlog' })}
+            onDelete={(p) => deleteTask(p.id)}
+            onAdd={() => { setShowGoals(false); setShowAdd(true) }}
+            onClose={() => setShowGoals(false)}
           />
         </div>
       )}

--- a/src/v2/components/SpacesHub.jsx
+++ b/src/v2/components/SpacesHub.jsx
@@ -1,4 +1,4 @@
-import { FolderKanban, RotateCw, BookOpen, Activity, ListTodo, LayoutDashboard, ChevronRight } from 'lucide-react'
+import { FolderKanban, RotateCw, BookOpen, Activity, ListTodo, LayoutDashboard, Target, ChevronRight } from 'lucide-react'
 import ModalShell from './ModalShell'
 import './SpacesHub.css'
 
@@ -13,7 +13,7 @@ import './SpacesHub.css'
 // the same hub a richer data shape.
 export default function SpacesHub({
   open, onClose,
-  onOpenProjects, onOpenRoutines, onOpenHabits, onOpenTasks, onOpenProfile, onOpenKnowledge,
+  onOpenProjects, onOpenRoutines, onOpenHabits, onOpenTasks, onOpenProfile, onOpenGoals, onOpenKnowledge,
 }) {
   const rows = [
     {
@@ -42,6 +42,15 @@ export default function SpacesHub({
       subtitle: 'Upcoming + backlog · subtasks',
       terminalCmd: '> tasks',
       onClick: onOpenTasks,
+    },
+    {
+      key: 'goals',
+      icon: Target,
+      tint: 'projects',
+      label: 'Goals',
+      subtitle: 'Projects · progress + sessions',
+      terminalCmd: '> goals',
+      onClick: onOpenGoals,
     },
     {
       key: 'projects',

--- a/src/v2/wallaby/GoalsView.css
+++ b/src/v2/wallaby/GoalsView.css
@@ -1,0 +1,170 @@
+/* Wallaby "Goals" surface — projects as loggd-style goals. List of goal cards
+ * + a detail with a metric card, progress bar, and semantic action buttons. */
+
+.wb-goals {
+  min-height: 100vh;
+  background: var(--wb-bg);
+  color: var(--wb-text);
+  padding: 16px 16px 120px;
+  font-family: var(--v2-font-body);
+  -webkit-font-smoothing: antialiased;
+}
+
+.wb-goals-head { margin-bottom: 16px; }
+.wb-goals-titlerow { display: flex; align-items: center; gap: 12px; }
+.wb-goals-title {
+  margin: 0;
+  font-family: var(--v2-font-display);
+  font-size: 28px;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+}
+.wb-goal-detail-title { font-size: 22px; }
+
+/* ── Chips ───────────────────────────────────────────────────────────────── */
+.wb-goal-chips { display: flex; flex-wrap: wrap; gap: 7px; margin-top: 12px; }
+.wb-goal-chip {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--tag, var(--wb-text-meta));
+  background: color-mix(in srgb, var(--tag, #888) 18%, transparent);
+  border-radius: 999px;
+  padding: 4px 11px;
+}
+.wb-goal-chip-soft {
+  color: var(--wb-text-meta);
+  background: var(--wb-card-2);
+}
+
+/* ── List ────────────────────────────────────────────────────────────────── */
+.wb-goals-list { display: flex; flex-direction: column; gap: 11px; }
+.wb-goals-empty { color: var(--wb-text-meta); text-align: center; padding: 40px 0; }
+.wb-goal-card {
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+  width: 100%;
+  text-align: left;
+  background: var(--wb-card);
+  border: 1px solid var(--wb-hairline);
+  border-radius: 16px;
+  padding: 15px;
+  box-shadow: var(--wb-shadow);
+  cursor: pointer;
+}
+.wb-goal-card-top { display: flex; align-items: center; gap: 10px; }
+.wb-goal-card-title {
+  flex: 1 1 auto;
+  font-family: var(--v2-font-display);
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--wb-text);
+}
+.wb-goal-card-chev { color: var(--wb-text-meta); flex: 0 0 auto; }
+.wb-goal-card-meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 12px;
+  color: var(--wb-text-meta);
+}
+
+/* ── Progress bar ────────────────────────────────────────────────────────── */
+.wb-progress {
+  height: 8px;
+  border-radius: 999px;
+  background: var(--wb-card-2);
+  overflow: hidden;
+}
+.wb-progress-big { height: 12px; }
+.wb-progress-fill {
+  height: 100%;
+  border-radius: 999px;
+  background: linear-gradient(90deg, var(--wb-action-primary), var(--wb-cat-pink));
+  transition: width 240ms ease;
+}
+
+/* ── Detail ──────────────────────────────────────────────────────────────── */
+.wb-goal-detail-body { display: flex; flex-direction: column; gap: 18px; }
+.wb-goal-metric-card {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  background: var(--wb-card);
+  border: 1px solid var(--wb-hairline);
+  border-radius: 18px;
+  padding: 18px;
+  box-shadow: var(--wb-shadow);
+}
+.wb-goal-metric-label {
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--wb-text-meta);
+}
+.wb-goal-metric-value {
+  font-family: var(--v2-font-display);
+  font-size: 40px;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  color: var(--wb-action-primary);
+  line-height: 1;
+}
+.wb-goal-metric-sub {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 12.5px;
+  color: var(--wb-text-meta);
+}
+
+.wb-goal-why {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+.wb-goal-why-label {
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--wb-text-meta);
+}
+.wb-goal-why-text { margin: 0; font-size: 15px; line-height: 1.45; color: var(--wb-text); }
+
+/* ── Semantic action buttons ─────────────────────────────────────────────── */
+.wb-goal-actions { display: flex; flex-direction: column; gap: 10px; }
+.wb-goal-actions-row { display: flex; gap: 10px; }
+.wb-goal-actions-row .wb-btn { flex: 1 1 0; }
+.wb-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  border: none;
+  border-radius: 13px;
+  padding: 14px 16px;
+  font: 700 14.5px/1 var(--v2-font-body);
+  color: #fff;
+  cursor: pointer;
+}
+.wb-btn-primary { background: var(--wb-action-primary); }
+.wb-btn-secondary { background: var(--wb-action-secondary); color: var(--wb-text); }
+.wb-btn-complete { background: var(--wb-action-complete); }
+.wb-btn-pause { background: var(--wb-action-pause); color: #1a1206; }
+.wb-btn-delete {
+  background: transparent;
+  color: var(--wb-action-delete);
+}
+.wb-btn-delete-solid { background: var(--wb-action-delete); }
+.wb-btn-ghost { background: var(--wb-card-2); color: var(--wb-text); }
+.wb-goal-confirm {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 14px;
+  color: var(--wb-text);
+}
+.wb-goal-confirm > span { flex: 1 1 auto; }
+.wb-goal-confirm .wb-btn { padding: 10px 14px; }

--- a/src/v2/wallaby/GoalsView.jsx
+++ b/src/v2/wallaby/GoalsView.jsx
@@ -1,0 +1,173 @@
+import { useMemo, useState } from 'react'
+import { ArrowLeft, Plus, Pencil, Check, Pause, Trash2, ChevronRight, Flame } from 'lucide-react'
+import { computeProjectBudget } from '../../scoring'
+import './GoalsView.css'
+
+// Wallaby "Goals" surface — Boomerang projects as loggd-style goals (IMG_1572).
+// A list of goal cards; tapping one opens the detail with a progress bar, a big
+// metric, a "why this matters" line, and the semantic action buttons
+// (orange Log session / slate Edit / green Complete / yellow Set aside / red
+// Delete). Maps project sessions + child steps onto the loggd metric model.
+export default function GoalsView({
+  projects = [], tasks = [], labels = [],
+  onLogSession, onComplete, onEdit, onSetAside, onDelete, onAdd, onClose,
+}) {
+  const [selectedId, setSelectedId] = useState(null)
+  const labelsById = useMemo(() => {
+    const m = {}; for (const l of labels) m[l.id] = l; return m
+  }, [labels])
+
+  const selected = projects.find(p => p.id === selectedId)
+  if (selected) {
+    return (
+      <GoalDetail
+        project={selected}
+        tasks={tasks}
+        labelsById={labelsById}
+        onBack={() => setSelectedId(null)}
+        onLogSession={onLogSession}
+        onComplete={(p) => { onComplete?.(p); setSelectedId(null) }}
+        onEdit={onEdit}
+        onSetAside={(p) => { onSetAside?.(p); setSelectedId(null) }}
+        onDelete={(p) => { onDelete?.(p); setSelectedId(null) }}
+      />
+    )
+  }
+
+  return (
+    <div className="wb-goals">
+      <header className="wb-goals-head">
+        <div className="wb-goals-titlerow">
+          {onClose && (
+            <button className="wb-back" onClick={onClose} aria-label="Back"><ArrowLeft size={20} strokeWidth={2.25} /></button>
+          )}
+          <h1 className="wb-goals-title">Goals</h1>
+        </div>
+      </header>
+
+      <div className="wb-goals-list">
+        {projects.length === 0 && <p className="wb-goals-empty">No goals yet. Tap + to start one.</p>}
+        {projects.map(p => {
+          const prog = progressFor(p, tasks)
+          const cat = (p.tags || []).map(id => labelsById[id]).find(Boolean)
+          return (
+            <button key={p.id} className="wb-goal-card" onClick={() => setSelectedId(p.id)}>
+              <div className="wb-goal-card-top">
+                <span className="wb-goal-card-title">{p.title}</span>
+                <ChevronRight size={18} strokeWidth={1.75} className="wb-goal-card-chev" />
+              </div>
+              {cat && <span className="wb-goal-chip" style={{ '--tag': cat.color }}>{cat.name}</span>}
+              <Progress value={prog.pct} />
+              <span className="wb-goal-card-meta">
+                {prog.label} · <Flame size={11} strokeWidth={2.25} /> {p.session_count || 0} sessions
+              </span>
+            </button>
+          )
+        })}
+      </div>
+
+      <button className="wb-fab wb-fab-habits" onClick={onAdd} aria-label="New goal"><Plus size={26} strokeWidth={2.5} /></button>
+    </div>
+  )
+}
+
+function GoalDetail({ project, tasks, labelsById, onBack, onLogSession, onComplete, onEdit, onSetAside, onDelete }) {
+  const [confirmDelete, setConfirmDelete] = useState(false)
+  const prog = progressFor(project, tasks)
+  const budget = computeProjectBudget(project, tasks)
+  const cats = (project.tags || []).map(id => labelsById[id]).filter(Boolean)
+  const target = project.due_date
+    ? new Date(project.due_date).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+    : null
+
+  return (
+    <div className="wb-goals">
+      <header className="wb-goals-head">
+        <div className="wb-goals-titlerow">
+          <button className="wb-back" onClick={onBack} aria-label="Back"><ArrowLeft size={20} strokeWidth={2.25} /></button>
+          <h1 className="wb-goals-title wb-goal-detail-title">{project.title}</h1>
+        </div>
+        <div className="wb-goal-chips">
+          {cats.map(c => <span key={c.id} className="wb-goal-chip" style={{ '--tag': c.color }}>{c.name}</span>)}
+          <span className="wb-goal-chip wb-goal-chip-soft">{target ? `Target ${target}` : 'Ongoing'}</span>
+        </div>
+      </header>
+
+      <div className="wb-goal-detail-body">
+        <div className="wb-goal-metric-card">
+          <span className="wb-goal-metric-label">{prog.metricLabel}</span>
+          <span className="wb-goal-metric-value">{prog.metricValue}</span>
+          <Progress value={prog.pct} big />
+          <span className="wb-goal-metric-sub">
+            <Flame size={12} strokeWidth={2.25} /> {project.session_count || 0} sessions · budget {budget}
+          </span>
+        </div>
+
+        {project.notes && (
+          <div className="wb-goal-why">
+            <span className="wb-goal-why-label">Why this matters</span>
+            <p className="wb-goal-why-text">{project.notes}</p>
+          </div>
+        )}
+
+        <div className="wb-goal-actions">
+          <button className="wb-btn wb-btn-primary" onClick={() => onLogSession?.(project)}>
+            <Flame size={16} strokeWidth={2.25} /> Log session
+          </button>
+          <button className="wb-btn wb-btn-secondary" onClick={() => onEdit?.(project)}>
+            <Pencil size={15} strokeWidth={2} /> Edit goal
+          </button>
+          <div className="wb-goal-actions-row">
+            <button className="wb-btn wb-btn-complete" onClick={() => onComplete?.(project)}>
+              <Check size={16} strokeWidth={2.5} /> Complete
+            </button>
+            <button className="wb-btn wb-btn-pause" onClick={() => onSetAside?.(project)}>
+              <Pause size={15} strokeWidth={2.25} /> Set aside
+            </button>
+          </div>
+          {confirmDelete ? (
+            <div className="wb-goal-confirm">
+              <span>Delete this goal?</span>
+              <button className="wb-btn wb-btn-delete-solid" onClick={() => onDelete?.(project)}>Delete</button>
+              <button className="wb-btn wb-btn-ghost" onClick={() => setConfirmDelete(false)}>Cancel</button>
+            </div>
+          ) : (
+            <button className="wb-btn wb-btn-delete" onClick={() => setConfirmDelete(true)}>
+              <Trash2 size={15} strokeWidth={2} /> Delete goal
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function Progress({ value, big }) {
+  return (
+    <div className={`wb-progress${big ? ' wb-progress-big' : ''}`}>
+      <div className="wb-progress-fill" style={{ width: `${Math.round(value * 100)}%` }} />
+    </div>
+  )
+}
+
+// Progress model: prefer child-step completion; fall back to session cap (10).
+function progressFor(project, tasks) {
+  const children = tasks.filter(t => t.parent_id === project.id)
+  if (children.length > 0) {
+    const done = children.filter(c => c.status === 'done').length
+    return {
+      pct: done / children.length,
+      label: `${done}/${children.length} steps`,
+      metricLabel: 'Steps complete',
+      metricValue: `${done} / ${children.length}`,
+    }
+  }
+  const sessions = project.session_count || 0
+  const cap = 10
+  return {
+    pct: Math.min(1, sessions / cap),
+    label: `${sessions} sessions`,
+    metricLabel: 'Sessions logged',
+    metricValue: `${sessions}`,
+  }
+}

--- a/src/wallaby-preview.jsx
+++ b/src/wallaby-preview.jsx
@@ -8,6 +8,7 @@ import './v2/wallaby/palette.css'
 import HabitsView from './v2/wallaby/HabitsView'
 import TasksView from './v2/wallaby/TasksView'
 import ProfileView from './v2/wallaby/ProfileView'
+import GoalsView from './v2/wallaby/GoalsView'
 
 document.documentElement.setAttribute('data-ui', 'v2')
 document.documentElement.setAttribute('data-theme', new URLSearchParams(location.search).get('theme') || 'wallaby-dark')
@@ -66,6 +67,35 @@ if (surface === 'tasks') {
       lifetimeDone={(window.__WALLABY_TASKS__ || []).filter(t => t.status === 'done').length || 142}
       routines={data}
       dailyHistory={window.__WALLABY_HISTORY__ || null}
+    />,
+  )
+} else if (surface === 'goals') {
+  const labels = [
+    { id: 'lf', name: 'finance', color: '#41C083' },
+    { id: 'lh', name: 'home', color: '#F0973E' },
+  ]
+  const projects = [
+    { id: 'g1', title: 'Pay off mortgage', status: 'project', tags: ['lf'], due_date: '2026-09-09', notes: "I don't want to be stressed.", session_count: 4 },
+    { id: 'g2', title: 'Renovate the kitchen', status: 'project', tags: ['lh'], notes: 'Make the space we actually want to cook in.', session_count: 2 },
+    { id: 'g3', title: 'Learn Spanish', status: 'project', tags: [], session_count: 7, notes: 'So I can talk with abuela.' },
+  ]
+  const goalTasks = [
+    { id: 'c1', parent_id: 'g2', status: 'done', title: 'Demo old cabinets' },
+    { id: 'c2', parent_id: 'g2', status: 'done', title: 'Pick countertops' },
+    { id: 'c3', parent_id: 'g2', status: 'not_started', title: 'Install backsplash' },
+    { id: 'c4', parent_id: 'g2', status: 'not_started', title: 'Paint walls' },
+  ]
+  root.render(
+    <GoalsView
+      projects={projects}
+      tasks={goalTasks}
+      labels={labels}
+      onLogSession={() => {}}
+      onComplete={() => {}}
+      onEdit={() => {}}
+      onSetAside={() => {}}
+      onDelete={() => {}}
+      onAdd={() => {}}
     />,
   )
 } else {

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,12 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-06
 
+- feat(ui): Wallaby Goals surface (projects as goals) [M]
+  - **What.** Fourth Wallaby surface (loggd `IMG_1572`): `src/v2/wallaby/GoalsView.{jsx,css}`. A goals list (project cards with category chip + gradient progress bar + sessions/steps meta) and a goal **detail** with a big metric card (steps-complete or sessions-logged, progress bar, budget), a "Why this matters" notes block, and the full **semantic action button** set — orange *Log session* / slate *Edit goal* / green *Complete* / yellow *Set aside* / red *Delete* (two-tap confirm).
+  - **Mapping.** Boomerang projects → goals. Progress prefers child-step completion (`done/total` of `parent_id` children), falling back to `session_count` toward the 10-session cap. Budget via `computeProjectBudget`. Category chips from `tags` → labels; target from `due_date` (else "Ongoing").
+  - **Wiring.** Reachable via **Spaces → Goals** (`onOpenGoals` overlay + escape-stack entry in `AppV2`). Log session → `logProjectSession`; Complete → `handleComplete`; Edit → `EditTaskModal`; Set aside → `updateTask({status:'backlog'})`; Delete → `deleteTask`.
+  - **Verification.** Driven through the real app against a created project (Spaces → Goals → detail shows `1/3 steps`, sessions, notes, and the semantic buttons).
+
 - feat(ui): Wallaby Profile/dashboard surface + heatmap fit-to-width [M]
   - **What.** Third Wallaby surface (loggd `IMG_1574`): `src/v2/wallaby/ProfileView.{jsx,css}`. Gradient avatar + "Your year" header with contribution count, a horizontally-scrollable row of **colorful stat pills** (day streak / points today / done today / best streak / lifetime done), an **Activity year-grid** (53-week contribution heatmap, Tasks/Points toggle, fed by `/api/analytics/history?days=365`), and per-habit grids below.
   - **Heatmap fix.** `ContributionHeatmap` now fits its container width (cells size purely by `width:100% + aspect-ratio`, fixed `height` dropped) and month labels position by `index/weeks %` — so the full 53-week year fits without horizontal scroll and labels stay aligned at any week count. Improves the Habits heatmaps too.


### PR DESCRIPTION
Fourth Wallaby surface — **Goals** (loggd `IMG_1572`), Boomerang projects rendered as goals.

## What's here
`src/v2/wallaby/GoalsView.{jsx,css}`:
- **Goals list** — project cards: title, category chip, gradient progress bar, sessions/steps meta
- **Goal detail** — big metric card (child-step `done/total` or `session_count`, progress bar, budget), a "Why this matters" notes block, and the full **semantic button set**: orange *Log session* / slate *Edit goal* / green *Complete* / yellow *Set aside* / red *Delete* (two-tap confirm)

## Mapping
Projects → goals. Progress prefers child-step completion (`done/total` of `parent_id` children), falling back to `session_count` toward the 10-cap. Budget via `computeProjectBudget`. Category chips from `tags`; target from `due_date` (else "Ongoing").

## Wiring
Reachable via **Spaces → Goals** (interim). Log session → `logProjectSession`; Complete → `handleComplete`; Edit → `EditTaskModal`; Set aside → `updateTask({status:'backlog'})`; Delete → `deleteTask`.

## Verification
- `npm run build` green, `npm run lint` 0 errors.
- Driven through the real app against a created project: Spaces → Goals → detail shows `1/3 steps`, sessions, notes, and the semantic buttons.

## Next
The **5-tab bottom nav** (Home/Habits/Tasks/Goals/Profile) to retire the interim Spaces entries, plus a Home dashboard.

https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk)_