### PR TITLE
fix(ui): wallaby — no close X on Quokka (it's a nav tab)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1068,7 +1068,9 @@ DOM nesting:
   modal's own close X returns you.
 - **Quokka** (`.wb-shell .v2-modal-overlay`) is rendered as the shell's active
   *surface* for the Quokka nav tab, so it keeps the header + nav visible and sits
-  in the band between them (you leave it via the nav, like any tab).
+  in the band between them (you leave it via the nav, like any tab). Its close X
+  is hidden (`.wb-shell .v2-modal-close { display:none }`) — a tab isn't an
+  overlay you dismiss. The full-screen overlay modals keep their X (only way back).
 Both strip the animation/rounded-card chrome and fill the page.
 Tapping a task → `EditTaskModal`, checkbox → `handleComplete`, subtask →
 `updateTask({checklists})`, Home check → toggle `completed_history` today, Goals

--- a/src/v2/wallaby/modals.css
+++ b/src/v2/wallaby/modals.css
@@ -59,7 +59,10 @@
     background: transparent;
   }
   [data-theme^="wallaby"] .wb-shell .v2-modal-header { padding: 22px 20px 16px; }
-  [data-theme^="wallaby"] .wb-shell .v2-modal-close { top: 16px; }
+  /* No close X on Quokka — it's a nav tab, you leave it via the bottom nav (not
+   * an overlay you dismiss). The X is only for the full-screen overlay modals
+   * that cover the nav. */
+  [data-theme^="wallaby"] .wb-shell .v2-modal-close { display: none; }
   [data-theme^="wallaby"] .wb-shell .v2-modal-header-slot { top: 24px; }
   [data-theme^="wallaby"] .wb-shell .v2-modal-body { padding-bottom: 16px; }
 

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,9 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-06
 
+- fix(ui): Wallaby — no close X on Quokka (it's a nav tab, not an overlay) [XS]
+  - Quokka is the shell's *surface* for the Quokka nav tab, but it still showed the ModalShell close X top-right — a vestigial overlay affordance (you leave a tab via the bottom nav, not an X). Hid it via `[data-theme^="wallaby"] .wb-shell .v2-modal-close { display: none }` in `modals.css`. The full-screen **overlay** modals (Edit/Add/Settings/Packages/Analytics/…) keep their X — they cover the nav, so the X is their only way back. Verified headless: Quokka close = `display:none`, Edit modal close = `display:flex`.
+
 - docs: add Local-Verification-Harness runbook (build + headless-screenshot in-session) [S]
   - `wiki/Local-Verification-Harness.md` documents the reproducible workflow for spinning up a real server inside a session and driving it headlessly: matching-`APP_VERSION` build (or the version-mismatch update overlay blocks all clicks), seeded background server, theme injection via `localStorage` (full settings blob + far-future `boom_last_modified`), puppeteer run from repo root with `domcontentloaded` (SSE never idles) + in-page `.click()` (fixed elements mis-fire on `elementHandle.click`), `elementFromPoint` layering diagnostics, and a Gotchas table (each entry cost a debugging loop). Linked from CLAUDE.md.
 


### PR DESCRIPTION
## What

Your screenshot showed Quokka — a bottom-nav **tab** — still carrying the ModalShell close **X** top-right. You leave a tab via the nav, so the X is a leftover overlay affordance. Removed it.

## Scope

Quokka is the only Wallaby surface rendered as a `ModalShell` *inside* `.wb-shell` (Home/Habits/Tasks/More are custom views; Profile/Goals/Notifications use a back arrow, which is correct for drill-downs). One scoped rule covers it:

```css
[data-theme^="wallaby"] .wb-shell .v2-modal-close { display: none; }
```

The full-screen **overlay** modals (Edit/Add/Settings/Packages/Analytics/Snooze/…) **keep** their X — they cover the nav, so the X is their only way back.

## Verified (headless, 390px, wallaby-dark)

- Quokka close X → `display: none` (screenshot: clean tab, no X)
- EditTaskModal close X → `display: flex` (unchanged)

Docs updated (Version-History, CLAUDE.md).

https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk)_