### PR TITLE
feat(ui): Quokka own page + nav swap; seed covers all timelines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1042,11 +1042,13 @@ tokens even if reached from a non-Wallaby theme.
 - `NotificationsView.{jsx,css}` — notifications center reading the existing
   `GET /api/notifications/log` (All/Unread, grouped Today/Yesterday/Earlier,
   type-colored icons, optimistic mark-all-read). Reskin — no new data.
-- `WallabyNav.{jsx,css}` + `WallabyShell.{jsx,css}` — the loggd IA. A fixed 4-tab
-  bottom nav (**Home · Habits · Tasks · More**) + the top header, over the active
-  surface. **More** routes to Profile · Goals · **Packages** (real modal) ·
-  **Timer** (coming-soon) · Vision (soon) · Daily (soon) · Settings. (Quokka is
-  in the top header; Packages/Timer moved out of nav into More per user.)
+- `WallabyNav.{jsx,css}` + `WallabyShell.{jsx,css}` — the loggd IA. A fixed 5-tab
+  bottom nav (**Home · Habits · Quokka · Tasks · More**) + the top header, over
+  the active surface. **Quokka** is its own page (the adviser rendered inline via
+  `.wb-quokka-page`, which strips the ModalShell chrome; the surface stops above
+  the nav). **More** routes to Profile · Goals · Analytics · **Packages** (real
+  modal) · **Timer** (coming-soon) · Vision (soon) · Daily (soon) · Settings.
+  (Header carries brand + bell + avatar only; tab icons color only when active.)
 
 **How the surfaces are reached (Wallaby mode).** `AppV2` renders `<WallabyShell>`
 (`position:fixed`, z-40 — covers the standard header + list) when

--- a/seed.js
+++ b/seed.js
@@ -16,6 +16,77 @@ function loadSeedData() {
   return JSON.parse(readFileSync(p, 'utf-8'))
 }
 
