### PR TITLE
feat(ui): Wallaby habit detail + month calendar; Single/Month/Year

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1007,8 +1007,12 @@ tokens even if reached from a non-Wallaby theme.
   `currentStreak`, `weekStart`/`addDays`/`fmtMonthDay`.
 - `HabitsView.{jsx,css}` — the **Habits** screen. Routines (filtered to
   non-paused) as habit cards: color icon tile + title + streak/count badges +
-  the grid. Single (full heatmap) / Week (7 day-cells + date stepper) / Month
-  (calendar grid). Distinct per-habit color by list index. Purple FAB.
+  the grid. Range tabs **Single** (rolling heatmap + month labels) / **Month**
+  (calendar) / **Year** (53-week heatmap). Tapping a card opens the **habit
+  detail** (loggd `IMG_1586`): Streak/Best/Total stat cards, a month completion
+  calendar (stepper + N-done/%), Edit (→ routine editor) / Archive (→
+  `togglePause`) / Delete (→ `deleteRoutine`). Distinct per-habit color by list
+  index. Purple FAB.
 - `TasksView.{jsx,css}` — the **Tasks** screen. Segmented Upcoming/Backlog,
   tasks grouped (Overdue/Today/Upcoming/Anytime), pink square checkboxes
   (orange for high-pri), label chips from `tags`, nested checklist items as
@@ -1056,12 +1060,14 @@ net-new features like Timer / Vision / Daily mood / gamification / notifications
 center / habit templates) lives in **`wiki/Wallaby-Ideas.md`** — keep it current
 as the reskin proceeds and new reference comes in.
 
-**Reskin still to do:** habit detail + month-calendar view (tap a Habits card →
-stats + completion calendar + archive/delete, loggd `IMG_1586`), per-card month
-labels + clickable heatmaps on the Habits single view, Tasks 3rd "Done" tab +
-TODAY/TOMORROW grouping, an optional persistent Wallaby top header (brand + bell
-+ avatar). **Deferred net-new features (after reskin):** Timer, Vision
-(eulogy/bucket list), Daily mood-journal, XP/levels/achievements.
+**Reskin still to do:** persistent Wallaby **top header** (brand + 🔔 bell +
+avatar) with the bell opening a **notifications center** that reads Boomerang's
+existing notification log (`GET /api/notifications/log`); **Tasks** — 3rd "Done"
+tab + TODAY/TOMORROW grouping + semi-random per-task checkbox colors (not tied to
+priority/label) + task tap → quick action sheet (reschedule/focus/edit/delete);
+tabbed **Settings** + **Analytics** reskin; richer **Today's Pulse** Home.
+**Deferred net-new features (after reskin):** Timer, Vision (eulogy/bucket list),
+Daily mood-journal, XP/levels/achievements, notifications gamification.
 
 ## Additional Notes
 - Single developer (ryakel) — no PR review process needed.

--- a/src/v2/AppV2.jsx
+++ b/src/v2/AppV2.jsx
@@ -1193,6 +1193,9 @@ export default function AppV2() {
           onOpenTask={(task) => setEditTarget(task)}
           onAddTask={() => setShowAdd(true)}
           onAddHabit={() => setShowRoutines(true)}
+          onEditHabit={(r) => { setEditRoutineId(r.id); setShowRoutines(true) }}
+          onArchiveHabit={(r) => togglePause(r.id)}
+          onDeleteHabit={(r) => deleteRoutine(r.id)}
           onLogSession={(p) => logProjectSession(p.id)}
           onCompleteProject={(p) => handleComplete(p.id)}
           onEditProject={(p) => setEditTarget(p)}

--- a/src/v2/wallaby/HabitsView.css
+++ b/src/v2/wallaby/HabitsView.css
@@ -107,6 +107,8 @@
   padding: 14px 15px 16px;
   box-shadow: var(--wb-shadow);
 }
+.wb-card-tappable { cursor: pointer; transition: border-color 140ms ease; }
+.wb-card-tappable:hover { border-color: var(--wb-hairline-strong); }
 .wb-card-head {
   display: flex;
   align-items: center;
@@ -232,3 +234,93 @@
 }
 .wb-fab-habits { background: var(--wb-fab-habits); }
 .wb-fab-tasks { background: var(--wb-fab-tasks); }
