### PR TITLE
feat(ui): Wallaby top header + notifications center

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1032,10 +1032,15 @@ tokens even if reached from a non-Wallaby theme.
   + Sunday-anchored week strip (activity dots), a streak-at-risk banner, and
   today's habits (non-paused routines) as checkable rows; the per-habit-colored
   check toggles today's entry in `completed_history`.
+- `WallabyHeader.{jsx,css}` — persistent top app bar (brand + 🔔 bell + avatar)
+  above every shell surface. Bell → notifications center; avatar → Profile.
+- `NotificationsView.{jsx,css}` — notifications center reading the existing
+  `GET /api/notifications/log` (All/Unread, grouped Today/Yesterday/Earlier,
+  type-colored icons, optimistic mark-all-read). Reskin — no new data.
 - `WallabyNav.{jsx,css}` + `WallabyShell.{jsx,css}` — the loggd IA. A fixed 5-tab
-  bottom nav (**Home · Habits · Tasks · Timer · More**) over the active surface.
-  Timer is a deferred-feature placeholder; **More** routes to Profile + Goals and
-  shows Coming-soon rows for Vision + Daily check-in.
+  bottom nav (**Home · Habits · Tasks · Timer · More**) + the top header, over
+  the active surface. Timer is a deferred-feature placeholder; **More** routes to
+  Profile + Goals and shows Coming-soon rows for Vision + Daily check-in.
 
 **How the surfaces are reached (Wallaby mode).** `AppV2` renders `<WallabyShell>`
 (`position:fixed`, z-40 — covers the standard header + list) when
@@ -1060,9 +1065,7 @@ net-new features like Timer / Vision / Daily mood / gamification / notifications
 center / habit templates) lives in **`wiki/Wallaby-Ideas.md`** — keep it current
 as the reskin proceeds and new reference comes in.
 
-**Reskin still to do:** persistent Wallaby **top header** (brand + 🔔 bell +
-avatar) with the bell opening a **notifications center** that reads Boomerang's
-existing notification log (`GET /api/notifications/log`); **Tasks** — 3rd "Done"
+**Reskin still to do:** **Tasks** — 3rd "Done"
 tab + TODAY/TOMORROW grouping + semi-random per-task checkbox colors (not tied to
 priority/label) + task tap → quick action sheet (reschedule/focus/edit/delete);
 tabbed **Settings** + **Analytics** reskin; richer **Today's Pulse** Home.

--- a/src/v2/wallaby/NotificationsView.css
+++ b/src/v2/wallaby/NotificationsView.css
@@ -1,0 +1,84 @@
+/* Wallaby notifications center — reads the existing notification_log. */
+.wb-notifs {
+  min-height: 100vh;
+  background: var(--wb-bg);
+  color: var(--wb-text);
+  padding: 16px 16px 120px;
+  font-family: var(--v2-font-body);
+  -webkit-font-smoothing: antialiased;
+}
+.wb-notifs-title { font-size: 24px; margin-right: auto; }
+.wb-notifs-markall {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 12.5px;
+  font-weight: 700;
+  color: var(--wb-action-complete);
+  background: none;
+  border: none;
+  cursor: pointer;
+  flex: 0 0 auto;
+}
+.wb-notifs-seg { margin-top: 14px; }
+
+.wb-notifs-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding: 60px 20px;
+  color: var(--wb-text-meta);
+  text-align: center;
+}
+.wb-notifs-empty-icon {
+  display: grid;
+  place-items: center;
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  background: var(--wb-card-2);
+  color: var(--wb-cat-green);
+}
+
+.wb-notifs-group { margin-top: 18px; }
+.wb-notifs-group-label {
+  margin: 0 2px 8px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--wb-text-meta);
+}
+.wb-notif {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  background: var(--wb-card);
+  border: 1px solid var(--wb-hairline);
+  border-radius: 14px;
+  padding: 13px 14px;
+  margin-bottom: 8px;
+}
+.wb-notif.is-unread { border-color: color-mix(in srgb, var(--wb-action-complete) 35%, transparent); }
+.wb-notif-icon {
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 10px;
+  background: var(--wb-card-2);
+  flex: 0 0 auto;
+}
+.wb-notif-text { flex: 1 1 auto; min-width: 0; display: flex; flex-direction: column; gap: 3px; }
+.wb-notif-title { font-size: 14.5px; font-weight: 650; color: var(--wb-text); }
+.wb-notif-body { font-size: 13px; color: var(--wb-text); opacity: 0.85; line-height: 1.4; }
+.wb-notif-meta { font-size: 11.5px; color: var(--wb-text-meta); margin-top: 1px; }
+.wb-notif-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--wb-action-complete);
+  flex: 0 0 auto;
+  margin-top: 6px;
+}

