### PR TITLE
feat(ui): Wallaby bottom-nav shell + Home daily agenda

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1024,16 +1024,26 @@ tokens even if reached from a non-Wallaby theme.
   notes block, and semantic action buttons (orange Log session / slate Edit /
   green Complete / yellow Set aside / red Delete, two-tap confirm).
 
-**How the surfaces are reached (interim).** Each mounts as a full-screen overlay
-(`.v2-habits-overlay` in `AppV2.css`) via the **Spaces hub**: Dashboard
-(`onOpenProfile`/`showProfile`), Habits (`onOpenHabits`/`showHabits`), Tasks
-(`onOpenTasks`/`showTasks`), Goals (`onOpenGoals`/`showGoals`), each with a back
-button and an escape-stack entry in `AppV2`. Tasks checkbox → `handleComplete`;
-subtask toggle → `updateTask({ checklists })`; row → `EditTaskModal`. Goals: Log
-session → `logProjectSession`, Complete → `handleComplete`, Set aside →
-`updateTask({status:'backlog'})`, Delete → `deleteTask`. The full remap promotes
-these to top-level **bottom-nav tabs** (Home/Habits/Tasks/Goals/Profile) — not
-yet built.
+- `HomeView.{jsx,css}` — the **Home** daily agenda (loggd `IMG_1582`). Date hero
+  + Sunday-anchored week strip (activity dots), a streak-at-risk banner, and
+  today's habits (non-paused routines) as checkable rows; the per-habit-colored
+  check toggles today's entry in `completed_history`.
+- `WallabyNav.{jsx,css}` + `WallabyShell.{jsx,css}` — the loggd IA. A fixed 5-tab
+  bottom nav (**Home · Habits · Tasks · Timer · More**) over the active surface.
+  Timer is a deferred-feature placeholder; **More** routes to Profile + Goals and
+  shows Coming-soon rows for Vision + Daily check-in.
+
+**How the surfaces are reached (Wallaby mode).** `AppV2` renders `<WallabyShell>`
+(`position:fixed`, z-40 — covers the standard header + list) when
+`isWallaby && !isDesktop`, and skips the standard `BottomTabs`. The shell owns
+tab state (Home/Habits/Tasks/Timer/More) and a `sub` state for Profile/Goals
+opened from More. Shared modals (Edit/Add/Settings, z-100) still open above the
+shell — tapping a task → `EditTaskModal`, checkbox → `handleComplete`, subtask →
+`updateTask({checklists})`, Home check → toggle `completed_history` today, Goals
+Log session → `logProjectSession` etc. Desktop keeps Kanban + drawer. The old
+`.v2-habits-overlay` Spaces entries (`showHabits`/`showTasks`/`showProfile`/
+`showGoals`) remain wired but are unreachable in Wallaby (the shell covers the
+Spaces hub) — kept as a fallback until the shell fully subsumes them.
 
 **Dev-only render harness.** `wallaby-preview.html` + `src/wallaby-preview.jsx`
 mount `HabitsView` in isolation (mock or API-injected routines) for
@@ -1041,8 +1051,12 @@ screenshot verification. NOT imported by `index.html`, so it never ships to
 prod or affects the running app. Verified via a headless-Chromium (puppeteer)
 screenshot loop — render before claiming a surface works.
 
-**Remaining surfaces (not built):** 5-tab bottom nav (Home/Habits/Tasks/Goals/
-Profile) to retire the interim Spaces entries, and a Home dashboard.
+**Reskin still to do:** habit detail + month-calendar view (tap a Habits card →
+stats + completion calendar + archive/delete, loggd `IMG_1586`), per-card month
+labels + clickable heatmaps on the Habits single view, Tasks 3rd "Done" tab +
+TODAY/TOMORROW grouping, an optional persistent Wallaby top header (brand + bell
++ avatar). **Deferred net-new features (after reskin):** Timer, Vision
+(eulogy/bucket list), Daily mood-journal, XP/levels/achievements.
 
 ## Additional Notes
 - Single developer (ryakel) — no PR review process needed.

