### PR TITLE
fix(ui): wallaby Home date contrast (today-selected) + full QA sweep

### DIFF
--- a/src/v2/wallaby/HomeView.css
+++ b/src/v2/wallaby/HomeView.css
@@ -122,6 +122,9 @@
   color: var(--wb-text);
 }
 .wb-home-weekday-cell.is-today .wb-home-week-date { color: var(--wb-action-complete); }
+/* When today is also the selected day, the purple selection wins — keep the
+   number white for contrast (the is-today green-on-purple was unreadable). */
+.wb-home-weekday-cell.is-selected.is-today .wb-home-week-date { color: #fff; }
 .wb-home-week-dot {
   width: 5px;
   height: 5px;

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,9 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-06
 
+- fix(ui): Wallaby Home — readable date when today is the selected day [XS]
+  - In the Home week strip, when **today was also the selected day** the date number rendered green-on-purple (the `is-today` green-text rule overrode the `is-selected` white-text rule by source order) — unreadable. Added a higher-specificity `.is-selected.is-today` rule keeping the number white. Found during a full headless QA sweep of every Wallaby surface (no other defects: no crashes/React errors; desktop correctly falls back to Kanban).
+
 - feat(ui): Wallaby reskin polish — Home daily-summary card + Profile Records [S]
   - **Home "Daily summary" card** (`HomeView`, today only): a backward-looking recap below Today's Pulse — `N tasks · M habits done today` headline, a day-streak chip, and a **mini 14-week activity heatmap** (reuses `ContributionHeatmap`, fed by `/api/analytics/history?days=98` so it survives task retention). Deep-work hours stay omitted until the Timer lands. `streak` now threads `WallabyShell → HomeView`.
   - **Profile "Records" section** (`ProfileView`): a 3-card strip between the stat pills and the Activity year-grid — **Best day** (tasks), **Best points**, **Longest streak** — all from the `records` prop (`computeRecords`), no new data.


### PR DESCRIPTION
## What

A full headless QA sweep of the Wallaby UI ("let's beat on it") plus the one real bug it surfaced.

## QA sweep (puppeteer, wallaby-dark, 390px mobile + 1280px desktop)

Exercised every surface and captured all console/page errors + ≥400 responses:

- **Home** — default, past-day selection, week nav, habit toggle, task toggle
- **Habits** — Single / Month / Year ranges + habit detail (stat cards, month calendar, archive)
- **Quokka** — full-page treatment (clean header/composer, typewriter suggestions)
- **Tasks** — Upcoming / Backlog / Done tabs + action sheet
- **More** → Profile, Goals, Analytics, Packages, Settings (Data tab)
- **Notifications** center, **Edit-task** modal (full page)

**Result: solid.** No crashes, no React errors, no broken endpoints — the only errors were the expected `POST /api/messages 400` ("no Anthropic API key") in this keyless sandbox, which is the graceful-degradation path. Desktop correctly falls back to Kanban (no `wb-shell`).

## The fix

In the Home week strip, when **today was also the selected day**, the date number rendered **green-on-purple** and was unreadable — the `is-today` green-text rule overrode the `is-selected` white-text rule by source order. Added a higher-specificity `.is-selected.is-today` rule keeping the number white. Verified: computed color now `rgb(255,255,255)`.

## Non-blocking observations (not fixed — flagging for your call)

- **EditTaskModal** status/size active pills use the v2 **white** active style, not the Wallaby **green** the rest of the app uses. Functional, just slightly inconsistent. Touches the shared modal, so I left it.
- **Weekly-habit day-streak** reads "1" — the streak is day-bucketed, so a once-a-week habit can never exceed 1 consecutive day. Semantically odd but consistent; worth revisiting with the eventual gamification/badges work.

https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk)_