### PR TITLE
fix(ui): Wallaby header rebrand + nav/menu placement + font + FAB

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1034,15 +1034,19 @@ tokens even if reached from a non-Wallaby theme.
   + Sunday-anchored week strip (activity dots), a streak-at-risk banner, and
   today's habits (non-paused routines) as checkable rows; the per-habit-colored
   check toggles today's entry in `completed_history`.
-- `WallabyHeader.{jsx,css}` — persistent top app bar (brand + 🔔 bell + avatar)
-  above every shell surface. Bell → notifications center; avatar → Profile.
+- `WallabyHeader.{jsx,css}` — persistent top app bar: the bouncing `BOOMERANG`
+  wordmark (reuses global `.v2-header-wordmark`, sync-bounce wired to
+  `syncStatus`) + `Logo` to its right; then **Quokka** (Sparkles) + 🔔 bell +
+  avatar. Bell → notifications center; avatar → Profile. (Routines display as
+  "Habits" — label only, no data rename.)
 - `NotificationsView.{jsx,css}` — notifications center reading the existing
   `GET /api/notifications/log` (All/Unread, grouped Today/Yesterday/Earlier,
   type-colored icons, optimistic mark-all-read). Reskin — no new data.
-- `WallabyNav.{jsx,css}` + `WallabyShell.{jsx,css}` — the loggd IA. A fixed 5-tab
-  bottom nav (**Home · Habits · Tasks · Timer · More**) + the top header, over
-  the active surface. Timer is a deferred-feature placeholder; **More** routes to
-  Profile + Goals and shows Coming-soon rows for Vision + Daily check-in.
+- `WallabyNav.{jsx,css}` + `WallabyShell.{jsx,css}` — the loggd IA. A fixed 4-tab
+  bottom nav (**Home · Habits · Tasks · More**) + the top header, over the active
+  surface. **More** routes to Profile · Goals · **Packages** (real modal) ·
+  **Timer** (coming-soon) · Vision (soon) · Daily (soon) · Settings. (Quokka is
+  in the top header; Packages/Timer moved out of nav into More per user.)
 
 **How the surfaces are reached (Wallaby mode).** `AppV2` renders `<WallabyShell>`
 (`position:fixed`, z-40 — covers the standard header + list) when

--- a/src/v2/AppV2.jsx
+++ b/src/v2/AppV2.jsx
@@ -1207,6 +1207,10 @@ export default function AppV2() {
           onSetAsideProject={(p) => updateTask(p.id, { status: 'backlog' })}
           onDeleteProject={(p) => deleteTask(p.id)}
           onOpenSettings={() => setShowSettings(true)}
+          onOpenAdviser={() => setShowAdviser(true)}
+          onOpenPackages={() => setShowPackages(true)}
+          syncStatus={syncStatus}
+          queueLength={queueLength}
         />
       )}
 

--- a/src/v2/wallaby/HabitsView.css
+++ b/src/v2/wallaby/HabitsView.css
@@ -220,7 +220,8 @@
 .wb-fab {
   position: fixed;
   right: 18px;
-  bottom: 92px;
+  /* Sit clear above the bottom nav (~64px) + the home-indicator inset. */
+  bottom: calc(80px + env(safe-area-inset-bottom));
   width: 56px;
   height: 56px;
   border-radius: 50%;
@@ -230,7 +231,8 @@
   color: #fff;
   cursor: pointer;
   box-shadow: 0 6px 20px rgba(0, 0, 0, 0.45);
-  z-index: 20;
+  /* Above the nav (z-45) so it never gets clipped by it. */
+  z-index: 47;
 }
 .wb-fab-habits { background: var(--wb-fab-habits); }
 .wb-fab-tasks { background: var(--wb-fab-tasks); }

--- a/src/v2/wallaby/WallabyHeader.css
+++ b/src/v2/wallaby/WallabyHeader.css
@@ -22,17 +22,17 @@
   display: inline-flex;
   align-items: center;
   gap: 8px;
