### PR TITLE
feat(ui): Wallaby Tasks refinements + QA pass (header overlap, home check)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1065,10 +1065,15 @@ net-new features like Timer / Vision / Daily mood / gamification / notifications
 center / habit templates) lives in **`wiki/Wallaby-Ideas.md`** — keep it current
 as the reskin proceeds and new reference comes in.
 
-**Reskin still to do:** **Tasks** — 3rd "Done"
-tab + TODAY/TOMORROW grouping + semi-random per-task checkbox colors (not tied to
-priority/label) + task tap → quick action sheet (reschedule/focus/edit/delete);
-tabbed **Settings** + **Analytics** reskin; richer **Today's Pulse** Home.
+**Reskin still to do:** tabbed **Settings** + **Analytics** reskin; richer
+**Today's Pulse** Home (pulse/summary/today's-tasks — mood/vision parts are
+deferred features). (Tasks Done-tab + grouping + checkbox colors + action sheet:
+done.)
+
+**Wallaby gotcha:** `store.localYMD(d)` requires a **Date** (`d.getFullYear()`),
+NOT an ISO string — wrap completion timestamps in `new Date(ts)`. The Wallaby
+`heatmapUtils.localYMD` handles strings; don't mix them up. (This silently broke
+the Home habit check — the throw aborted the handler.)
 **Deferred net-new features (after reskin):** Timer, Vision (eulogy/bucket list),
 Daily mood-journal, XP/levels/achievements, notifications gamification.
 

