### PR TITLE
chore(ui): turn off Terminal theme (not ripped out)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -941,6 +941,17 @@ The Boomerang wordmark popover (Analytics + Done, top-left) was already in place
 
 ### Terminal Theme Stress Test (2026-05-10, shipped to main 2026-05-11)
 
+> **STATUS — turned OFF, not ripped out (2026-06-06).** Wallaby became the daily
+> driver, so Terminal was removed from the Settings theme picker (only Standard /
+> Wallaby remain) and existing terminal users are migrated **terminal-dark →
+> wallaby-dark, terminal-light → wallaby-light** at three points: `loadSettings()`
+> (store.js), the `index.html` pre-paint script, and (via `loadSettings`) the
+> AppV2 mount effect. **All terminal code/CSS/components stay in place** (`src/v2/terminal/`,
+> `useTerminalMode`, `terminalTitle`/`terminalCommand` props, the
+> `check:terminal-titles` smoke test) — this is fully reversible: re-add the
+> `{ value: 'terminal', label: 'Terminal' }` picker option and drop the two
+> migration shims to bring it back. The "didn't stick" rip-out (below) is NOT done.
+
 **Working hypothesis: terminal may become the default forever.** PR A–H shipped a four-palette family — Light, Dark, Terminal Dark (GitHub Dark), Terminal Light (GitHub Light) — with terminal-specific structural overrides (ASCII flourishes, monospace stack, bracket toggles, `> verb` modal headers, `// manage` section, density signals on TaskCard, no-button-chrome on settings controls, WeekStrip toggle from home stats date). The user shipped v0.11.0 to `main` on 2026-05-11 with terminal as their daily driver; the 30-day decision criterion (terminal-forever vs. didn't-stick) starts clocking from there. Light/dark stay maintained as defensive baseline.
 
 **The convention while we stress-test:**

--- a/index.html
+++ b/index.html
@@ -28,6 +28,12 @@
           s.theme = 'terminal-dark'
           try { localStorage.setItem('boom_settings_v1', JSON.stringify(s)) } catch(_) {}
         }
+        // Terminal mode turned off (2026-06-06): migrate to Wallaby pre-paint so
+        // current terminal users don't flash the terminal palette on first load.
+        if (s && (s.theme === 'terminal-dark' || s.theme === 'terminal-light')) {
+          s.theme = s.theme === 'terminal-light' ? 'wallaby-light' : 'wallaby-dark'
+          try { localStorage.setItem('boom_settings_v1', JSON.stringify(s)) } catch(_) {}
+        }
         var themeColors = {
           light: '#FFFFFF',
           dark: '#0B0B0F',

--- a/src/store.js
+++ b/src/store.js
@@ -265,6 +265,13 @@ export function loadSettings() {
     saved.theme = 'terminal-dark'
     save(SETTINGS_KEY, saved)
   }
+  // Terminal mode turned OFF (2026-06-06): removed from the picker and migrated
+  // to Wallaby (the daily driver). Terminal CSS/components are kept in place
+  // (not ripped out), so this is reversible — only the stored preference flips.
+  if (saved.theme === 'terminal-dark' || saved.theme === 'terminal-light') {
+    saved.theme = saved.theme === 'terminal-light' ? 'wallaby-light' : 'wallaby-dark'
+    save(SETTINGS_KEY, saved)
+  }
   return { ...DEFAULT_SETTINGS, ...saved }
 }
 export function saveSettings(settings) { save(SETTINGS_KEY, settings); touchModified() }

--- a/src/v2/components/SettingsModal.jsx
+++ b/src/v2/components/SettingsModal.jsx
@@ -2497,12 +2497,11 @@ export default function SettingsModal({
                   <div className="v2-settings-row v2-settings-row-stacked">
                     <div className="v2-settings-row-text">
                       <div className="v2-settings-row-label">Theme</div>
-                      <div className="v2-settings-row-hint">Standard is the calm Wheneri-flavored UI. Terminal is monospace + ASCII flourishes. Wallaby is a deep-navy, heatmap-first dashboard.</div>
+                      <div className="v2-settings-row-hint">Standard is the calm Wheneri-flavored UI. Wallaby is a deep-navy, heatmap-first dashboard.</div>
                     </div>
                     <div className="v2-settings-segment" role="radiogroup" aria-label="Theme family">
                       {[
                         { value: 'standard', label: 'Standard' },
-                        { value: 'terminal', label: 'Terminal' },
                         { value: 'wallaby', label: 'Wallaby' },
                       ].map(opt => (
                         <button

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,9 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-06
 
+- chore(ui): turn OFF Terminal theme (not ripped out) [S]
+  - Wallaby is the daily driver, so Terminal is removed from the Settings theme picker (only **Standard / Wallaby** remain). Existing terminal users migrate **terminal-dark → wallaby-dark, terminal-light → wallaby-light** at three points: `loadSettings()` (store.js), the `index.html` pre-paint script (no first-frame flash), and the AppV2 mount effect (via `loadSettings`). **All terminal code stays in place** — `src/v2/terminal/`, `useTerminalMode`, `terminalTitle`/`terminalCommand` props, `check:terminal-titles` — so it's reversible (re-add the picker option + drop the two shims). The full "didn't stick" rip-out is NOT done. Verified headless: `terminal-dark` in storage → renders `wallaby-dark` (+ WallabyShell); picker shows only Standard/Wallaby.
+
 - feat(ui): Wallaby nav per-tab active colors + More cleanup + Analytics segments [S]
   - **Bottom nav** — each tab lights up its **own** color when active instead of a single shared green: Home blue, Habits green, Quokka purple, Tasks orange, More pink (`--nav-color` inline var per tab → `.wb-nav-tab.is-active`). (User: "each of the buttons on the bottom menu to be a different color when highlighted.")
   - **More menu** — Timer / Vision / Daily check-in rows **removed entirely** (deferred features, no "coming soon" placeholders). More now lists Profile / Goals / Analytics / Packages / Settings. Dropped the dead `Placeholder` component + `sub==='timer'` branch + unused icon imports.


### PR DESCRIPTION
## What

Turn **off** Terminal mode — but **not** rip it out. Quick win #1.

- **Picker:** Settings → Theme family now lists only **Standard / Wallaby** (Terminal option removed; hint updated).
- **Migration → Wallaby** (your pick): existing terminal users flip **terminal-dark → wallaby-dark, terminal-light → wallaby-light**, applied at all three theme sync points:
  - `loadSettings()` (store.js) — the canonical migration
  - `index.html` pre-paint script — so current terminal users don't flash the terminal palette on first frame
  - AppV2 mount effect — inherits it via `loadSettings()`
- **Reversible:** all terminal code stays put — `src/v2/terminal/`, `useTerminalMode`, `terminalTitle`/`terminalCommand` props, the `check:terminal-titles` smoke test. To bring it back: re-add the `{ value: 'terminal' }` picker option + drop the two migration shims. The full "didn't stick" rip-out is **not** done.

## Verified (headless, 390px)

- Seeded `terminal-dark` in localStorage → after load: `data-theme=wallaby-dark`, stored=`wallaby-dark`, WallabyShell mounted.
- Theme family options: `["Standard","Wallaby"]`.
- `npm run lint` → 0 errors; `check:terminal-titles` still passes (smoke test kept).

Docs updated (CLAUDE.md Terminal section now carries a STATUS banner; Version-History).

https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk)_