### PR TITLE
fix(ui): Wallaby Done-tab checkbox reopens instead of re-completing

### DIFF
--- a/src/v2/AppV2.jsx
+++ b/src/v2/AppV2.jsx
@@ -1184,7 +1184,7 @@ export default function AppV2() {
               completeRoutine(routine.id)
             }
           }}
-          onCompleteTask={(task) => handleComplete(task.id)}
+          onCompleteTask={(task) => task.status === 'done' ? uncompleteTask(task.id) : handleComplete(task.id)}
           onToggleItem={(task, clId, itemId) => {
             const checklists = (task.checklists || []).map(cl =>
               cl.id !== clId ? cl : { ...cl, items: (cl.items || []).map(it => it.id === itemId ? { ...it, completed: !it.completed } : it) },

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -11,6 +11,7 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
   - **QA — bugs found + fixed:**
     - **Home habit check did nothing** (felt unclickable): the toggle handler called `store.localYMD(isoString)` but that helper needs a `Date` → `getFullYear is not a function` threw and aborted silently. Wrapped in `new Date(ts)`. Toggle now logs/clears today's completion + advances the streak.
     - **Header overlapped the status bar in PWA standalone:** the header set `env(safe-area-inset-top)` as *bottom* padding and didn't add it to its height. Now `height = bar + inset`, `padding-top: inset` (box-border) so brand/bell sit below the notch.
+    - **Done-tab checkbox re-completed instead of reopening:** wired the Tasks checkbox to be status-aware — `task.status === 'done' ? uncompleteTask : handleComplete`. Clicking a completed task now reopens it.
   - Interaction sweep (headless): 12/12 surfaces/affordances pass (nav tabs, habit check, Tasks grouping/colors/Done/action-sheet, habit-card→detail, bell→notifications, avatar→profile, More→Goals).
 
 - docs(wallaby): capture loggd reference assets + full feature catalog [S]


### PR DESCRIPTION
QA follow-up: the Tasks checkbox always called `handleComplete`, so on the **Done** tab it re-completed an already-done task instead of reopening it. Made it status-aware — `done → uncompleteTask`, else `handleComplete`. Clicking a completed task now reopens it (verified headless: Done count drops on reopen click).

Build green, lint clean.

https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk)_