+  min-width: 0;
+}
+/* Bouncing wordmark reuses the global .v2-header-wordmark classes (Header.css);
+ * just size it for the Wallaby bar. Logo sits to the RIGHT of the text. */
+.wb-header-wordmark.v2-header-wordmark {
+  display: inline-flex;
   font-family: var(--v2-font-display);
   font-size: 17px;
   font-weight: 800;
-  letter-spacing: -0.01em;
+  letter-spacing: 0.02em;
   color: var(--wb-text);
-}
-.wb-header-mark {
-  width: 16px;
-  height: 16px;
-  border-radius: 5px;
-  background: var(--wb-action-complete);
 }
 .wb-header-actions { display: flex; align-items: center; gap: 10px; }
 .wb-header-btn {

--- a/src/v2/wallaby/WallabyHeader.jsx
+++ b/src/v2/wallaby/WallabyHeader.jsx
@@ -1,16 +1,66 @@
-import { Bell } from 'lucide-react'
+import { useEffect, useRef, useState } from 'react'
+import { Sparkles, Bell } from 'lucide-react'
+import Logo from '../../components/Logo'
 import './WallabyHeader.css'
 
-// Wallaby persistent top app bar (loggd): brand wordmark left, notifications
-// bell (with unread badge) + avatar right. Sits above every shell surface.
-export default function WallabyHeader({ unread = 0, onBell, onAvatar }) {
+const WORDMARK_LETTERS = 'BOOMERANG'.split('')
+
+// Mirrors Header.jsx so the wordmark bounces on save the same way.
+function deriveSyncVisualState(syncStatus, queueLength, animState) {
+  if (syncStatus === 'offline') return 'offline'
+  if (animState === 'saving') return 'saving'
+  if (animState === 'just-synced') return 'just-synced'
+  if (queueLength > 0) return 'degraded'
+  return 'idle'
+}
+
+// Wallaby persistent top app bar: bouncing BOOMERANG wordmark + logo (to the
+// right of the text), then Quokka · Packages · notifications bell · avatar.
+export default function WallabyHeader({
+  unread = 0, onBell, onAvatar, onOpenAdviser,
+  syncStatus = 'synced', queueLength = 0,
+}) {
+  const SAVING_MIN_HOLD = 1300
+  const FLASH_MS = 700
+  const [animState, setAnimState] = useState('idle')
+  const allowFlashRef = useRef(false)
+  const timerRef = useRef(null)
+
+  useEffect(() => () => { if (timerRef.current) clearTimeout(timerRef.current) }, [])
+
+  useEffect(() => {
+    if (syncStatus === 'saving') {
+      allowFlashRef.current = false
+      setAnimState('saving')
+      if (timerRef.current) clearTimeout(timerRef.current)
+      timerRef.current = setTimeout(() => {
+        timerRef.current = null
+        if (allowFlashRef.current) {
+          setAnimState('just-synced')
+          timerRef.current = setTimeout(() => { timerRef.current = null; setAnimState('idle') }, FLASH_MS)
+        } else { setAnimState('idle') }
+      }, SAVING_MIN_HOLD)
+    } else if (syncStatus === 'synced' && animState === 'saving') {
+      allowFlashRef.current = true
+    }
+  }, [syncStatus, animState])
+
+  const syncVisualState = deriveSyncVisualState(syncStatus, queueLength, animState)
+
   return (
     <header className="wb-header">
-      <span className="wb-header-brand">
-        <span className="wb-header-mark" aria-hidden="true" />
-        Boomerang
-      </span>
+      <div className="wb-header-brand">
+        <span className="v2-header-wordmark wb-header-wordmark" data-sync-state={syncVisualState}>
+          {WORDMARK_LETTERS.map((ch, i) => (
+            <span key={i} className="v2-header-wordmark-letter" style={{ '--letter-index': i }}>{ch}</span>
+          ))}
+        </span>
+        <Logo size={24} />
+      </div>
       <div className="wb-header-actions">
+        {onOpenAdviser && (
+          <button className="wb-header-btn" onClick={onOpenAdviser} aria-label="Quokka"><Sparkles size={20} strokeWidth={1.9} /></button>
+        )}
         <button className="wb-header-btn" onClick={onBell} aria-label="Notifications">
           <Bell size={20} strokeWidth={1.9} />
           {unread > 0 && <span className="wb-header-badge">{unread > 99 ? '99+' : unread}</span>}

--- a/src/v2/wallaby/WallabyNav.jsx
+++ b/src/v2/wallaby/WallabyNav.jsx
@@ -1,12 +1,12 @@
-import { Home, Activity, ListTodo, Timer, Menu } from 'lucide-react'
+import { Home, Activity, ListTodo, Menu } from 'lucide-react'
 import './WallabyNav.css'
 
-// Wallaby bottom nav (loggd IA): Home · Habits · Tasks · Timer · More.
+// Wallaby bottom nav: Home · Habits · Tasks · More. (Timer + Packages live in
+// the More menu; Quokka lives in the top header.)
 const TABS = [
   { id: 'home', label: 'Home', icon: Home },
   { id: 'habits', label: 'Habits', icon: Activity },
   { id: 'tasks', label: 'Tasks', icon: ListTodo },
-  { id: 'timer', label: 'Timer', icon: Timer },
   { id: 'more', label: 'More', icon: Menu },
 ]
 

--- a/src/v2/wallaby/WallabyShell.css
+++ b/src/v2/wallaby/WallabyShell.css
@@ -63,7 +63,9 @@
 .wb-more-chev { color: var(--wb-text-meta); flex: 0 0 auto; }
 
 /* ── Deferred-feature placeholder ────────────────────────────────────────── */
+.wb-placeholder-back { position: absolute; top: 16px; left: 16px; }
 .wb-placeholder {
+  position: relative;
   min-height: 100vh;
   display: flex;
   flex-direction: column;

--- a/src/v2/wallaby/WallabyShell.jsx
+++ b/src/v2/wallaby/WallabyShell.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { Timer, BookOpen, Smile, Settings, FolderKanban, User, ChevronRight } from 'lucide-react'
+import { Timer, Package, BookOpen, Smile, Settings, FolderKanban, User, ChevronRight, ArrowLeft } from 'lucide-react'
 import HomeView from './HomeView'
 import HabitsView from './HabitsView'
 import TasksView from './TasksView'
@@ -21,7 +21,8 @@ export default function WallabyShell({
   onRescheduleTask, onDeleteTask,
   onEditHabit, onArchiveHabit, onDeleteHabit,
   onLogSession, onCompleteProject, onEditProject, onSetAsideProject, onDeleteProject,
-  onOpenSettings,
+  onOpenSettings, onOpenAdviser, onOpenPackages,
+  syncStatus = 'synced', queueLength = 0,
 }) {
   const [tab, setTab] = useState('home')
   const [sub, setSub] = useState(null) // 'profile' | 'goals' | 'notifications' | null
@@ -83,10 +84,18 @@ export default function WallabyShell({
         onReschedule={onRescheduleTask} onDelete={onDeleteTask}
       />
     )
-  } else if (tab === 'timer') {
-    surface = <Placeholder icon={<Timer size={34} strokeWidth={1.75} />} title="Timer" body="Focus timer is coming after the reskin." />
+  } else if (sub === 'timer') {
+    surface = <Placeholder icon={<Timer size={34} strokeWidth={1.75} />} title="Timer" body="Focus timer is coming after the reskin." onClose={() => setSub(null)} />
   } else {
-    surface = <MoreMenu onOpenProfile={() => setSub('profile')} onOpenGoals={() => setSub('goals')} onOpenSettings={onOpenSettings} />
+    surface = (
+      <MoreMenu
+        onOpenProfile={() => setSub('profile')}
+        onOpenGoals={() => setSub('goals')}
+        onOpenTimer={() => setSub('timer')}
+        onOpenPackages={onOpenPackages}
+        onOpenSettings={onOpenSettings}
+      />
+    )
   }
 
   return (
@@ -95,6 +104,9 @@ export default function WallabyShell({
         unread={unread}
         onBell={() => setSub('notifications')}
         onAvatar={() => setSub('profile')}
+        onOpenAdviser={onOpenAdviser}
+        syncStatus={syncStatus}
+        queueLength={queueLength}
       />
       <div className="wb-shell-surface">{surface}</div>
       <WallabyNav
@@ -105,10 +117,12 @@ export default function WallabyShell({
   )
 }
 
-function MoreMenu({ onOpenProfile, onOpenGoals, onOpenSettings }) {
+function MoreMenu({ onOpenProfile, onOpenGoals, onOpenTimer, onOpenPackages, onOpenSettings }) {
   const rows = [
     { key: 'profile', icon: User, label: 'Profile', sub: 'Stats + your activity year', onClick: onOpenProfile },
     { key: 'goals', icon: FolderKanban, label: 'Goals', sub: 'Projects · progress + sessions', onClick: onOpenGoals },
+    { key: 'packages', icon: Package, label: 'Packages', sub: 'Track deliveries', onClick: onOpenPackages },
+    { key: 'timer', icon: Timer, label: 'Timer', sub: 'Focus sessions', onClick: onOpenTimer },
     { key: 'vision', icon: BookOpen, label: 'Vision', sub: 'Coming soon', soon: true },
     { key: 'daily', icon: Smile, label: 'Daily check-in', sub: 'Coming soon', soon: true },
     { key: 'settings', icon: Settings, label: 'Settings', sub: 'App configuration', onClick: onOpenSettings },
@@ -140,9 +154,12 @@ function MoreMenu({ onOpenProfile, onOpenGoals, onOpenSettings }) {
   )
 }
 
-function Placeholder({ icon, title, body }) {
+function Placeholder({ icon, title, body, onClose }) {
   return (
     <div className="wb-placeholder">
+      {onClose && (
+        <button className="wb-back wb-placeholder-back" onClick={onClose} aria-label="Back"><ArrowLeft size={20} strokeWidth={2.25} /></button>
+      )}
       <span className="wb-placeholder-icon">{icon}</span>
       <h2 className="wb-placeholder-title">{title}</h2>
       <p className="wb-placeholder-body">{body}</p>

--- a/src/v2/wallaby/palette.css
+++ b/src/v2/wallaby/palette.css
@@ -46,9 +46,8 @@
 
 /* ── Wallaby dark (flagship) ─────────────────────────────────────────────── */
 :root[data-ui="v2"][data-theme="wallaby-dark"] {
-  /* Clean grotesk over Syne for the dashboard register */
-  --v2-font-display: 'Inter', system-ui, -apple-system, 'Segoe UI', sans-serif;
-  --v2-font-body: 'Inter', system-ui, -apple-system, 'Segoe UI', sans-serif;
+  /* Fonts inherit the v2 defaults (Syne display / DM Sans body) — Wallaby
+   * keeps the standard v2 typography per user preference. */
 
   /* Canvas + surfaces (navy) */
   --v2-bg: #0E1322;
@@ -96,9 +95,6 @@
 
 /* ── Wallaby light ───────────────────────────────────────────────────────── */
 :root[data-ui="v2"][data-theme="wallaby-light"] {
-  --v2-font-display: 'Inter', system-ui, -apple-system, 'Segoe UI', sans-serif;
-  --v2-font-body: 'Inter', system-ui, -apple-system, 'Segoe UI', sans-serif;
-
   --v2-bg: #F4F6FB;
   --v2-surface: #FFFFFF;
   --v2-text: #18203A;

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,13 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-06
 
+- fix(ui): Wallaby header rebrand + nav/menu placement + font + FAB [S]
+  - **Header**: real Boomerang branding back — the bouncing `BOOMERANG` wordmark (reuses the global `.v2-header-wordmark` + sync-bounce, wired to `syncStatus`/`queueLength`) with the **`Logo` to the right of the text**. Header actions: **Quokka** (Sparkles) + bell + avatar.
+  - **Placement per user**: **Quokka stays in the top header**; **Timer + Packages moved into the More menu** (Packages → the real PackagesModal; Timer → "coming soon" placeholder). Bottom nav is now **Home · Habits · Tasks · More** (Timer removed).
+  - **Font**: dropped Wallaby's Inter override — inherits the v2 typography (Syne display / DM Sans body) per preference.
+  - **FAB fix**: the Habits/Tasks `+` FAB had `z-index:20` (below the nav's `z-45`) so the nav clipped it; raised to `z-47` and `bottom: calc(80px + safe-area)` so it floats clear.
+  - Note: **"Habits" is a display label for routines** — no data change; same `routines`/`completed_history`. Standard/Terminal still say "Routines."
+
 - feat(ui): Wallaby Home calendar is interactive [S]
   - The Home date hero + week strip were inert. Now: tap a **day** to select it (purple highlight); the habit rows reflect that day's completion and the check **toggles/backfills** that day (`onToggleHabit(routine, ymd)` → adds/removes a local-noon `completed_history` entry). **Week navigation** via ‹ › chevrons (future days disabled). Tapping the date hero (or the "Today" pill that appears off-today) jumps back to today. Streak-at-risk banner only shows when today is selected.
 


### PR DESCRIPTION
Addresses your header/nav feedback.

- **Header rebrand**: the bouncing **BOOMERANG** wordmark is back (reuses the global `.v2-header-wordmark` + sync-bounce, wired to `syncStatus`) with the **Logo to the right of the text**. Actions: **Quokka** + bell + avatar.
- **Placement**: Quokka stays in the top header; **Timer + Packages moved into the More menu** (Packages → the real PackagesModal; Timer → coming-soon). Bottom nav is now **Home · Habits · Tasks · More**.
- **Font**: dropped Wallaby's Inter override — inherits the v2 typography (Syne / DM Sans) you prefer.
- **FAB clip fix**: the `+` FAB had `z-index:20` (below the nav's `z-45`), so the nav clipped it — raised to `z-47` + `bottom: calc(80px + safe-area)`.

Also FYI in the notes: **"Habits" is just the Wallaby display label for routines** — no data rename/migration.

Verified headless: wordmark+logo-right+Quokka in header, 4-tab nav, More lists Packages+Timer, FAB clears the nav. Build green, lint clean.

https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk)_