--- a/src/v2/AppV2.jsx
+++ b/src/v2/AppV2.jsx
@@ -1177,8 +1177,9 @@ export default function AppV2() {
           onToggleHabit={(routine) => {
             const today = localYMD(new Date())
             const hist = Array.isArray(routine.completed_history) ? routine.completed_history : []
-            if (hist.some(ts => localYMD(ts) === today)) {
-              updateRoutine(routine.id, { completed_history: hist.filter(ts => localYMD(ts) !== today) })
+            const isToday = (ts) => localYMD(new Date(ts)) === today
+            if (hist.some(isToday)) {
+              updateRoutine(routine.id, { completed_history: hist.filter(ts => !isToday(ts)) })
             } else {
               completeRoutine(routine.id)
             }
@@ -1192,6 +1193,8 @@ export default function AppV2() {
           }}
           onOpenTask={(task) => setEditTarget(task)}
           onAddTask={() => setShowAdd(true)}
+          onRescheduleTask={(task, ymd) => updateTask(task.id, { due_date: ymd })}
+          onDeleteTask={(task) => deleteTask(task.id)}
           onAddHabit={() => setShowRoutines(true)}
           onEditHabit={(r) => { setEditRoutineId(r.id); setShowRoutines(true) }}
           onArchiveHabit={(r) => togglePause(r.id)}

--- a/src/v2/wallaby/TasksView.css
+++ b/src/v2/wallaby/TasksView.css
@@ -208,3 +208,120 @@
   text-decoration: line-through;
   opacity: 0.6;
 }
+
+/* ── Tasks refinements: section icons, counts, notes sub, done state ─────── */
+.wb-tasks-section-label { display: flex; align-items: center; gap: 6px; }
+.wb-tasks-section-icon { color: var(--wb-text-meta); }
+.wb-seg-count {
+  margin-left: 6px;
+  font-size: 10.5px;
+  font-weight: 800;
+  opacity: 0.8;
+}
+.wb-check { display: grid; place-items: center; }
+.wb-task-sub {
+  font-size: 12.5px;
+  color: var(--wb-text-meta);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.wb-task-title.is-done { text-decoration: line-through; color: var(--wb-text-meta); }
+
+/* ── Task action sheet ───────────────────────────────────────────────────── */
+.wb-sheet-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 90;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: flex-end;
+  animation: wb-fade 160ms ease;
+}
+.wb-sheet {
+  position: relative;
+  width: 100%;
+  background: var(--wb-card);
+  border-top-left-radius: 22px;
+  border-top-right-radius: 22px;
+  border-top: 1px solid var(--wb-hairline);
+  padding: 22px 18px calc(26px + env(safe-area-inset-bottom));
+  box-shadow: 0 -8px 32px rgba(0, 0, 0, 0.45);
+  animation: wb-slideup 200ms cubic-bezier(0.2, 0.7, 0.2, 1);
+}
+@keyframes wb-fade { from { opacity: 0 } to { opacity: 1 } }
+@keyframes wb-slideup { from { transform: translateY(100%) } to { transform: translateY(0) } }
+.wb-sheet-close {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  display: grid;
+  place-items: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: none;
+  background: var(--wb-card-2);
+  color: var(--wb-text-meta);
+  cursor: pointer;
+}
+.wb-sheet-title {
+  margin: 0 36px 8px 0;
+  font-family: var(--v2-font-display);
+  font-size: 19px;
+  font-weight: 800;
+  color: var(--wb-text);
+}
+.wb-sheet-meta { display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 18px; }
+.wb-sheet-section-label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--wb-text-meta);
+  margin-bottom: 9px;
+}
+.wb-sheet-resched { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 18px; }
+.wb-sheet-chip {
+  flex: 1 1 calc(50% - 4px);
+  padding: 11px;
+  border-radius: 11px;
+  border: 1px solid var(--wb-hairline);
+  background: var(--wb-card-2);
+  color: var(--wb-text);
+  font-size: 13.5px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.wb-sheet-chip:hover { border-color: var(--wb-hairline-strong); }
+.wb-sheet-actions { display: flex; flex-direction: column; gap: 2px; }
+.wb-sheet-row {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  width: 100%;
+  text-align: left;
+  padding: 14px 6px;
+  background: none;
+  border: none;
+  border-radius: 10px;
+  color: var(--wb-text);
+  font-size: 15px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.wb-sheet-row:hover { background: var(--wb-card-2); }
+.wb-sheet-row-danger { color: var(--wb-action-delete); }
+.wb-sheet-row.is-soon { color: var(--wb-text-meta); cursor: default; }
+.wb-sheet-row.is-soon:hover { background: none; }
+.wb-sheet-soon {
+  margin-left: auto;
+  font-size: 11px;
+  font-weight: 700;
+  background: var(--wb-card-2);
+  border-radius: 999px;
+  padding: 2px 8px;
+}

--- a/src/v2/wallaby/TasksView.jsx
+++ b/src/v2/wallaby/TasksView.jsx
@@ -1,33 +1,50 @@
 import { useMemo, useState } from 'react'
-import { ArrowLeft, Search, Plus, Check } from 'lucide-react'
+import {
+  ArrowLeft, Search, Plus, Check, Sun, ArrowRight, AlertCircle, CalendarDays,
+  Inbox, CheckCircle2, Archive, Pencil, Trash2, Timer, X, Calendar,
+} from 'lucide-react'
 import { localYMD } from './heatmapUtils'
 import './TasksView.css'
 
 const ACTIVE = ['not_started', 'doing', 'waiting', 'in_progress']
+const CHECK_COLORS = ['#EA6C9D', '#F0973E', '#E6B43E', '#4F8DF5', '#41C083', '#8C7CF0']
+function taskColor(id) {
+  const s = String(id ?? '')
+  let h = 0
+  for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) >>> 0
+  return CHECK_COLORS[h % CHECK_COLORS.length]
+}
+const SECTION_ICON = {
+  overdue: AlertCircle, today: Sun, tomorrow: ArrowRight,
+  soon: CalendarDays, anytime: Inbox, backlog: Inbox, done: CheckCircle2,
+}
 
-// Wallaby "Tasks" surface — loggd-style task list. Segmented Upcoming / Backlog,
-// pink square checkboxes, nested checklist items as circular sub-checkboxes,
-// colored label chips, green FAB. Reads Boomerang's task + label shape directly.
 export default function TasksView({
   tasks = [], labels = [],
-  onToggleComplete, onToggleItem, onAdd, onClose, onOpenTask,
+  onToggleComplete, onToggleItem, onOpenTask, onAdd, onReschedule, onDelete,
 }) {
   const [tab, setTab] = useState('upcoming')
   const [query, setQuery] = useState('')
   const [searchOpen, setSearchOpen] = useState(false)
+  const [sheetTask, setSheetTask] = useState(null)
 
   const labelsById = useMemo(() => {
-    const m = {}
-    for (const l of labels) m[l.id] = l
-    return m
+    const m = {}; for (const l of labels) m[l.id] = l; return m
   }, [labels])
+
+  const counts = useMemo(() => ({
+    upcoming: tasks.filter(t => ACTIVE.includes(t.status) && !t.gmail_pending && !t.parent_id).length,
+    backlog: tasks.filter(t => t.status === 'backlog' && !t.gmail_pending && !t.parent_id).length,
+    done: tasks.filter(t => t.status === 'done').length,
+  }), [tasks])
 
   const visible = useMemo(() => {
     const q = query.trim().toLowerCase()
     return tasks.filter(t => {
-      if (t.gmail_pending) return false
-      if (t.parent_id) return false
-      if (tab === 'backlog' ? t.status !== 'backlog' : !ACTIVE.includes(t.status)) return false
+      if (t.gmail_pending || t.parent_id) return false
+      if (tab === 'done') { if (t.status !== 'done') return false }
+      else if (tab === 'backlog') { if (t.status !== 'backlog') return false }
+      else if (!ACTIVE.includes(t.status)) return false
       if (q && !t.title.toLowerCase().includes(q)) return false
       return true
     })
@@ -39,30 +56,27 @@ export default function TasksView({
     <div className="wb-tasks">
       <header className="wb-tasks-head">
         <div className="wb-tasks-titlerow">
-          {onClose && (
-            <button className="wb-back" onClick={onClose} aria-label="Back">
-              <ArrowLeft size={20} strokeWidth={2.25} />
-            </button>
-          )}
           <h1 className="wb-tasks-title">Tasks</h1>
           <button
             className={`wb-icon-btn${searchOpen ? ' is-active' : ''}`}
             onClick={() => { setSearchOpen(o => !o); if (searchOpen) setQuery('') }}
             aria-label="Search tasks"
-          >
-            <Search size={18} strokeWidth={2} />
-          </button>
+          ><Search size={18} strokeWidth={2} /></button>
         </div>
 
         <div className="wb-seg" role="tablist" aria-label="Task list">
-          {[{ id: 'upcoming', label: 'Upcoming' }, { id: 'backlog', label: 'Backlog' }].map(t => (
+          {[
+            { id: 'upcoming', label: 'Upcoming', n: counts.upcoming },
+            { id: 'backlog', label: 'Backlog', n: counts.backlog },
+            { id: 'done', label: 'Done', n: counts.done },
+          ].map(t => (
             <button
               key={t.id}
               role="tab"
               aria-selected={tab === t.id}
               className={`wb-seg-btn${tab === t.id ? ' is-active' : ''}`}
               onClick={() => setTab(t.id)}
-            >{t.label}</button>
+            >{t.label}{t.n ? <span className="wb-seg-count">{t.n}</span> : null}</button>
           ))}
         </div>
 
@@ -78,61 +92,75 @@ export default function TasksView({
       </header>
 
       <div className="wb-tasks-list">
-        {sections.length === 0 && (
-          <p className="wb-tasks-empty">Nothing here.</p>
-        )}
-        {sections.map(sec => (
-          <section key={sec.key} className="wb-tasks-section">
-            <h2 className="wb-tasks-section-label">{sec.label} <span className="wb-tasks-count">{sec.items.length}</span></h2>
-            {sec.items.map(task => (
-              <TaskRow
-                key={task.id}
-                task={task}
-                labelsById={labelsById}
-                onToggleComplete={onToggleComplete}
-                onToggleItem={onToggleItem}
-                onOpenTask={onOpenTask}
-              />
-            ))}
-          </section>
-        ))}
+        {sections.length === 0 && <p className="wb-tasks-empty">Nothing here.</p>}
+        {sections.map(sec => {
+          const SIcon = SECTION_ICON[sec.key] || CalendarDays
+          return (
+            <section key={sec.key} className="wb-tasks-section">
+              <h2 className="wb-tasks-section-label">
+                <SIcon size={13} strokeWidth={2.25} className="wb-tasks-section-icon" />
+                {sec.label} <span className="wb-tasks-count">{sec.items.length}</span>
+              </h2>
+              {sec.items.map(task => (
+                <TaskRow
+                  key={task.id}
+                  task={task}
+                  labelsById={labelsById}
+                  done={tab === 'done'}
+                  onToggleComplete={onToggleComplete}
+                  onToggleItem={onToggleItem}
+                  onOpen={() => setSheetTask(task)}
+                />
+              ))}
+            </section>
+          )
+        })}
       </div>
 
-      <button className="wb-fab wb-fab-tasks" onClick={onAdd} aria-label="New task">
-        <Plus size={26} strokeWidth={2.5} />
-      </button>
+      <button className="wb-fab wb-fab-tasks" onClick={onAdd} aria-label="New task"><Plus size={26} strokeWidth={2.5} /></button>
+
+      {sheetTask && (
+        <TaskActionSheet
+          task={sheetTask}
+          labelsById={labelsById}
+          onClose={() => setSheetTask(null)}
+          onEdit={() => { const t = sheetTask; setSheetTask(null); onOpenTask?.(t) }}
+          onReschedule={(ymd) => { onReschedule?.(sheetTask, ymd); setSheetTask(null) }}
+          onDelete={() => { onDelete?.(sheetTask); setSheetTask(null) }}
+        />
+      )}
     </div>
   )
 }
 
-function TaskRow({ task, labelsById, onToggleComplete, onToggleItem, onOpenTask }) {
+function TaskRow({ task, labelsById, done, onToggleComplete, onToggleItem, onOpen }) {
   const items = (Array.isArray(task.checklists) ? task.checklists : []).flatMap(cl =>
-    (cl.items || []).map(it => ({ ...it, clId: cl.id })),
-  )
+    (cl.items || []).map(it => ({ ...it, clId: cl.id })))
   const due = dueMeta(task.due_date)
   const tagChips = (task.tags || []).map(id => labelsById[id]).filter(Boolean)
+  const color = taskColor(task.id)
 
   return (
     <div className="wb-task">
       <div className="wb-task-main">
         <button
-          className={`wb-check${task.high_priority ? ' wb-check-hi' : ''}`}
+          className={`wb-check${done ? ' is-done' : ''}`}
+          style={done ? { background: color, borderColor: color } : { borderColor: color }}
           onClick={() => onToggleComplete?.(task)}
-          aria-label="Complete task"
-        />
-        <button className="wb-task-body" onClick={() => onOpenTask?.(task)}>
-          <span className="wb-task-title">{task.title}</span>
-          {(tagChips.length > 0 || due) && (
+          aria-label={done ? 'Reopen task' : 'Complete task'}
+        >{done && <Check size={14} strokeWidth={3} color="#fff" />}</button>
+        <button className="wb-task-body" onClick={onOpen}>
+          <span className={`wb-task-title${done ? ' is-done' : ''}`}>{task.title}</span>
+          {task.notes && !done && <span className="wb-task-sub">{task.notes.replace(/\s+/g, ' ').trim().slice(0, 80)}</span>}
+          {(tagChips.length > 0 || due) && !done && (
             <span className="wb-task-meta">
               {due && <span className={`wb-task-due${due.tone ? ` wb-task-due-${due.tone}` : ''}`}>{due.label}</span>}
-              {tagChips.map(l => (
-                <span key={l.id} className="wb-task-tag" style={{ '--tag': l.color }}>{l.name}</span>
-              ))}
+              {tagChips.map(l => <span key={l.id} className="wb-task-tag" style={{ '--tag': l.color }}>{l.name}</span>)}
             </span>
           )}
         </button>
       </div>
-      {items.length > 0 && (
+      {items.length > 0 && !done && (
         <ul className="wb-subtasks">
           {items.map(it => (
             <li key={it.id} className="wb-subtask">
@@ -140,14 +168,49 @@ function TaskRow({ task, labelsById, onToggleComplete, onToggleItem, onOpenTask 
                 className={`wb-subcheck${it.completed ? ' is-done' : ''}`}
                 onClick={() => onToggleItem?.(task, it.clId, it.id)}
                 aria-label={it.completed ? 'Uncheck' : 'Check'}
-              >
-                {it.completed && <Check size={11} strokeWidth={3} />}
-              </button>
+              >{it.completed && <Check size={11} strokeWidth={3} />}</button>
               <span className={`wb-subtask-text${it.completed ? ' is-done' : ''}`}>{it.text}</span>
             </li>
           ))}
         </ul>
       )}
+    </div>
+  )
+}
+
+function TaskActionSheet({ task, labelsById, onClose, onEdit, onReschedule, onDelete }) {
+  const due = dueMeta(task.due_date)
+  const tagChips = (task.tags || []).map(id => labelsById[id]).filter(Boolean)
+  const ymd = (offset) => { const d = new Date(); d.setDate(d.getDate() + offset); return localYMD(d) }
+  const opts = [
+    { label: 'Today', sub: '', act: () => onReschedule(ymd(0)) },
+    { label: 'Tomorrow', sub: '', act: () => onReschedule(ymd(1)) },
+    { label: 'Next week', sub: '', act: () => onReschedule(ymd(7)) },
+    { label: 'No date', sub: '', act: () => onReschedule(null) },
+  ]
+  return (
+    <div className="wb-sheet-backdrop" onClick={onClose}>
+      <div className="wb-sheet" onClick={e => e.stopPropagation()}>
+        <button className="wb-sheet-close" onClick={onClose} aria-label="Close"><X size={18} strokeWidth={2.25} /></button>
+        <h3 className="wb-sheet-title">{task.title}</h3>
+        <div className="wb-sheet-meta">
+          {due && <span className={`wb-task-due${due.tone ? ` wb-task-due-${due.tone}` : ''}`}>{due.label}</span>}
+          {tagChips.map(l => <span key={l.id} className="wb-task-tag" style={{ '--tag': l.color }}>{l.name}</span>)}
+        </div>
+
+        <div className="wb-sheet-section-label"><Calendar size={13} strokeWidth={2.25} /> Reschedule</div>
+        <div className="wb-sheet-resched">
+          {opts.map(o => (
+            <button key={o.label} className="wb-sheet-chip" onClick={o.act}>{o.label}</button>
+          ))}
+        </div>
+
+        <div className="wb-sheet-actions">
+          <button className="wb-sheet-row is-soon" disabled><Timer size={17} strokeWidth={2} /> Start focus timer <span className="wb-sheet-soon">Soon</span></button>
+          <button className="wb-sheet-row" onClick={onEdit}><Pencil size={16} strokeWidth={2} /> Edit task</button>
+          <button className="wb-sheet-row wb-sheet-row-danger" onClick={onDelete}><Trash2 size={16} strokeWidth={2} /> Delete task</button>
+        </div>
+      </div>
     </div>
   )
 }
@@ -168,23 +231,30 @@ function dueMeta(due) {
 }
 
 function groupTasks(list, tab) {
+  if (tab === 'done') {
+    const sorted = [...list].sort((a, b) => (b.completed_at || '').localeCompare(a.completed_at || ''))
+    return sorted.length ? [{ key: 'done', label: 'Completed', items: sorted.slice(0, 100) }] : []
+  }
   if (tab === 'backlog') {
     return list.length ? [{ key: 'backlog', label: 'Backlog', items: list }] : []
   }
   const today = localYMD(new Date())
-  const buckets = { overdue: [], today: [], soon: [], anytime: [] }
+  const tmr = (() => { const d = new Date(); d.setDate(d.getDate() + 1); return localYMD(d) })()
+  const b = { overdue: [], today: [], tomorrow: [], soon: [], anytime: [] }
   for (const t of list) {
-    if (!t.due_date) { buckets.anytime.push(t); continue }
+    if (!t.due_date) { b.anytime.push(t); continue }
     const d = localYMD(t.due_date)
-    if (d < today) buckets.overdue.push(t)
-    else if (d === today) buckets.today.push(t)
-    else buckets.soon.push(t)
+    if (d < today) b.overdue.push(t)
+    else if (d === today) b.today.push(t)
+    else if (d === tmr) b.tomorrow.push(t)
+    else b.soon.push(t)
   }
-  const byDue = (a, b) => (a.due_date || '').localeCompare(b.due_date || '')
+  const byDue = (x, y) => (x.due_date || '').localeCompare(y.due_date || '')
   const out = []
-  if (buckets.overdue.length) out.push({ key: 'overdue', label: 'Overdue', items: buckets.overdue.sort(byDue) })
-  if (buckets.today.length) out.push({ key: 'today', label: 'Today', items: buckets.today })
-  if (buckets.soon.length) out.push({ key: 'soon', label: 'Upcoming', items: buckets.soon.sort(byDue) })
-  if (buckets.anytime.length) out.push({ key: 'anytime', label: 'Anytime', items: buckets.anytime })
+  if (b.overdue.length) out.push({ key: 'overdue', label: 'Overdue', items: b.overdue.sort(byDue) })
+  if (b.today.length) out.push({ key: 'today', label: 'Today', items: b.today })
+  if (b.tomorrow.length) out.push({ key: 'tomorrow', label: 'Tomorrow', items: b.tomorrow })
+  if (b.soon.length) out.push({ key: 'soon', label: 'Upcoming', items: b.soon.sort(byDue) })
+  if (b.anytime.length) out.push({ key: 'anytime', label: 'Anytime', items: b.anytime })
   return out
 }

--- a/src/v2/wallaby/WallabyHeader.css
+++ b/src/v2/wallaby/WallabyHeader.css
@@ -5,12 +5,14 @@
   left: 0;
   right: 0;
   z-index: 46;
-  height: var(--wb-header-h, 52px);
+  box-sizing: border-box;
+  /* Total height = bar + the notch/status-bar inset, with the inset as TOP
+   * padding so the brand/bell sit BELOW the status bar in PWA standalone. */
+  height: calc(var(--wb-header-h, 52px) + env(safe-area-inset-top));
+  padding: env(safe-area-inset-top) 16px 0;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0 16px calc(0px + env(safe-area-inset-top));
-  padding-top: env(safe-area-inset-top);
   background: color-mix(in srgb, var(--wb-card) 92%, transparent);
   backdrop-filter: blur(16px);
   -webkit-backdrop-filter: blur(16px);

--- a/src/v2/wallaby/WallabyShell.jsx
+++ b/src/v2/wallaby/WallabyShell.jsx
@@ -18,6 +18,7 @@ export default function WallabyShell({
   tasks = [], routines = [], projects = [], labels = [],
   dailyStats = {}, streak = 0, records = {}, lifetimeDone = 0,
   onToggleHabit, onCompleteTask, onToggleItem, onOpenTask, onAddTask, onAddHabit,
+  onRescheduleTask, onDeleteTask,
   onEditHabit, onArchiveHabit, onDeleteHabit,
   onLogSession, onCompleteProject, onEditProject, onSetAsideProject, onDeleteProject,
   onOpenSettings,
@@ -79,6 +80,7 @@ export default function WallabyShell({
         tasks={tasks} labels={labels}
         onToggleComplete={onCompleteTask} onToggleItem={onToggleItem}
         onOpenTask={onOpenTask} onAdd={onAddTask}
+        onReschedule={onRescheduleTask} onDelete={onDeleteTask}
       />
     )
   } else if (tab === 'timer') {

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,13 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-06
 
+- feat(ui): Wallaby Tasks refinements + QA pass (header overlap, home check) [M]
+  - **Tasks** (loggd `IMG_1581` + `task-action-sheet`): 3rd **Done** tab (Upcoming/Backlog/Done with counts); **TODAY/TOMORROW** grouping with section icons (Overdue/Today/Tomorrow/Upcoming/Anytime); **semi-random per-task checkbox colors** (cycled by id hash — not priority/label, per direction); notes subtitle line; **task tap → action sheet** (Reschedule Today/Tomorrow/Next week/No date · Edit · Delete · Focus-timer "Soon"). Reschedule → `updateTask({due_date})`, Delete → `deleteTask`.
+  - **QA — bugs found + fixed:**
+    - **Home habit check did nothing** (felt unclickable): the toggle handler called `store.localYMD(isoString)` but that helper needs a `Date` → `getFullYear is not a function` threw and aborted silently. Wrapped in `new Date(ts)`. Toggle now logs/clears today's completion + advances the streak.
+    - **Header overlapped the status bar in PWA standalone:** the header set `env(safe-area-inset-top)` as *bottom* padding and didn't add it to its height. Now `height = bar + inset`, `padding-top: inset` (box-border) so brand/bell sit below the notch.
+  - Interaction sweep (headless): 12/12 surfaces/affordances pass (nav tabs, habit check, Tasks grouping/colors/Done/action-sheet, habit-card→detail, bell→notifications, avatar→profile, More→Goals).
+
 - docs(wallaby): capture loggd reference assets + full feature catalog [S]
   - loggd.life blocks automated fetch, so durably committed the reference into `wiki/wallaby-reference/` (6 clean app-export PDFs + 16 downscaled screenshots, ~3.5MB, indexed by README). Expanded `wiki/Wallaby-Ideas.md` with the complete Help-Center feature catalog (Notes, Focus Timer modes, Vision's 6 exercises, Goals Life Areas + auto goal-tags, habit scheduling types, XP/12-tiers/badges/feature-unlocks, Community, 3-level privacy, Free/Pro). Added the **all-skins principle**: net-new features are theme-agnostic (shared app layer, every skin) — and that boundary is the reskin→fork line.
 

--- a/wiki/Wallaby-Ideas.md
+++ b/wiki/Wallaby-Ideas.md
@@ -35,7 +35,7 @@ Bottom nav (loggd): **Home · Habits · Tasks · Timer · More**.
 |---|---|---|
 | Habits — Single/Month/Year heatmap cards | ✅ | per-habit color, streak/count badges, per-card month labels |
 | Habit detail + month calendar | ✅ | tap a card → Streak/Best/Total + completion calendar + Archive/Delete/Edit (`IMG_1586`) |
-| Tasks — list | ✅ (partial) | ⬜ add **Done** tab (Upcoming/Backlog/Done w/ counts); ⬜ TODAY/TOMORROW grouping w/ icons; ⬜ per-task checkbox color (priority? label? — ❓); ⬜ notes subtitle line |
+| Tasks — list | ✅ | Upcoming/Backlog/**Done** tabs w/ counts; Overdue/Today/Tomorrow/Upcoming/Anytime grouping w/ icons; semi-random per-task checkbox colors; notes subtitle; **tap → action sheet** (reschedule/edit/delete, focus="soon") |
 | Goals (projects) — list + detail | ✅ | metric, progress, semantic buttons |
 | Profile / dashboard | ✅ (partial) | ⬜ add **Level / XP / achievements** row (🅿️ those are new features); ❓ Public Profile sub-tab |
 | Home — daily agenda | ✅ (basic) | ⬜ enrich toward **Today's Pulse** (below) |


### PR DESCRIPTION
Finishes the Tasks reskin and includes a first QA pass that fixed two real bugs you'd hit.

## Tasks refinements (loggd `IMG_1581` + `task-action-sheet`)
- 3rd **Done** tab → Upcoming/Backlog/Done with counts
- **Overdue/Today/Tomorrow/Upcoming/Anytime** grouping with section icons
- **Semi-random per-task checkbox colors** (cycled by id hash — not priority/label, per your call)
- Notes subtitle line
- **Task tap → action sheet**: Reschedule (Today/Tomorrow/Next week/No date) · Edit · Delete · Focus timer ("Soon"). Reschedule → `updateTask({due_date})`, Delete → `deleteTask`.

## QA — bugs found + fixed
- **Home habit check did nothing** (a "feels unclickable" bug): the toggle handler called `store.localYMD(isoString)`, but that helper expects a `Date` (`d.getFullYear()`), so it threw `getFullYear is not a function` and aborted silently. Wrapped in `new Date(ts)` — toggle now logs/clears today + advances the streak.
- **Header overlapped the status bar in PWA standalone:** the header used `env(safe-area-inset-top)` as *bottom* padding and didn't add it to its height. Now `height = bar + inset` with `padding-top: inset` (border-box) so the brand/bell sit below the notch.

## Verification
- `npm run build` green, `npm run lint` 0 errors.
- Headless interaction sweep: **12/12** affordances pass (nav tabs, home check, Tasks grouping/colors/Done/action-sheet, habit→detail, bell→notifications, avatar→profile, More→Goals).

Note: the PWA safe-area fix is a CSS-logic fix — best confirmed on-device (headless can't simulate the notch inset).

https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk)_