### PR TITLE
feat: local Badges / Achievements (self-derived, all skins)

### DIFF
--- a/src/badges.js
+++ b/src/badges.js
@@ -1,0 +1,56 @@
+// Local, self-derived achievements — NO new data/schema. Everything here is
+// computed from data the app already tracks (done tasks, streaks, daily records,
+// routine completion history, the analytics daily series). Theme-agnostic: this
+// is shared logic surfaced in every skin (Analytics for all, Profile in Wallaby).
+//
+// Each badge: { id, name, desc, emoji, tier, earned, current, target }.
+// `tier` drives display color: bronze | silver | gold.
+
+// Longest run of consecutive calendar days with any completion, from the
+// analytics daily series ([{ day:'YYYY-MM-DD', tasks, points }]).
+function longestActiveRun(daily) {
+  const active = (daily || []).filter(d => (d.tasks || 0) > 0).map(d => d.day).sort()
+  if (active.length === 0) return 0
+  let best = 1, run = 1
+  for (let i = 1; i < active.length; i++) {
+    const prev = new Date(active[i - 1] + 'T00:00:00'); prev.setDate(prev.getDate() + 1)
+    const prevKey = `${prev.getFullYear()}-${String(prev.getMonth() + 1).padStart(2, '0')}-${String(prev.getDate()).padStart(2, '0')}`
+    if (prevKey === active[i]) { run++; best = Math.max(best, run) } else { run = 1 }
+  }
+  return best
+}
+
+// Build the full badge list with earned state + progress. All inputs are
+// already computed elsewhere — pass them in (lifetimeDone is a count, history
+// is the analytics daily series [{day,tasks,points}]).
+export function computeBadges({ lifetimeDone = 0, routines = [], records = {}, streak = 0, history = [] } = {}) {
+  const bestStreak = Math.max(streak || 0, records?.longestStreak || 0)
+  const bestDayTasks = records?.bestTasks || 0
+  const bestDayPoints = records?.bestPoints || 0
+  const topHabit = Math.max(0, ...((routines || []).map(r => (r.completed_history?.length || 0))))
+  const totalPoints = (history || []).reduce((n, d) => n + (d.points || 0), 0)
+  const activeRun = longestActiveRun(history)
+
+  const mk = (id, name, desc, emoji, tier, current, target) =>
+    ({ id, name, desc, emoji, tier, current, target, earned: current >= target })
+
+  return [
+    mk('first_step', 'First Step', 'Complete your first task', '🌱', 'bronze', lifetimeDone, 1),
+    mk('getting_going', 'Getting Going', 'Complete 10 tasks', '🚀', 'bronze', lifetimeDone, 10),
+    mk('century', 'Century', 'Complete 100 tasks', '💯', 'silver', lifetimeDone, 100),
+    mk('five_hundred', '500 Club', 'Complete 500 tasks', '🏆', 'gold', lifetimeDone, 500),
+    mk('week_warrior', 'Week Warrior', '7-day completion streak', '🔥', 'bronze', bestStreak, 7),
+    mk('fortnight', 'Fortnight', '14-day completion streak', '⚡', 'silver', bestStreak, 14),
+    mk('monthly_master', 'Monthly Master', '30-day completion streak', '👑', 'gold', bestStreak, 30),
+    mk('consistent', 'Consistent', 'Active every day for a week', '📅', 'silver', activeRun, 7),
+    mk('big_day', 'Big Day', '10 tasks done in one day', '☄️', 'silver', bestDayTasks, 10),
+    mk('point_storm', 'Point Storm', '100 points in one day', '⛈️', 'gold', bestDayPoints, 100),
+    mk('habit_former', 'Habit Former', 'A habit logged 30 times', '🌿', 'silver', topHabit, 30),
+    mk('point_collector', 'Point Collector', 'Earn 1,000 points', '💎', 'gold', totalPoints, 1000),
+  ]
+}
+
+export function badgeSummary(badges) {
+  const earned = badges.filter(b => b.earned).length
+  return { earned, total: badges.length }
+}