--- a/src/v2/wallaby/NotificationsView.jsx
+++ b/src/v2/wallaby/NotificationsView.jsx
@@ -1,0 +1,96 @@
+import { useMemo, useState } from 'react'
+import {
+  ArrowLeft, Bell, AlertCircle, Clock, Layers, Package, CloudSun, Sparkles, CheckCheck,
+} from 'lucide-react'
+import { localYMD } from './heatmapUtils'
+import './NotificationsView.css'
+
+// Type → icon + accent. Reskin of Boomerang's existing notification_log; no
+// gamification — just the real notifications the app already produces.
+function meta(type = '') {
+  if (type.includes('overdue') || type.includes('highpri')) return { Icon: AlertCircle, color: 'var(--wb-action-delete)' }
+  if (type.includes('stale')) return { Icon: Clock, color: 'var(--wb-cat-orange)' }
+  if (type.includes('pileup')) return { Icon: Layers, color: 'var(--wb-cat-purple)' }
+  if (type.includes('package')) return { Icon: Package, color: 'var(--wb-cat-blue)' }
+  if (type.includes('weather')) return { Icon: CloudSun, color: 'var(--wb-cat-blue)' }
+  if (type.includes('quokka') || type.includes('adviser')) return { Icon: Sparkles, color: 'var(--wb-cat-purple)' }
+  return { Icon: Bell, color: 'var(--wb-cat-green)' }
+}
+
+function ago(iso) {
+  const t = new Date(iso).getTime()
+  if (Number.isNaN(t)) return ''
+  const s = Math.max(0, (Date.now() - t) / 1000)
+  if (s < 60) return 'just now'
+  if (s < 3600) return `${Math.floor(s / 60)}m ago`
+  if (s < 86400) return `${Math.floor(s / 3600)}h ago`
+  return `${Math.floor(s / 86400)}d ago`
+}
+
+function bucket(iso) {
+  const today = localYMD(new Date())
+  const y = new Date(); y.setDate(y.getDate() - 1)
+  const d = localYMD(iso)
+  if (d === today) return 'Today'
+  if (d === localYMD(y)) return 'Yesterday'
+  return 'Earlier'
+}
+
+export default function NotificationsView({ entries = [], onMarkAllRead, onClose }) {
+  const [tab, setTab] = useState('all')
+  const unreadCount = useMemo(() => entries.filter(e => !e.tapped_at).length, [entries])
+
+  const shown = tab === 'unread' ? entries.filter(e => !e.tapped_at) : entries
+  const groups = useMemo(() => {
+    const order = ['Today', 'Yesterday', 'Earlier']
+    const map = {}
+    for (const e of shown) (map[bucket(e.sent_at)] ||= []).push(e)
+    return order.filter(k => map[k]).map(k => ({ label: k, items: map[k] }))
+  }, [shown])
+
+  return (
+    <div className="wb-notifs">
+      <header className="wb-habits-head">
+        <div className="wb-habits-titlerow">
+          <button className="wb-back" onClick={onClose} aria-label="Back"><ArrowLeft size={20} strokeWidth={2.25} /></button>
+          <h1 className="wb-habits-title wb-notifs-title">Notifications</h1>
+          {unreadCount > 0 && onMarkAllRead && (
+            <button className="wb-notifs-markall" onClick={onMarkAllRead}><CheckCheck size={15} strokeWidth={2} /> Mark all read</button>
+          )}
+        </div>
+        <div className="wb-seg wb-notifs-seg" role="tablist">
+          {[{ id: 'all', label: 'All' }, { id: 'unread', label: `Unread${unreadCount ? ` (${unreadCount})` : ''}` }].map(t => (
+            <button key={t.id} className={`wb-seg-btn${tab === t.id ? ' is-active' : ''}`} onClick={() => setTab(t.id)}>{t.label}</button>
+          ))}
+        </div>
+      </header>
+
+      {groups.length === 0 && (
+        <div className="wb-notifs-empty">
+          <span className="wb-notifs-empty-icon"><Bell size={30} strokeWidth={1.75} /></span>
+          <p>{tab === 'unread' ? "You're all caught up." : 'No notifications yet.'}</p>
+        </div>
+      )}
+
+      {groups.map(g => (
+        <section key={g.label} className="wb-notifs-group">
+          <h2 className="wb-notifs-group-label">{g.label}</h2>
+          {g.items.map(e => {
+            const { Icon, color } = meta(e.type)
+            return (
+              <div key={e.id} className={`wb-notif${e.tapped_at ? '' : ' is-unread'}`}>
+                <span className="wb-notif-icon" style={{ color }}><Icon size={18} strokeWidth={2} /></span>
+                <div className="wb-notif-text">
+                  {e.title && <span className="wb-notif-title">{e.title}</span>}
+                  {e.body && <span className="wb-notif-body">{e.body}</span>}
+                  <span className="wb-notif-meta">{e.channel ? `${e.channel} · ` : ''}{ago(e.sent_at)}</span>
+                </div>
+                {!e.tapped_at && <span className="wb-notif-dot" />}
+              </div>
+            )
+          })}
+        </section>
+      ))}
+    </div>
+  )
+}

