### PR TITLE
fix(ui): move Quokka from header into the main bottom nav

### DIFF
--- a/src/v2/wallaby/WallabyHeader.jsx
+++ b/src/v2/wallaby/WallabyHeader.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { Sparkles, Bell } from 'lucide-react'
+import { Bell } from 'lucide-react'
 import Logo from '../../components/Logo'
 import './WallabyHeader.css'
 
@@ -17,7 +17,7 @@ function deriveSyncVisualState(syncStatus, queueLength, animState) {
 // Wallaby persistent top app bar: bouncing BOOMERANG wordmark + logo (to the
 // right of the text), then Quokka · Packages · notifications bell · avatar.
 export default function WallabyHeader({
-  unread = 0, onBell, onAvatar, onOpenAdviser,
+  unread = 0, onBell, onAvatar,
   syncStatus = 'synced', queueLength = 0,
 }) {
   const SAVING_MIN_HOLD = 1300
@@ -58,9 +58,6 @@ export default function WallabyHeader({
         </span>
       </div>
       <div className="wb-header-actions">
-        {onOpenAdviser && (
-          <button className="wb-header-btn" onClick={onOpenAdviser} aria-label="Quokka"><Sparkles size={20} strokeWidth={1.9} /></button>
-        )}
         <button className="wb-header-btn" onClick={onBell} aria-label="Notifications">
           <Bell size={20} strokeWidth={1.9} />
           {unread > 0 && <span className="wb-header-badge">{unread > 99 ? '99+' : unread}</span>}

--- a/src/v2/wallaby/WallabyNav.css
+++ b/src/v2/wallaby/WallabyNav.css
@@ -26,5 +26,6 @@
   transition: color 140ms ease;
 }
 .wb-nav-tab.is-active { color: var(--wb-action-complete); }
+.wb-nav-tab-action { color: var(--wb-cat-purple); }
 .wb-nav-icon { display: block; }
 .wb-nav-label { font-size: 10.5px; font-weight: 600; }

--- a/src/v2/wallaby/WallabyNav.jsx
+++ b/src/v2/wallaby/WallabyNav.jsx
@@ -1,28 +1,30 @@
-import { Home, Activity, ListTodo, Menu } from 'lucide-react'
+import { Home, Activity, ListTodo, Sparkles, Menu } from 'lucide-react'
 import './WallabyNav.css'
 
-// Wallaby bottom nav: Home · Habits · Tasks · More. (Timer + Packages live in
-// the More menu; Quokka lives in the top header.)
+// Wallaby bottom nav: Home · Habits · Tasks · Quokka · More. Quokka is an
+// action (opens the adviser), not a destination tab. (Timer + Packages live in
+// the More menu.)
 const TABS = [
   { id: 'home', label: 'Home', icon: Home },
   { id: 'habits', label: 'Habits', icon: Activity },
   { id: 'tasks', label: 'Tasks', icon: ListTodo },
+  { id: 'quokka', label: 'Quokka', icon: Sparkles, action: true },
   { id: 'more', label: 'More', icon: Menu },
 ]
 
-export default function WallabyNav({ active, onChange }) {
+export default function WallabyNav({ active, onChange, onQuokka }) {
   return (
     <nav className="wb-nav" role="tablist" aria-label="Primary">
       {TABS.map(t => {
         const Icon = t.icon
-        const on = active === t.id
+        const on = !t.action && active === t.id
         return (
           <button
             key={t.id}
-            role="tab"
-            aria-selected={on}
-            className={`wb-nav-tab${on ? ' is-active' : ''}`}
-            onClick={() => onChange(t.id)}
+            role={t.action ? undefined : 'tab'}
+            aria-selected={t.action ? undefined : on}
+            className={`wb-nav-tab${on ? ' is-active' : ''}${t.action ? ' wb-nav-tab-action' : ''}`}
+            onClick={() => (t.action ? onQuokka?.() : onChange(t.id))}
           >
             <Icon size={22} strokeWidth={on ? 2.4 : 1.9} className="wb-nav-icon" />
             <span className="wb-nav-label">{t.label}</span>

--- a/src/v2/wallaby/WallabyShell.jsx
+++ b/src/v2/wallaby/WallabyShell.jsx
@@ -104,7 +104,6 @@ export default function WallabyShell({
         unread={unread}
         onBell={() => setSub('notifications')}
         onAvatar={() => setSub('profile')}
-        onOpenAdviser={onOpenAdviser}
         syncStatus={syncStatus}
         queueLength={queueLength}
       />
@@ -112,6 +111,7 @@ export default function WallabyShell({
       <WallabyNav
         active={sub ? '' : tab}
         onChange={(t) => { setSub(null); setTab(t) }}
+        onQuokka={onOpenAdviser}
       />
     </div>
   )


### PR DESCRIPTION
Corrects my misread of "Quokka in the main one" — that meant the main **nav**, not the header.

- **Quokka moved into the bottom nav**: Home · Habits · Tasks · **Quokka** · More. It's an action item (purple accent) that opens the adviser, not a destination tab.
- **Removed from the top header** (keeps bell + avatar).

Verified headless: nav = `[Home,Habits,Tasks,Quokka,More]`, header has no Quokka, tapping Quokka opens the adviser. Build green, lint clean.

https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk)_