### PR TITLE
feat(ui): wallaby nav per-tab colors + More cleanup + Analytics segments

### DIFF
--- a/src/v2/wallaby/WallabyNav.css
+++ b/src/v2/wallaby/WallabyNav.css
@@ -25,6 +25,6 @@
   cursor: pointer;
   transition: color 140ms ease;
 }
-.wb-nav-tab.is-active { color: var(--wb-action-complete); }
+.wb-nav-tab.is-active { color: var(--nav-color, var(--wb-action-complete)); }
 .wb-nav-icon { display: block; }
 .wb-nav-label { font-size: 10.5px; font-weight: 600; }

--- a/src/v2/wallaby/WallabyNav.jsx
+++ b/src/v2/wallaby/WallabyNav.jsx
@@ -3,12 +3,13 @@ import './WallabyNav.css'
 
 // Wallaby bottom nav: Home · Habits · Quokka · Tasks · More. Quokka is its own
 // page (the adviser). (Timer + Packages live in the More menu.)
+// Each tab lights up its own color when active (not a single shared accent).
 const TABS = [
-  { id: 'home', label: 'Home', icon: Home },
-  { id: 'habits', label: 'Habits', icon: Activity },
-  { id: 'quokka', label: 'Quokka', icon: Sparkles },
-  { id: 'tasks', label: 'Tasks', icon: ListTodo },
-  { id: 'more', label: 'More', icon: Menu },
+  { id: 'home', label: 'Home', icon: Home, color: 'var(--wb-cat-blue)' },
+  { id: 'habits', label: 'Habits', icon: Activity, color: 'var(--wb-cat-green)' },
+  { id: 'quokka', label: 'Quokka', icon: Sparkles, color: 'var(--wb-cat-purple)' },
+  { id: 'tasks', label: 'Tasks', icon: ListTodo, color: 'var(--wb-cat-orange)' },
+  { id: 'more', label: 'More', icon: Menu, color: 'var(--wb-cat-pink)' },
 ]
 
 export default function WallabyNav({ active, onChange }) {
@@ -23,6 +24,7 @@ export default function WallabyNav({ active, onChange }) {
             role="tab"
             aria-selected={on}
             className={`wb-nav-tab${on ? ' is-active' : ''}`}
+            style={{ '--nav-color': t.color }}
             onClick={() => onChange(t.id)}
           >
             <Icon size={22} strokeWidth={on ? 2.4 : 1.9} className="wb-nav-icon" />

--- a/src/v2/wallaby/WallabyShell.jsx
+++ b/src/v2/wallaby/WallabyShell.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { Timer, Package, BookOpen, Smile, Settings, BarChart3, FolderKanban, User, ChevronRight, ArrowLeft } from 'lucide-react'
+import { Package, Settings, BarChart3, FolderKanban, User, ChevronRight } from 'lucide-react'
 import HomeView from './HomeView'
 import HabitsView from './HabitsView'
 import TasksView from './TasksView'
@@ -104,15 +104,12 @@ export default function WallabyShell({
         onReschedule={onRescheduleTask} onDelete={onDeleteTask}
       />
     )
-  } else if (sub === 'timer') {
-    surface = <Placeholder icon={<Timer size={34} strokeWidth={1.75} />} title="Timer" body="Focus timer is coming after the reskin." onClose={() => setSub(null)} />
   } else {
     surface = (
       <MoreMenu
         onOpenProfile={() => setSub('profile')}
         onOpenGoals={() => setSub('goals')}
         onOpenAnalytics={onOpenAnalytics}
-        onOpenTimer={() => setSub('timer')}
         onOpenPackages={onOpenPackages}
         onOpenSettings={onOpenSettings}
       />
@@ -137,15 +134,14 @@ export default function WallabyShell({
   )
 }
 
-function MoreMenu({ onOpenProfile, onOpenGoals, onOpenAnalytics, onOpenTimer, onOpenPackages, onOpenSettings }) {
+function MoreMenu({ onOpenProfile, onOpenGoals, onOpenAnalytics, onOpenPackages, onOpenSettings }) {
+  // Timer / Vision / Daily check-in are deferred features — hidden entirely
+  // until implemented (no "coming soon" placeholder rows).
   const rows = [
     { key: 'profile', icon: User, label: 'Profile', sub: 'Stats + your activity year', onClick: onOpenProfile },
     { key: 'goals', icon: FolderKanban, label: 'Goals', sub: 'Projects · progress + sessions', onClick: onOpenGoals },
     { key: 'analytics', icon: BarChart3, label: 'Analytics', sub: 'Productivity insights', onClick: onOpenAnalytics },
     { key: 'packages', icon: Package, label: 'Packages', sub: 'Track deliveries', onClick: onOpenPackages },
-    { key: 'timer', icon: Timer, label: 'Timer', sub: 'Focus sessions', onClick: onOpenTimer },
-    { key: 'vision', icon: BookOpen, label: 'Vision', sub: 'Coming soon', soon: true },
-    { key: 'daily', icon: Smile, label: 'Daily check-in', sub: 'Coming soon', soon: true },
     { key: 'settings', icon: Settings, label: 'Settings', sub: 'App configuration', onClick: onOpenSettings },
   ]
   return (
@@ -171,19 +167,6 @@ function MoreMenu({ onOpenProfile, onOpenGoals, onOpenAnalytics, onOpenTimer, on
           )
         })}
       </div>
-    </div>
-  )
-}
-
-function Placeholder({ icon, title, body, onClose }) {
-  return (
-    <div className="wb-placeholder">
-      {onClose && (
-        <button className="wb-back wb-placeholder-back" onClick={onClose} aria-label="Back"><ArrowLeft size={20} strokeWidth={2.25} /></button>
-      )}
-      <span className="wb-placeholder-icon">{icon}</span>
-      <h2 className="wb-placeholder-title">{title}</h2>
-      <p className="wb-placeholder-body">{body}</p>
     </div>
   )
 }

--- a/src/v2/wallaby/analytics.css
+++ b/src/v2/wallaby/analytics.css
@@ -25,30 +25,37 @@
 }
 [data-theme^="wallaby"] .v2-analytics-summary-num { color: var(--wb-action-complete); }
 
-/* Range / metric toggles → clean contained segmented controls, green active */
+/* Range / metric toggles → full-width segmented controls, matching the Tasks
+ * header (`.wb-tasks .wb-seg`): contained pill track, subtle card-3 active fill.
+ * (User: selectors looked awkward as small left-floating pills → "use the way
+ * tasks does this for analytics.") */
 [data-theme^="wallaby"] .v2-analytics-range,
 [data-theme^="wallaby"] .v2-analytics-metric {
-  display: inline-flex;
+  display: flex;
+  width: 100%;
   gap: 2px;
   background: var(--wb-card-2);
   border: 1px solid var(--wb-hairline);
   border-radius: 999px;
   padding: 3px;
+  margin: 0 0 10px;
 }
 [data-theme^="wallaby"] .v2-analytics-range-btn,
 [data-theme^="wallaby"] .v2-analytics-metric-btn {
+  flex: 1 1 0;
   border: none;
   background: transparent;
   border-radius: 999px;
-  padding: 7px 13px;
+  padding: 9px 8px;
   color: var(--wb-text-meta);
-  font-weight: 700;
+  font: 600 13px/1 var(--v2-font-body);
+  cursor: pointer;
 }
 [data-theme^="wallaby"] .v2-analytics-range-btn-active,
 [data-theme^="wallaby"] .v2-analytics-metric-btn-active {
-  background: var(--wb-action-complete);
-  color: #fff;
-  border: none;
+  background: var(--wb-card-3);
+  color: var(--wb-text);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
 }
 
 /* Chart fills pick up the Wallaby accent (purple) over the v2 orange */

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,11 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-06
 
+- feat(ui): Wallaby nav per-tab active colors + More cleanup + Analytics segments [S]
+  - **Bottom nav** — each tab lights up its **own** color when active instead of a single shared green: Home blue, Habits green, Quokka purple, Tasks orange, More pink (`--nav-color` inline var per tab → `.wb-nav-tab.is-active`). (User: "each of the buttons on the bottom menu to be a different color when highlighted.")
+  - **More menu** — Timer / Vision / Daily check-in rows **removed entirely** (deferred features, no "coming soon" placeholders). More now lists Profile / Goals / Analytics / Packages / Settings. Dropped the dead `Placeholder` component + `sub==='timer'` branch + unused icon imports.
+  - **Analytics selectors** — the range (7d/30d/90d/1y/All) and metric (Tasks/Points, Balance Tags/Energy) toggles were small left-floating pills with dead space; reskinned to **full-width segmented controls matching the Tasks header** (`.wb-tasks .wb-seg`: contained pill track, subtle card-3 active fill). (User: "selectors at the top look awkward" + "use the way tasks does this for analytics.")
+
 - ci: route Docker base-image pulls through mirror.gcr.io (fix flaky builds) [XS]
   - The Docker build kept failing on `node:22-alpine` pulls from `registry-1.docker.io` (`i/o timeout` / `DeadlineExceeded`) — a recurring GitHub-runner ↔ Docker Hub connectivity flake (3× in one session), unrelated to app code. Fix: `setup-buildx-action` now sets a buildkitd registry **mirror** (`docker.io → mirror.gcr.io`, Google's reliable mirror of Docker Hub official images). Falls back to docker.io if the mirror lacks an image. Applied to **both** the dev and prod workflows; the dev one also now runs buildx on **PR builds** (previously non-PR only, so PR builds pulled straight from Hub).
 


### PR DESCRIPTION
## Three Wallaby tweaks

1. **Bottom nav — per-tab active colors** (User: "each of the buttons on the bottom menu to be a different color when highlighted"). Each tab lights up its own color when active instead of a shared green: Home **blue**, Habits **green**, Quokka **purple**, Tasks **orange**, More **pink** (via a `--nav-color` inline var → `.wb-nav-tab.is-active`).

2. **More menu — Timer / Vision / Daily check-in removed** (User: "should be hidden fully until we're ready to implement them"). No more "coming soon" placeholder rows. More now lists Profile / Goals / Analytics / Packages / Settings. Also dropped the dead `Placeholder` component, the `sub==='timer'` branch, and unused icon imports.

3. **Analytics selectors → Tasks-style segmented controls** (User: "selectors at the top look awkward" + "use the way tasks does this for analytics"). The range (7d/30d/90d/1y/All) and metric (Tasks/Points; Balance Tags/Energy) toggles were small left-floating pills with dead space — now **full-width segmented controls** matching the Tasks header (`.wb-tasks .wb-seg`: contained pill track, subtle `card-3` active fill).

## Verified (headless, 390px, wallaby-dark)

- Nav `--nav-color` per tab: Home `#4F8DF5`, Habits `#41C083`, Quokka `#8C7CF0`, Tasks `#F0973E`, More `#EA6C9D`.
- More rows: `["Profile","Goals","Analytics","Packages","Settings"]`.
- Analytics range + metric both 342px wide (full card width). Screenshot confirms clean full-width segments.
- `npm run lint` → 0 errors.

https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk)_