--- a/src/v2/AppV2.jsx
+++ b/src/v2/AppV2.jsx
@@ -1498,6 +1498,10 @@ export default function AppV2() {
       <AnalyticsModal
         open={showAnalytics}
         onClose={() => setShowAnalytics(false)}
+        tasks={tasks}
+        routines={routines}
+        records={records}
+        streak={streak}
       />
 
       {isDesktop && (

--- a/src/v2/components/AnalyticsModal.jsx
+++ b/src/v2/components/AnalyticsModal.jsx
@@ -3,6 +3,8 @@ import { ENERGY_TYPES, loadLabels } from '../../store'
 import ModalShell from './ModalShell'
 import EmptyState from './EmptyState'
 import BalanceRadar from './BalanceRadar'
+import BadgesGrid from './BadgesGrid'
+import { computeBadges } from '../../badges'
 import { BarChart3 } from 'lucide-react'
 import './AnalyticsModal.css'
 
@@ -50,7 +52,7 @@ function buildHeatMapGrid(dailyData, metric) {
   return { weeks, months, maxVal }
 }
 
-export default function AnalyticsModal({ open, onClose }) {
+export default function AnalyticsModal({ open, onClose, tasks = [], routines = [], records = {}, streak = 0 }) {
   const labels = useMemo(() => loadLabels(), [])
   const labelMap = useMemo(() => Object.fromEntries(labels.map(l => [l.id, l])), [labels])
   const [range, setRange] = useState(30)
@@ -102,6 +104,12 @@ export default function AnalyticsModal({ open, onClose }) {
   }, [open])
 
   const heatMap = useMemo(() => buildHeatMapGrid(heatMapData, heatMapMetric), [heatMapData, heatMapMetric])
+
+  // Local achievements — derived from data we already have (no new schema).
+  const badges = useMemo(() => computeBadges({
+    lifetimeDone: tasks.filter(t => t.status === 'done').length,
+    routines, records, streak, history: heatMapData || [],
+  }), [tasks, routines, records, streak, heatMapData])
 
   // Radar spokes derived from history.
   const radarSpokes = useMemo(() => {
@@ -390,6 +398,13 @@ export default function AnalyticsModal({ open, onClose }) {
               </div>
             </section>
           )}
+
+          <section className="v2-analytics-section">
+            <div className="v2-analytics-section-head">
+              <h2 className="v2-analytics-section-title">Achievements</h2>
+            </div>
+            <BadgesGrid badges={badges} />
+          </section>
 
           {throttleDecisions.filter(d => !d.feedback).length > 0 && (
             <section className="v2-analytics-section">

--- a/src/v2/components/BadgesGrid.css
+++ b/src/v2/components/BadgesGrid.css
@@ -1,0 +1,71 @@
+/* Shared achievements grid — theme-agnostic, uses v2 tokens (Wallaby overrides
+ * --v2-* so it inherits the right palette automatically). */
+.v2-badges-head {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 10px;
+}
+.v2-badges-count {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--v2-text-meta);
+}
+.v2-badges-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(104px, 1fr));
+  gap: 10px;
+}
+.v2-badge {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 3px;
+  padding: 14px 10px 12px;
+  border-radius: 14px;
+  background: var(--v2-surface);
+  border: 1px solid var(--v2-hairline);
+  opacity: 0.55;
+  filter: grayscale(0.7);
+}
+.v2-badge.is-earned {
+  opacity: 1;
+  filter: none;
+}
+.v2-badge-bronze.is-earned { border-color: color-mix(in srgb, #C58A4A 60%, transparent); background: color-mix(in srgb, #C58A4A 12%, var(--v2-surface)); }
+.v2-badge-silver.is-earned { border-color: color-mix(in srgb, #9FB0C3 60%, transparent); background: color-mix(in srgb, #9FB0C3 12%, var(--v2-surface)); }
+.v2-badge-gold.is-earned   { border-color: color-mix(in srgb, #E8B23A 65%, transparent); background: color-mix(in srgb, #E8B23A 14%, var(--v2-surface)); }
+.v2-badge-emoji { font-size: 26px; line-height: 1; }
+.v2-badge-name { font-size: 12.5px; font-weight: 700; color: var(--v2-text); }
+.v2-badge-desc { font-size: 10.5px; color: var(--v2-text-meta); line-height: 1.25; }
+.v2-badge-earned-tag {
+  margin-top: 4px;
+  font-size: 9.5px;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--v2-accent);
+}
+.v2-badge-progress {
+  position: relative;
+  margin-top: 6px;
+  width: 100%;
+  height: 14px;
+  border-radius: 999px;
+  background: var(--v2-hairline);
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.v2-badge-progress-fill {
+  position: absolute;
+  left: 0; top: 0; bottom: 0;
+  background: color-mix(in srgb, var(--v2-accent) 45%, transparent);
+}
+.v2-badge-progress-label {
+  position: relative;
+  font-size: 9px;
+  font-weight: 700;
+  color: var(--v2-text-meta);
+}

--- a/src/v2/components/BadgesGrid.jsx
+++ b/src/v2/components/BadgesGrid.jsx
@@ -1,0 +1,47 @@
+import { badgeSummary } from '../../badges'
+import './BadgesGrid.css'
+
+// Shared, theme-agnostic achievements grid. Earned badges render in their tier
+// color; locked ones are dimmed with a progress bar. No new data — `badges`
+// comes from computeBadges(). Used in AnalyticsModal (all skins) + Wallaby
+// Profile. Sorted earned-first, then by closest-to-earning.
+export default function BadgesGrid({ badges = [] }) {
+  if (!badges.length) return null
+  const { earned, total } = badgeSummary(badges)
+  const sorted = [...badges].sort((a, b) => {
+    if (a.earned !== b.earned) return a.earned ? -1 : 1
+    if (a.earned) return 0
+    return (b.current / b.target) - (a.current / a.target)
+  })
+  return (
+    <div className="v2-badges">
+      <div className="v2-badges-head">
+        <span className="v2-badges-count">{earned}/{total} earned</span>
+      </div>
+      <div className="v2-badges-grid">
+        {sorted.map(b => {
+          const pct = Math.min(100, Math.round((b.current / b.target) * 100))
+          return (
+            <div
+              key={b.id}
+              className={`v2-badge v2-badge-${b.tier}${b.earned ? ' is-earned' : ''}`}
+              title={b.earned ? `${b.name} — earned` : `${b.name}: ${b.current}/${b.target}`}
+            >
+              <span className="v2-badge-emoji">{b.emoji}</span>
+              <span className="v2-badge-name">{b.name}</span>
+              <span className="v2-badge-desc">{b.desc}</span>
+              {b.earned
+                ? <span className="v2-badge-earned-tag">Earned</span>
+                : (
+                  <span className="v2-badge-progress">
+                    <span className="v2-badge-progress-fill" style={{ width: `${pct}%` }} />
+                    <span className="v2-badge-progress-label">{b.current}/{b.target}</span>
+                  </span>
+                )}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/src/v2/wallaby/ProfileView.jsx
+++ b/src/v2/wallaby/ProfileView.jsx
@@ -1,6 +1,8 @@
 import { useEffect, useMemo, useState } from 'react'
 import { ArrowLeft, Flame, Zap, CheckCircle2, Trophy, Star, TrendingUp } from 'lucide-react'
 import ContributionHeatmap from './ContributionHeatmap'
+import BadgesGrid from '../components/BadgesGrid'
+import { computeBadges } from '../../badges'
 import { WALLABY_COLORS, historyByDay } from './heatmapUtils'
 import './ProfileView.css'
 
@@ -48,6 +50,11 @@ export default function ProfileView({
     { icon: Star, label: 'Lifetime done', value: lifetimeDone, color: 'var(--wb-cat-pink)' },
   ]
 
+  const badges = useMemo(
+    () => computeBadges({ lifetimeDone, routines, records, streak, history: history || [] }),
+    [lifetimeDone, routines, records, streak, history],
+  )
+
   const habits = (routines || []).filter(r => (r.completed_history?.length || 0) > 0)
 
   return (
@@ -94,6 +101,11 @@ export default function ProfileView({
             )
           })}
         </div>
+      </section>
+
+      <section className="wb-profile-section">
+        <h2 className="wb-profile-section-title">Achievements</h2>
+        <BadgesGrid badges={badges} />
       </section>
 
       <section className="wb-profile-section">

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -4,6 +4,13 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ---
 
+## 2026-06-07
+
+- feat: local Badges / Achievements (self-derived, all skins) [M]
+  - 12 achievements computed entirely from data the app already tracks — **no new schema/endpoints**: lifetime done, best/longest streak (`computeStreak`/`computeRecords`), best-day tasks/points, top habit completion count, total points + longest active-day run (from `/api/analytics/history`). Badges: First Step, Getting Going (10), Century (100), 500 Club, Week Warrior (7-streak), Fortnight (14), Monthly Master (30), Consistent (active 7 days straight), Big Day (10/day), Point Storm (100 pts/day), Habit Former (habit ×30), Point Collector (1,000 pts). Bronze/silver/gold tiers.
+  - Shared, theme-agnostic: `src/badges.js` (`computeBadges`) + `src/v2/components/BadgesGrid.{jsx,css}` (earned in tier color, locked dimmed with a progress bar, "N/12 earned"). Surfaced in the shared **AnalyticsModal** (all skins — fed `tasks`/`routines`/`records`/`streak` from AppV2) and the Wallaby **Profile** (new Achievements section). Verified headless: 3/12 earned render correctly from seed.
+  - Out of scope (deferred, keeps it no-fork): persisted "seen" set + earn-celebration toast.
+
 ## 2026-06-06
 
 - chore(ui): turn OFF Terminal theme (not ripped out) [S]

--- a/wiki/Wallaby-Ideas.md
+++ b/wiki/Wallaby-Ideas.md
@@ -70,7 +70,7 @@ The real Home is a scrolling daily dashboard. Reskin-able parts (existing data):
 - 🅿️ **Timer** — focus timer, full + compact (`timer-full.pdf`/`timer-compact.pdf`): activity heatmap, session log (Pomodoro/Tracking), streak, time distribution by task/goal/habit/tag, focus patterns, CSV export. Feeds Home summary + Analytics focus-time.
 - 🅿️ **Vision** — full board (`vision.pdf`): Eulogy / Bucket List / Mission / Definition of Success (6 life areas) / **Odyssey Plan** (3 paths) / **Future Calendar** (ideal Tuesday/Sunday); per-section Public/Private.
 - 🅿️ **Notes** — Notion-like nested-page tree + writing heatmap (`notes.pdf`). **User: should INTERFACE WITH their Notion** — Boomerang already has a Notion-backed Knowledge base; build Notes *on* that (one Notion source of truth), don't fork a second store.
-- 🅿️ **Badges / achievements** (`badges.pdf`). **User: award LOCALLY (self-gamification) from existing analytics — no leaderboards/social needed.** Derive from streak/completion/points data already computed; skip competitive parts.
+- ✅ **Badges / achievements** (`badges.pdf`) — DONE (2026-06-07). 12 self-derived badges (bronze/silver/gold) from existing analytics, no new schema. `src/badges.js` + shared `BadgesGrid`, surfaced in AnalyticsModal (all skins) + Wallaby Profile. Deferred: persisted "seen" + earn-celebration toast; XP/levels economy (the bigger gamification fork).
 - 🅿️ **Daily check-in** — rainbow mood slider (1–10) + reflection journal — `IMG_1580`
 - 🅿️ **Notifications center** (bell) — grouped feed, All/Unread, mark-all-read — `PDF 3`
 - 🅿️ **Weekly review / Week in Review** — recap of streaks, XP, check-ins, % habits


### PR DESCRIPTION
## Quick win #2: local Badges / Achievements

Self-gamification you flagged — **no new schema/endpoints**, all derived from data we already compute. Works in **all skins**.

**12 badges** (bronze/silver/gold), from existing data:
First Step · Getting Going (10) · Century (100) · 500 Club · Week Warrior (7-streak) · Fortnight (14) · Monthly Master (30) · Consistent (active 7 days straight) · Big Day (10/day) · Point Storm (100 pts/day) · Habit Former (habit ×30) · Point Collector (1,000 pts).

Sources: `computeStreak`/`computeRecords`, done-count, routine `completed_history`, and the `/api/analytics/history` daily series.

## Structure (theme-agnostic)
- `src/badges.js` — `computeBadges({lifetimeDone, routines, records, streak, history})` → earned + progress.
- `src/v2/components/BadgesGrid.{jsx,css}` — earned in tier color, locked dimmed with a progress bar, "N/12 earned". Uses `--v2-*` tokens so Wallaby restyles it automatically.
- Surfaced in **AnalyticsModal** (all skins — AppV2 now passes `tasks/routines/records/streak`) and the Wallaby **Profile** (new Achievements section).

## Verified

Headless (wallaby-dark): renders 3/12 earned from seed (First Step, Getting Going, Habit Former), locked badges show progress (Week Warrior 1/7, Century 13/100, 500 Club 13/500…). `npm run lint` → 0 errors.

Deferred (keeps it no-fork): persisted "seen" set + earn-celebration toast; the XP/levels points economy.

https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk)_