### PR TITLE
feat(ui): Wallaby Home → "Today's Pulse" (per-day content)

### DIFF
--- a/src/v2/wallaby/HomeView.css
+++ b/src/v2/wallaby/HomeView.css
@@ -217,3 +217,105 @@
   transition: transform 120ms ease;
 }
 .wb-home-check:active { transform: scale(0.92); }
+
+/* ── Today's Pulse card ──────────────────────────────────────────────────── */
+.wb-pulse {
+  background: var(--wb-card);
+  border: 1px solid var(--wb-hairline);
+  border-radius: 16px;
+  padding: 14px 15px;
+  box-shadow: var(--wb-shadow);
+  margin-bottom: 16px;
+}
+.wb-pulse-title {
+  font-family: var(--v2-font-display);
+  font-size: 13px;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--wb-text-meta);
+  margin-bottom: 11px;
+}
+.wb-pulse-row {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 9px 11px;
+  border-radius: 11px;
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--wb-text);
+  margin-bottom: 7px;
+}
+.wb-pulse-row:last-child { margin-bottom: 0; }
+.wb-pulse-row em { font-style: normal; color: var(--wb-text-meta); font-weight: 600; }
+.wb-pulse-risk { background: color-mix(in srgb, var(--wb-action-delete) 18%, transparent); color: var(--wb-action-primary); }
+.wb-pulse-habits { background: color-mix(in srgb, var(--wb-cat-purple) 16%, transparent); }
+.wb-pulse-tasks { background: var(--wb-card-2); }
+.wb-pulse-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--wb-cat-purple); flex: 0 0 auto; }
+.wb-pulse-tasks .wb-pulse-dot { background: var(--wb-cat-blue); }
+
+/* ── Section cards (Tasks / Habits) ──────────────────────────────────────── */
+.wb-home-card {
+  background: var(--wb-card);
+  border: 1px solid var(--wb-hairline);
+  border-radius: 16px;
+  padding: 14px 15px;
+  box-shadow: var(--wb-shadow);
+  margin-bottom: 14px;
+}
+.wb-home-card-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+.wb-home-card-title { margin: 0; font-family: var(--v2-font-display); font-size: 17px; font-weight: 700; }
+.wb-home-card-count { font-size: 12.5px; font-weight: 700; color: var(--wb-text-meta); }
+.wb-home-empty-sm { color: var(--wb-text-meta); font-size: 13.5px; margin: 4px 0; }
+
+.wb-home-progress { height: 6px; border-radius: 999px; background: var(--wb-card-2); overflow: hidden; margin-bottom: 12px; }
+.wb-home-progress-fill { height: 100%; border-radius: 999px; background: var(--wb-action-complete); transition: width 240ms ease; }
+
+/* ── Task rows on Home ───────────────────────────────────────────────────── */
+.wb-home-tasks { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 4px; }
+.wb-home-task { display: flex; align-items: flex-start; gap: 11px; padding: 6px 0; }
+.wb-home-taskcheck {
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
+  width: 22px;
+  height: 22px;
+  margin-top: 1px;
+  border-radius: 6px;
+  border: 2px solid var(--wb-hairline-strong);
+  background: transparent;
+  cursor: pointer;
+}
+.wb-home-taskcheck.is-done { background: var(--wb-action-complete); border-color: var(--wb-action-complete); }
+.wb-home-task-body { flex: 1 1 auto; min-width: 0; display: flex; flex-direction: column; gap: 3px; background: none; border: none; padding: 0; text-align: left; cursor: pointer; }
+.wb-home-task-title { font-size: 14.5px; font-weight: 550; color: var(--wb-text); line-height: 1.3; }
+.wb-home-task-title.is-done { text-decoration: line-through; color: var(--wb-text-meta); }
+.wb-home-task-meta { display: flex; flex-wrap: wrap; align-items: center; gap: 6px; }
+.wb-home-task-overdue { font-size: 11.5px; font-weight: 700; color: var(--wb-action-delete); }
+.wb-home-task-tag {
+  font-size: 11px; font-weight: 600;
+  color: var(--tag, var(--wb-text-meta));
+  background: color-mix(in srgb, var(--tag, #888) 18%, transparent);
+  border-radius: 999px; padding: 2px 9px;
+}
+
+/* Habit rows inside the card — icon tile + title + streak + check on one line */
+.wb-home-card .wb-home-habits { gap: 4px; }
+.wb-home-card .wb-home-habit {
+  background: none;
+  border: none;
+  box-shadow: none;
+  padding: 7px 0;
+  gap: 11px;
+}
+.wb-home-habit-icon { background: var(--wb-card-2); }
+.wb-home-card .wb-home-habit-title { flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 14.5px; font-weight: 600; }
+.wb-home-card .wb-home-habit.is-done .wb-home-habit-title { text-decoration: line-through; color: var(--wb-text-meta); }
+.wb-home-habit-streak { display: inline-flex; align-items: center; gap: 3px; font-size: 12px; font-weight: 700; color: #F0973E; flex: 0 0 auto; }
+.wb-home-card .wb-home-check { width: 30px; height: 30px; }

--- a/src/v2/wallaby/HomeView.jsx
+++ b/src/v2/wallaby/HomeView.jsx
@@ -8,15 +8,21 @@ import './HomeView.css'
 
 const ENERGY_ICONS = { desk: Monitor, people: Users, errand: MapPin, creative: Palette, physical: Dumbbell }
 const DOW = ['S', 'M', 'T', 'W', 'T', 'F', 'S']
+const ACTIVE = ['not_started', 'doing', 'waiting', 'in_progress']
 
-// Wallaby "Home" — the daily agenda (loggd IMG_1582). Tappable date + week
-// strip: pick a day (or page weeks) and the habit rows reflect/toggle that
-// day's completion. "Checking" toggles the selected day in completed_history.
-export default function HomeView({ routines = [], onToggleHabit, onOpenProfile }) {
+// Wallaby "Home" — the daily "pulse". Tappable date + week strip: pick a day
+// and the whole page (summary + tasks + habits) reflects that day. Today shows
+// what's due/carrying; past days show what you did. "Checking" toggles the
+// selected day's completion.
+export default function HomeView({
+  routines = [], tasks = [], labels = [],
+  onToggleHabit, onCompleteTask, onOpenTask, onOpenProfile,
+}) {
   const today = new Date(); today.setHours(0, 0, 0, 0)
   const todayKey = localYMD(today)
   const [weekOffset, setWeekOffset] = useState(0)
   const [selectedKey, setSelectedKey] = useState(todayKey)
+  const labelsById = useMemo(() => { const m = {}; for (const l of labels) m[l.id] = l; return m }, [labels])
 
   const habits = useMemo(() => routines.filter(r => !r.paused), [routines])
   const enriched = useMemo(() => habits.map((r, i) => {
@@ -44,6 +50,24 @@ export default function HomeView({ routines = [], onToggleHabit, onOpenProfile }
 
   const selDate = new Date(`${selectedKey}T12:00:00`)
   const isFutureSel = selectedKey > todayKey
+  const isToday = selectedKey === todayKey
+
+  // Tasks for the selected day: completed-that-day, plus (active) due-that-day —
+  // and on today, anything carrying (due ≤ today). So each day shows its own work.
+  const tasksForDay = useMemo(() => {
+    return tasks.filter(t => {
+      if (t.parent_id || t.gmail_pending) return false
+      const dueKey = t.due_date ? String(t.due_date).slice(0, 10) : null
+      const doneKey = (t.status === 'done' && t.completed_at) ? localYMD(new Date(t.completed_at)) : null
+      if (doneKey === selectedKey) return true
+      if (ACTIVE.includes(t.status)) return isToday ? (dueKey ? dueKey <= todayKey : false) : dueKey === selectedKey
+      return false
+    }).sort((a, b) => (a.status === 'done' ? 1 : 0) - (b.status === 'done' ? 1 : 0))
+  }, [tasks, selectedKey, todayKey, isToday])
+  const tasksDone = tasksForDay.filter(t => t.status === 'done').length
+
+  const habitsTotal = habits.length
+  const habitsDone = enriched.filter(h => h.byDay[selectedKey]).length
 
   return (
     <div className="wb-home">
@@ -81,44 +105,99 @@ export default function HomeView({ routines = [], onToggleHabit, onOpenProfile }
         {onOpenProfile && <button className="wb-home-avatar" onClick={onOpenProfile} aria-label="Profile" />}
       </header>
 
-      {atRisk.length > 0 && selectedKey === todayKey && (
-        <div className="wb-home-risk">
-          <Flame size={16} strokeWidth={2.25} className="wb-home-risk-icon" />
-          <span className="wb-home-risk-text">
-            {atRisk.length} streak{atRisk.length === 1 ? '' : 's'} at risk: {atRisk.slice(0, 2).map(h => h.routine.title).join(', ')}
-            {atRisk.length > 2 ? '…' : ''}
-          </span>
-          <ChevronRight size={16} strokeWidth={2} className="wb-home-risk-chev" />
+      {/* Today's Pulse — the at-a-glance card (today only). */}
+      {isToday && (
+        <div className="wb-pulse">
+          <div className="wb-pulse-title">Today's Pulse</div>
+          {atRisk.length > 0 && (
+            <div className="wb-pulse-row wb-pulse-risk">
+              <Flame size={16} strokeWidth={2.25} />
+              <span>{atRisk.length === 1 ? `${atRisk[0].routine.title} streak at risk` : `${atRisk.length} streaks at risk`}</span>
+            </div>
+          )}
+          <div className="wb-pulse-row wb-pulse-habits">
+            <span className="wb-pulse-dot" />
+            <span>{habitsTotal - habitsDone} habit{habitsTotal - habitsDone === 1 ? '' : 's'} left <em>({habitsDone}/{habitsTotal} done)</em></span>
+          </div>
+          <div className="wb-pulse-row wb-pulse-tasks">
+            <span className="wb-pulse-dot" />
+            <span>{tasksForDay.length} task{tasksForDay.length === 1 ? '' : 's'} for today</span>
+          </div>
         </div>
       )}
 
-      <div className="wb-home-section-label">Habits <span className="wb-home-count">{habits.length}</span></div>
+      {/* Tasks for the selected day */}
+      <section className="wb-home-card">
+        <div className="wb-home-card-head">
+          <h2 className="wb-home-card-title">Tasks</h2>
+          <span className="wb-home-card-count">{tasksDone}/{tasksForDay.length} done</span>
+        </div>
+        {tasksForDay.length === 0 ? (
+          <p className="wb-home-empty-sm">{isToday ? 'Nothing due — enjoy it.' : 'No tasks that day.'}</p>
+        ) : (
+          <>
+            {tasksForDay.length > 0 && (
+              <div className="wb-home-progress"><div className="wb-home-progress-fill" style={{ width: `${Math.round((tasksDone / tasksForDay.length) * 100)}%` }} /></div>
+            )}
+            <ul className="wb-home-tasks">
+              {tasksForDay.map(t => {
+                const done = t.status === 'done'
+                const overdue = !done && t.due_date && String(t.due_date).slice(0, 10) < todayKey
+                const chips = (t.tags || []).map(id => labelsById[id]).filter(Boolean)
+                return (
+                  <li key={t.id} className="wb-home-task">
+                    <button
+                      className={`wb-home-taskcheck${done ? ' is-done' : ''}`}
+                      onClick={() => onCompleteTask?.(t)}
+                      aria-label={done ? 'Reopen' : 'Complete'}
+                    >{done && <Check size={13} strokeWidth={3} color="#fff" />}</button>
+                    <button className="wb-home-task-body" onClick={() => onOpenTask?.(t)}>
+                      <span className={`wb-home-task-title${done ? ' is-done' : ''}`}>{t.title}</span>
+                      {(overdue || chips.length > 0) && (
+                        <span className="wb-home-task-meta">
+                          {overdue && <span className="wb-home-task-overdue">overdue</span>}
+                          {chips.slice(0, 2).map(l => <span key={l.id} className="wb-home-task-tag" style={{ '--tag': l.color }}>{l.name}</span>)}
+                        </span>
+                      )}
+                    </button>
+                  </li>
+                )
+              })}
+            </ul>
+          </>
+        )}
+      </section>
 
-      <div className="wb-home-habits">
-        {enriched.map(({ routine, color, byDay, streak }) => {
-          const Icon = ENERGY_ICONS[routine.energy] || Repeat
-          const doneSel = !!byDay[selectedKey]
-          return (
-            <div key={routine.id} className={`wb-home-habit${doneSel ? ' is-done' : ''}`}>
-              <span className="wb-home-habit-icon" style={{ color }}><Icon size={18} strokeWidth={2} /></span>
-              <div className="wb-home-habit-text">
+      {/* Habits for the selected day */}
+      <section className="wb-home-card">
+        <div className="wb-home-card-head">
+          <h2 className="wb-home-card-title">Habits</h2>
+          <span className="wb-home-card-count">{habitsDone}/{habitsTotal} done</span>
+        </div>
+        <div className="wb-home-habits">
+          {enriched.map(({ routine, color, byDay, streak }) => {
+            const Icon = ENERGY_ICONS[routine.energy] || Repeat
+            const doneSel = !!byDay[selectedKey]
+            return (
+              <div key={routine.id} className={`wb-home-habit${doneSel ? ' is-done' : ''}`}>
+                <span className="wb-home-habit-icon" style={{ background: color }}><Icon size={16} strokeWidth={2} color="#fff" /></span>
                 <span className="wb-home-habit-title">{routine.title}</span>
-                <span className="wb-home-habit-streak"><Flame size={12} strokeWidth={2.25} /> {streak} day{streak === 1 ? '' : 's'}</span>
+                {streak > 0 && <span className="wb-home-habit-streak"><Flame size={12} strokeWidth={2.25} /> {streak}</span>}
+                <button
+                  className={`wb-home-check${doneSel ? ' is-done' : ''}`}
+                  style={doneSel ? { background: color, borderColor: color } : { borderColor: color }}
+                  onClick={() => !isFutureSel && onToggleHabit?.(routine, selectedKey)}
+                  disabled={isFutureSel}
+                  aria-label={doneSel ? 'Mark not done' : 'Mark done'}
+                >
+                  {doneSel && <Check size={18} strokeWidth={3} color="#fff" />}
+                </button>
               </div>
-              <button
-                className={`wb-home-check${doneSel ? ' is-done' : ''}`}
-                style={doneSel ? { background: color, borderColor: color } : { borderColor: color }}
-                onClick={() => !isFutureSel && onToggleHabit?.(routine, selectedKey)}
-                disabled={isFutureSel}
-                aria-label={doneSel ? 'Mark not done' : 'Mark done'}
-              >
-                {doneSel && <Check size={18} strokeWidth={3} color="#fff" />}
-              </button>
-            </div>
-          )
-        })}
-        {habits.length === 0 && <p className="wb-home-empty">No habits yet. Add routines to see them here.</p>}
-      </div>
+            )
+          })}
+          {habits.length === 0 && <p className="wb-home-empty-sm">No habits yet.</p>}
+        </div>
+      </section>
     </div>
   )
 }

--- a/src/v2/wallaby/WallabyShell.jsx
+++ b/src/v2/wallaby/WallabyShell.jsx
@@ -64,7 +64,12 @@ export default function WallabyShell({
   } else if (sub === 'notifications') {
     surface = <NotificationsView entries={notifEntries} onMarkAllRead={markAllRead} onClose={() => setSub(null)} />
   } else if (tab === 'home') {
-    surface = <HomeView routines={routines} onToggleHabit={onToggleHabit} />
+    surface = (
+      <HomeView
+        routines={routines} tasks={tasks} labels={labels}
+        onToggleHabit={onToggleHabit} onCompleteTask={onCompleteTask} onOpenTask={onOpenTask}
+      />
+    )
   } else if (tab === 'habits') {
     surface = (
       <HabitsView

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,10 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-06
 
+- feat(ui): Wallaby Home → "Today's Pulse" (per-day content) [M]
+  - Makes the clickable calendar meaningful — the whole Home now reflects the **selected day** (loggd today-page, `d35f6ec0`/`bd6d7aa6`). New: a **Today's Pulse** card (today only — streak-at-risk · "N habits left (x/y done)" · "N tasks for today"), a **Tasks card** (the day's tasks: due/carrying on today, due-or-completed on past days, with checkbox/reopen, overdue + label chips, and an `n/m done` progress bar), and the **Habits card** (the day's completion + per-habit streak). Selecting a different day swaps the tasks + habit states + counts; past days drop the pulse card.
+  - `HomeView` now takes `tasks`/`labels` + `onCompleteTask`/`onOpenTask` (threaded via `WallabyShell`). Reskin — existing data only; mood/vision/deep-work/year-grid parts stay deferred. Public-Profile sub-tab intentionally omitted (per user).
+
 - feat(ui): Wallaby Settings visual reskin (notifications "fire") [S]
   - `src/v2/wallaby/settings.css` (imported via AppV2.css, gated `[data-theme^="wallaby"]`): visual-only reskin of the existing SettingsModal — **every Boomerang setting + tab preserved**. Tabs → single scrollable row with a green underline on the active tab; `.v2-settings-block`s → grouped navy cards; toggles → loggd **green** when on; segmented controls → green active; inputs/buttons → navy surfaces. **Notifications** get the standout treatment: a CHANNELS card + per-type cards on the elevated surface with Push/Email/Pushover toggle tiles. Standard/Terminal untouched.
 

--- a/wiki/Wallaby-Ideas.md
+++ b/wiki/Wallaby-Ideas.md
@@ -37,16 +37,16 @@ Bottom nav (loggd): **Home · Habits · Tasks · Timer · More**.
 | Habit detail + month calendar | ✅ | tap a card → Streak/Best/Total + completion calendar + Archive/Delete/Edit (`IMG_1586`) |
 | Tasks — list | ✅ | Upcoming/Backlog/**Done** tabs w/ counts; Overdue/Today/Tomorrow/Upcoming/Anytime grouping w/ icons; semi-random per-task checkbox colors; notes subtitle; **tap → action sheet** (reschedule/edit/delete, focus="soon") |
 | Goals (projects) — list + detail | ✅ | metric, progress, semantic buttons |
-| Profile / dashboard | ✅ (partial) | ⬜ add **Level / XP / achievements** row (🅿️ those are new features); ❓ Public Profile sub-tab |
+| Profile / dashboard | ✅ (partial) | ⬜ adopt the rich loggd profile layout (avatar/level/XP/bio/year-grid/per-metric grids) **minus public/share** (user: "like this without the public part"); Level/XP/badges = 🅿️ gamification |
 | Home — daily agenda | ✅ (basic) | ⬜ enrich toward **Today's Pulse** (below) |
 | Settings (visual reskin) | ✅ | Account / Notifications / Preferences / Privacy / API; per-type Push/Email toggles (Boomerang already has the data) |
 | Analytics — "Your productivity insights" | ⬜ / 🅿️ | Tabbed **Overview / Habits / Tasks / Goals / Focus**. Weekly **points** total + ‹week› nav, 🔥current/🏆best streak, stat cards (Habits checks, Tasks completed, Focus time, Check-ins), **Points Breakdown by activity type**, weekly **mood bar-chart** + **reflections** recap. Reskin-able: points/streak/habit+task counts (Boomerang has these). Deferred: focus-time, check-ins, mood, badge points (tied to new features). Reached via More/Profile. |
 
 ### Home "Today's Pulse" (richer Home — PDF 1)
 The real Home is a scrolling daily dashboard. Reskin-able parts (existing data):
-- ⬜ **Pulse** banner: "X habits left (n/m done)", "n tasks for today", streak-at-risk
+- ✅ **Pulse** card (today): "X habits left (n/m done)", "n tasks for today", streak-at-risk
 - ⬜ **Daily summary** card: "You put in Xh deep work, finished N tasks…" + mini activity heatmap + day-streak
-- ⬜ **Tasks today** section (n/m done, Manage/Hide)
+- ✅ **Tasks card** for the selected day (n/m done + progress bar)
 - ✅ **Habits today** section (checkable rows)
 - ✅ **Interactive date/week strip** — select a day (backfill that day), page weeks, jump to today
 - 🅿️ **Reflection + Today's Mood** (new — mood journal)


### PR DESCRIPTION
Answers "what's the point of a clickable calendar if it doesn't show anything different" — now the whole Home reflects the **selected day** (loggd today-page reference).

## What's new
- **Today's Pulse** card (today only): streak-at-risk · "N habits left (x/y done)" · "N tasks for today"
- **Tasks card** for the selected day: due/carrying on today, due-or-completed on past days; checkbox (complete/reopen), overdue + label chips, and an `n/m done` progress bar
- **Habits card**: the day's completion + per-habit streak flame

Selecting a different day swaps the tasks + habit states + counts; past days drop the pulse card. So the calendar now drives real content.

`HomeView` takes `tasks`/`labels` + `onCompleteTask`/`onOpenTask` (via `WallabyShell`). **Reskin — existing data only**; mood/vision/deep-work/year-grid stay deferred, and the **Public-Profile** sub-tab is intentionally omitted per your note.

Verified headless: today → pulse + Tasks + Habits cards (14 tasks, 5 habits); past day → no pulse, that day's tasks. Build green, lint clean.

https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk)_