### PR TITLE
fix(ui): Wallaby header — logo on the left of the wordmark

### DIFF
--- a/src/v2/wallaby/WallabyHeader.jsx
+++ b/src/v2/wallaby/WallabyHeader.jsx
@@ -50,12 +50,12 @@ export default function WallabyHeader({
   return (
     <header className="wb-header">
       <div className="wb-header-brand">
+        <Logo size={24} />
         <span className="v2-header-wordmark wb-header-wordmark" data-sync-state={syncVisualState}>
           {WORDMARK_LETTERS.map((ch, i) => (
             <span key={i} className="v2-header-wordmark-letter" style={{ '--letter-index': i }}>{ch}</span>
           ))}
         </span>
-        <Logo size={24} />
       </div>
       <div className="wb-header-actions">
         {onOpenAdviser && (


### PR DESCRIPTION
Flips the Wallaby header brand order: **Logo on the left**, BOOMERANG wordmark on the right (matches the standard v2 header). Verified headless. Build green.

https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk)_