### PR TITLE
feat(dev): dev-only reseed button in Settings → Data

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -887,7 +887,7 @@ Free-form natural-language control surface — user says "I've rescheduled my FA
 - Version check on every view/modal navigation via `/api/health`
 - Docker multi-stage build with QEMU-safe arm64 support
 - `sharp` as devDependency for icon generation
-- Dev seed system: `SEED_DB=1` populates DB with realistic ADHD test data at startup (Claude API or static fallback)
+- Dev seed system: `SEED_DB=1` populates DB with realistic ADHD test data at startup (Claude API or static fallback). On-demand reseed via `POST /api/dev/seed` (wipes + reloads). Both the endpoint and the **Settings → Data → "Reseed dev database"** button are hard-gated to the dev environment — `isDevEnv` in `server.js` is true only when `APP_VERSION` is `dev` or `dev-<sha>` (prod builds use `v1.x.x` git tags), exposed to the client via `isDev` on `/api/health`. The endpoint 403s and the button is hidden anywhere else, so prod can't be wiped by it.
 
 ### UI v2 (Opt-in Maturity Refresh, 2026-05-03)
 Boomerang ships with two UIs that share the same underlying app (server, hooks, store, contexts, API).

--- a/server.js
+++ b/server.js
@@ -58,6 +58,10 @@ registerKnowledgeTools()
 
 // --- App version ---
 const appVersion = process.env.APP_VERSION || 'dev'
+// Dev environment signal: prod images are built `APP_VERSION=v1.x.x` (git tag),
+// the dev image is built `APP_VERSION=dev-<sha>`, and a bare local run is 'dev'.
+// Used to gate the dev-only reseed (button + endpoint) so it can never touch prod.
+const isDevEnv = appVersion === 'dev' || appVersion.startsWith('dev-')
 
 // --- Environment (fallback keys — user can override via UI) ---
 let envApiKey = process.env.ANTHROPIC_API_KEY
@@ -181,7 +185,7 @@ app.use(express.json({ limit: '2mb' }))
 
 // --- Health check ---
 app.get('/api/health', (req, res) => {
-  res.json({ status: 'ok', appVersion })
+  res.json({ status: 'ok', appVersion, isDev: isDevEnv })
 })
 
 // --- Server logs endpoint ---
@@ -3538,7 +3542,13 @@ app.post('/api/adviser/chats/:id/unstar', (req, res) => {
 })
 
 // --- Dev seed endpoint ---
