### PR TITLE
feat(ui): wallaby reskin polish — Home daily-summary + Profile Records

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1079,10 +1079,13 @@ net-new features like Timer / Vision / Daily mood / gamification / notifications
 center / habit templates) lives in **`wiki/Wallaby-Ideas.md`** — keep it current
 as the reskin proceeds and new reference comes in.
 
-**Reskin still to do:** tabbed **Settings** + **Analytics** reskin; richer
-**Today's Pulse** Home (pulse/summary/today's-tasks — mood/vision parts are
-deferred features). (Tasks Done-tab + grouping + checkbox colors + action sheet:
-done.)
+**Reskin still to do:** tabbed **Analytics** restructure (Overview/Habits/Tasks
+tabs) — but it's mostly gated behind deferred features (focus-time/mood) and
+would touch the *shared* AnalyticsModal, so it's parked. (Done: Tasks
+Done-tab + grouping + checkbox colors + action sheet; Settings + Analytics
+visual reskin; full-page modals; **Home daily-summary card** + **Profile Records
+strip**. The remaining Home "Today's Pulse" gaps — daily mood / vision whisper —
+are deferred net-new features, not reskin.)
 
 **Wallaby gotcha:** `store.localYMD(d)` requires a **Date** (`d.getFullYear()`),
 NOT an ISO string — wrap completion timestamps in `new Date(ts)`. The Wallaby

--- a/src/v2/wallaby/HomeView.css
+++ b/src/v2/wallaby/HomeView.css
@@ -255,6 +255,50 @@
 .wb-pulse-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--wb-cat-purple); flex: 0 0 auto; }
 .wb-pulse-tasks .wb-pulse-dot { background: var(--wb-cat-blue); }
 
