### PR TITLE
feat(ui): wallaby modals render as full pages, not slide-up sheets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1054,8 +1054,14 @@ tokens even if reached from a non-Wallaby theme.
 (`position:fixed`, z-40 — covers the standard header + list) when
 `isWallaby && !isDesktop`, and skips the standard `BottomTabs`. The shell owns
 tab state (Home/Habits/Tasks/Timer/More) and a `sub` state for Profile/Goals
-opened from More. Shared modals (Edit/Add/Settings, z-100) still open above the
-shell — tapping a task → `EditTaskModal`, checkbox → `handleComplete`, subtask →
+opened from More. Shared modals (Edit/Add/Settings/Analytics/Packages/Quokka,
+z-100) open above the shell, and on mobile in Wallaby they render as **full
+pages** (no slide-up sheet): `src/v2/wallaby/modals.css` pins every
+`.v2-modal-overlay` between the WallabyHeader (top: 52px + inset) and WallabyNav
+(bottom: 64px + inset), strips the animation/rounded-card chrome, and fills the
+page — so the app never feels like a stack of slide-up menus. Quokka is one such
+page (the `quokka` tab renders `AdviserModal` and lets this treatment size it).
+Tapping a task → `EditTaskModal`, checkbox → `handleComplete`, subtask →
 `updateTask({checklists})`, Home check → toggle `completed_history` today, Goals
 Log session → `logProjectSession` etc. Desktop keeps Kanban + drawer. The old
 `.v2-habits-overlay` Spaces entries (`showHabits`/`showTasks`/`showProfile`/

--- a/src/v2/AppV2.css
+++ b/src/v2/AppV2.css
@@ -3,6 +3,7 @@
 @import './wallaby/palette.css';
 @import './wallaby/settings.css';
 @import './wallaby/analytics.css';
+@import './wallaby/modals.css';
 
 /* Wallaby "Habits" surface mounts as a full-screen overlay above the app. */
 .v2-habits-overlay {

--- a/src/v2/wallaby/WallabyShell.css
+++ b/src/v2/wallaby/WallabyShell.css
@@ -19,34 +19,6 @@
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
 }
-/* Quokka renders as a full page (the adviser chat). Stop the surface above the
- * nav so the composer never hides behind it, and let the page fill exactly. */
-.wb-shell-surface-stop-at-nav {
-  bottom: calc(var(--wb-nav-h) + env(safe-area-inset-bottom));
-  overflow: hidden;
-}
-.wb-quokka-page { position: absolute; inset: 0; }
-/* Strip the modal chrome so the adviser sits as an inline page. */
-.wb-quokka-page .v2-modal-overlay {
-  position: absolute;
-  inset: 0;
-  z-index: 1;
-  background: transparent;
-  display: block;
-  padding: 0;
-}
-.wb-quokka-page .v2-modal {
-  position: absolute;
-  inset: 0;
-  max-width: none;
-  width: 100%;
-  height: 100%;
-  border-radius: 0;
-  border: none;
-  box-shadow: none;
-  animation: none;
-}
-.wb-quokka-page .v2-modal-close { display: none; }
 
 /* ── More menu ───────────────────────────────────────────────────────────── */
 .wb-more {

--- a/src/v2/wallaby/WallabyShell.jsx
+++ b/src/v2/wallaby/WallabyShell.jsx
@@ -83,17 +83,17 @@ export default function WallabyShell({
       />
     )
   } else if (tab === 'quokka') {
+    // Rendered via the global Wallaby modal-page treatment (modals.css), so it
+    // sits as a page between header and nav like every other surface.
     surface = (
-      <div className="wb-quokka-page">
-        <AdviserModal
-          open
-          adviser={adviser}
-          onClose={() => setTab('home')}
-          onAfterCommit={onAdviserAfterCommit}
-          onOpenEasterEgg={onOpenEasterEgg}
-          draftSeed=""
-        />
-      </div>
+      <AdviserModal
+        open
+        adviser={adviser}
+        onClose={() => setTab('home')}
+        onAfterCommit={onAdviserAfterCommit}
+        onOpenEasterEgg={onOpenEasterEgg}
+        draftSeed=""
+      />
     )
   } else if (tab === 'tasks') {
     surface = (
@@ -128,7 +128,7 @@ export default function WallabyShell({
         syncStatus={syncStatus}
         queueLength={queueLength}
       />
-      <div className={`wb-shell-surface${!sub && tab === 'quokka' ? ' wb-shell-surface-stop-at-nav' : ''}`}>{surface}</div>
+      <div className="wb-shell-surface">{surface}</div>
       <WallabyNav
         active={sub ? '' : tab}
         onChange={(t) => { setSub(null); setTab(t) }}

--- a/src/v2/wallaby/analytics.css
+++ b/src/v2/wallaby/analytics.css
@@ -25,16 +25,30 @@
 }
 [data-theme^="wallaby"] .v2-analytics-summary-num { color: var(--wb-action-complete); }
 
-/* Range / metric toggles → green active */
+/* Range / metric toggles → clean contained segmented controls, green active */
+[data-theme^="wallaby"] .v2-analytics-range,
+[data-theme^="wallaby"] .v2-analytics-metric {
+  display: inline-flex;
+  gap: 2px;
+  background: var(--wb-card-2);
+  border: 1px solid var(--wb-hairline);
+  border-radius: 999px;
+  padding: 3px;
+}
+[data-theme^="wallaby"] .v2-analytics-range-btn,
+[data-theme^="wallaby"] .v2-analytics-metric-btn {
+  border: none;
+  background: transparent;
+  border-radius: 999px;
+  padding: 7px 13px;
+  color: var(--wb-text-meta);
+  font-weight: 700;
+}
 [data-theme^="wallaby"] .v2-analytics-range-btn-active,
 [data-theme^="wallaby"] .v2-analytics-metric-btn-active {
   background: var(--wb-action-complete);
   color: #fff;
-}
-[data-theme^="wallaby"] .v2-analytics-range-btn,
-[data-theme^="wallaby"] .v2-analytics-metric-btn {
-  background: var(--wb-card-2);
-  border-color: var(--wb-hairline);
+  border: none;
 }
 
 /* Chart fills pick up the Wallaby accent (purple) over the v2 orange */

--- a/src/v2/wallaby/modals.css
+++ b/src/v2/wallaby/modals.css
@@ -1,0 +1,39 @@
+/* ════════════════════════════════════════════════════════════════════════
+ * Wallaby modals → full PAGES (no slide-up sheets). Gated to mobile + Wallaby.
+ * Every ModalShell (Packages, Settings, Analytics, Edit, Add, Quokka, …)
+ * renders as a solid full page that sits between the persistent top header and
+ * the bottom nav, so the app never feels like a stack of slide-up menus.
+ * (User: "the wallaby theme shouldn't have the slide up menus. Everything
+ * should have its own page.")
+ * ════════════════════════════════════════════════════════════════════════ */
+
+@media (max-width: 767px) {
+  [data-theme^="wallaby"] .v2-modal-overlay {
+    top: calc(52px + env(safe-area-inset-top));   /* below the WallabyHeader */
+    bottom: calc(64px + env(safe-area-inset-bottom)); /* above the WallabyNav */
+    left: 0;
+    right: 0;
+    background: var(--wb-bg);
+    align-items: stretch;
+    justify-content: stretch;
+    animation: none;
+  }
+  [data-theme^="wallaby"] .v2-modal {
+    min-height: 0;
+    max-height: none;
+    height: 100%;
+    width: 100%;
+    max-width: none;
+    border-radius: 0;
+    box-shadow: none;
+    animation: none;
+  }
+  [data-theme^="wallaby"] .v2-modal-header {
+    padding: 22px 20px 16px;
+  }
+  [data-theme^="wallaby"] .v2-modal-title { font-size: 26px; }
+
+  /* Quokka/adviser toolbar: spread chats / new-chat across the page width
+   * instead of floating both to the right with a big empty gutter. */
+  [data-theme^="wallaby"] .v2-adviser-toolbar { justify-content: space-between; }
+}

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,10 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-06
 
+- feat(ui): Wallaby — all modals render as full pages, not slide-up sheets [S]
+  - New `src/v2/wallaby/modals.css` (mobile + `[data-theme^="wallaby"]` gated, imported via `AppV2.css`): **every** ModalShell surface (Packages, Settings, Analytics, Edit, Add, Quokka, …) now renders as a solid full **page** that sits between the persistent WallabyHeader (top: 52px + inset) and WallabyNav (bottom: 64px + inset) — no slide-up sheet, no animation, no rounded card chrome. (User: "the wallaby theme shouldn't have the slide up menus. Everything should have its own page.") The Quokka branch in `WallabyShell` now relies on this global treatment instead of the bespoke `.wb-quokka-page` chrome-stripping (removed) — the header/nav splits that looked strange are gone because the surface no longer double-stacks an inline page inside a stop-at-nav surface.
+  - **Analytics buttons fix:** the range (7d/30d/90d) and metric toggles were loose pill buttons; reskinned to **contained segmented controls** (rounded track on `--wb-card-2`, green active fill) in `analytics.css`.
+
 - feat(ui): Quokka is its own page; nav swap; idle icon [S]
   - Quokka moved to the **center** nav slot (Home · Habits · **Quokka** · Tasks · More) and is now **its own page** instead of a pop-up: selecting the tab renders the adviser inline in the shell surface (`.wb-quokka-page` strips the ModalShell chrome; the surface stops above the nav so the composer clears it). Its icon is muted when idle and green when active **like every other tab** (dropped the always-purple). `WallabyShell` takes `adviser`/`onOpenEasterEgg`; the AppV2 adviser modal stays for non-Wallaby.
 


### PR DESCRIPTION
## What

In Wallaby mode on mobile, every modal now renders as a full **page** between the persistent header and bottom nav — no more slide-up sheets. Directly addresses: *"the wallaby theme shouldn't have the slide up menus. Everything should have its own page. Packages and Settings are both ones I've noticed."*

## Changes

- **`src/v2/wallaby/modals.css`** (new, imported via `AppV2.css`) — mobile + `[data-theme^="wallaby"]` gated. Pins every `.v2-modal-overlay` between the WallabyHeader (top: 52px + inset) and WallabyNav (bottom: 64px + inset), strips animation / rounded-card / shadow chrome, fills the page. Applies to Packages, Settings, Analytics, Edit, Add, Quokka — all of them.
- **Quokka page** — `WallabyShell` now leans on this global treatment instead of the bespoke `.wb-quokka-page` chrome-stripping (removed from `WallabyShell.css` + `.jsx`). Fixes the strange header/nav splits at the top of the Quokka page (it was double-stacking an inline page inside a stop-at-nav surface).
- **Analytics toggles** — range (7d/30d/90d) + metric toggles reskinned from loose pills to contained **segmented controls** (rounded track on `--wb-card-2`, green active fill) in `analytics.css`.

## Verification

- `npm run build` ✅
- `npm run check:terminal-titles` ✅
- eslint clean on changed files
- Headless Chromium (880px viewport): Analytics + Quokka pages confirmed at overlay `top:52 / bottom:816`, header + nav visible, active button fill `rgb(52,194,126)` (green).

Standard / Terminal themes untouched (gated). Docs updated (`Version-History.md`, `CLAUDE.md`).

https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk)_