+
+/* ── Habit detail + month calendar (loggd IMG_1586) ──────────────────────── */
+.wb-hd-title { font-size: 22px; margin-right: auto; }
+.wb-hd-body { display: flex; flex-direction: column; gap: 16px; }
+.wb-hd-id { display: flex; align-items: center; gap: 10px; }
+.wb-hd-icon { display: grid; place-items: center; width: 32px; height: 32px; border-radius: 9px; flex: 0 0 auto; }
+.wb-hd-cadence { font-size: 13px; font-weight: 700; }
+.wb-hd-desc { margin: 0; font-size: 14.5px; line-height: 1.45; color: var(--wb-text); }
+
+.wb-hd-stats {
+  display: flex;
+  gap: 10px;
+}
+.wb-hd-stat {
+  flex: 1 1 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 14px 8px;
+  background: var(--wb-card);
+  border: 1px solid var(--wb-hairline);
+  border-radius: 14px;
+  box-shadow: var(--wb-shadow);
+}
+.wb-hd-stat-v {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-family: var(--v2-font-display);
+  font-size: 22px;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+}
+.wb-hd-stat-l { font-size: 11.5px; font-weight: 600; color: var(--wb-text-meta); }
+
+.wb-hd-today {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  align-self: flex-start;
+  font-size: 13px;
+  font-weight: 700;
+  padding: 7px 13px;
+  border-radius: 999px;
+  background: var(--wb-card-2);
+  color: var(--wb-text-meta);
+}
+.wb-hd-today.is-done { background: color-mix(in srgb, var(--wb-action-complete) 22%, transparent); color: var(--wb-action-complete); }
+
+.wb-hd-cal {
+  background: var(--wb-card);
+  border: 1px solid var(--wb-hairline);
+  border-radius: 16px;
+  padding: 14px;
+  box-shadow: var(--wb-shadow);
+}
+.wb-hd-cal .wb-stepper { background: transparent; border: none; padding: 0 0 12px; }
+.wb-hd-cal-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 12px;
+  font-size: 13px;
+  color: var(--wb-text-meta);
+}
+.wb-hd-cal-pct { font-weight: 800; }
+
+.wb-hd-actions { display: flex; flex-direction: column; gap: 10px; }
+
+/* Shared semantic buttons (mirrors GoalsView so the detail styles standalone) */
+.wb-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  border: none;
+  border-radius: 13px;
+  padding: 13px 16px;
+  font: 700 14px/1 var(--v2-font-body);
+  color: #fff;
+  cursor: pointer;
+}
+.wb-btn-secondary { background: var(--wb-action-secondary); color: var(--wb-text); }
+.wb-btn-delete { background: transparent; color: var(--wb-action-delete); }
+.wb-btn-delete-solid { background: var(--wb-action-delete); }
+.wb-btn-ghost { background: var(--wb-card-2); color: var(--wb-text); }
+.wb-goal-confirm { display: flex; align-items: center; gap: 10px; font-size: 14px; color: var(--wb-text); }
+.wb-goal-confirm > span { flex: 1 1 auto; }
+.wb-goal-confirm .wb-btn { padding: 10px 14px; }

--- a/src/v2/wallaby/HabitsView.jsx
+++ b/src/v2/wallaby/HabitsView.jsx
@@ -1,12 +1,11 @@
 import { useMemo, useState } from 'react'
 import {
-  Plus, Flame, ChevronLeft, ChevronRight, ArrowLeft,
+  Plus, Flame, ChevronLeft, ChevronRight, ArrowLeft, Pencil, Check, Archive, Trash2,
   Monitor, Users, MapPin, Palette, Dumbbell, Repeat,
 } from 'lucide-react'
 import ContributionHeatmap from './ContributionHeatmap'
 import {
-  WALLABY_COLORS, historyByDay, currentStreak,
-  weekStart, addDays, fmtMonthDay, localYMD,
+  WALLABY_COLORS, historyByDay, currentStreak, longestStreak, localYMD,
 } from './heatmapUtils'
 import './HabitsView.css'
 