+/* ── Daily summary card (recap + mini heatmap) ───────────────────────────── */
+.wb-summary {
+  background: var(--wb-card);
+  border: 1px solid var(--wb-hairline);
+  border-radius: 16px;
+  padding: 14px 15px;
+  box-shadow: var(--wb-shadow);
+  margin-bottom: 16px;
+}
+.wb-summary-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 13px;
+}
+.wb-summary-line { display: flex; align-items: center; flex-wrap: wrap; gap: 12px; min-width: 0; }
+.wb-summary-stat {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--v2-font-display);
+  font-size: 17px;
+  font-weight: 800;
+  letter-spacing: -0.01em;
+  color: var(--wb-text);
+}
+.wb-summary-stat svg { color: var(--wb-action-complete); }
+.wb-summary-line .wb-summary-stat:nth-child(2) svg { color: var(--wb-cat-purple); }
+.wb-summary-sub { font-size: 12.5px; font-weight: 600; color: var(--wb-text-meta); }
+.wb-summary-streak {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  flex: 0 0 auto;
+  font-size: 12.5px;
+  font-weight: 800;
+  color: var(--wb-action-primary);
+  background: color-mix(in srgb, var(--wb-action-primary) 16%, transparent);
+  border-radius: 999px;
+  padding: 4px 10px;
+}
+.wb-summary-heat { overflow: hidden; }
+
 /* ── Section cards (Tasks / Habits) ──────────────────────────────────────── */
 .wb-home-card {
   background: var(--wb-card);

--- a/src/v2/wallaby/HomeView.jsx
+++ b/src/v2/wallaby/HomeView.jsx
@@ -1,8 +1,9 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import {
-  Check, Flame, ChevronRight, ChevronLeft,
+  Check, Flame, ChevronRight, ChevronLeft, CheckCircle2, Repeat2,
   Monitor, Users, MapPin, Palette, Dumbbell, Repeat,
 } from 'lucide-react'
+import ContributionHeatmap from './ContributionHeatmap'
 import { WALLABY_COLORS, historyByDay, currentStreak, localYMD } from './heatmapUtils'
 import './HomeView.css'
 
@@ -15,13 +16,26 @@ const ACTIVE = ['not_started', 'doing', 'waiting', 'in_progress']
 // what's due/carrying; past days show what you did. "Checking" toggles the
 // selected day's completion.
 export default function HomeView({
-  routines = [], tasks = [], labels = [],
+  routines = [], tasks = [], labels = [], streak = 0,
   onToggleHabit, onCompleteTask, onOpenTask, onOpenProfile,
 }) {
   const today = new Date(); today.setHours(0, 0, 0, 0)
   const todayKey = localYMD(today)
   const [weekOffset, setWeekOffset] = useState(0)
   const [selectedKey, setSelectedKey] = useState(todayKey)
+
+  // Mini activity heatmap for the daily-summary card — the server-aggregated
+  // completion history survives task retention/cleanup, so it's the right
+  // source for "your last few weeks" (a local tasks scan would miss old ones).
+  const [summaryByDay, setSummaryByDay] = useState(null)
+  useEffect(() => {
+    let alive = true
+    fetch('/api/analytics/history?days=98')
+      .then(r => r.ok ? r.json() : null)
+      .then(d => { if (alive && d?.daily) { const m = {}; for (const x of d.daily) m[x.day] = x.tasks; setSummaryByDay(m) } })
+      .catch(() => {})
+    return () => { alive = false }
+  }, [])
   const labelsById = useMemo(() => { const m = {}; for (const l of labels) m[l.id] = l; return m }, [labels])
 
   const habits = useMemo(() => routines.filter(r => !r.paused), [routines])
@@ -123,6 +137,27 @@ export default function HomeView({
             <span className="wb-pulse-dot" />
             <span>{tasksForDay.length} task{tasksForDay.length === 1 ? '' : 's'} for today</span>
           </div>
+        </div>
+      )}
+
+      {/* Daily summary — backward-looking recap (today only): what you did plus a
+          mini activity heatmap. Deep-work hours are intentionally omitted until
+          the Timer feature lands. */}
+      {isToday && (
+        <div className="wb-summary">
+          <div className="wb-summary-head">
+            <div className="wb-summary-line">
+              <span className="wb-summary-stat"><CheckCircle2 size={15} strokeWidth={2.5} /> {tasksDone} task{tasksDone === 1 ? '' : 's'}</span>
+              <span className="wb-summary-stat"><Repeat2 size={15} strokeWidth={2.5} /> {habitsDone} habit{habitsDone === 1 ? '' : 's'}</span>
+              <span className="wb-summary-sub">done today</span>
+            </div>
+            {streak > 0 && <span className="wb-summary-streak"><Flame size={14} strokeWidth={2.5} /> {streak} day{streak === 1 ? '' : 's'}</span>}
+          </div>
+          {summaryByDay && (
+            <div className="wb-summary-heat">
+              <ContributionHeatmap valueByDay={summaryByDay} color="var(--wb-action-complete)" weeks={14} cellSize={11} gap={3} radius={3} />
+            </div>
+          )}
         </div>
       )}
 

--- a/src/v2/wallaby/ProfileView.css
+++ b/src/v2/wallaby/ProfileView.css
@@ -109,6 +109,38 @@
 }
 .wb-profile-section-head .wb-profile-section-title { margin-bottom: 0; }
 
+/* ── Records (all-time bests, from computeRecords) ───────────────────────── */
+.wb-profile-records { display: grid; grid-template-columns: repeat(3, 1fr); gap: 9px; }
+.wb-profile-record {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  background: var(--wb-card);
+  border: 1px solid var(--wb-hairline);
+  border-radius: 14px;
+  padding: 13px 12px;
+  box-shadow: var(--wb-shadow);
+}
+.wb-profile-record-icon {
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
+  color: var(--rec);
+  background: color-mix(in srgb, var(--rec) 16%, transparent);
+}
+.wb-profile-record-value {
+  font-family: var(--v2-font-display);
+  font-size: 22px;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  color: var(--wb-text);
+  line-height: 1;
+}
+.wb-profile-record-value em { font-style: normal; font-size: 12px; font-weight: 700; color: var(--wb-text-meta); margin-left: 3px; }
+.wb-profile-record-label { font-size: 11.5px; font-weight: 600; color: var(--wb-text-meta); }
+
 /* Segmented control (reused) */
 .wb-profile .wb-seg {
   display: inline-flex;

--- a/src/v2/wallaby/ProfileView.jsx
+++ b/src/v2/wallaby/ProfileView.jsx
@@ -77,6 +77,26 @@ export default function ProfileView({
       </div>
 
       <section className="wb-profile-section">
+        <h2 className="wb-profile-section-title">Records</h2>
+        <div className="wb-profile-records">
+          {[
+            { icon: CheckCircle2, label: 'Best day', value: records?.bestTasks ?? 0, unit: 'tasks', color: 'var(--wb-cat-green)' },
+            { icon: Zap, label: 'Best points', value: records?.bestPoints ?? 0, unit: 'pts', color: 'var(--wb-cat-purple)' },
+            { icon: Trophy, label: 'Longest streak', value: bestStreak, unit: 'days', color: 'var(--wb-cat-blue)' },
+          ].map(r => {
+            const Icon = r.icon
+            return (
+              <div key={r.label} className="wb-profile-record" style={{ '--rec': r.color }}>
+                <span className="wb-profile-record-icon"><Icon size={15} strokeWidth={2.25} /></span>
+                <span className="wb-profile-record-value">{r.value}<em>{r.unit}</em></span>
+                <span className="wb-profile-record-label">{r.label}</span>
+              </div>
+            )
+          })}
+        </div>
+      </section>
+
+      <section className="wb-profile-section">
         <div className="wb-profile-section-head">
           <h2 className="wb-profile-section-title">Activity</h2>
           <div className="wb-seg">

--- a/src/v2/wallaby/WallabyShell.jsx
+++ b/src/v2/wallaby/WallabyShell.jsx
@@ -68,7 +68,7 @@ export default function WallabyShell({
   } else if (tab === 'home') {
     surface = (
       <HomeView
-        routines={routines} tasks={tasks} labels={labels}
+        routines={routines} tasks={tasks} labels={labels} streak={streak}
         onToggleHabit={onToggleHabit} onCompleteTask={onCompleteTask} onOpenTask={onOpenTask}
       />
     )

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,11 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-06
 
+- feat(ui): Wallaby reskin polish — Home daily-summary card + Profile Records [S]
+  - **Home "Daily summary" card** (`HomeView`, today only): a backward-looking recap below Today's Pulse — `N tasks · M habits done today` headline, a day-streak chip, and a **mini 14-week activity heatmap** (reuses `ContributionHeatmap`, fed by `/api/analytics/history?days=98` so it survives task retention). Deep-work hours stay omitted until the Timer lands. `streak` now threads `WallabyShell → HomeView`.
+  - **Profile "Records" section** (`ProfileView`): a 3-card strip between the stat pills and the Activity year-grid — **Best day** (tasks), **Best points**, **Longest streak** — all from the `records` prop (`computeRecords`), no new data.
+  - Both are Wallaby-scoped components, additive, reuse existing primitives/data. Verified headless (wallaby-dark, 390px): summary card + records strip render with real seeded data.
+
 - feat(dev): dev-only "Reseed dev database" button (Settings → Data) [S]
   - One-tap reseed without touching a terminal: **Settings → Data → "Reseed dev database"** wipes the DB and reloads fresh seed fixtures (tasks rebased to today + ~250 days of synthesized routine history), then reloads the app. Confirm dialog first; no undo.
   - **Hard-gated to dev, two layers:** `server.js` computes `isDevEnv` (true only when `APP_VERSION` is `dev` or `dev-<sha>` — prod images build `v1.x.x` git tags) and (1) exposes `isDev` on `GET /api/health` so the button only renders on the dev build, and (2) makes `POST /api/dev/seed` return **403** outside dev. So even a stale client pointed at prod can't wipe it.

--- a/wiki/Wallaby-Ideas.md
+++ b/wiki/Wallaby-Ideas.md
@@ -37,15 +37,15 @@ Bottom nav (loggd): **Home · Habits · Tasks · Timer · More**.
 | Habit detail + month calendar | ✅ | tap a card → Streak/Best/Total + completion calendar + Archive/Delete/Edit (`IMG_1586`) |
 | Tasks — list | ✅ | Upcoming/Backlog/**Done** tabs w/ counts; Overdue/Today/Tomorrow/Upcoming/Anytime grouping w/ icons; semi-random per-task checkbox colors; notes subtitle; **tap → action sheet** (reschedule/edit/delete, focus="soon") |
 | Goals (projects) — list + detail | ✅ | metric, progress, semantic buttons |
-| Profile / dashboard | ✅ (partial) | ⬜ adopt the rich loggd profile layout (avatar/level/XP/bio/year-grid/per-metric grids) **minus public/share** (user: "like this without the public part"); Level/XP/badges = 🅿️ gamification |
-| Home — daily agenda | ✅ (basic) | ⬜ enrich toward **Today's Pulse** (below) |
+| Profile / dashboard | ✅ | avatar/bio/year-grid (Tasks/Points)/per-habit grids + **Records strip** (Best day / Best points / Longest streak, from `computeRecords`). Level/XP/badges = 🅿️ gamification; public/share intentionally omitted |
+| Home — daily agenda | ✅ | Pulse + **Daily-summary card** (N tasks·M habits done + day-streak + mini 14-week heatmap) + per-day tasks/habits + interactive date strip. Mood/vision parts = 🅿️ |
 | Settings (visual reskin) | ✅ | Account / Notifications / Preferences / Privacy / API; per-type Push/Email toggles (Boomerang already has the data) |
 | Analytics (visual reskin) | ✅ (reskin) / 🅿️ | Tabbed **Overview / Habits / Tasks / Goals / Focus**. Weekly **points** total + ‹week› nav, 🔥current/🏆best streak, stat cards (Habits checks, Tasks completed, Focus time, Check-ins), **Points Breakdown by activity type**, weekly **mood bar-chart** + **reflections** recap. Reskin-able: points/streak/habit+task counts (Boomerang has these). Deferred: focus-time, check-ins, mood, badge points (tied to new features). Reached via More/Profile. |
 
 ### Home "Today's Pulse" (richer Home — PDF 1)
 The real Home is a scrolling daily dashboard. Reskin-able parts (existing data):
 - ✅ **Pulse** card (today): "X habits left (n/m done)", "n tasks for today", streak-at-risk
-- ⬜ **Daily summary** card: "You put in Xh deep work, finished N tasks…" + mini activity heatmap + day-streak
+- ✅ **Daily summary** card: "N tasks · M habits done today" + mini 14-week activity heatmap + day-streak chip (deep-work hours deferred with Timer)
 - ✅ **Tasks card** for the selected day (n/m done + progress bar)
 - ✅ **Habits today** section (checkable rows)
 - ✅ **Interactive date/week strip** — select a day (backfill that day), page weeks, jump to today


### PR DESCRIPTION
## What

Two of the three outstanding Wallaby reskin ⬜ polish items — both additive, Wallaby-scoped, reusing existing data/primitives (no migration, no shared-component churn).

### Home — "Daily summary" card
A backward-looking recap below Today's Pulse (today only):
- `N tasks · M habits done today` headline + a **day-streak** chip
- a **mini 14-week activity heatmap** (reuses `ContributionHeatmap`, fed by `/api/analytics/history?days=98` so it survives task retention/cleanup)
- Deep-work hours intentionally omitted until the Timer feature lands.
- `streak` now threads `WallabyShell → HomeView`.

### Profile — "Records" strip
A 3-card row between the stat pills and the Activity year-grid:
- **Best day** (tasks) · **Best points** · **Longest streak**
- All from the existing `records` prop (`computeRecords`) — no new data.

## Verification

`npm run build` ✅ · eslint clean. Rendered headless (puppeteer, wallaby-dark, 390px) against seeded data — both surfaces render correctly:
- Home: summary card shows "2 tasks · 5 habits done today", 1-day chip, heatmap.
- Profile: Records shows Best day 2 / Best points 40 / Longest streak 2.

## Scope note

The third reskin ⬜ — **tabbed Analytics restructure** — is parked: it's mostly gated behind deferred features (focus-time, mood) and would touch the *shared* AnalyticsModal (all themes), so it's a bigger call than "polish." Flagged in CLAUDE.md.

https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk)_