--- a/src/v2/wallaby/WallabyHeader.css
+++ b/src/v2/wallaby/WallabyHeader.css
@@ -1,0 +1,71 @@
+/* Wallaby top app bar — fixed, above the surface, below the shared modals. */
+.wb-header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 46;
+  height: var(--wb-header-h, 52px);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 16px calc(0px + env(safe-area-inset-top));
+  padding-top: env(safe-area-inset-top);
+  background: color-mix(in srgb, var(--wb-card) 92%, transparent);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border-bottom: 1px solid var(--wb-hairline);
+}
+.wb-header-brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--v2-font-display);
+  font-size: 17px;
+  font-weight: 800;
+  letter-spacing: -0.01em;
+  color: var(--wb-text);
+}
+.wb-header-mark {
+  width: 16px;
+  height: 16px;
+  border-radius: 5px;
+  background: var(--wb-action-complete);
+}
+.wb-header-actions { display: flex; align-items: center; gap: 10px; }
+.wb-header-btn {
+  position: relative;
+  display: grid;
+  place-items: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 10px;
+  border: none;
+  background: transparent;
+  color: var(--wb-text-meta);
+  cursor: pointer;
+}
+.wb-header-btn:hover { color: var(--wb-text); }
+.wb-header-badge {
+  position: absolute;
+  top: 2px;
+  right: 1px;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 4px;
+  border-radius: 999px;
+  background: var(--wb-action-delete);
+  color: #fff;
+  font-size: 10px;
+  font-weight: 800;
+  line-height: 16px;
+  text-align: center;
+}
+.wb-header-avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: none;
+  cursor: pointer;
+  background: linear-gradient(135deg, var(--wb-cat-green), var(--wb-cat-blue));
+}

--- a/src/v2/wallaby/WallabyHeader.jsx
+++ b/src/v2/wallaby/WallabyHeader.jsx
@@ -1,0 +1,22 @@
+import { Bell } from 'lucide-react'
+import './WallabyHeader.css'
+
+// Wallaby persistent top app bar (loggd): brand wordmark left, notifications
+// bell (with unread badge) + avatar right. Sits above every shell surface.
+export default function WallabyHeader({ unread = 0, onBell, onAvatar }) {
+  return (
+    <header className="wb-header">
+      <span className="wb-header-brand">
+        <span className="wb-header-mark" aria-hidden="true" />
+        Boomerang
+      </span>
+      <div className="wb-header-actions">
+        <button className="wb-header-btn" onClick={onBell} aria-label="Notifications">
+          <Bell size={20} strokeWidth={1.9} />
+          {unread > 0 && <span className="wb-header-badge">{unread > 99 ? '99+' : unread}</span>}
+        </button>
+        <button className="wb-header-avatar" onClick={onAvatar} aria-label="Profile" />
+      </div>
+    </header>
+  )
+}

--- a/src/v2/wallaby/WallabyShell.css
+++ b/src/v2/wallaby/WallabyShell.css
@@ -1,6 +1,7 @@
 /* Wallaby shell — full-screen container with a fixed bottom nav. Surfaces
  * already carry 120px bottom padding so their content clears the nav. */
 .wb-shell {
+  --wb-header-h: 52px;
   position: fixed;
   inset: 0;
   z-index: 40;
@@ -8,7 +9,10 @@
 }
 .wb-shell-surface {
   position: absolute;
-  inset: 0;
+  top: calc(var(--wb-header-h) + env(safe-area-inset-top));
+  left: 0;
+  right: 0;
+  bottom: 0;
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
 }

