### PR TITLE
fix(ui): wallaby Quokka — Chats + New chat as top icon buttons

### DIFF
--- a/src/v2/components/AdviserModal.jsx
+++ b/src/v2/components/AdviserModal.jsx
@@ -1,9 +1,10 @@
 import { useEffect, useRef, useState } from 'react'
 import {
   Sparkles, Send, StopCircle, CheckCircle2, XCircle, Loader2,
-  History, Trash2, Plus, Star, AlertCircle,
+  History, Trash2, Plus, Star, AlertCircle, Search,
 } from 'lucide-react'
 import { renderMarkdown } from '../../utils/renderMarkdown'
+import { useWallabyMode } from '../hooks/useWallabyMode'
 import ModalShell from './ModalShell'
 import EmptyState from './EmptyState'
 import TypingSuggestions from './TypingSuggestions'
@@ -177,6 +178,7 @@ export default function AdviserModal({ open, adviser, onClose, onAfterCommit, on
   } = adviser
   const [input, setInput] = useState('')
   const [showHistory, setShowHistory] = useState(false)
+  const wallaby = useWallabyMode()
   const scrollRef = useRef(null)
   const inputRef = useRef(null)
   const lastDraftRef = useRef(null)
@@ -257,19 +259,24 @@ export default function AdviserModal({ open, adviser, onClose, onAfterCommit, on
   return (
     <ModalShell open={open} onClose={onClose} title="Quokka" terminalTitle="> quokka" width="wide" flexBody>
       <div className="v2-adviser-toolbar">
+        {/* In Wallaby, these sit at the top of the page as icon buttons matching
+         * the Tasks header (search-style chip). Elsewhere they're labeled pills. */}
         <button
-          className="v2-adviser-tool-btn"
+          className={wallaby ? `wb-icon-btn${showHistory ? ' is-active' : ''}` : 'v2-adviser-tool-btn'}
           onClick={() => setShowHistory(v => !v)}
-          aria-label="Chat history"
+          aria-label="Chats"
         >
-          <History size={14} strokeWidth={1.75} /> {chats.length > 0 ? `${chats.length} chat${chats.length !== 1 ? 's' : ''}` : 'Chats'}
+          {wallaby
+            ? <Search size={18} strokeWidth={2} />
+            : <><History size={14} strokeWidth={1.75} /> {chats.length > 0 ? `${chats.length} chat${chats.length !== 1 ? 's' : ''}` : 'Chats'}</>}
         </button>
         {!showHistory && (
           <button
-            className="v2-adviser-tool-btn v2-adviser-tool-btn-primary"
+            className={wallaby ? 'wb-icon-btn wb-icon-btn-accent' : 'v2-adviser-tool-btn v2-adviser-tool-btn-primary'}
             onClick={handleNewChat}
+            aria-label="New chat"
           >
-            <Plus size={14} strokeWidth={2} /> New chat
+            {wallaby ? <Plus size={18} strokeWidth={2.5} /> : <><Plus size={14} strokeWidth={2} /> New chat</>}
           </button>
         )}
       </div>

--- a/src/v2/wallaby/modals.css
+++ b/src/v2/wallaby/modals.css
@@ -79,6 +79,26 @@
   [data-theme^="wallaby"] .wb-shell .v2-modal-header-slot { top: 24px; }
   [data-theme^="wallaby"] .wb-shell .v2-modal-body { padding-bottom: 16px; }
 
+  /* Quokka: pull Chats + New-chat up into the title row as icon buttons (like
+   * the Tasks header), pinned top-right. The toolbar lives in the flex body
+   * (which is overflow:hidden, not the scroller), and its containing block is
+   * `.v2-modal`, so absolute-positioning it here doesn't scroll or get clipped. */
+  [data-theme^="wallaby"] .wb-shell .v2-adviser-toolbar {
+    position: absolute;
+    top: 14px;
+    right: 16px;
+    z-index: 3;
+    margin: 0;
+    padding: 0;
+    border: none;
+    gap: 8px;
+  }
+  [data-theme^="wallaby"] .wb-shell .v2-adviser-toolbar .wb-icon-btn-accent {
+    background: var(--wb-cat-purple);
+    border-color: var(--wb-cat-purple);
+    color: #fff;
+  }
+
   /* Quokka/adviser toolbar: spread chats / new-chat across the page width. */
   [data-theme^="wallaby"] .v2-adviser-toolbar { justify-content: space-between; }
 }

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,9 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-06
 
+- fix(ui): Wallaby Quokka — Chats + New chat as top icon buttons [XS]
+  - The Chats / New-chat controls sat in a full-width band below the title, eating vertical space. In Wallaby they're now compact **icon buttons pinned to the title row** (top-right), matching the Tasks header: **Chats → search magnifier** (`wb-icon-btn`, the same icon Tasks uses), **New chat → purple `+`** (`wb-icon-btn-accent`). (User: "Put chats and new chats at the top with the same search icon from tasks.") `AdviserModal` swaps to icon buttons via `useWallabyMode()`; `modals.css` absolute-positions the toolbar top-right (it lives in the non-scrolling flex body, containing block `.v2-modal`, so it pins cleanly). Non-Wallaby keeps the labeled pills. Tapping the magnifier still opens the chat history list.
+
 - fix(ui): Wallaby full-screen modals use a back arrow, not a dismiss X [S]
   - Full-screen Wallaby pages (Packages/Analytics/Settings/Edit/Add/Snooze/…) showed the ModalShell dismiss **X** (top-right). But they're pages you navigate *into* (Packages/Analytics/Settings from More), so the consistent affordance is a **back arrow** (top-left), matching the drill-down views (Profile/Goals/Notifications). (User: "Packages has this x instead of the back arrow.") `ModalShell` now swaps `X → ArrowLeft` when `useWallabyMode() && !useIsDesktop()` (new `useWallabyMode` hook mirrors `useTerminalMode`; button gets class `v2-modal-back`); `modals.css` positions it top-left styled like `.wb-back` and drops the title below it. Non-Wallaby/desktop keep the X. Quokka still has no affordance (tab). Verified headless: Packages/Edit → back arrow top-left (x=16, aria=Back); Quokka → hidden.
 


### PR DESCRIPTION
## What

Per your screenshot + ask ("Put chats and new chats at the top with the same search icon from tasks"): the Quokka **Chats** + **New chat** controls move out of the full-width band below the title and up into the **title row** as compact icon buttons, matching the Tasks header:

- **Chats** → search magnifier (`wb-icon-btn` — the exact icon/style Tasks uses). Still opens the chat history list.
- **New chat** → purple `+` (`wb-icon-btn-accent`).

This reclaims the vertical space the band used (the empty state now sits higher).

## How

- `AdviserModal` renders icon buttons instead of labeled pills when `useWallabyMode()` is true; non-Wallaby keeps the existing "Chats" / "+ New chat" pills.
- `modals.css` absolute-positions the toolbar top-right for the in-shell Quokka. Safe because the toolbar lives in the **non-scrolling** flex body (`.v2-modal-body-flex` is `overflow:hidden`; the messages list is the scroller) and its containing block is `.v2-modal` — so it pins to the title row without scrolling or clipping.

## Verified (headless, 390px, wallaby-dark)

Toolbar `position: absolute`; two buttons top-right — `wb-icon-btn` (aria=Chats, magnifier) at x=294 and `wb-icon-btn wb-icon-btn-accent` (aria=New chat, +) at x=338. Screenshot confirms title-row placement. `npm run lint` → 0 errors.

https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk)_