### PR TITLE
fix(ui): wallaby full-screen modals use a back arrow, not a dismiss X

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1063,14 +1063,17 @@ DOM nesting:
   WallabyNav too. This is deliberate — the old version pinned the overlay
   *between* header and nav (`bottom: 64px`), but the nav is content-sized, so a
   clickable strip of the Home surface showed through below the overlay and the
-  header/nav stayed interactive behind the "page" (taps leaked through; you had
-  to use the X). Full-screen takeover means nothing behind is reachable; the
-  modal's own close X returns you.
+  header/nav stayed interactive behind the "page" (taps leaked through). Full-screen
+  takeover means nothing behind is reachable. The dismiss control is a **back
+  arrow** (top-left, like the drill-down views) — `ModalShell` swaps the X for a
+  lucide `ArrowLeft` when `useWallabyMode() && !useIsDesktop()` (class
+  `v2-modal-back`), styled in `modals.css` to match `.wb-back`. (User: "Packages
+  has this x instead of the back arrow.")
 - **Quokka** (`.wb-shell .v2-modal-overlay`) is rendered as the shell's active
   *surface* for the Quokka nav tab, so it keeps the header + nav visible and sits
-  in the band between them (you leave it via the nav, like any tab). Its close X
-  is hidden (`.wb-shell .v2-modal-close { display:none }`) — a tab isn't an
-  overlay you dismiss. The full-screen overlay modals keep their X (only way back).
+  in the band between them (you leave it via the nav, like any tab). Its dismiss
+  control is hidden (`.wb-shell .v2-modal-close { display:none }`) — a tab isn't
+  an overlay you dismiss. The full-screen overlay modals keep their back arrow.
 Both strip the animation/rounded-card chrome and fill the page.
 Tapping a task → `EditTaskModal`, checkbox → `handleComplete`, subtask →
 `updateTask({checklists})`, Home check → toggle `completed_history` today, Goals

--- a/src/v2/components/ModalShell.jsx
+++ b/src/v2/components/ModalShell.jsx
@@ -1,10 +1,19 @@
 import { useEffect } from 'react'
-import { X } from 'lucide-react'
+import { X, ArrowLeft } from 'lucide-react'
 import { useTerminalMode } from '../hooks/useTerminalMode'
+import { useWallabyMode } from '../hooks/useWallabyMode'
+import { useIsDesktop } from '../../hooks/useIsDesktop'
 import './ModalShell.css'
 
 export default function ModalShell({ open, onClose, title, terminalTitle, subtitle, headerSlot, children, width = 'narrow', flexBody = false }) {
   const terminal = useTerminalMode()
+  // In Wallaby on mobile, modals are full-screen pages, so the dismiss control
+  // is a back arrow (top-left) — consistent with the drill-down views — not a
+  // dismiss X. Desktop/other themes keep the X. (Call both hooks unconditionally
+  // — never short-circuit a hook call.)
+  const wallaby = useWallabyMode()
+  const isDesktop = useIsDesktop()
+  const backNav = wallaby && !isDesktop
   useEffect(() => {
     if (!open) return
     const onKey = (e) => { if (e.key === 'Escape') onClose() }
@@ -25,8 +34,8 @@ export default function ModalShell({ open, onClose, title, terminalTitle, subtit
         className={`v2-modal v2-modal-${width}${flexBody ? ' v2-modal-flex' : ''}`}
         onClick={e => e.stopPropagation()}
       >
-        <button className="v2-modal-close" onClick={onClose} aria-label="Close">
-          <X size={18} strokeWidth={1.75} />
+        <button className={`v2-modal-close${backNav ? ' v2-modal-back' : ''}`} onClick={onClose} aria-label={backNav ? 'Back' : 'Close'}>
+          {backNav ? <ArrowLeft size={20} strokeWidth={2.25} /> : <X size={18} strokeWidth={1.75} />}
         </button>
         {headerSlot && <div className="v2-modal-header-slot">{headerSlot}</div>}
         <header className="v2-modal-header">

--- a/src/v2/hooks/useWallabyMode.js
+++ b/src/v2/hooks/useWallabyMode.js
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react'
+
+// Returns true when the active v2 theme is a Wallaby sub-variant ('wallaby-dark'
+// or 'wallaby-light'). Mirrors useTerminalMode — subscribes to documentElement's
+// data-theme attribute via MutationObserver so it re-renders on theme flips
+// (Settings change + the pre-paint script both mutate the attribute directly).
+export function useWallabyMode() {
+  const [isWallaby, setIsWallaby] = useState(() => {
+    if (typeof document === 'undefined') return false
+    return (document.documentElement.getAttribute('data-theme') || '').startsWith('wallaby')
+  })
+
+  useEffect(() => {
+    if (typeof document === 'undefined') return
+    const root = document.documentElement
+    const update = () => setIsWallaby((root.getAttribute('data-theme') || '').startsWith('wallaby'))
+    const observer = new MutationObserver(update)
+    observer.observe(root, { attributes: true, attributeFilter: ['data-theme'] })
+    update()
+    return () => observer.disconnect()
+  }, [])
+
+  return isWallaby
+}

--- a/src/v2/wallaby/modals.css
+++ b/src/v2/wallaby/modals.css
@@ -10,9 +10,11 @@
  *     reachable — fixes taps "leaking" to the Home rows / nav / header behind a
  *     page (the old band stopped at a hardcoded 64px nav height, but the nav is
  *     content-sized, leaving a clickable strip of Home showing through). The
- *     modal's own close X is how you return. (User: "stuff that used to be
- *     drawers still hijack the screen so clicking on items in the home row does
- *     things behind it … I have to click close in the upper right.")
+ *     dismiss control is a BACK ARROW (top-left, like the drill-down views —
+ *     ModalShell swaps the X→ArrowLeft in Wallaby mobile), since these are
+ *     full-screen pages you navigate back from. (User: "stuff that used to be
+ *     drawers still hijack the screen … I have to click close in the upper
+ *     right" + "Packages has this x instead of the back arrow.")
  *
  *  2. QUOKKA — rendered as the shell's active SURFACE for the Quokka nav tab,
  *     so its `.v2-modal-overlay` lives INSIDE `.wb-shell`. It keeps the header +
@@ -39,12 +41,23 @@
     box-shadow: none;
     animation: none;
   }
-  /* The page now starts at the very top of the screen, so the header row needs
-   * the notch/status-bar inset (the close X + autosave slot ride along). */
+  /* The page starts at the very top of the screen. The dismiss control is a
+   * back arrow (top-LEFT, like the drill-down views), so the title drops below
+   * it; the autosave slot still rides top-right. All pick up the notch inset. */
   [data-theme^="wallaby"] .v2-modal-header {
-    padding: calc(34px + env(safe-area-inset-top)) 20px 16px;
+    padding: calc(60px + env(safe-area-inset-top)) 20px 16px;
   }
-  [data-theme^="wallaby"] .v2-modal-close { top: calc(14px + env(safe-area-inset-top)); }
+  [data-theme^="wallaby"] .v2-modal-back {
+    top: calc(14px + env(safe-area-inset-top));
+    left: 16px;
+    right: auto;
+    width: 36px;
+    height: 36px;
+    border-radius: 10px;
+    background: var(--wb-card);
+    border: 1px solid var(--wb-hairline);
+    color: var(--wb-text);
+  }
   [data-theme^="wallaby"] .v2-modal-header-slot { top: calc(22px + env(safe-area-inset-top)); }
   [data-theme^="wallaby"] .v2-modal-title { font-size: 26px; }
   /* Give the body bottom safe-area room so the last controls clear the home bar. */

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,9 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-06
 
+- fix(ui): Wallaby full-screen modals use a back arrow, not a dismiss X [S]
+  - Full-screen Wallaby pages (Packages/Analytics/Settings/Edit/Add/Snooze/…) showed the ModalShell dismiss **X** (top-right). But they're pages you navigate *into* (Packages/Analytics/Settings from More), so the consistent affordance is a **back arrow** (top-left), matching the drill-down views (Profile/Goals/Notifications). (User: "Packages has this x instead of the back arrow.") `ModalShell` now swaps `X → ArrowLeft` when `useWallabyMode() && !useIsDesktop()` (new `useWallabyMode` hook mirrors `useTerminalMode`; button gets class `v2-modal-back`); `modals.css` positions it top-left styled like `.wb-back` and drops the title below it. Non-Wallaby/desktop keep the X. Quokka still has no affordance (tab). Verified headless: Packages/Edit → back arrow top-left (x=16, aria=Back); Quokka → hidden.
+
 - fix(ui): Wallaby — no close X on Quokka (it's a nav tab, not an overlay) [XS]
   - Quokka is the shell's *surface* for the Quokka nav tab, but it still showed the ModalShell close X top-right — a vestigial overlay affordance (you leave a tab via the bottom nav, not an X). Hid it via `[data-theme^="wallaby"] .wb-shell .v2-modal-close { display: none }` in `modals.css`. The full-screen **overlay** modals (Edit/Add/Settings/Packages/Analytics/…) keep their X — they cover the nav, so the X is their only way back. Verified headless: Quokka close = `display:none`, Edit modal close = `display:flex`.
 


### PR DESCRIPTION
## What

Full-screen Wallaby pages (Packages, Analytics, Settings, Edit, Add, Snooze, …) showed the ModalShell dismiss **X** top-right. But these are pages you navigate *into* — Packages/Analytics/Settings from the More menu — so the consistent affordance is a **back arrow** (←, top-left), matching the drill-down views (Profile/Goals/Notifications). (User: *"Packages has this x instead of the back arrow."*)

## How

- New `useWallabyMode` hook (mirrors `useTerminalMode` — MutationObserver on `data-theme`).
- `ModalShell` renders `ArrowLeft` instead of `X` when `useWallabyMode() && !useIsDesktop()` (button gets class `v2-modal-back`, `aria-label="Back"`). Both hooks called unconditionally (Rules of Hooks).
- `modals.css` positions the back button top-left, styled like `.wb-back`, and drops the title below it.
- Non-Wallaby and desktop keep the X. **Quokka** still has no dismiss control (it's a tab — `.wb-shell .v2-modal-close { display:none }`).

## Verified (headless, 390px, wallaby-dark)

- **Packages** (from More) → back arrow top-left (x=16, `aria=Back`) — screenshot confirms ← + "Packages" title below.
- **Edit task** → back arrow top-left.
- **Quokka** → no dismiss control (hidden).

`npm run lint` → 0 errors. `check:terminal-titles` → OK. Docs updated (Version-History, CLAUDE.md).

https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk)_