--- a/src/v2/wallaby/WallabyShell.jsx
+++ b/src/v2/wallaby/WallabyShell.jsx
@@ -1,11 +1,13 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Timer, BookOpen, Smile, Settings, FolderKanban, User, ChevronRight } from 'lucide-react'
 import HomeView from './HomeView'
 import HabitsView from './HabitsView'
 import TasksView from './TasksView'
 import ProfileView from './ProfileView'
 import GoalsView from './GoalsView'
+import NotificationsView from './NotificationsView'
 import WallabyNav from './WallabyNav'
+import WallabyHeader from './WallabyHeader'
 import './WallabyShell.css'
 
 // Wallaby shell — the loggd IA. Full-screen container shown in Wallaby mode on
@@ -21,7 +23,23 @@ export default function WallabyShell({
   onOpenSettings,
 }) {
   const [tab, setTab] = useState('home')
-  const [sub, setSub] = useState(null) // 'profile' | 'goals' | null
+  const [sub, setSub] = useState(null) // 'profile' | 'goals' | 'notifications' | null
+
+  // Notifications center reads the existing notification_log (reskin — no new
+  // data). Mark-all-read is optimistic client-side for now; reliable read
+  // persistence is part of the backend notifications fix.
+  const [notifEntries, setNotifEntries] = useState([])
+  useEffect(() => {
+    fetch('/api/notifications/log?limit=200')
+      .then(r => r.ok ? r.json() : null)
+      .then(d => { if (d?.entries) setNotifEntries(d.entries) })
+      .catch(() => {})
+  }, [])
+  const unread = notifEntries.filter(e => !e.tapped_at).length
+  const markAllRead = () => {
+    const now = new Date().toISOString()
+    setNotifEntries(prev => prev.map(e => e.tapped_at ? e : { ...e, tapped_at: now }))
+  }
 
   let surface
   if (sub === 'profile') {
@@ -41,8 +59,10 @@ export default function WallabyShell({
         onClose={() => setSub(null)}
       />
     )
+  } else if (sub === 'notifications') {
+    surface = <NotificationsView entries={notifEntries} onMarkAllRead={markAllRead} onClose={() => setSub(null)} />
   } else if (tab === 'home') {
-    surface = <HomeView routines={routines} onToggleHabit={onToggleHabit} onOpenProfile={() => setSub('profile')} />
+    surface = <HomeView routines={routines} onToggleHabit={onToggleHabit} />
   } else if (tab === 'habits') {
     surface = (
       <HabitsView
@@ -69,6 +89,11 @@ export default function WallabyShell({
 
   return (
     <div className="wb-shell">
+      <WallabyHeader
+        unread={unread}
+        onBell={() => setSub('notifications')}
+        onAvatar={() => setSub('profile')}
+      />
       <div className="wb-shell-surface">{surface}</div>
       <WallabyNav
         active={sub ? '' : tab}

--- a/src/wallaby-preview.jsx
+++ b/src/wallaby-preview.jsx
@@ -10,6 +10,7 @@ import TasksView from './v2/wallaby/TasksView'
 import ProfileView from './v2/wallaby/ProfileView'
 import GoalsView from './v2/wallaby/GoalsView'
 import HomeView from './v2/wallaby/HomeView'
+import NotificationsView from './v2/wallaby/NotificationsView'
 
 document.documentElement.setAttribute('data-ui', 'v2')
 document.documentElement.setAttribute('data-theme', new URLSearchParams(location.search).get('theme') || 'wallaby-dark')
@@ -101,6 +102,15 @@ if (surface === 'tasks') {
   )
 } else if (surface === 'home') {
   root.render(<HomeView routines={data} onToggleHabit={() => {}} onOpenProfile={() => {}} />)
+} else if (surface === 'notifications') {
+  const now = Date.now()
+  const entries = [
+    { id: 'n1', type: 'overdue', title: 'Code review for PR #142', body: '1 day overdue — still on your list.', channel: 'push', sent_at: new Date(now - 2 * 3600e3).toISOString() },
+    { id: 'n2', type: 'stale', title: 'Clean out fridge', body: "Carrying for 6 days — want to knock it out?", channel: 'push', sent_at: new Date(now - 5 * 3600e3).toISOString() },
+    { id: 'n3', type: 'package_delivered', title: 'Package delivered', body: 'Your order was delivered.', channel: 'pushover', sent_at: new Date(now - 26 * 3600e3).toISOString(), tapped_at: new Date(now - 25 * 3600e3).toISOString() },
+    { id: 'n4', type: 'nudge', title: 'Morning review', body: 'Plan the day — 3 tasks waiting.', channel: 'email', sent_at: new Date(now - 50 * 3600e3).toISOString(), tapped_at: new Date(now - 49 * 3600e3).toISOString() },
+  ]
+  root.render(<NotificationsView entries={entries} onMarkAllRead={() => {}} onClose={() => {}} />)
 } else {
   root.render(<HabitsView routines={data} onAdd={() => {}} />)
 }

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,12 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-06
 
+- feat(ui): Wallaby top header + notifications center [M]
+  - **What.** Persistent Wallaby top app bar (`WallabyHeader`): brand wordmark + 🔔 bell (unread badge) + avatar, above every shell surface. Bell → `NotificationsView` — a loggd-style notifications center that reads Boomerang's **existing** `GET /api/notifications/log`: All/Unread tabs, grouped Today/Yesterday/Earlier, type-colored icons (overdue/stale/pileup/package/weather/quokka), channel + time-ago, unread dots, optimistic Mark-all-read. Avatar → Profile.
+  - **Wiring.** `WallabyShell` fetches the log once for the badge + center; header offsets the surface (`--wb-header-h`). Home's redundant date-hero avatar removed (header owns it).
+  - **Scope.** Reskin — reads the existing log; no new data. (Reliable read-state persistence + the underlying notification-delivery bug are backend follow-ups, flagged separately.)
+  - **Verification.** Real app: header brand/bell/avatar over Home; center renders grouped real-typed entries with the right icons.
+
 - feat(ui): Wallaby habit detail + month calendar; Habits Single/Month/Year [M]
   - **What.** Tapping a Habits card opens the **habit detail** (loggd `IMG_1586`): icon + cadence, description, **Streak / Best / Total** stat cards, a "logged today" pill, a **month calendar** of completions (‹›  stepper + "N days completed / X%"), and **Archive / Delete** (two-tap). Edit (pencil) opens the routine editor.
   - Habits range tabs are now **Single / Month / Year** (per direction): Single = rolling heatmap **with per-card month labels**, Month = calendar grid, Year = full 53-week heatmap. Cards are tappable. Added `longestStreak` to `heatmapUtils`.

--- a/wiki/Wallaby-Ideas.md
+++ b/wiki/Wallaby-Ideas.md
@@ -14,7 +14,8 @@ delete — strike through or mark `DROPPED` instead.
 Bottom nav (loggd): **Home · Habits · Tasks · Timer · More**.
 - ✅ Bottom-nav shell (`WallabyShell`/`WallabyNav`), Wallaby-mode only, mobile.
 - More → Profile, Goals, Settings + Coming-soon (Vision, Daily).
-- ❓ Persistent top app header (brand wordmark + notifications bell + avatar) above each surface — loggd has one; not yet built.
+- ✅ Persistent top app header (`WallabyHeader`: brand + 🔔 bell + avatar) above each surface; bell → notifications center, avatar → Profile.
+- ✅ Notifications center (`NotificationsView`) — reads existing `/api/notifications/log`, All/Unread, grouped, type icons, optimistic mark-all-read. (🅿️ reliable read-state persistence + delivery-bug fix = backend follow-up.)
 - 🅿️ Desktop layout for Wallaby (currently desktop keeps Kanban + drawer).
 
 ## 2. Surfaces — reskin status


### PR DESCRIPTION
Reskin: the persistent top app bar + a notifications center driven by Boomerang's **existing** notification log.

## What's here
- `WallabyHeader` — brand wordmark + 🔔 bell (unread badge) + avatar, above every shell surface. Bell → notifications center; avatar → Profile.
- `NotificationsView` — loggd-style center reading `GET /api/notifications/log`: All/Unread tabs, grouped Today/Yesterday/Earlier, type-colored icons (overdue/stale/pileup/package/weather/quokka), channel + time-ago, unread dots, optimistic Mark-all-read.
- `WallabyShell` fetches the log for the badge + center, offsets the surface by `--wb-header-h`; Home's redundant avatar removed.

## Scope
**Reskin** — reads the existing log, no new data/schema/endpoints. Reliable read-state persistence + the underlying "notifications are fucked" delivery bug are **backend follow-ups**, flagged separately (not in this PR).

## Verification
- `npm run build` green, `npm run lint` 0 errors.
- Real app: header over Home (brand/bell/avatar); center renders grouped, real-typed entries with correct icons + Unread filter.

https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk)_