### PR TITLE
feat(ui): swipe-to-reveal actions on Wallaby task rows

### DIFF
--- a/src/hooks/useSwipeActions.js
+++ b/src/hooks/useSwipeActions.js
@@ -1,0 +1,47 @@
+import { useCallback, useRef, useState } from 'react'
+
+// Swipe-left-to-reveal-actions gesture, extracted from the v2 TaskCard so the
+// Wallaby TaskRow (and any future row) can reuse the exact same behavior.
+// Returns the live offset, open state, the touch handlers to spread on the
+// moving element, and a close() helper. `openOffset` should match the revealed
+// action panel's width (negative px). Vertical scrolling cancels the swipe.
+export function useSwipeActions({ openOffset = -132, threshold = 56, vertCancel = 12, disabled = false } = {}) {
+  const [x, setX] = useState(0)
+  const [swiping, setSwiping] = useState(false)
+  const [open, setOpen] = useState(false)
+  const start = useRef(null)
+
+  const close = useCallback(() => { setOpen(false); setX(0) }, [])
+
+  const onTouchStart = useCallback((e) => {
+    if (disabled) return
+    const t = e.touches[0]
+    start.current = { x: t.clientX, y: t.clientY, startX: x }
+  }, [x, disabled])
+
+  const onTouchMove = useCallback((e) => {
+    if (disabled || !start.current) return
+    const t = e.touches[0]
+    const dx = t.clientX - start.current.x
+    const dy = t.clientY - start.current.y
+    if (!swiping && Math.abs(dy) > Math.abs(dx) && Math.abs(dy) > vertCancel) {
+      start.current = null
+      return
+    }
+    if (Math.abs(dx) > 8) {
+      setSwiping(true)
+      const next = start.current.startX + dx
+      setX(Math.max(openOffset, Math.min(0, next)))
+    }
+  }, [swiping, disabled, vertCancel, openOffset])
+
+  const onTouchEnd = useCallback(() => {
+    if (!start.current) { setSwiping(false); return }
+    if (x < -threshold) { setOpen(true); setX(openOffset) }
+    else close()
+    start.current = null
+    setTimeout(() => setSwiping(false), 200)
+  }, [x, threshold, openOffset, close])
+
+  return { x, swiping, open, close, handlers: { onTouchStart, onTouchMove, onTouchEnd } }
+}

--- a/src/v2/wallaby/TasksView.css
+++ b/src/v2/wallaby/TasksView.css
@@ -102,12 +102,43 @@
   padding: 1px 7px;
 }
 
+/* Swipe-to-reveal wrapper: actions sit behind, the .wb-task slides left. */
+.wb-task-swipe {
+  position: relative;
+  margin-bottom: 8px;
+  border-radius: 14px;
+  overflow: hidden;
+}
+.wb-task-swipe-actions {
+  position: absolute;
+  inset: 0 0 0 auto;
+  display: flex;
+}
+.wb-task-swipe-act {
+  width: 66px;
+  border: none;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 3px;
+  color: #fff;
+  font-size: 11px;
+  font-weight: 700;
+  cursor: pointer;
+}
+.wb-task-swipe-done { background: var(--wb-action-complete); }
+.wb-task-swipe-del { background: var(--wb-action-delete); }
+
 .wb-task {
+  position: relative;
+  z-index: 1;
   background: var(--wb-card);
   border: 1px solid var(--wb-hairline);
   border-radius: 14px;
   padding: 13px 14px;
-  margin-bottom: 8px;
+  transition: transform 200ms ease;
+  will-change: transform;
 }
 .wb-task-main {
   display: flex;

--- a/src/v2/wallaby/TasksView.jsx
+++ b/src/v2/wallaby/TasksView.jsx
@@ -4,6 +4,7 @@ import {
   Inbox, CheckCircle2, Archive, Pencil, Trash2, Timer, X, Calendar,
 } from 'lucide-react'
 import { localYMD } from './heatmapUtils'
+import { useSwipeActions } from '../../hooks/useSwipeActions'
 import './TasksView.css'
 
 const ACTIVE = ['not_started', 'doing', 'waiting', 'in_progress']
@@ -109,6 +110,7 @@ export default function TasksView({
                   done={tab === 'done'}
                   onToggleComplete={onToggleComplete}
                   onToggleItem={onToggleItem}
+                  onDelete={onDelete}
                   onOpen={() => setSheetTask(task)}
                 />
               ))}
@@ -133,15 +135,37 @@ export default function TasksView({
   )
 }
 