+// Destructive: clearAllData() then reloads seed fixtures. Hard-gated to the dev
+// environment so it can never wipe a production database, even if a stale client
+// somehow renders the button against prod.
 app.post('/api/dev/seed', async (req, res) => {
+  if (!isDevEnv) {
+    return res.status(403).json({ error: 'Reseed is only available in the dev environment.' })
+  }
   try {
     await seedDatabase()
     res.json({ ok: true, message: 'Database seeded' })

--- a/src/v2/components/SettingsModal.jsx
+++ b/src/v2/components/SettingsModal.jsx
@@ -2276,6 +2276,10 @@ export default function SettingsModal({
   // the debounced flush fires; back to false after 2s.
   const [justSaved, setJustSaved] = useState(false)
   const justSavedTimer = useRef(null)
+  // Dev-only reseed: only the dev environment exposes the button. The server
+  // also hard-gates POST /api/dev/seed to dev, so this is just visibility.
+  const [isDev, setIsDev] = useState(false)
+  const [reseeding, setReseeding] = useState(false)
   // Easter egg trigger — 7 taps on the Build row within a rolling 2s
   // window opens the hidden tic-tac-toe game. Android-build-number
   // metaphor. Undocumented in user-facing copy.
@@ -2297,6 +2301,41 @@ export default function SettingsModal({
   useEffect(() => {
     if (open) setSettings(loadSettings())
   }, [open])
+
+  // Detect the dev environment (gates the reseed button). /api/health returns
+  // isDev:true only when APP_VERSION is 'dev' or 'dev-<sha>'.
+  useEffect(() => {
+    if (!open) return
+    let alive = true
+    fetch('/api/health')
+      .then(r => r.ok ? r.json() : null)
+      .then(d => { if (alive && d) setIsDev(!!d.isDev) })
+      .catch(() => {})
+    return () => { alive = false }
+  }, [open])
+
+  const handleReseed = () => {
+    setConfirmDialog({
+      title: 'Reseed dev database',
+      message: 'This WIPES the dev database and reloads fresh seed data (tasks rebased to today + synthesized routine history). Dev only — there is no undo. Continue?',
+      onConfirm: async () => {
+        setConfirmDialog(null)
+        setReseeding(true)
+        try {
+          const res = await fetch('/api/dev/seed', { method: 'POST' })
+          if (!res.ok) {
+            const body = await res.json().catch(() => ({}))
+            throw new Error(body.error || `Reseed failed (${res.status})`)
+          }
+          // Fresh data — full reload so every view rehydrates from the seeded DB.
+          window.location.reload()
+        } catch (err) {
+          setReseeding(false)
+          setConfirmDialog({ title: 'Reseed failed', message: err.message, onConfirm: () => setConfirmDialog(null) })
+        }
+      },
+    })
+  }
 
   // Cleanup the saved-flash timer on unmount.
   useEffect(() => () => {
@@ -2717,6 +2756,16 @@ export default function SettingsModal({
                 <Upload size={13} strokeWidth={1.75} /> Import from markdown
               </button>
             </div>
+
+            {isDev && (
+              <div className="v2-settings-block">
+                <div className="v2-form-label">Developer · dev only</div>
+                <div className="v2-settings-row-hint">Wipe this dev database and reload fresh seed data (tasks rebased to today, ~250 days of routine history). Only shown on the dev build; the server blocks it everywhere else.</div>
+                <button className="v2-settings-btn" onClick={handleReseed} disabled={reseeding}>
+                  <RefreshCw size={13} strokeWidth={1.75} /> {reseeding ? 'Reseeding…' : 'Reseed dev database'}
+                </button>
+              </div>
+            )}
 
             <div className="v2-settings-danger">
               <div className="v2-form-label">Danger zone</div>

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,10 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-06
 
+- feat(dev): dev-only "Reseed dev database" button (Settings → Data) [S]
+  - One-tap reseed without touching a terminal: **Settings → Data → "Reseed dev database"** wipes the DB and reloads fresh seed fixtures (tasks rebased to today + ~250 days of synthesized routine history), then reloads the app. Confirm dialog first; no undo.
+  - **Hard-gated to dev, two layers:** `server.js` computes `isDevEnv` (true only when `APP_VERSION` is `dev` or `dev-<sha>` — prod images build `v1.x.x` git tags) and (1) exposes `isDev` on `GET /api/health` so the button only renders on the dev build, and (2) makes `POST /api/dev/seed` return **403** outside dev. So even a stale client pointed at prod can't wipe it.
+
 - feat(ui): Wallaby — all modals render as full pages, not slide-up sheets [S]
   - New `src/v2/wallaby/modals.css` (mobile + `[data-theme^="wallaby"]` gated, imported via `AppV2.css`): **every** ModalShell surface (Packages, Settings, Analytics, Edit, Add, Quokka, …) now renders as a solid full **page** that sits between the persistent WallabyHeader (top: 52px + inset) and WallabyNav (bottom: 64px + inset) — no slide-up sheet, no animation, no rounded card chrome. (User: "the wallaby theme shouldn't have the slide up menus. Everything should have its own page.") The Quokka branch in `WallabyShell` now relies on this global treatment instead of the bespoke `.wb-quokka-page` chrome-stripping (removed) — the header/nav splits that looked strange are gone because the surface no longer double-stacks an inline page inside a stop-at-nav surface.
   - **Analytics buttons fix:** the range (7d/30d/90d) and metric toggles were loose pill buttons; reskinned to **contained segmented controls** (rounded track on `--wb-card-2`, green active fill) in `analytics.css`.


### PR DESCRIPTION
## What

A one-tap **"Reseed dev database"** button in **Settings → Data**, visible only on the dev build. Wipes the DB and reloads fresh seed fixtures (tasks rebased to today + ~250 days of synthesized routine history), then reloads the app. Confirm dialog first; no undo.

## Safety — hard-gated to dev, two layers

`server.js` computes `isDevEnv` — true only when `APP_VERSION` is `dev` or `dev-<sha>` (prod images build from `v1.x.x` git tags):

1. **Visibility:** `GET /api/health` now returns `isDev`; the button only renders when that's true. SettingsModal fetches it on open.
2. **Enforcement:** `POST /api/dev/seed` returns **403** outside dev.

So even a stale client pointed at prod can't trigger a wipe — the request is rejected server-side regardless of what the UI shows.

## Verification

- `npm run build` ✅ · eslint clean · `node --check server.js` ✅
- `isDev` logic checked across `dev` → true, `dev-abc1234` → true, `v1.29.0` → false.

> **Note:** stacks on #418 — until that merges, this PR's diff shows both commits. Merge #418 first (or either order; both rebase cleanly to `dev`).

https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk)_