### PR TITLE
feat(ui): Wallaby Home calendar is interactive

### DIFF
--- a/src/v2/AppV2.jsx
+++ b/src/v2/AppV2.jsx
@@ -1174,14 +1174,16 @@ export default function AppV2() {
           streak={streak}
           records={records}
           lifetimeDone={tasks.filter(t => t.status === 'done').length}
-          onToggleHabit={(routine) => {
-            const today = localYMD(new Date())
+          onToggleHabit={(routine, ymd) => {
+            const day = ymd || localYMD(new Date())
             const hist = Array.isArray(routine.completed_history) ? routine.completed_history : []
-            const isToday = (ts) => localYMD(new Date(ts)) === today
-            if (hist.some(isToday)) {
-              updateRoutine(routine.id, { completed_history: hist.filter(ts => !isToday(ts)) })
+            const onDay = (ts) => localYMD(new Date(ts)) === day
+            if (hist.some(onDay)) {
+              updateRoutine(routine.id, { completed_history: hist.filter(ts => !onDay(ts)) })
             } else {
-              completeRoutine(routine.id)
+              // Pin to local noon of the chosen day so it buckets correctly
+              // regardless of timezone (backfilling a past day, or today).
+              updateRoutine(routine.id, { completed_history: [...hist, `${day}T12:00:00.000Z`] })
             }
           }}
           onCompleteTask={(task) => task.status === 'done' ? uncompleteTask(task.id) : handleComplete(task.id)}

--- a/src/v2/wallaby/HomeView.css
+++ b/src/v2/wallaby/HomeView.css
@@ -19,11 +19,18 @@
   box-shadow: var(--wb-shadow);
   margin-bottom: 16px;
 }
+.wb-home-head { position: relative; }
 .wb-home-date {
   display: flex;
   align-items: center;
   gap: 13px;
   margin-bottom: 16px;
+  width: 100%;
+  background: none;
+  border: none;
+  padding: 0;
+  text-align: left;
+  cursor: pointer;
 }
 .wb-home-daycircle {
   display: grid;
@@ -38,6 +45,16 @@
   font-weight: 800;
   flex: 0 0 auto;
 }
+.wb-home-daycircle.is-other { background: var(--wb-cat-purple); }
+.wb-home-todaypill {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--wb-action-complete);
+  background: color-mix(in srgb, var(--wb-action-complete) 18%, transparent);
+  border-radius: 999px;
+  padding: 4px 10px;
+  flex: 0 0 auto;
+}
 .wb-home-datetext { display: flex; flex-direction: column; flex: 1 1 auto; }
 .wb-home-weekday {
   font-family: var(--v2-font-display);
@@ -47,30 +64,57 @@
 }
 .wb-home-month { font-size: 13px; color: var(--wb-text-meta); }
 .wb-home-avatar {
+  position: absolute;
+  top: 16px;
+  right: 16px;
   width: 38px;
   height: 38px;
   border-radius: 50%;
   border: none;
-  flex: 0 0 auto;
   background: linear-gradient(135deg, var(--wb-cat-green), var(--wb-cat-blue));
   cursor: pointer;
 }
 
+.wb-home-weekrow { display: flex; align-items: center; gap: 4px; }
+.wb-home-weeknav {
+  display: grid;
+  place-items: center;
+  width: 26px;
+  height: 44px;
+  flex: 0 0 auto;
+  border: none;
+  background: none;
+  color: var(--wb-text-meta);
+  cursor: pointer;
+  border-radius: 8px;
+}
+.wb-home-weeknav:disabled { opacity: 0.3; cursor: default; }
 .wb-home-week {
   display: flex;
   justify-content: space-between;
   gap: 4px;
+  flex: 1 1 auto;
 }
 .wb-home-weekday-cell {
   flex: 1 1 0;
+  min-width: 0;
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 5px;
   padding: 6px 0;
   border-radius: 12px;
+  border: none;
+  background: none;
+  cursor: pointer;
 }
 .wb-home-weekday-cell.is-today { background: color-mix(in srgb, var(--wb-action-complete) 18%, transparent); }
+.wb-home-weekday-cell.is-selected {
+  background: var(--wb-cat-purple);
+}
+.wb-home-weekday-cell.is-selected .wb-home-week-date,
+.wb-home-weekday-cell.is-selected .wb-home-week-dow { color: #fff; }
+.wb-home-weekday-cell.is-future { opacity: 0.32; cursor: default; }
 .wb-home-week-dow { font-size: 11px; font-weight: 600; color: var(--wb-text-meta); }
 .wb-home-week-date {
   font-size: 14px;

--- a/src/v2/wallaby/HomeView.jsx
+++ b/src/v2/wallaby/HomeView.jsx
@@ -1,6 +1,6 @@
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import {
-  Check, Flame, ChevronRight,
+  Check, Flame, ChevronRight, ChevronLeft,
   Monitor, Users, MapPin, Palette, Dumbbell, Repeat,
 } from 'lucide-react'
 import { WALLABY_COLORS, historyByDay, currentStreak, localYMD } from './heatmapUtils'
@@ -9,66 +9,79 @@ import './HomeView.css'
 const ENERGY_ICONS = { desk: Monitor, people: Users, errand: MapPin, creative: Palette, physical: Dumbbell }
 const DOW = ['S', 'M', 'T', 'W', 'T', 'F', 'S']
 
-// Wallaby "Home" — the daily agenda (loggd IMG_1582). Date hero + week strip,
-// a streak-at-risk banner, and today's habits as checkable rows. "Checking" a
-// habit toggles today's entry in its completed_history.
+// Wallaby "Home" — the daily agenda (loggd IMG_1582). Tappable date + week
+// strip: pick a day (or page weeks) and the habit rows reflect/toggle that
+// day's completion. "Checking" toggles the selected day in completed_history.
 export default function HomeView({ routines = [], onToggleHabit, onOpenProfile }) {
-  const today = new Date()
+  const today = new Date(); today.setHours(0, 0, 0, 0)
   const todayKey = localYMD(today)
+  const [weekOffset, setWeekOffset] = useState(0)
+  const [selectedKey, setSelectedKey] = useState(todayKey)
 
   const habits = useMemo(() => routines.filter(r => !r.paused), [routines])
-
   const enriched = useMemo(() => habits.map((r, i) => {
     const byDay = historyByDay(r.completed_history)
-    return {
-      routine: r,
-      color: WALLABY_COLORS[i % WALLABY_COLORS.length],
-      doneToday: !!byDay[todayKey],
-      streak: currentStreak(byDay),
-      byDay,
-    }
-  }), [habits, todayKey])
+    return { routine: r, color: WALLABY_COLORS[i % WALLABY_COLORS.length], byDay, streak: currentStreak(byDay) }
+  }), [habits])
 
-  // Streak at risk: a live streak that hasn't been logged today yet.
-  const atRisk = enriched.filter(h => !h.doneToday && h.streak > 0)
+  // Streak at risk: a live streak not yet logged TODAY.
+  const atRisk = enriched.filter(h => !h.byDay[todayKey] && h.streak > 0)
 
-  // Week strip (Sunday-anchored) with activity dots.
-  const weekStart = new Date(today); weekStart.setDate(today.getDate() - today.getDay()); weekStart.setHours(0, 0, 0, 0)
+  // Week strip (Sunday-anchored), paged by weekOffset.
+  const weekStart = new Date(today)
+  weekStart.setDate(today.getDate() - today.getDay() + weekOffset * 7)
   const week = Array.from({ length: 7 }, (_, i) => {
     const d = new Date(weekStart); d.setDate(weekStart.getDate() + i)
     const key = localYMD(d)
     return {
       key, dow: DOW[i], date: d.getDate(),
       isToday: key === todayKey,
+      isSelected: key === selectedKey,
+      isFuture: key > todayKey,
       active: enriched.some(h => h.byDay[key]),
     }
   })
 
+  const selDate = new Date(`${selectedKey}T12:00:00`)
+  const isFutureSel = selectedKey > todayKey
+
   return (
     <div className="wb-home">
       <header className="wb-home-head">
-        <div className="wb-home-date">
-          <span className="wb-home-daycircle">{today.getDate()}</span>
+        <button
+          className="wb-home-date"
+          onClick={() => { setSelectedKey(todayKey); setWeekOffset(0) }}
+          aria-label="Jump to today"
+        >
+          <span className={`wb-home-daycircle${selectedKey === todayKey ? '' : ' is-other'}`}>{selDate.getDate()}</span>
           <div className="wb-home-datetext">
-            <span className="wb-home-weekday">{today.toLocaleDateString('en-US', { weekday: 'long' })}</span>
-            <span className="wb-home-month">{today.toLocaleDateString('en-US', { month: 'long', year: 'numeric' })}</span>
+            <span className="wb-home-weekday">{selDate.toLocaleDateString('en-US', { weekday: 'long' })}</span>
+            <span className="wb-home-month">{selDate.toLocaleDateString('en-US', { month: 'long', year: 'numeric' })}</span>
           </div>
-          {onOpenProfile && (
-            <button className="wb-home-avatar" onClick={onOpenProfile} aria-label="Profile" />
-          )}
+          {selectedKey !== todayKey && <span className="wb-home-todaypill">Today</span>}
+        </button>
+        <div className="wb-home-weekrow">
+          <button className="wb-home-weeknav" onClick={() => setWeekOffset(o => o - 1)} aria-label="Previous week"><ChevronLeft size={18} strokeWidth={2.25} /></button>
+          <div className="wb-home-week">
+            {week.map(d => (
+              <button
+                key={d.key}
+                className={`wb-home-weekday-cell${d.isSelected ? ' is-selected' : ''}${d.isToday ? ' is-today' : ''}${d.isFuture ? ' is-future' : ''}`}
+                onClick={() => setSelectedKey(d.key)}
+                disabled={d.isFuture}
+              >
+                <span className="wb-home-week-dow">{d.dow}</span>
+                <span className="wb-home-week-date">{d.date}</span>
+                <span className={`wb-home-week-dot${d.active ? ' is-active' : ''}`} />
+              </button>
+            ))}
+          </div>
+          <button className="wb-home-weeknav" onClick={() => setWeekOffset(o => Math.min(0, o + 1))} disabled={weekOffset >= 0} aria-label="Next week"><ChevronRight size={18} strokeWidth={2.25} /></button>
         </div>
-        <div className="wb-home-week">
-          {week.map(d => (
-            <div key={d.key} className={`wb-home-weekday-cell${d.isToday ? ' is-today' : ''}`}>
-              <span className="wb-home-week-dow">{d.dow}</span>
-              <span className="wb-home-week-date">{d.date}</span>
-              <span className={`wb-home-week-dot${d.active ? ' is-active' : ''}`} />
-            </div>
-          ))}
-        </div>
+        {onOpenProfile && <button className="wb-home-avatar" onClick={onOpenProfile} aria-label="Profile" />}
       </header>
 
-      {atRisk.length > 0 && (
+      {atRisk.length > 0 && selectedKey === todayKey && (
         <div className="wb-home-risk">
           <Flame size={16} strokeWidth={2.25} className="wb-home-risk-icon" />
           <span className="wb-home-risk-text">
@@ -82,22 +95,24 @@ export default function HomeView({ routines = [], onToggleHabit, onOpenProfile }
       <div className="wb-home-section-label">Habits <span className="wb-home-count">{habits.length}</span></div>
 
       <div className="wb-home-habits">
-        {enriched.map(({ routine, color, doneToday, streak }) => {
+        {enriched.map(({ routine, color, byDay, streak }) => {
           const Icon = ENERGY_ICONS[routine.energy] || Repeat
+          const doneSel = !!byDay[selectedKey]
           return (
-            <div key={routine.id} className={`wb-home-habit${doneToday ? ' is-done' : ''}`}>
+            <div key={routine.id} className={`wb-home-habit${doneSel ? ' is-done' : ''}`}>
               <span className="wb-home-habit-icon" style={{ color }}><Icon size={18} strokeWidth={2} /></span>
               <div className="wb-home-habit-text">
                 <span className="wb-home-habit-title">{routine.title}</span>
                 <span className="wb-home-habit-streak"><Flame size={12} strokeWidth={2.25} /> {streak} day{streak === 1 ? '' : 's'}</span>
               </div>
               <button
-                className={`wb-home-check${doneToday ? ' is-done' : ''}`}
-                style={doneToday ? { background: color, borderColor: color } : { borderColor: color }}
-                onClick={() => onToggleHabit?.(routine)}
-                aria-label={doneToday ? 'Mark not done' : 'Mark done'}
+                className={`wb-home-check${doneSel ? ' is-done' : ''}`}
+                style={doneSel ? { background: color, borderColor: color } : { borderColor: color }}
+                onClick={() => !isFutureSel && onToggleHabit?.(routine, selectedKey)}
+                disabled={isFutureSel}
+                aria-label={doneSel ? 'Mark not done' : 'Mark done'}
               >
-                {doneToday && <Check size={18} strokeWidth={3} color="#fff" />}
+                {doneSel && <Check size={18} strokeWidth={3} color="#fff" />}
               </button>
             </div>
           )

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,9 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-06
 
+- feat(ui): Wallaby Home calendar is interactive [S]
+  - The Home date hero + week strip were inert. Now: tap a **day** to select it (purple highlight); the habit rows reflect that day's completion and the check **toggles/backfills** that day (`onToggleHabit(routine, ymd)` → adds/removes a local-noon `completed_history` entry). **Week navigation** via ‹ › chevrons (future days disabled). Tapping the date hero (or the "Today" pill that appears off-today) jumps back to today. Streak-at-risk banner only shows when today is selected.
+
 - feat(ui): Wallaby Tasks refinements + QA pass (header overlap, home check) [M]
   - **Tasks** (loggd `IMG_1581` + `task-action-sheet`): 3rd **Done** tab (Upcoming/Backlog/Done with counts); **TODAY/TOMORROW** grouping with section icons (Overdue/Today/Tomorrow/Upcoming/Anytime); **semi-random per-task checkbox colors** (cycled by id hash — not priority/label, per direction); notes subtitle line; **task tap → action sheet** (Reschedule Today/Tomorrow/Next week/No date · Edit · Delete · Focus-timer "Soon"). Reschedule → `updateTask({due_date})`, Delete → `deleteTask`.
   - **QA — bugs found + fixed:**

--- a/wiki/Wallaby-Ideas.md
+++ b/wiki/Wallaby-Ideas.md
@@ -48,6 +48,7 @@ The real Home is a scrolling daily dashboard. Reskin-able parts (existing data):
 - ⬜ **Daily summary** card: "You put in Xh deep work, finished N tasks…" + mini activity heatmap + day-streak
 - ⬜ **Tasks today** section (n/m done, Manage/Hide)
 - ✅ **Habits today** section (checkable rows)
+- ✅ **Interactive date/week strip** — select a day (backfill that day), page weeks, jump to today
 - 🅿️ **Reflection + Today's Mood** (new — mood journal)
 - 🅿️ **Vision Whisper** (new — mission/vision)
 - ❓ Week/Month toggle on the Home week strip


### PR DESCRIPTION
Fixes the "calendar at top of Home isn't clickable" report.

- Tap a **day** in the week strip → select it (purple highlight); habit rows reflect that day and the check **toggles/backfills** that day (`onToggleHabit(routine, ymd)` → add/remove a local-noon `completed_history` entry).
- **Week navigation** via ‹ › chevrons (future days disabled).
- Tapping the date hero / the "Today" pill (appears when off-today) jumps back to today.
- Streak-at-risk banner only shows when today is selected.

Verified headless: select past day → purple highlight + Today pill; habit toggle backfills the selected day; week nav works. Build green, lint clean.

https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk)_