-function TaskRow({ task, labelsById, done, onToggleComplete, onToggleItem, onOpen }) {
+function TaskRow({ task, labelsById, done, onToggleComplete, onToggleItem, onDelete, onOpen }) {
   const items = (Array.isArray(task.checklists) ? task.checklists : []).flatMap(cl =>
     (cl.items || []).map(it => ({ ...it, clId: cl.id })))
   const due = dueMeta(task.due_date)
   const tagChips = (task.tags || []).map(id => labelsById[id]).filter(Boolean)
   const color = taskColor(task.id)
+  // Swipe-left reveals quick actions (parity with the v2 TaskCard).
+  const swipe = useSwipeActions({ openOffset: -132 })
+  const handleBody = () => { if (swipe.swiping) return; if (swipe.open) { swipe.close(); return } onOpen?.() }
 
   return (
-    <div className="wb-task">
+    <div className="wb-task-swipe">
+      <div className="wb-task-swipe-actions">
+        <button
+          className="wb-task-swipe-act wb-task-swipe-done"
+          onClick={() => { onToggleComplete?.(task); swipe.close() }}
+        >
+          <Check size={16} strokeWidth={2.5} />{done ? 'Reopen' : 'Done'}
+        </button>
+        <button
+          className="wb-task-swipe-act wb-task-swipe-del"
+          onClick={() => { onDelete?.(task); swipe.close() }}
+        >
+          <Trash2 size={16} strokeWidth={2} />Delete
+        </button>
+      </div>
+      <div
+        className="wb-task"
+        style={{ transform: swipe.x !== 0 ? `translateX(${swipe.x}px)` : undefined }}
+        {...swipe.handlers}
+      >
       <div className="wb-task-main">
         <button
           className={`wb-check${done ? ' is-done' : ''}`}
@@ -149,7 +173,7 @@ function TaskRow({ task, labelsById, done, onToggleComplete, onToggleItem, onOpe
           onClick={() => onToggleComplete?.(task)}
           aria-label={done ? 'Reopen task' : 'Complete task'}
         >{done && <Check size={14} strokeWidth={3} color="#fff" />}</button>
-        <button className="wb-task-body" onClick={onOpen}>
+        <button className="wb-task-body" onClick={handleBody}>
           <span className={`wb-task-title${done ? ' is-done' : ''}`}>{task.title}</span>
           {task.notes && !done && <span className="wb-task-sub">{task.notes.replace(/\s+/g, ' ').trim().slice(0, 80)}</span>}
           {(tagChips.length > 0 || due) && !done && (
@@ -174,6 +198,7 @@ function TaskRow({ task, labelsById, done, onToggleComplete, onToggleItem, onOpe
           ))}
         </ul>
       )}
+      </div>
     </div>
   )
 }

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,9 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-07
 
+- feat(ui): swipe-to-reveal actions on Wallaby task rows [S]
+  - Brings the Wallaby `TasksView` rows to parity with the v2 TaskCard: swipe a row left to reveal **Done/Reopen** (green) + **Delete** (red). Extracted the v2 TaskCard's gesture into a shared `src/hooks/useSwipeActions.js` (offset/threshold/vertical-cancel, returns `{x, open, swiping, close, handlers}`) and wired it into the Wallaby `TaskRow` (actions panel behind, row slides on `translateX`). Tapping the row still opens the action sheet; an open swipe closes on body tap. Verified headless (touch-emulated): drag-left settles at `translateX(-132)` with Done/Delete revealed. (Standard skin already had swipe via the v2 TaskCard.)
+
 - feat(tasks): natural-language due dates in the shared DateField (all skins) [M]
   - The due-date field now accepts typed natural language — "tomorrow", "next tue", "in 3 days", "fri", "next week", "6/9", or a raw `YYYY-MM-DD` — parsed locally by `src/utils/parseNaturalDate.js` (pure, dependency-free, **no AI/network**). A live "→ 2026-06-19" preview shows while typing; Enter/blur commits (unparseable input reverts). A calendar button still opens the native date picker (overlaid `<input type=date>` at opacity:0 for reliable iOS-PWA tap). `DateField` rewritten (text input + cal button); the parsed-preview wraps to its own line so the control stays usable in the half-width DUE column. Used by Add + Edit task modals → works in every skin. Verified headless: parser unit-checked (today/tomorrow/in N/weekday/next-weekday/M-D/ISO), and in-modal typing "next fri" → preview + commit to the ISO date.
 


### PR DESCRIPTION
## Quick win #4: swipe gestures on Wallaby task rows

Brings the Wallaby `TasksView` rows to parity with the v2 TaskCard — swipe a row left to reveal **Done/Reopen** (green) + **Delete** (red).

- Extracted the v2 TaskCard's gesture into a shared **`src/hooks/useSwipeActions.js`** (`{x, open, swiping, close, handlers}`; tunable offset/threshold/vertical-cancel) — reusable by any row.
- Wired into the Wallaby `TaskRow`: actions panel sits behind, the `.wb-task` slides on `translateX`. Tapping the row still opens the action sheet; an open swipe closes on body tap.
- Standard skin already had swipe (via the v2 TaskCard), so this brings Wallaby to the same all-skins behavior.

## Verified

Headless with touch emulation: drag-left on a row settles at `translateX(-132)` with Done + Delete revealed (screenshot confirms green check / red trash). `npm run lint` → 0 errors.

https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk)_