### PR TITLE
docs(wallaby): running ideas backlog from loggd reference

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1051,6 +1051,11 @@ screenshot verification. NOT imported by `index.html`, so it never ships to
 prod or affects the running app. Verified via a headless-Chromium (puppeteer)
 screenshot loop — render before claiming a surface works.
 
+**Running backlog of every observed loggd feature** (reskin status + deferred
+net-new features like Timer / Vision / Daily mood / gamification / notifications
+center / habit templates) lives in **`wiki/Wallaby-Ideas.md`** — keep it current
+as the reskin proceeds and new reference comes in.
+
 **Reskin still to do:** habit detail + month-calendar view (tap a Habits card →
 stats + completion calendar + archive/delete, loggd `IMG_1586`), per-card month
 labels + clickable heatmaps on the Habits single view, Tasks 3rd "Done" tab +

--- a/wiki/Wallaby-Ideas.md
+++ b/wiki/Wallaby-Ideas.md
@@ -1,0 +1,72 @@
+# Wallaby — Running Ideas & Backlog
+
+Living catalog of everything observed in the loggd.life reference (screenshots +
+PDFs, 2026-06-06), mapped to Boomerang. **Current phase = reskin only.** Net-new
+features are parked here until the reskin lands. Add to this list freely; don't
+delete — strike through or mark `DROPPED` instead.
+
+**Legend:** ✅ done · 🔧 in progress · ⬜ reskin todo · 🅿️ deferred (new feature) · ❓ needs decision
+
+---
+
+## 1. Information architecture
+
+Bottom nav (loggd): **Home · Habits · Tasks · Timer · More**.
+- ✅ Bottom-nav shell (`WallabyShell`/`WallabyNav`), Wallaby-mode only, mobile.
+- More → Profile, Goals, Settings + Coming-soon (Vision, Daily).
+- ❓ Persistent top app header (brand wordmark + notifications bell + avatar) above each surface — loggd has one; not yet built.
+- 🅿️ Desktop layout for Wallaby (currently desktop keeps Kanban + drawer).
+
+## 2. Surfaces — reskin status
+
+| Surface | Status | Notes |
+|---|---|---|
+| Habits — Single/Week/Month heatmap cards | ✅ | per-habit color, streak/count badges |
+| Tasks — list | ✅ (partial) | ⬜ add **Done** tab (Upcoming/Backlog/Done w/ counts); ⬜ TODAY/TOMORROW grouping w/ icons; ⬜ per-task checkbox color (priority? label? — ❓); ⬜ notes subtitle line |
+| Goals (projects) — list + detail | ✅ | metric, progress, semantic buttons |
+| Profile / dashboard | ✅ (partial) | ⬜ add **Level / XP / achievements** row (🅿️ those are new features); ❓ Public Profile sub-tab |
+| Home — daily agenda | ✅ (basic) | ⬜ enrich toward **Today's Pulse** (below) |
+| Habit detail + month calendar | ⬜ | loggd `IMG_1586`: tap a habit → stats (🔥Streak / Best / Total) + completion calendar + Archive/Delete. Reskin of routine detail. |
+| Habits single-view month labels + tap→calendar | ⬜ | per-card month labels; heatmap is the tap target |
+| Settings (tabbed) | ⬜ | Account / Notifications / Preferences / Privacy / API; per-type Push/Email toggles (Boomerang already has the data) |
+
+### Home "Today's Pulse" (richer Home — PDF 1)
+The real Home is a scrolling daily dashboard. Reskin-able parts (existing data):
+- ⬜ **Pulse** banner: "X habits left (n/m done)", "n tasks for today", streak-at-risk
+- ⬜ **Daily summary** card: "You put in Xh deep work, finished N tasks…" + mini activity heatmap + day-streak
+- ⬜ **Tasks today** section (n/m done, Manage/Hide)
+- ✅ **Habits today** section (checkable rows)
+- 🅿️ **Reflection + Today's Mood** (new — mood journal)
+- 🅿️ **Vision Whisper** (new — mission/vision)
+- ❓ Week/Month toggle on the Home week strip
+
+## 3. Deferred net-new features (after reskin)
+
+**Gamification (PDF 3):**
+- 🅿️ XP + Levels (named tiers: Committed, Devoted, …) — `Lvl 35 · 7,625 XP`
+- 🅿️ Badges with rarity (Common/Uncommon/Rare/Epic) + XP rewards (One Month Club, Quarter Veteran, Year One, Week Warrior…)
+- 🅿️ Achievements row on Profile (Pro Member, Month Master, Dedicated, Perfect Week, Visionary)
+- 🅿️ Streak milestones + "streak at risk" protection
+- 🅿️ Goal progress % nudges ("25% Progress!")
+- 🅿️ Leaderboard ("#1 on the weekly leaderboard")
+
+**New surfaces / features:**
+- 🅿️ **Timer** — focus timer (deep-work sessions feed Home summary)
+- 🅿️ **Vision** — Eulogy Method + Bucket List (checklists, progress, "Think Big") — `IMG_1579`
+- 🅿️ **Daily check-in** — rainbow mood slider (1–10) + reflection journal — `IMG_1580`
+- 🅿️ **Notifications center** (bell) — grouped feed, All/Unread, mark-all-read — `PDF 3`
+- 🅿️ **Weekly review / Week in Review** — recap of streaks, XP, check-ins, % habits
+- 🅿️ **Public Profile** — shareable read-only profile (Overview vs Public Profile sub-tabs)
+
+**Habit mechanics (PDF 4 + IMG_1582):**
+- 🅿️ **Habit templates** picker on create ("Pick a habit" — categorized: Sync/Health/Nutrition…, Custom)
+- 🅿️ **Multi-check habits** (do N times/day — the count badges like "2")
+- 🅿️ **Timed habits** (e.g. Meditation `0m/15m`, play button)
+- 🅿️ **Habit sync sources** (GitHub Activity, Post on Threads/Reddit — auto-logged from external activity)
+- 🅿️ Single / Weekly / **Yearly** range option (vs current Single/Week/Month)
+
+## 4. Open questions (❓ for the next screenshot/answer)
+1. Persistent top header in Wallaby (brand + bell + avatar) — include in reskin, or skip until notifications/gamification land?
+2. Tasks checkbox colors — driven by priority, by first label/category color, or fixed per task?
+3. Home week strip Week/Month toggle — needed in the reskin?
+4. Active bottom-nav color — currently green; keep?


### PR DESCRIPTION
Captures the full loggd feature surface (from the screenshots + 4 PDFs) as a living backlog so nothing gets lost while we reskin.

`wiki/Wallaby-Ideas.md`:
- **IA** + per-surface **reskin status** (done / todo)
- The richer **Today's Pulse** Home breakdown (which parts are reskin vs new)
- **Deferred net-new features**: Timer, Vision (eulogy/bucket list), Daily mood-journal, Notifications center, gamification (XP/levels/badges/rarity/leaderboard/goal-progress nudges), habit templates, multi-check & timed habits, public profile, weekly review
- **Open questions** for the next pass (top header, checkbox colors, week/month toggle, nav color)

Plus a pointer from `CLAUDE.md`. Docs only — no code.

https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk)_