### PR TITLE
feat(ui): Wallaby Settings visual reskin (notifications "fire")

### DIFF
--- a/src/v2/AppV2.css
+++ b/src/v2/AppV2.css
@@ -1,6 +1,7 @@
 @import './tokens.css';
 @import './terminal/index.css';
 @import './wallaby/palette.css';
+@import './wallaby/settings.css';
 
 /* Wallaby "Habits" surface mounts as a full-screen overlay above the app. */
 .v2-habits-overlay {

--- a/src/v2/wallaby/settings.css
+++ b/src/v2/wallaby/settings.css
@@ -1,0 +1,96 @@
+/* ════════════════════════════════════════════════════════════════════════
+ * Wallaby Settings reskin — visual only, gated on [data-theme^="wallaby"].
+ * The SettingsModal already consumes --v2-* tokens (so it's navy in Wallaby);
+ * this layers the loggd card/toggle/tab aesthetic on top WITHOUT touching the
+ * markup. Every Boomerang setting is preserved. Notifications get the loggd
+ * "card per type, green toggles" treatment.
+ * ════════════════════════════════════════════════════════════════════════ */
+
+/* ── Tabs → underline style, single scrollable row ───────────────────────── */
+[data-theme^="wallaby"] .v2-settings-tabs {
+  flex-wrap: nowrap;
+  overflow-x: auto;
+  gap: 2px;
+  border-bottom-color: var(--wb-hairline);
+  scrollbar-width: none;
+}
+[data-theme^="wallaby"] .v2-settings-tabs::-webkit-scrollbar { display: none; }
+[data-theme^="wallaby"] .v2-settings-tab {
+  flex: 0 0 auto;
+  border: none;
+  border-radius: 0;
+  border-bottom: 2px solid transparent;
+  padding: 8px 12px 10px;
+  font-weight: 700;
+}
+[data-theme^="wallaby"] .v2-settings-tab-active,
+[data-theme^="wallaby"] .v2-settings-tab.v2-settings-tab-active {
+  background: transparent;
+  color: var(--wb-text);
+  border: none;
+  border-bottom: 2px solid var(--wb-action-complete);
+}
+
+/* ── Blocks → grouped navy cards ─────────────────────────────────────────── */
+[data-theme^="wallaby"] .v2-settings-block {
+  background: var(--wb-card);
+  border: 1px solid var(--wb-hairline);
+  border-radius: 16px;
+  padding: 16px;
+  margin-bottom: 12px;
+  box-shadow: var(--wb-shadow);
+}
+[data-theme^="wallaby"] .v2-settings-block + .v2-settings-block { padding-top: 16px; }
+[data-theme^="wallaby"] .v2-settings-block:last-child { padding-bottom: 16px; }
+
+/* ── Toggles → loggd green ───────────────────────────────────────────────── */
+[data-theme^="wallaby"] .v2-settings-toggle input:checked + .v2-settings-toggle-track {
+  background: var(--wb-action-complete);
+}
+
+/* ── Segmented controls → green active ───────────────────────────────────── */
+[data-theme^="wallaby"] .v2-settings-segment-btn-active {
+  background: var(--wb-action-complete);
+  color: #fff;
+}
+
+/* ── Inputs / buttons → navy surfaces ────────────────────────────────────── */
+[data-theme^="wallaby"] .v2-form-input,
+[data-theme^="wallaby"] .v2-settings-compact-input {
+  background: var(--wb-card-2);
+  border-color: var(--wb-hairline);
+}
+[data-theme^="wallaby"] .v2-settings-btn {
+  background: var(--wb-card-2);
+  border-color: var(--wb-hairline);
+}
+
+/* ── Notifications: the "fire" treatment ─────────────────────────────────── */
+/* Cards sit inside a block-card, so use the elevated surface for contrast and
+ * lay the three channels out as clean toggle tiles. */
+[data-theme^="wallaby"] .v2-notif-cards {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+[data-theme^="wallaby"] .v2-notif-card {
+  background: var(--wb-card-2);
+  border: 1px solid var(--wb-hairline);
+  border-radius: 14px;
+  padding: 14px;
+}
+[data-theme^="wallaby"] .v2-notif-card-label {
+  font-weight: 700;
+  color: var(--wb-text);
+}
+[data-theme^="wallaby"] .v2-notif-card-channel {
+  background: var(--wb-card-3);
+  border: 1px solid var(--wb-hairline);
+  border-radius: 11px;
+  padding: 10px 4px;
+}
+[data-theme^="wallaby"] .v2-notif-card-channel:hover { background: var(--wb-card); }
+[data-theme^="wallaby"] .v2-notif-card-freq-input {
+  background: var(--wb-card-3);
+  border-color: var(--wb-hairline);
+}

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,9 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-06
 
+- feat(ui): Wallaby Settings visual reskin (notifications "fire") [S]
+  - `src/v2/wallaby/settings.css` (imported via AppV2.css, gated `[data-theme^="wallaby"]`): visual-only reskin of the existing SettingsModal — **every Boomerang setting + tab preserved**. Tabs → single scrollable row with a green underline on the active tab; `.v2-settings-block`s → grouped navy cards; toggles → loggd **green** when on; segmented controls → green active; inputs/buttons → navy surfaces. **Notifications** get the standout treatment: a CHANNELS card + per-type cards on the elevated surface with Push/Email/Pushover toggle tiles. Standard/Terminal untouched.
+
 - fix(ui): Wallaby header rebrand + nav/menu placement + font + FAB [S]
   - **Header**: real Boomerang branding back — the bouncing `BOOMERANG` wordmark (reuses the global `.v2-header-wordmark` + sync-bounce, wired to `syncStatus`/`queueLength`) with the **`Logo` to the right of the text**. Header actions: **Quokka** (Sparkles) + bell + avatar.
   - **Placement per user**: **Quokka stays in the top header**; **Timer + Packages moved into the More menu** (Packages → the real PackagesModal; Timer → "coming soon" placeholder). Bottom nav is now **Home · Habits · Tasks · More** (Timer removed).

--- a/wiki/Wallaby-Ideas.md
+++ b/wiki/Wallaby-Ideas.md
@@ -39,7 +39,7 @@ Bottom nav (loggd): **Home · Habits · Tasks · Timer · More**.
 | Goals (projects) — list + detail | ✅ | metric, progress, semantic buttons |
 | Profile / dashboard | ✅ (partial) | ⬜ add **Level / XP / achievements** row (🅿️ those are new features); ❓ Public Profile sub-tab |
 | Home — daily agenda | ✅ (basic) | ⬜ enrich toward **Today's Pulse** (below) |
-| Settings (tabbed) | ⬜ | Account / Notifications / Preferences / Privacy / API; per-type Push/Email toggles (Boomerang already has the data) |
+| Settings (visual reskin) | ✅ | Account / Notifications / Preferences / Privacy / API; per-type Push/Email toggles (Boomerang already has the data) |
 | Analytics — "Your productivity insights" | ⬜ / 🅿️ | Tabbed **Overview / Habits / Tasks / Goals / Focus**. Weekly **points** total + ‹week› nav, 🔥current/🏆best streak, stat cards (Habits checks, Tasks completed, Focus time, Check-ins), **Points Breakdown by activity type**, weekly **mood bar-chart** + **reflections** recap. Reskin-able: points/streak/habit+task counts (Boomerang has these). Deferred: focus-time, check-ins, mood, badge points (tied to new features). Reached via More/Profile. |
 
 ### Home "Today's Pulse" (richer Home — PDF 1)


### PR DESCRIPTION
Visual reskin of Settings to the Wallaby look — **every Boomerang setting + tab preserved** (CSS-only, gated `[data-theme^="wallaby"]`, Standard/Terminal untouched).

- Tabs → single scrollable row with a **green underline** on the active tab
- Settings blocks → grouped **navy cards**
- Toggles → loggd **green** when on; segmented controls → green active
- Inputs/buttons → navy surfaces
- **Notifications (the "fire" one):** a CHANNELS card + per-type cards on the elevated surface with Push/Email/Pushover toggle tiles

`src/v2/wallaby/settings.css`, imported via `AppV2.css`.

Verified headless: More → Settings opens; Notifications renders 10 carded types with green channel toggles; General shows the green segmented theme/mode + underline tabs. Build green, lint clean.

(Note: I went with the visual-reskin approach per your call — the full loggd 5-tab restructure would've risked relocating Boomerang's many integration settings.)

https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk)_