@@ -14,28 +13,43 @@ const ENERGY_ICONS = { desk: Monitor, people: Users, errand: MapPin, creative: P
 const DOW = ['M', 'T', 'W', 'T', 'F', 'S', 'S']
 const MODES = [
   { id: 'single', label: 'Single' },
-  { id: 'week', label: 'Week' },
   { id: 'month', label: 'Month' },
+  { id: 'year', label: 'Year' },
 ]
 
-// Wallaby "Habits" surface — Boomerang routines rendered as loggd-style habit
-// cards. Each routine gets a stable per-habit color and a GitHub contribution
-// grid built from its completed_history. Three views: Single (full heatmap),
-// Week (7 day-cells with a date stepper), Month (calendar grid).
-export default function HabitsView({ routines = [], onAdd, onClose }) {
+// Wallaby "Habits" surface — Boomerang routines as loggd-style habit cards.
+// Per-habit color + a contribution grid from completed_history. Single (rolling
+// heatmap) / Month (calendar) / Year (full-year heatmap). Tapping a card opens
+// the habit detail + month-calendar (loggd IMG_1586).
+export default function HabitsView({
+  routines = [], onAdd, onClose,
+  onEditHabit, onArchiveHabit, onDeleteHabit,
+}) {
   const [mode, setMode] = useState('single')
-  const [weekOffset, setWeekOffset] = useState(0)
   const [monthOffset, setMonthOffset] = useState(0)
+  const [selectedId, setSelectedId] = useState(null)
 
   const habits = useMemo(() => routines.filter(r => !r.paused), [routines])
-
-  const wkStart = weekStart(new Date(), weekOffset)
-  const wkEnd = addDays(wkStart, 6)
+  const colorOf = (r) => WALLABY_COLORS[Math.max(0, habits.findIndex(h => h.id === r.id)) % WALLABY_COLORS.length]
 
   const monthRef = useMemo(() => {
     const d = new Date(); d.setDate(1); d.setMonth(d.getMonth() + monthOffset); d.setHours(0, 0, 0, 0)
     return d
   }, [monthOffset])
+
+  const selected = habits.find(h => h.id === selectedId)
+  if (selected) {
+    return (
+      <HabitDetail
+        routine={selected}
+        color={colorOf(selected)}
+        onBack={() => setSelectedId(null)}
+        onEdit={onEditHabit}
+        onArchive={(r) => { onArchiveHabit?.(r); setSelectedId(null) }}
+        onDelete={(r) => { onDeleteHabit?.(r); setSelectedId(null) }}
+      />
+    )
+  }
 
   return (
     <div className="wb-habits">
@@ -60,22 +74,6 @@ export default function HabitsView({ routines = [], onAdd, onClose }) {
           </div>
         </div>
 
-        {mode === 'week' && (
-          <div className="wb-stepper">
-            <button className="wb-stepper-btn" onClick={() => setWeekOffset(o => o - 1)} aria-label="Previous week">
-              <ChevronLeft size={18} strokeWidth={2.25} />
-            </button>
-            <span className="wb-stepper-label">{fmtMonthDay(wkStart)} – {fmtMonthDay(wkEnd)}, {wkEnd.getFullYear()}</span>
-            <button
-              className="wb-stepper-btn"
-              onClick={() => setWeekOffset(o => Math.min(0, o + 1))}
-              disabled={weekOffset >= 0}
-              aria-label="Next week"
-            >
-              <ChevronRight size={18} strokeWidth={2.25} />
-            </button>
-          </div>
-        )}
         {mode === 'month' && (
           <div className="wb-stepper">
             <button className="wb-stepper-btn" onClick={() => setMonthOffset(o => o - 1)} aria-label="Previous month">
@@ -97,14 +95,14 @@ export default function HabitsView({ routines = [], onAdd, onClose }) {
       </header>
 
       <div className="wb-habits-list">
-        {habits.map((r, i) => (
+        {habits.map(r => (
           <HabitCard
             key={r.id}
             routine={r}
-            color={WALLABY_COLORS[i % WALLABY_COLORS.length]}
+            color={colorOf(r)}
             mode={mode}
-            wkStart={wkStart}
             monthRef={monthRef}
+            onOpen={() => setSelectedId(r.id)}
           />
         ))}
       </div>
@@ -116,14 +114,14 @@ export default function HabitsView({ routines = [], onAdd, onClose }) {
   )
 }
 
-function HabitCard({ routine, color, mode, wkStart, monthRef }) {
+function HabitCard({ routine, color, mode, monthRef, onOpen }) {
   const Icon = ENERGY_ICONS[routine.energy] || Repeat
   const valueByDay = useMemo(() => historyByDay(routine.completed_history), [routine.completed_history])
   const total = routine.completed_history?.length || 0
   const streak = useMemo(() => currentStreak(valueByDay), [valueByDay])
 
   return (
-    <article className="wb-card" style={{ '--habit': color }}>
+    <article className="wb-card wb-card-tappable" style={{ '--habit': color }} onClick={onOpen}>
       <div className="wb-card-head">
         <span className="wb-card-icon" style={{ background: color }}>
           <Icon size={16} strokeWidth={2} color="#fff" />
@@ -139,30 +137,14 @@ function HabitCard({ routine, color, mode, wkStart, monthRef }) {
 
       {mode === 'single' && (
         <div className="wb-card-body">
-          <ContributionHeatmap valueByDay={valueByDay} color={color} weeks={22} cellSize={13} gap={3} />
+          <ContributionHeatmap valueByDay={valueByDay} color={color} weeks={26} gap={3} showMonths />
         </div>
       )}
-
-      {mode === 'week' && (
-        <div className="wb-week">
-          {Array.from({ length: 7 }, (_, i) => {
-            const day = addDays(wkStart, i)
-            const key = localYMD(day)
-            const done = (valueByDay[key] || 0) > 0
-            const isToday = key === localYMD(new Date())
-            return (
-              <div key={key} className={`wb-week-day${isToday ? ' is-today' : ''}`}>
-                <span className="wb-week-dow">{DOW[i]}</span>
-                <span
-                  className={`wb-week-cell${done ? ' is-done' : ''}`}
-                  style={done ? { background: color, borderColor: color } : undefined}
-                >{day.getDate()}</span>
-              </div>
-            )
-          })}
+      {mode === 'year' && (
+        <div className="wb-card-body">
+          <ContributionHeatmap valueByDay={valueByDay} color={color} weeks={53} gap={2} showMonths />
         </div>
       )}
-
       {mode === 'month' && (
         <MonthGrid monthRef={monthRef} valueByDay={valueByDay} color={color} />
       )}
@@ -173,7 +155,7 @@ function HabitCard({ routine, color, mode, wkStart, monthRef }) {
 function MonthGrid({ monthRef, valueByDay, color }) {
   const cells = useMemo(() => {
     const first = new Date(monthRef)
-    const startPad = (first.getDay() + 6) % 7 // Monday-anchored leading blanks
+    const startPad = (first.getDay() + 6) % 7
     const daysInMonth = new Date(first.getFullYear(), first.getMonth() + 1, 0).getDate()
     const out = []
     for (let i = 0; i < startPad; i++) out.push(null)
@@ -196,6 +178,95 @@ function MonthGrid({ monthRef, valueByDay, color }) {
             style={c.done ? { background: color, borderColor: color } : undefined}
           >{c.d}</span>
         ))}
+    </div>
+  )
+}
+
+// ── Habit detail + month calendar (loggd IMG_1586) ─────────────────────────
+function HabitDetail({ routine, color, onBack, onEdit, onArchive, onDelete }) {
+  const [monthOffset, setMonthOffset] = useState(0)
+  const [confirmDelete, setConfirmDelete] = useState(false)
+  const Icon = ENERGY_ICONS[routine.energy] || Repeat
+  const valueByDay = useMemo(() => historyByDay(routine.completed_history), [routine.completed_history])
+  const total = routine.completed_history?.length || 0
+  const streak = useMemo(() => currentStreak(valueByDay), [valueByDay])
+  const best = useMemo(() => longestStreak(valueByDay), [valueByDay])
+  const doneToday = !!valueByDay[localYMD(new Date())]
+  const cadence = routine.cadence ? routine.cadence[0].toUpperCase() + routine.cadence.slice(1) : 'Routine'
+
+  const monthRef = useMemo(() => {
+    const d = new Date(); d.setDate(1); d.setMonth(d.getMonth() + monthOffset); d.setHours(0, 0, 0, 0)
+    return d
+  }, [monthOffset])
+
+  const monthStats = useMemo(() => {
+    const first = new Date(monthRef)
+    const daysInMonth = new Date(first.getFullYear(), first.getMonth() + 1, 0).getDate()
+    let done = 0
+    for (let d = 1; d <= daysInMonth; d++) {
+      const day = new Date(first.getFullYear(), first.getMonth(), d)
+      if (valueByDay[localYMD(day)]) done++
+    }
+    return { done, pct: Math.round((done / daysInMonth) * 100) }
+  }, [monthRef, valueByDay])
+
+  return (
+    <div className="wb-habits wb-habit-detail">
+      <header className="wb-habits-head">
+        <div className="wb-habits-titlerow">
+          <button className="wb-back" onClick={onBack} aria-label="Back"><ArrowLeft size={20} strokeWidth={2.25} /></button>
+          <h1 className="wb-habits-title wb-hd-title">{routine.title}</h1>
+          {onEdit && (
+            <button className="wb-back" onClick={() => onEdit(routine)} aria-label="Edit habit"><Pencil size={17} strokeWidth={2} /></button>
+          )}
+        </div>
+      </header>
+
+      <div className="wb-hd-body">
+        <div className="wb-hd-id">
+          <span className="wb-hd-icon" style={{ background: color }}><Icon size={18} strokeWidth={2} color="#fff" /></span>
+          <span className="wb-hd-cadence" style={{ color }}>{cadence}</span>
+        </div>
+        {routine.notes && <p className="wb-hd-desc">{routine.notes}</p>}
+
+        <div className="wb-hd-stats">
+          <div className="wb-hd-stat"><span className="wb-hd-stat-v" style={{ color }}><Flame size={16} strokeWidth={2.25} /> {streak}</span><span className="wb-hd-stat-l">Streak</span></div>
+          <div className="wb-hd-stat"><span className="wb-hd-stat-v">{best}</span><span className="wb-hd-stat-l">Best</span></div>
+          <div className="wb-hd-stat"><span className="wb-hd-stat-v">{total}</span><span className="wb-hd-stat-l">Total</span></div>
+        </div>
+
+        <div className={`wb-hd-today${doneToday ? ' is-done' : ''}`}>
+          {doneToday ? <><Check size={15} strokeWidth={2.5} /> Done today</> : 'Not logged today'}
+        </div>
+
+        <div className="wb-hd-cal">
+          <div className="wb-stepper">
+            <button className="wb-stepper-btn" onClick={() => setMonthOffset(o => o - 1)} aria-label="Previous month"><ChevronLeft size={18} strokeWidth={2.25} /></button>
+            <span className="wb-stepper-label">{monthRef.toLocaleDateString('en-US', { month: 'long', year: 'numeric' })}</span>
+            <button className="wb-stepper-btn" onClick={() => setMonthOffset(o => Math.min(0, o + 1))} disabled={monthOffset >= 0} aria-label="Next month"><ChevronRight size={18} strokeWidth={2.25} /></button>
+          </div>
+          <MonthGrid monthRef={monthRef} valueByDay={valueByDay} color={color} />
+          <div className="wb-hd-cal-foot">
+            <span>{monthStats.done} day{monthStats.done === 1 ? '' : 's'} completed</span>
+            <span className="wb-hd-cal-pct" style={{ color }}>{monthStats.pct}%</span>
+          </div>
+        </div>
+
+        <div className="wb-hd-actions">
+          {onArchive && (
+            <button className="wb-btn wb-btn-secondary" onClick={() => onArchive(routine)}><Archive size={15} strokeWidth={2} /> Archive</button>
+          )}
+          {confirmDelete ? (
+            <div className="wb-goal-confirm">
+              <span>Delete this habit?</span>
+              <button className="wb-btn wb-btn-delete-solid" onClick={() => onDelete?.(routine)}>Delete</button>
+              <button className="wb-btn wb-btn-ghost" onClick={() => setConfirmDelete(false)}>Cancel</button>
+            </div>
+          ) : (
+            <button className="wb-btn wb-btn-delete" onClick={() => setConfirmDelete(true)}><Trash2 size={15} strokeWidth={2} /> Delete habit</button>
+          )}
+        </div>
+      </div>
     </div>
   )
 }

--- a/src/v2/wallaby/WallabyShell.jsx
+++ b/src/v2/wallaby/WallabyShell.jsx
@@ -16,6 +16,7 @@ export default function WallabyShell({
   tasks = [], routines = [], projects = [], labels = [],
   dailyStats = {}, streak = 0, records = {}, lifetimeDone = 0,
   onToggleHabit, onCompleteTask, onToggleItem, onOpenTask, onAddTask, onAddHabit,
+  onEditHabit, onArchiveHabit, onDeleteHabit,
   onLogSession, onCompleteProject, onEditProject, onSetAsideProject, onDeleteProject,
   onOpenSettings,
 }) {
@@ -43,7 +44,15 @@ export default function WallabyShell({
   } else if (tab === 'home') {
     surface = <HomeView routines={routines} onToggleHabit={onToggleHabit} onOpenProfile={() => setSub('profile')} />
   } else if (tab === 'habits') {
-    surface = <HabitsView routines={routines} onAdd={onAddHabit} />
+    surface = (
+      <HabitsView
+        routines={routines}
+        onAdd={onAddHabit}
+        onEditHabit={onEditHabit}
+        onArchiveHabit={onArchiveHabit}
+        onDeleteHabit={onDeleteHabit}
+      />
+    )
   } else if (tab === 'tasks') {
     surface = (
       <TasksView

--- a/src/v2/wallaby/heatmapUtils.js
+++ b/src/v2/wallaby/heatmapUtils.js
@@ -46,6 +46,19 @@ export function currentStreak(valueByDay) {
   return streak
 }
 
+// Longest run of consecutive logged days anywhere in the history.
+export function longestStreak(valueByDay) {
+  const days = Object.keys(valueByDay).filter(k => valueByDay[k]).sort()
+  if (days.length === 0) return 0
+  let best = 1, run = 1
+  for (let i = 1; i < days.length; i++) {
+    const prev = new Date(days[i - 1]); prev.setDate(prev.getDate() + 1)
+    if (localYMD(prev) === days[i]) { run++; best = Math.max(best, run) }
+    else run = 1
+  }
+  return best
+}
+
 // Monday-anchored start of the week containing `ref` (+ weekOffset weeks).
 export function weekStart(ref, weekOffset = 0) {
   const d = new Date(ref)

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,12 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-06
 
+- feat(ui): Wallaby habit detail + month calendar; Habits Single/Month/Year [M]
+  - **What.** Tapping a Habits card opens the **habit detail** (loggd `IMG_1586`): icon + cadence, description, **Streak / Best / Total** stat cards, a "logged today" pill, a **month calendar** of completions (‹›  stepper + "N days completed / X%"), and **Archive / Delete** (two-tap). Edit (pencil) opens the routine editor.
+  - Habits range tabs are now **Single / Month / Year** (per direction): Single = rolling heatmap **with per-card month labels**, Month = calendar grid, Year = full 53-week heatmap. Cards are tappable. Added `longestStreak` to `heatmapUtils`.
+  - **Wiring.** `HabitsView` manages list↔detail internally; detail actions thread through `WallabyShell` → `AppV2`: Edit → routine editor (`setEditRoutineId`+`setShowRoutines`), Archive → `togglePause`, Delete → `deleteRoutine`. **Reskin only** — reads `completed_history`, no new data.
+  - **Verification.** Rendered via the harness: detail (Streak/Best/Total + month calendar), Single with month labels, Year heatmap.
+
 - feat(ui): Wallaby bottom-nav shell + Home daily agenda [L]
   - **What.** The loggd IA. `WallabyShell` + `WallabyNav` give Wallaby mode a 5-tab bottom nav — **Home · Habits · Tasks · Timer · More** — over the active surface. New `HomeView` (loggd `IMG_1582`): date hero + week strip, streak-at-risk banner, today's habits as checkable rows (per-habit color check toggles today's `completed_history`). **More** routes to Profile + Goals and shows deferred-feature placeholders (Timer, Vision, Daily check-in) — those features land after the reskin per scope.
   - **Integration.** `AppV2` renders `<WallabyShell>` (z-40, covers header/list) when `isWallaby && !isDesktop`, and skips the standard `BottomTabs`. Shared modals (Edit/Add/Settings, z-100) still open above the shell. Habits/Tasks/Profile/Goals are now reached as nav tabs / More entries rather than the interim Spaces rows.

--- a/wiki/Wallaby-Ideas.md
+++ b/wiki/Wallaby-Ideas.md
@@ -21,13 +21,12 @@ Bottom nav (loggd): **Home · Habits · Tasks · Timer · More**.
 
 | Surface | Status | Notes |
 |---|---|---|
-| Habits — Single/Week/Month heatmap cards | ✅ | per-habit color, streak/count badges |
+| Habits — Single/Month/Year heatmap cards | ✅ | per-habit color, streak/count badges, per-card month labels |
+| Habit detail + month calendar | ✅ | tap a card → Streak/Best/Total + completion calendar + Archive/Delete/Edit (`IMG_1586`) |
 | Tasks — list | ✅ (partial) | ⬜ add **Done** tab (Upcoming/Backlog/Done w/ counts); ⬜ TODAY/TOMORROW grouping w/ icons; ⬜ per-task checkbox color (priority? label? — ❓); ⬜ notes subtitle line |
 | Goals (projects) — list + detail | ✅ | metric, progress, semantic buttons |
 | Profile / dashboard | ✅ (partial) | ⬜ add **Level / XP / achievements** row (🅿️ those are new features); ❓ Public Profile sub-tab |
 | Home — daily agenda | ✅ (basic) | ⬜ enrich toward **Today's Pulse** (below) |
-| Habit detail + month calendar | ⬜ | loggd `IMG_1586`: tap a habit → stats (🔥Streak / Best / Total) + completion calendar + Archive/Delete. Reskin of routine detail. |
-| Habits single-view month labels + tap→calendar | ⬜ | per-card month labels; heatmap is the tap target |
 | Settings (tabbed) | ⬜ | Account / Notifications / Preferences / Privacy / API; per-type Push/Email toggles (Boomerang already has the data) |
 | Analytics — "Your productivity insights" | ⬜ / 🅿️ | Tabbed **Overview / Habits / Tasks / Goals / Focus**. Weekly **points** total + ‹week› nav, 🔥current/🏆best streak, stat cards (Habits checks, Tasks completed, Focus time, Check-ins), **Points Breakdown by activity type**, weekly **mood bar-chart** + **reflections** recap. Reskin-able: points/streak/habit+task counts (Boomerang has these). Deferred: focus-time, check-ins, mood, badge points (tied to new features). Reached via More/Profile. |
 


### PR DESCRIPTION
The clickable-heatmap → calendar flow you emphasized.

## What's here
- **Habit detail + month calendar** (loggd IMG_1586): tap a Habits card → icon + cadence, description, **Streak / Best / Total** stat cards, a "logged today" pill, a **month completion calendar** (‹›  stepper + "N days completed / X%"), and **Archive / Delete** (two-tap) + **Edit** (→ routine editor).
- Habits range tabs → **Single / Month / Year** (per your call): Single = rolling heatmap **with per-card month labels**, Month = calendar, Year = full 53-week heatmap. Cards tappable.
- `longestStreak` added to `heatmapUtils`.

## Wiring
`HabitsView` manages list↔detail internally; detail actions thread `WallabyShell` → `AppV2`: Edit → `setEditRoutineId`+`setShowRoutines`, Archive → `togglePause`, Delete → `deleteRoutine`.

## Scope
**Reskin only** — reads `completed_history`, uses existing pause/delete/edit. No new data, schema, or endpoints.

## Verification
- `npm run build` green, `npm run lint` 0 errors.
- Rendered via harness: detail (Streak/Best/Total + month calendar + Archive/Delete), Single with month labels, Year heatmap.

https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk)_