### PR TITLE
feat(ui): Wallaby Analytics visual reskin + reachable from More

### DIFF
--- a/src/v2/AppV2.css
+++ b/src/v2/AppV2.css
@@ -2,6 +2,7 @@
 @import './terminal/index.css';
 @import './wallaby/palette.css';
 @import './wallaby/settings.css';
+@import './wallaby/analytics.css';
 
 /* Wallaby "Habits" surface mounts as a full-screen overlay above the app. */
 .v2-habits-overlay {

--- a/src/v2/AppV2.jsx
+++ b/src/v2/AppV2.jsx
@@ -1209,6 +1209,7 @@ export default function AppV2() {
           onOpenSettings={() => setShowSettings(true)}
           onOpenAdviser={() => setShowAdviser(true)}
           onOpenPackages={() => setShowPackages(true)}
+          onOpenAnalytics={() => setShowAnalytics(true)}
           syncStatus={syncStatus}
           queueLength={queueLength}
         />

--- a/src/v2/wallaby/WallabyShell.jsx
+++ b/src/v2/wallaby/WallabyShell.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { Timer, Package, BookOpen, Smile, Settings, FolderKanban, User, ChevronRight, ArrowLeft } from 'lucide-react'
+import { Timer, Package, BookOpen, Smile, Settings, BarChart3, FolderKanban, User, ChevronRight, ArrowLeft } from 'lucide-react'
 import HomeView from './HomeView'
 import HabitsView from './HabitsView'
 import TasksView from './TasksView'
@@ -21,7 +21,7 @@ export default function WallabyShell({
   onRescheduleTask, onDeleteTask,
   onEditHabit, onArchiveHabit, onDeleteHabit,
   onLogSession, onCompleteProject, onEditProject, onSetAsideProject, onDeleteProject,
-  onOpenSettings, onOpenAdviser, onOpenPackages,
+  onOpenSettings, onOpenAdviser, onOpenPackages, onOpenAnalytics,
   syncStatus = 'synced', queueLength = 0,
 }) {
   const [tab, setTab] = useState('home')
@@ -96,6 +96,7 @@ export default function WallabyShell({
       <MoreMenu
         onOpenProfile={() => setSub('profile')}
         onOpenGoals={() => setSub('goals')}
+        onOpenAnalytics={onOpenAnalytics}
         onOpenTimer={() => setSub('timer')}
         onOpenPackages={onOpenPackages}
         onOpenSettings={onOpenSettings}
@@ -122,10 +123,11 @@ export default function WallabyShell({
   )
 }
 
-function MoreMenu({ onOpenProfile, onOpenGoals, onOpenTimer, onOpenPackages, onOpenSettings }) {
+function MoreMenu({ onOpenProfile, onOpenGoals, onOpenAnalytics, onOpenTimer, onOpenPackages, onOpenSettings }) {
   const rows = [
     { key: 'profile', icon: User, label: 'Profile', sub: 'Stats + your activity year', onClick: onOpenProfile },
     { key: 'goals', icon: FolderKanban, label: 'Goals', sub: 'Projects · progress + sessions', onClick: onOpenGoals },
+    { key: 'analytics', icon: BarChart3, label: 'Analytics', sub: 'Productivity insights', onClick: onOpenAnalytics },
     { key: 'packages', icon: Package, label: 'Packages', sub: 'Track deliveries', onClick: onOpenPackages },
     { key: 'timer', icon: Timer, label: 'Timer', sub: 'Focus sessions', onClick: onOpenTimer },
     { key: 'vision', icon: BookOpen, label: 'Vision', sub: 'Coming soon', soon: true },

--- a/src/v2/wallaby/analytics.css
+++ b/src/v2/wallaby/analytics.css
@@ -1,0 +1,49 @@
+/* ════════════════════════════════════════════════════════════════════════
+ * Wallaby Analytics reskin — visual only, gated on [data-theme^="wallaby"].
+ * Cards Boomerang's existing analytics sections + greens the accents, without
+ * touching the markup or the rich charts (daily bars / DOW / breakdown / heatmap).
+ * ════════════════════════════════════════════════════════════════════════ */
+
+/* Sections → grouped navy cards */
+[data-theme^="wallaby"] .v2-analytics-section {
+  background: var(--wb-card);
+  border: 1px solid var(--wb-hairline);
+  border-radius: 16px;
+  padding: 16px;
+  margin-bottom: 12px;
+  box-shadow: var(--wb-shadow);
+}
+
+/* Summary "big number" band → its own card + green hero number */
+[data-theme^="wallaby"] .v2-analytics-summary {
+  background: var(--wb-card);
+  border: 1px solid var(--wb-hairline);
+  border-radius: 16px;
+  padding: 16px;
+  margin: 4px 0 12px;
+  box-shadow: var(--wb-shadow);
+}
+[data-theme^="wallaby"] .v2-analytics-summary-num { color: var(--wb-action-complete); }
+
+/* Range / metric toggles → green active */
+[data-theme^="wallaby"] .v2-analytics-range-btn-active,
+[data-theme^="wallaby"] .v2-analytics-metric-btn-active {
+  background: var(--wb-action-complete);
+  color: #fff;
+}
+[data-theme^="wallaby"] .v2-analytics-range-btn,
+[data-theme^="wallaby"] .v2-analytics-metric-btn {
+  background: var(--wb-card-2);
+  border-color: var(--wb-hairline);
+}
+
+/* Chart fills pick up the Wallaby accent (purple) over the v2 orange */
+[data-theme^="wallaby"] .v2-analytics-daily-bar,
+[data-theme^="wallaby"] .v2-analytics-bd-fill,
+[data-theme^="wallaby"] .v2-analytics-dow-fill {
+  background: var(--wb-cat-purple);
+}
+[data-theme^="wallaby"] .v2-analytics-bd-track,
+[data-theme^="wallaby"] .v2-analytics-dow-track {
+  background: var(--wb-card-2);
+}

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,9 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-06
 
+- feat(ui): Wallaby Analytics visual reskin + reachable from More [S]
+  - `src/v2/wallaby/analytics.css` (Wallaby-gated, via AppV2.css): visual reskin of the existing AnalyticsModal — sections → navy cards, the summary "big number" → its own card with a **green** hero value, range/metric toggles → green active, chart fills (daily bars / DOW / breakdown) → Wallaby purple. All of Boomerang's analytics preserved (daily, by-day-of-week, balance radar, by-tag, by-energy, heatmap). Added **More → Analytics** (`onOpenAnalytics` → existing `showAnalytics`). Standard/Terminal untouched.
+
 - feat(ui): Wallaby Home → "Today's Pulse" (per-day content) [M]
   - Makes the clickable calendar meaningful — the whole Home now reflects the **selected day** (loggd today-page, `d35f6ec0`/`bd6d7aa6`). New: a **Today's Pulse** card (today only — streak-at-risk · "N habits left (x/y done)" · "N tasks for today"), a **Tasks card** (the day's tasks: due/carrying on today, due-or-completed on past days, with checkbox/reopen, overdue + label chips, and an `n/m done` progress bar), and the **Habits card** (the day's completion + per-habit streak). Selecting a different day swaps the tasks + habit states + counts; past days drop the pulse card.
   - `HomeView` now takes `tasks`/`labels` + `onCompleteTask`/`onOpenTask` (threaded via `WallabyShell`). Reskin — existing data only; mood/vision/deep-work/year-grid parts stay deferred. Public-Profile sub-tab intentionally omitted (per user).

--- a/wiki/Wallaby-Ideas.md
+++ b/wiki/Wallaby-Ideas.md
@@ -40,7 +40,7 @@ Bottom nav (loggd): **Home · Habits · Tasks · Timer · More**.
 | Profile / dashboard | ✅ (partial) | ⬜ adopt the rich loggd profile layout (avatar/level/XP/bio/year-grid/per-metric grids) **minus public/share** (user: "like this without the public part"); Level/XP/badges = 🅿️ gamification |
 | Home — daily agenda | ✅ (basic) | ⬜ enrich toward **Today's Pulse** (below) |
 | Settings (visual reskin) | ✅ | Account / Notifications / Preferences / Privacy / API; per-type Push/Email toggles (Boomerang already has the data) |
-| Analytics — "Your productivity insights" | ⬜ / 🅿️ | Tabbed **Overview / Habits / Tasks / Goals / Focus**. Weekly **points** total + ‹week› nav, 🔥current/🏆best streak, stat cards (Habits checks, Tasks completed, Focus time, Check-ins), **Points Breakdown by activity type**, weekly **mood bar-chart** + **reflections** recap. Reskin-able: points/streak/habit+task counts (Boomerang has these). Deferred: focus-time, check-ins, mood, badge points (tied to new features). Reached via More/Profile. |
+| Analytics (visual reskin) | ✅ (reskin) / 🅿️ | Tabbed **Overview / Habits / Tasks / Goals / Focus**. Weekly **points** total + ‹week› nav, 🔥current/🏆best streak, stat cards (Habits checks, Tasks completed, Focus time, Check-ins), **Points Breakdown by activity type**, weekly **mood bar-chart** + **reflections** recap. Reskin-able: points/streak/habit+task counts (Boomerang has these). Deferred: focus-time, check-ins, mood, badge points (tied to new features). Reached via More/Profile. |
 
 ### Home "Today's Pulse" (richer Home — PDF 1)
 The real Home is a scrolling daily dashboard. Reskin-able parts (existing data):


### PR DESCRIPTION
Visual reskin of Analytics to the Wallaby look (CSS-only, gated, Standard/Terminal untouched) + made it reachable.

- Sections → navy cards; summary "big number" → its own card with a **green** hero value
- Range (7d/30d/90d/1y/All) + metric (Tasks/Points) toggles → green active
- Chart fills (daily bars / day-of-week / breakdown) → Wallaby purple
- All of Boomerang's analytics preserved: daily completions, by-day-of-week, balance radar (Tags/Energy), by-tag, by-energy, 52-week heatmap
- **More → Analytics** entry (`onOpenAnalytics` → existing `showAnalytics`)

Verified headless: opens from More; All-range shows 7 carded sections + green summary. (30d default reads empty here only because the seed's completions are 2–4 months old.) Build green, lint clean.

https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk)_