+const ONE_DAY = 86400000
+const isDateOnly = (v) => /^\d{4}-\d{2}-\d{2}$/.test(String(v))
+const shiftIso = (v, ms) => {
+  if (!v) return v
+  const t = new Date(v).getTime()
+  if (Number.isNaN(t)) return v
+  const d = new Date(t + ms)
+  return isDateOnly(v) ? d.toISOString().slice(0, 10) : d.toISOString()
+}
+
+// The static seed is frozen at whatever date it was generated. To keep dev data
+// always current ("cover all timelines"), at seed time we:
+//   1. Rebase every TASK date so the most-recent completion lands today (so
+//      overdue stays overdue, upcoming stays upcoming, done is recent).
+//   2. Synthesize a rich, cadence-based completion history for each active
+//      routine spanning ~250 days up to today — so habit heatmaps, the Home
+//      "Today's Pulse", and Analytics (7d/30d/90d/year) all have real data.
+function makeSeedCurrent(data) {
+  const now = Date.now()
+
+  // ── 1. Rebase task dates on the latest task completion ──────────────────
+  let maxCompleted = 0
+  for (const t of data.tasks || []) {
+    const c = t.completed_at ? new Date(t.completed_at).getTime() : 0
+    if (c > maxCompleted) maxCompleted = c
+    for (const h of t.completed_history || []) {
+      const hh = new Date(h).getTime(); if (hh > maxCompleted) maxCompleted = hh
+    }
+  }
+  if (maxCompleted) {
+    const shift = now - maxCompleted
+    const taskDateFields = ['completed_at', 'created_at', 'last_touched', 'snoozed_until', 'waiting_at', 'last_session_at', 'due_date']
+    for (const t of data.tasks || []) {
+      for (const f of taskDateFields) if (t[f]) t[f] = shiftIso(t[f], shift)
+      if (Array.isArray(t.completed_history)) t.completed_history = t.completed_history.map(h => shiftIso(h, shift))
+      if (Array.isArray(t.comments)) t.comments = t.comments.map(c => ({ ...c, timestamp: shiftIso(c.timestamp, shift) }))
+    }
+  }
+
+  // ── 2. Synthesize rich routine history up to today ──────────────────────
+  const STEP = { daily: 1, weekly: 7, monthly: 30, quarterly: 91, annually: 365 }
+  for (const r of data.routines || []) {
+    const step = STEP[r.cadence] || 1
+    if (r.paused) {
+      // Keep paused routines light but recent: a handful in the last ~60 days.
+      const hist = []
+      for (let n = 0; n < 3; n++) {
+        const d = new Date(now - (10 + n * 18) * ONE_DAY); d.setHours(9, 0, 0, 0)
+        hist.push(d.toISOString())
+      }
+      r.completed_history = hist
+      r.created_at = shiftIso(r.created_at, now - new Date(r.created_at || now).getTime())
+      continue
+    }
+    const days = step === 1 ? 250 : step * 30   // ~250d daily, ~30 cycles otherwise
+    const adherence = 0.8
+    const hist = []
+    for (let d = days; d >= 0; d -= step) {
+      // Always log the last couple of cadence slots for a live streak.
+      if (d <= step || Math.random() < adherence) {
+        const ts = new Date(now - d * ONE_DAY); ts.setHours(8 + Math.floor(Math.random() * 10), 0, 0, 0)
+        hist.push(ts.toISOString())
+      }
+    }
+    r.completed_history = hist
+    r.created_at = new Date(now - (days + step) * ONE_DAY).toISOString()
+  }
+
+  return data
+}
+
 /**
  * Seed the database from static JSON.
  * Called from server.js after initDb() when SEED_DB=1,
@@ -32,6 +103,8 @@ export async function seedDatabase() {
   if (!data.tasks || !data.routines || !data.labels || !data.settings) {
     throw new Error('[Seed] Invalid seed data — missing tasks, routines, labels, or settings')
   }
+
+  makeSeedCurrent(data)
 
   clearAllData()
   for (const task of data.tasks) upsertTask(task)

--- a/src/v2/AppV2.jsx
+++ b/src/v2/AppV2.jsx
@@ -1207,9 +1207,10 @@ export default function AppV2() {
           onSetAsideProject={(p) => updateTask(p.id, { status: 'backlog' })}
           onDeleteProject={(p) => deleteTask(p.id)}
           onOpenSettings={() => setShowSettings(true)}
-          onOpenAdviser={() => setShowAdviser(true)}
           onOpenPackages={() => setShowPackages(true)}
           onOpenAnalytics={() => setShowAnalytics(true)}
+          adviser={adviserState}
+          onOpenEasterEgg={openEasterEgg}
           syncStatus={syncStatus}
           queueLength={queueLength}
         />

--- a/src/v2/wallaby/WallabyNav.css
+++ b/src/v2/wallaby/WallabyNav.css
@@ -26,6 +26,5 @@
   transition: color 140ms ease;
 }
 .wb-nav-tab.is-active { color: var(--wb-action-complete); }
-.wb-nav-tab-action { color: var(--wb-cat-purple); }
 .wb-nav-icon { display: block; }
 .wb-nav-label { font-size: 10.5px; font-weight: 600; }

--- a/src/v2/wallaby/WallabyNav.jsx
+++ b/src/v2/wallaby/WallabyNav.jsx
@@ -1,30 +1,29 @@
-import { Home, Activity, ListTodo, Sparkles, Menu } from 'lucide-react'
+import { Home, Activity, Sparkles, ListTodo, Menu } from 'lucide-react'
 import './WallabyNav.css'
 
-// Wallaby bottom nav: Home · Habits · Tasks · Quokka · More. Quokka is an
-// action (opens the adviser), not a destination tab. (Timer + Packages live in
-// the More menu.)
+// Wallaby bottom nav: Home · Habits · Quokka · Tasks · More. Quokka is its own
+// page (the adviser). (Timer + Packages live in the More menu.)
 const TABS = [
   { id: 'home', label: 'Home', icon: Home },
   { id: 'habits', label: 'Habits', icon: Activity },
+  { id: 'quokka', label: 'Quokka', icon: Sparkles },
   { id: 'tasks', label: 'Tasks', icon: ListTodo },
-  { id: 'quokka', label: 'Quokka', icon: Sparkles, action: true },
   { id: 'more', label: 'More', icon: Menu },
 ]
 
-export default function WallabyNav({ active, onChange, onQuokka }) {
+export default function WallabyNav({ active, onChange }) {
   return (
     <nav className="wb-nav" role="tablist" aria-label="Primary">
       {TABS.map(t => {
         const Icon = t.icon
-        const on = !t.action && active === t.id
+        const on = active === t.id
         return (
           <button
             key={t.id}
-            role={t.action ? undefined : 'tab'}
-            aria-selected={t.action ? undefined : on}
-            className={`wb-nav-tab${on ? ' is-active' : ''}${t.action ? ' wb-nav-tab-action' : ''}`}
-            onClick={() => (t.action ? onQuokka?.() : onChange(t.id))}
+            role="tab"
+            aria-selected={on}
+            className={`wb-nav-tab${on ? ' is-active' : ''}`}
+            onClick={() => onChange(t.id)}
           >
             <Icon size={22} strokeWidth={on ? 2.4 : 1.9} className="wb-nav-icon" />
             <span className="wb-nav-label">{t.label}</span>

--- a/src/v2/wallaby/WallabyShell.css
+++ b/src/v2/wallaby/WallabyShell.css
@@ -7,6 +7,9 @@
   z-index: 40;
   background: var(--wb-bg);
 }
+.wb-shell {
+  --wb-nav-h: 64px;
+}
 .wb-shell-surface {
   position: absolute;
   top: calc(var(--wb-header-h) + env(safe-area-inset-top));
@@ -16,6 +19,34 @@
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
 }
+/* Quokka renders as a full page (the adviser chat). Stop the surface above the
+ * nav so the composer never hides behind it, and let the page fill exactly. */
+.wb-shell-surface-stop-at-nav {
+  bottom: calc(var(--wb-nav-h) + env(safe-area-inset-bottom));
+  overflow: hidden;
+}
+.wb-quokka-page { position: absolute; inset: 0; }
+/* Strip the modal chrome so the adviser sits as an inline page. */
+.wb-quokka-page .v2-modal-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  background: transparent;
+  display: block;
+  padding: 0;
+}
+.wb-quokka-page .v2-modal {
+  position: absolute;
+  inset: 0;
+  max-width: none;
+  width: 100%;
+  height: 100%;
+  border-radius: 0;
+  border: none;
+  box-shadow: none;
+  animation: none;
+}
+.wb-quokka-page .v2-modal-close { display: none; }
 
 /* ── More menu ───────────────────────────────────────────────────────────── */
 .wb-more {

--- a/src/v2/wallaby/WallabyShell.jsx
+++ b/src/v2/wallaby/WallabyShell.jsx
@@ -8,6 +8,7 @@ import GoalsView from './GoalsView'
 import NotificationsView from './NotificationsView'
 import WallabyNav from './WallabyNav'
 import WallabyHeader from './WallabyHeader'
+import AdviserModal from '../components/AdviserModal'
 import './WallabyShell.css'
 
 // Wallaby shell — the loggd IA. Full-screen container shown in Wallaby mode on
@@ -21,7 +22,8 @@ export default function WallabyShell({
   onRescheduleTask, onDeleteTask,
   onEditHabit, onArchiveHabit, onDeleteHabit,
   onLogSession, onCompleteProject, onEditProject, onSetAsideProject, onDeleteProject,
-  onOpenSettings, onOpenAdviser, onOpenPackages, onOpenAnalytics,
+  onOpenSettings, onOpenPackages, onOpenAnalytics,
+  adviser, onAdviserAfterCommit, onOpenEasterEgg,
   syncStatus = 'synced', queueLength = 0,
 }) {
   const [tab, setTab] = useState('home')
@@ -80,6 +82,19 @@ export default function WallabyShell({
         onDeleteHabit={onDeleteHabit}
       />
     )
+  } else if (tab === 'quokka') {
+    surface = (
+      <div className="wb-quokka-page">
+        <AdviserModal
+          open
+          adviser={adviser}
+          onClose={() => setTab('home')}
+          onAfterCommit={onAdviserAfterCommit}
+          onOpenEasterEgg={onOpenEasterEgg}
+          draftSeed=""
+        />
+      </div>
+    )
   } else if (tab === 'tasks') {
     surface = (
       <TasksView
@@ -113,11 +128,10 @@ export default function WallabyShell({
         syncStatus={syncStatus}
         queueLength={queueLength}
       />
-      <div className="wb-shell-surface">{surface}</div>
+      <div className={`wb-shell-surface${!sub && tab === 'quokka' ? ' wb-shell-surface-stop-at-nav' : ''}`}>{surface}</div>
       <WallabyNav
         active={sub ? '' : tab}
         onChange={(t) => { setSub(null); setTab(t) }}
-        onQuokka={onOpenAdviser}
       />
     </div>
   )

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,12 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-06
 
+- feat(ui): Quokka is its own page; nav swap; idle icon [S]
+  - Quokka moved to the **center** nav slot (Home · Habits · **Quokka** · Tasks · More) and is now **its own page** instead of a pop-up: selecting the tab renders the adviser inline in the shell surface (`.wb-quokka-page` strips the ModalShell chrome; the surface stops above the nav so the composer clears it). Its icon is muted when idle and green when active **like every other tab** (dropped the always-purple). `WallabyShell` takes `adviser`/`onOpenEasterEgg`; the AppV2 adviser modal stays for non-Wallaby.
+
+- chore(dev): seed covers all timelines (rebased to today + rich habit history) [S]
+  - The static `seed-data.json` was frozen at Jan–Apr, so recent views (heatmaps, Today's Pulse, Analytics 7d/30d) rendered empty. `seed.js` `makeSeedCurrent()` now, at seed time: (1) **rebases every task date** so the latest completion lands today (overdue stays overdue, upcoming stays upcoming); (2) **synthesizes rich cadence-based routine history** spanning ~250 days up to today (daily habit → ~188 entries Sep→today; weekly → ~24). So dev data covers all timeframes. Dev-only; benefits every skin.
+
 - feat(ui): Wallaby Analytics visual reskin + reachable from More [S]
   - `src/v2/wallaby/analytics.css` (Wallaby-gated, via AppV2.css): visual reskin of the existing AnalyticsModal — sections → navy cards, the summary "big number" → its own card with a **green** hero value, range/metric toggles → green active, chart fills (daily bars / DOW / breakdown) → Wallaby purple. All of Boomerang's analytics preserved (daily, by-day-of-week, balance radar, by-tag, by-energy, heatmap). Added **More → Analytics** (`onOpenAnalytics` → existing `showAnalytics`). Standard/Terminal untouched.
 


### PR DESCRIPTION
Two changes.

## Quokka → its own page
- Moved to the **center** nav slot: **Home · Habits · Quokka · Tasks · More** (swapped with Tasks).
- Now **its own page**, not a pop-up: the tab renders the adviser inline in the shell surface (`.wb-quokka-page` strips the ModalShell chrome; the surface stops above the nav so the composer clears it). Nav stays visible.
- Icon is **muted when idle, green when active** like every other tab (dropped the always-purple).

## Seed covers all timelines (dev)
The static `seed-data.json` was frozen at Jan–Apr, so recent views rendered empty. `seed.js` `makeSeedCurrent()` now, at seed time:
1. **Rebases every task date** so the latest completion lands today (overdue stays overdue, upcoming stays upcoming).
2. **Synthesizes rich cadence-based routine history** spanning ~250 days up to today (daily habit → ~188 entries; weekly → ~24).

So heatmaps / Today's Pulse / Analytics (7d/30d/90d/year) all populate. Dev-only, benefits every skin.

Verified headless: nav order swapped; Quokka idle=muted / active=green; Quokka renders as a page (nav + composer visible); fresh seed spans **Nov 2025 → today**. Build green, lint clean.

https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk)_