--- a/src/v2/AppV2.jsx
+++ b/src/v2/AppV2.jsx
@@ -22,6 +22,7 @@ import HabitsView from './wallaby/HabitsView'
 import TasksView from './wallaby/TasksView'
 import ProfileView from './wallaby/ProfileView'
 import GoalsView from './wallaby/GoalsView'
+import WallabyShell from './wallaby/WallabyShell'
 import SuggestionsModal from './components/SuggestionsModal'
 import PackagesModal from './components/PackagesModal'
 import AdviserModal from './components/AdviserModal'
@@ -436,6 +437,9 @@ export default function AppV2() {
   const dailyStats = computeDailyStats(tasks, settingsForRings)
   const streak = computeStreak(tasks, settingsForRings)
   const records = useMemo(() => computeRecords(tasks), [tasks])
+  // Wallaby presents the full loggd IA (bottom-nav shell) on mobile. Desktop
+  // keeps the Kanban + drawer for now.
+  const isWallaby = (settingsForRings.theme || '').startsWith('wallaby')
   // Per-routine streak map → threaded down to TaskCard so routine-spawned
   // tasks can render an inline 🔥N. Recomputed only when `routines` changes.
   const routineStreaks = useMemo(() => {
@@ -1139,7 +1143,7 @@ export default function AppV2() {
       {/* Bottom tab bar — mobile only. Hidden on desktop (which has
        * its own Kanban + side-drawer navigation pattern). The strip
        * itself also has a @media gate as belt-and-suspenders. */}
-      {!isDesktop && (
+      {!isDesktop && !isWallaby && (
         <BottomTabs
           activeTab={activeTab}
           onTabChange={(next) => {
@@ -1154,6 +1158,47 @@ export default function AppV2() {
           onQuickAdd={(title) => addTask({ title })}
           onAddLongPress={() => setShowAdd(true)}
           onWhatNow={() => setShowWhatNow(true)}
+        />
+      )}
+
+      {/* Wallaby shell — the loggd IA (Home/Habits/Tasks/Timer/More) on mobile.
+        * Covers the standard list + header (z below the shared modals, which
+        * still open above it). Replaces BottomTabs in Wallaby mode. */}
+      {isWallaby && !isDesktop && (
+        <WallabyShell
+          tasks={tasks}
+          routines={routines}
+          projects={projectTasks}
+          labels={labels}
+          dailyStats={dailyStats}
+          streak={streak}
+          records={records}
+          lifetimeDone={tasks.filter(t => t.status === 'done').length}
+          onToggleHabit={(routine) => {
+            const today = localYMD(new Date())
+            const hist = Array.isArray(routine.completed_history) ? routine.completed_history : []
+            if (hist.some(ts => localYMD(ts) === today)) {
+              updateRoutine(routine.id, { completed_history: hist.filter(ts => localYMD(ts) !== today) })
+            } else {
+              completeRoutine(routine.id)
+            }
+          }}
+          onCompleteTask={(task) => handleComplete(task.id)}
+          onToggleItem={(task, clId, itemId) => {
+            const checklists = (task.checklists || []).map(cl =>
+              cl.id !== clId ? cl : { ...cl, items: (cl.items || []).map(it => it.id === itemId ? { ...it, completed: !it.completed } : it) },
+            )
+            updateTask(task.id, { checklists })
+          }}
+          onOpenTask={(task) => setEditTarget(task)}
+          onAddTask={() => setShowAdd(true)}
+          onAddHabit={() => setShowRoutines(true)}
+          onLogSession={(p) => logProjectSession(p.id)}
+          onCompleteProject={(p) => handleComplete(p.id)}
+          onEditProject={(p) => setEditTarget(p)}
+          onSetAsideProject={(p) => updateTask(p.id, { status: 'backlog' })}
+          onDeleteProject={(p) => deleteTask(p.id)}
+          onOpenSettings={() => setShowSettings(true)}
         />
       )}
 

--- a/src/v2/wallaby/HomeView.css
+++ b/src/v2/wallaby/HomeView.css
@@ -1,0 +1,175 @@
+/* Wallaby "Home" — daily agenda. Date hero + week strip, streak-at-risk
+ * banner, today's habits as checkable rows. */
+
+.wb-home {
+  min-height: 100vh;
+  background: var(--wb-bg);
+  color: var(--wb-text);
+  padding: 16px 16px 120px;
+  font-family: var(--v2-font-body);
+  -webkit-font-smoothing: antialiased;
+}
+
+/* ── Date hero + week strip ──────────────────────────────────────────────── */
+.wb-home-head {
+  background: var(--wb-card);
+  border: 1px solid var(--wb-hairline);
+  border-radius: 18px;
+  padding: 16px;
+  box-shadow: var(--wb-shadow);
+  margin-bottom: 16px;
+}
+.wb-home-date {
+  display: flex;
+  align-items: center;
+  gap: 13px;
+  margin-bottom: 16px;
+}
+.wb-home-daycircle {
+  display: grid;
+  place-items: center;
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background: var(--wb-action-complete);
+  color: #fff;
+  font-family: var(--v2-font-display);
+  font-size: 22px;
+  font-weight: 800;
+  flex: 0 0 auto;
+}
+.wb-home-datetext { display: flex; flex-direction: column; flex: 1 1 auto; }
+.wb-home-weekday {
+  font-family: var(--v2-font-display);
+  font-size: 20px;
+  font-weight: 800;
+  letter-spacing: -0.01em;
+}
+.wb-home-month { font-size: 13px; color: var(--wb-text-meta); }
+.wb-home-avatar {
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  border: none;
+  flex: 0 0 auto;
+  background: linear-gradient(135deg, var(--wb-cat-green), var(--wb-cat-blue));
+  cursor: pointer;
+}
+
+.wb-home-week {
+  display: flex;
+  justify-content: space-between;
+  gap: 4px;
+}
+.wb-home-weekday-cell {
+  flex: 1 1 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 5px;
+  padding: 6px 0;
+  border-radius: 12px;
+}
+.wb-home-weekday-cell.is-today { background: color-mix(in srgb, var(--wb-action-complete) 18%, transparent); }
+.wb-home-week-dow { font-size: 11px; font-weight: 600; color: var(--wb-text-meta); }
+.wb-home-week-date {
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--wb-text);
+}
+.wb-home-weekday-cell.is-today .wb-home-week-date { color: var(--wb-action-complete); }
+.wb-home-week-dot {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: transparent;
+}
+.wb-home-week-dot.is-active { background: var(--wb-cat-purple); }
+
+/* ── Streak-at-risk banner ───────────────────────────────────────────────── */
+.wb-home-risk {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 12px 14px;
+  border-radius: 13px;
+  margin-bottom: 18px;
+  background: linear-gradient(90deg, color-mix(in srgb, var(--wb-action-delete) 30%, transparent), color-mix(in srgb, var(--wb-cat-purple) 22%, transparent));
+  border: 1px solid color-mix(in srgb, var(--wb-action-delete) 30%, transparent);
+}
+.wb-home-risk-icon { color: var(--wb-action-primary); flex: 0 0 auto; }
+.wb-home-risk-text { flex: 1 1 auto; font-size: 13.5px; font-weight: 600; }
+.wb-home-risk-chev { color: var(--wb-text-meta); flex: 0 0 auto; }
+
+/* ── Habits list ─────────────────────────────────────────────────────────── */
+.wb-home-section-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0 2px 10px;
+  font-family: var(--v2-font-display);
+  font-size: 17px;
+  font-weight: 700;
+}
+.wb-home-count {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--wb-text-meta);
+  background: var(--wb-card-2);
+  border-radius: 999px;
+  padding: 1px 8px;
+}
+.wb-home-habits { display: flex; flex-direction: column; gap: 9px; }
+.wb-home-empty { color: var(--wb-text-meta); text-align: center; padding: 30px 0; }
+.wb-home-habit {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  background: var(--wb-card);
+  border: 1px solid var(--wb-hairline);
+  border-radius: 14px;
+  padding: 13px 14px;
+  box-shadow: var(--wb-shadow);
+}
+.wb-home-habit-icon {
+  display: grid;
+  place-items: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 10px;
+  background: var(--wb-card-2);
+  flex: 0 0 auto;
+}
+.wb-home-habit-text { flex: 1 1 auto; min-width: 0; display: flex; flex-direction: column; gap: 3px; }
+.wb-home-habit-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--wb-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.wb-home-habit.is-done .wb-home-habit-title {
+  text-decoration: line-through;
+  color: var(--wb-text-meta);
+}
+.wb-home-habit-streak {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 12px;
+  color: var(--wb-text-meta);
+}
+.wb-home-check {
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 10px;
+  border: 2px solid var(--wb-hairline-strong);
+  background: transparent;
+  cursor: pointer;
+  transition: transform 120ms ease;
+}
+.wb-home-check:active { transform: scale(0.92); }

--- a/src/v2/wallaby/HomeView.jsx
+++ b/src/v2/wallaby/HomeView.jsx
@@ -1,0 +1,109 @@
+import { useMemo } from 'react'
+import {
+  Check, Flame, ChevronRight,
+  Monitor, Users, MapPin, Palette, Dumbbell, Repeat,
+} from 'lucide-react'
+import { WALLABY_COLORS, historyByDay, currentStreak, localYMD } from './heatmapUtils'
+import './HomeView.css'
+
+const ENERGY_ICONS = { desk: Monitor, people: Users, errand: MapPin, creative: Palette, physical: Dumbbell }
+const DOW = ['S', 'M', 'T', 'W', 'T', 'F', 'S']
+
+// Wallaby "Home" — the daily agenda (loggd IMG_1582). Date hero + week strip,
+// a streak-at-risk banner, and today's habits as checkable rows. "Checking" a
+// habit toggles today's entry in its completed_history.
+export default function HomeView({ routines = [], onToggleHabit, onOpenProfile }) {
+  const today = new Date()
+  const todayKey = localYMD(today)
+
+  const habits = useMemo(() => routines.filter(r => !r.paused), [routines])
+
+  const enriched = useMemo(() => habits.map((r, i) => {
+    const byDay = historyByDay(r.completed_history)
+    return {
+      routine: r,
+      color: WALLABY_COLORS[i % WALLABY_COLORS.length],
+      doneToday: !!byDay[todayKey],
+      streak: currentStreak(byDay),
+      byDay,
+    }
+  }), [habits, todayKey])
+
+  // Streak at risk: a live streak that hasn't been logged today yet.
+  const atRisk = enriched.filter(h => !h.doneToday && h.streak > 0)
+
+  // Week strip (Sunday-anchored) with activity dots.
+  const weekStart = new Date(today); weekStart.setDate(today.getDate() - today.getDay()); weekStart.setHours(0, 0, 0, 0)
+  const week = Array.from({ length: 7 }, (_, i) => {
+    const d = new Date(weekStart); d.setDate(weekStart.getDate() + i)
+    const key = localYMD(d)
+    return {
+      key, dow: DOW[i], date: d.getDate(),
+      isToday: key === todayKey,
+      active: enriched.some(h => h.byDay[key]),
+    }
+  })
+
+  return (
+    <div className="wb-home">
+      <header className="wb-home-head">
+        <div className="wb-home-date">
+          <span className="wb-home-daycircle">{today.getDate()}</span>
+          <div className="wb-home-datetext">
+            <span className="wb-home-weekday">{today.toLocaleDateString('en-US', { weekday: 'long' })}</span>
+            <span className="wb-home-month">{today.toLocaleDateString('en-US', { month: 'long', year: 'numeric' })}</span>
+          </div>
+          {onOpenProfile && (
+            <button className="wb-home-avatar" onClick={onOpenProfile} aria-label="Profile" />
+          )}
+        </div>
+        <div className="wb-home-week">
+          {week.map(d => (
+            <div key={d.key} className={`wb-home-weekday-cell${d.isToday ? ' is-today' : ''}`}>
+              <span className="wb-home-week-dow">{d.dow}</span>
+              <span className="wb-home-week-date">{d.date}</span>
+              <span className={`wb-home-week-dot${d.active ? ' is-active' : ''}`} />
+            </div>
+          ))}
+        </div>
+      </header>
+
+      {atRisk.length > 0 && (
+        <div className="wb-home-risk">
+          <Flame size={16} strokeWidth={2.25} className="wb-home-risk-icon" />
+          <span className="wb-home-risk-text">
+            {atRisk.length} streak{atRisk.length === 1 ? '' : 's'} at risk: {atRisk.slice(0, 2).map(h => h.routine.title).join(', ')}
+            {atRisk.length > 2 ? '…' : ''}
+          </span>
+          <ChevronRight size={16} strokeWidth={2} className="wb-home-risk-chev" />
+        </div>
+      )}
+
+      <div className="wb-home-section-label">Habits <span className="wb-home-count">{habits.length}</span></div>
+
+      <div className="wb-home-habits">
+        {enriched.map(({ routine, color, doneToday, streak }) => {
+          const Icon = ENERGY_ICONS[routine.energy] || Repeat
+          return (
+            <div key={routine.id} className={`wb-home-habit${doneToday ? ' is-done' : ''}`}>
+              <span className="wb-home-habit-icon" style={{ color }}><Icon size={18} strokeWidth={2} /></span>
+              <div className="wb-home-habit-text">
+                <span className="wb-home-habit-title">{routine.title}</span>
+                <span className="wb-home-habit-streak"><Flame size={12} strokeWidth={2.25} /> {streak} day{streak === 1 ? '' : 's'}</span>
+              </div>
+              <button
+                className={`wb-home-check${doneToday ? ' is-done' : ''}`}
+                style={doneToday ? { background: color, borderColor: color } : { borderColor: color }}
+                onClick={() => onToggleHabit?.(routine)}
+                aria-label={doneToday ? 'Mark not done' : 'Mark done'}
+              >
+                {doneToday && <Check size={18} strokeWidth={3} color="#fff" />}
+              </button>
+            </div>
+          )
+        })}
+        {habits.length === 0 && <p className="wb-home-empty">No habits yet. Add routines to see them here.</p>}
+      </div>
+    </div>
+  )
+}

--- a/src/v2/wallaby/WallabyNav.css
+++ b/src/v2/wallaby/WallabyNav.css
@@ -1,0 +1,30 @@
+/* Wallaby bottom nav — fixed 5-tab bar. */
+.wb-nav {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 45;
+  display: flex;
+  background: color-mix(in srgb, var(--wb-card) 92%, transparent);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border-top: 1px solid var(--wb-hairline);
+  padding: 8px 6px calc(8px + env(safe-area-inset-bottom));
+}
+.wb-nav-tab {
+  flex: 1 1 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  background: none;
+  border: none;
+  padding: 4px 0;
+  color: var(--wb-text-meta);
+  cursor: pointer;
+  transition: color 140ms ease;
+}
+.wb-nav-tab.is-active { color: var(--wb-action-complete); }
+.wb-nav-icon { display: block; }
+.wb-nav-label { font-size: 10.5px; font-weight: 600; }

--- a/src/v2/wallaby/WallabyNav.jsx
+++ b/src/v2/wallaby/WallabyNav.jsx
@@ -1,0 +1,34 @@
+import { Home, Activity, ListTodo, Timer, Menu } from 'lucide-react'
+import './WallabyNav.css'
+
+// Wallaby bottom nav (loggd IA): Home · Habits · Tasks · Timer · More.
+const TABS = [
+  { id: 'home', label: 'Home', icon: Home },
+  { id: 'habits', label: 'Habits', icon: Activity },
+  { id: 'tasks', label: 'Tasks', icon: ListTodo },
+  { id: 'timer', label: 'Timer', icon: Timer },
+  { id: 'more', label: 'More', icon: Menu },
+]
+
+export default function WallabyNav({ active, onChange }) {
+  return (
+    <nav className="wb-nav" role="tablist" aria-label="Primary">
+      {TABS.map(t => {
+        const Icon = t.icon
+        const on = active === t.id
+        return (
+          <button
+            key={t.id}
+            role="tab"
+            aria-selected={on}
+            className={`wb-nav-tab${on ? ' is-active' : ''}`}
+            onClick={() => onChange(t.id)}
+          >
+            <Icon size={22} strokeWidth={on ? 2.4 : 1.9} className="wb-nav-icon" />
+            <span className="wb-nav-label">{t.label}</span>
+          </button>
+        )
+      })}
+    </nav>
+  )
+}

--- a/src/v2/wallaby/WallabyShell.css
+++ b/src/v2/wallaby/WallabyShell.css
@@ -1,0 +1,88 @@
+/* Wallaby shell — full-screen container with a fixed bottom nav. Surfaces
+ * already carry 120px bottom padding so their content clears the nav. */
+.wb-shell {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+  background: var(--wb-bg);
+}
+.wb-shell-surface {
+  position: absolute;
+  inset: 0;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+/* ── More menu ───────────────────────────────────────────────────────────── */
+.wb-more {
+  min-height: 100vh;
+  padding: 16px 16px 120px;
+  color: var(--wb-text);
+  font-family: var(--v2-font-body);
+}
+.wb-more-title {
+  margin: 4px 0 16px;
+  font-family: var(--v2-font-display);
+  font-size: 28px;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+}
+.wb-more-list { display: flex; flex-direction: column; gap: 9px; }
+.wb-more-row {
+  display: flex;
+  align-items: center;
+  gap: 13px;
+  width: 100%;
+  text-align: left;
+  background: var(--wb-card);
+  border: 1px solid var(--wb-hairline);
+  border-radius: 14px;
+  padding: 14px 15px;
+  box-shadow: var(--wb-shadow);
+  cursor: pointer;
+  color: var(--wb-text);
+}
+.wb-more-row.is-soon { opacity: 0.5; cursor: default; }
+.wb-more-icon {
+  display: grid;
+  place-items: center;
+  width: 38px;
+  height: 38px;
+  border-radius: 11px;
+  background: var(--wb-card-2);
+  color: var(--wb-cat-purple);
+  flex: 0 0 auto;
+}
+.wb-more-text { flex: 1 1 auto; min-width: 0; display: flex; flex-direction: column; gap: 2px; }
+.wb-more-label { font-size: 15px; font-weight: 650; }
+.wb-more-sub { font-size: 12.5px; color: var(--wb-text-meta); }
+.wb-more-chev { color: var(--wb-text-meta); flex: 0 0 auto; }
+
+/* ── Deferred-feature placeholder ────────────────────────────────────────── */
+.wb-placeholder {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 40px 32px 120px;
+  color: var(--wb-text);
+}
+.wb-placeholder-icon {
+  display: grid;
+  place-items: center;
+  width: 76px;
+  height: 76px;
+  border-radius: 50%;
+  background: var(--wb-card-2);
+  color: var(--wb-cat-purple);
+  margin-bottom: 18px;
+}
+.wb-placeholder-title {
+  margin: 0 0 8px;
+  font-family: var(--v2-font-display);
+  font-size: 22px;
+  font-weight: 800;
+}
+.wb-placeholder-body { margin: 0; font-size: 14px; color: var(--wb-text-meta); max-width: 260px; }

--- a/src/v2/wallaby/WallabyShell.jsx
+++ b/src/v2/wallaby/WallabyShell.jsx
@@ -1,0 +1,115 @@
+import { useState } from 'react'
+import { Timer, BookOpen, Smile, Settings, FolderKanban, User, ChevronRight } from 'lucide-react'
+import HomeView from './HomeView'
+import HabitsView from './HabitsView'
+import TasksView from './TasksView'
+import ProfileView from './ProfileView'
+import GoalsView from './GoalsView'
+import WallabyNav from './WallabyNav'
+import './WallabyShell.css'
+
+// Wallaby shell — the loggd IA. Full-screen container shown in Wallaby mode on
+// mobile: a bottom nav (Home/Habits/Tasks/Timer/More) over the active surface.
+// "More" opens secondary surfaces (Profile, Goals) and deferred-feature
+// placeholders (Timer, Vision, Daily) — those features land after the reskin.
+export default function WallabyShell({
+  tasks = [], routines = [], projects = [], labels = [],
+  dailyStats = {}, streak = 0, records = {}, lifetimeDone = 0,
+  onToggleHabit, onCompleteTask, onToggleItem, onOpenTask, onAddTask, onAddHabit,
+  onLogSession, onCompleteProject, onEditProject, onSetAsideProject, onDeleteProject,
+  onOpenSettings,
+}) {
+  const [tab, setTab] = useState('home')
+  const [sub, setSub] = useState(null) // 'profile' | 'goals' | null
+
+  let surface
+  if (sub === 'profile') {
+    surface = (
+      <ProfileView
+        dailyStats={dailyStats} streak={streak} records={records}
+        lifetimeDone={lifetimeDone} routines={routines}
+        onClose={() => setSub(null)}
+      />
+    )
+  } else if (sub === 'goals') {
+    surface = (
+      <GoalsView
+        projects={projects} tasks={tasks} labels={labels}
+        onLogSession={onLogSession} onComplete={onCompleteProject} onEdit={onEditProject}
+        onSetAside={onSetAsideProject} onDelete={onDeleteProject} onAdd={onAddTask}
+        onClose={() => setSub(null)}
+      />
+    )
+  } else if (tab === 'home') {
+    surface = <HomeView routines={routines} onToggleHabit={onToggleHabit} onOpenProfile={() => setSub('profile')} />
+  } else if (tab === 'habits') {
+    surface = <HabitsView routines={routines} onAdd={onAddHabit} />
+  } else if (tab === 'tasks') {
+    surface = (
+      <TasksView
+        tasks={tasks} labels={labels}
+        onToggleComplete={onCompleteTask} onToggleItem={onToggleItem}
+        onOpenTask={onOpenTask} onAdd={onAddTask}
+      />
+    )
+  } else if (tab === 'timer') {
+    surface = <Placeholder icon={<Timer size={34} strokeWidth={1.75} />} title="Timer" body="Focus timer is coming after the reskin." />
+  } else {
+    surface = <MoreMenu onOpenProfile={() => setSub('profile')} onOpenGoals={() => setSub('goals')} onOpenSettings={onOpenSettings} />
+  }
+
+  return (
+    <div className="wb-shell">
+      <div className="wb-shell-surface">{surface}</div>
+      <WallabyNav
+        active={sub ? '' : tab}
+        onChange={(t) => { setSub(null); setTab(t) }}
+      />
+    </div>
+  )
+}
+
+function MoreMenu({ onOpenProfile, onOpenGoals, onOpenSettings }) {
+  const rows = [
+    { key: 'profile', icon: User, label: 'Profile', sub: 'Stats + your activity year', onClick: onOpenProfile },
+    { key: 'goals', icon: FolderKanban, label: 'Goals', sub: 'Projects · progress + sessions', onClick: onOpenGoals },
+    { key: 'vision', icon: BookOpen, label: 'Vision', sub: 'Coming soon', soon: true },
+    { key: 'daily', icon: Smile, label: 'Daily check-in', sub: 'Coming soon', soon: true },
+    { key: 'settings', icon: Settings, label: 'Settings', sub: 'App configuration', onClick: onOpenSettings },
+  ]
+  return (
+    <div className="wb-more">
+      <h1 className="wb-more-title">More</h1>
+      <div className="wb-more-list">
+        {rows.map(r => {
+          const Icon = r.icon
+          return (
+            <button
+              key={r.key}
+              className={`wb-more-row${r.soon ? ' is-soon' : ''}`}
+              onClick={() => !r.soon && r.onClick?.()}
+              disabled={r.soon}
+            >
+              <span className="wb-more-icon"><Icon size={20} strokeWidth={1.9} /></span>
+              <span className="wb-more-text">
+                <span className="wb-more-label">{r.label}</span>
+                <span className="wb-more-sub">{r.sub}</span>
+              </span>
+              {!r.soon && <ChevronRight size={18} strokeWidth={1.75} className="wb-more-chev" />}
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+function Placeholder({ icon, title, body }) {
+  return (
+    <div className="wb-placeholder">
+      <span className="wb-placeholder-icon">{icon}</span>
+      <h2 className="wb-placeholder-title">{title}</h2>
+      <p className="wb-placeholder-body">{body}</p>
+    </div>
+  )
+}

--- a/src/wallaby-preview.jsx
+++ b/src/wallaby-preview.jsx
@@ -9,6 +9,7 @@ import HabitsView from './v2/wallaby/HabitsView'
 import TasksView from './v2/wallaby/TasksView'
 import ProfileView from './v2/wallaby/ProfileView'
 import GoalsView from './v2/wallaby/GoalsView'
+import HomeView from './v2/wallaby/HomeView'
 
 document.documentElement.setAttribute('data-ui', 'v2')
 document.documentElement.setAttribute('data-theme', new URLSearchParams(location.search).get('theme') || 'wallaby-dark')
@@ -98,6 +99,8 @@ if (surface === 'tasks') {
       onAdd={() => {}}
     />,
   )
+} else if (surface === 'home') {
+  root.render(<HomeView routines={data} onToggleHabit={() => {}} onOpenProfile={() => {}} />)
 } else {
   root.render(<HabitsView routines={data} onAdd={() => {}} />)
 }

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,12 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-06
 
+- feat(ui): Wallaby bottom-nav shell + Home daily agenda [L]
+  - **What.** The loggd IA. `WallabyShell` + `WallabyNav` give Wallaby mode a 5-tab bottom nav — **Home · Habits · Tasks · Timer · More** — over the active surface. New `HomeView` (loggd `IMG_1582`): date hero + week strip, streak-at-risk banner, today's habits as checkable rows (per-habit color check toggles today's `completed_history`). **More** routes to Profile + Goals and shows deferred-feature placeholders (Timer, Vision, Daily check-in) — those features land after the reskin per scope.
+  - **Integration.** `AppV2` renders `<WallabyShell>` (z-40, covers header/list) when `isWallaby && !isDesktop`, and skips the standard `BottomTabs`. Shared modals (Edit/Add/Settings, z-100) still open above the shell. Habits/Tasks/Profile/Goals are now reached as nav tabs / More entries rather than the interim Spaces rows.
+  - **Scope.** Reskin-only: net-new features (Timer logic, Vision, Daily mood-journal, XP/levels/achievements) are deferred — placeholders for now.
+  - **Verification.** Driven through the real app in wallaby-dark: Home renders the daily agenda + week strip, all 5 tabs switch, More lists Profile/Goals/Settings + Coming-soon Vision/Daily.
+
 - feat(ui): Wallaby Goals surface (projects as goals) [M]
   - **What.** Fourth Wallaby surface (loggd `IMG_1572`): `src/v2/wallaby/GoalsView.{jsx,css}`. A goals list (project cards with category chip + gradient progress bar + sessions/steps meta) and a goal **detail** with a big metric card (steps-complete or sessions-logged, progress bar, budget), a "Why this matters" notes block, and the full **semantic action button** set — orange *Log session* / slate *Edit goal* / green *Complete* / yellow *Set aside* / red *Delete* (two-tap confirm).
   - **Mapping.** Boomerang projects → goals. Progress prefers child-step completion (`done/total` of `parent_id` children), falling back to `session_count` toward the 10-session cap. Budget via `computeProjectBudget`. Category chips from `tags` → labels; target from `due_date` (else "Ongoing").


### PR DESCRIPTION
The keystone — the loggd information architecture.

## What's here
- `WallabyShell` + `WallabyNav` — a fixed **5-tab bottom nav (Home · Habits · Tasks · Timer · More)** over the active surface, shown in Wallaby mode on mobile.
- `HomeView` — the **Home daily agenda** (loggd IMG_1582): date hero + week strip (activity dots), a streak-at-risk banner, and today's habits as checkable rows (per-habit-colored check toggles today's `completed_history`).
- **More** routes to Profile + Goals, with **Coming-soon** placeholders for Timer / Vision / Daily check-in.

## Integration
`AppV2` renders `<WallabyShell>` (`position:fixed`, z-40 — covers the standard header + list) when `isWallaby && !isDesktop`, and skips the standard `BottomTabs`. Shared modals (Edit/Add/Settings, z-100) still open above the shell. Desktop keeps Kanban + drawer.

## Scope
**Reskin-only.** Net-new features (Timer logic, Vision, Daily mood-journal, XP/levels/achievements) are deferred to placeholders per direction — this PR is navigation + the daily-agenda reskin.

## Verification
- `npm run build` green, `npm run lint` 0 errors.
- Driven through the real built app in wallaby-dark: Home renders the agenda + week strip (Saturday 6 highlighted), all 5 tabs switch, More lists Profile/Goals/Settings + Coming-soon Vision/Daily.

## Next (reskin)
Habit detail + month-calendar (tap a Habits card), per-card month labels + clickable heatmaps, Tasks "Done" tab + TODAY/TOMORROW grouping, optional persistent top header.

https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk)_