### PR TITLE
feat(analytics): tabbed AnalyticsModal — Overview / Tasks / Habits

### DIFF
--- a/src/v2/components/AnalyticsModal.css
+++ b/src/v2/components/AnalyticsModal.css
@@ -42,6 +42,28 @@
   border-color: var(--v2-text);
 }
 
+/* Section tabs (Overview / Tasks / Habits) */
+.v2-analytics-tabs {
+  display: flex;
+  gap: 4px;
+  margin: 0 0 16px;
+}
+.v2-analytics-tab {
+  flex: 1 1 0;
+  padding: 9px 10px;
+  border-radius: var(--v2-radius-pill);
+  background: transparent;
+  color: var(--v2-text-meta);
+  border: 1px solid var(--v2-hairline);
+  font: 700 12px/1 var(--v2-font-body);
+  cursor: pointer;
+}
+.v2-analytics-tab-active {
+  background: var(--v2-text);
+  color: var(--v2-bg);
+  border-color: var(--v2-text);
+}
+
 .v2-analytics-summary {
   display: flex;
   align-items: baseline;
@@ -175,6 +197,17 @@
   width: 10px;
   height: 10px;
   border-radius: 50%;
+}
+
+/* Habits "By habit" rows: no color dot, longer names, and a wider value
+ * column for the "204× · 🔥2 · today" meta. */
+.v2-analytics-bd-habits .v2-analytics-bd-row {
+  grid-template-columns: minmax(96px, 1.4fr) minmax(36px, 1fr) auto;
+}
+.v2-analytics-bd-habits .v2-analytics-bd-value {
+  width: auto;
+  white-space: nowrap;
+  color: var(--v2-text-meta);
 }
 
 .v2-analytics-bd-label {

--- a/src/v2/components/AnalyticsModal.jsx
+++ b/src/v2/components/AnalyticsModal.jsx
@@ -57,6 +57,7 @@ export default function AnalyticsModal({ open, onClose, tasks = [], routines = [
   const labelMap = useMemo(() => Object.fromEntries(labels.map(l => [l.id, l])), [labels])
   const [range, setRange] = useState(30)
   const [metric, setMetric] = useState('tasks')
+  const [tab, setTab] = useState('overview') // overview | tasks | habits
   const [history, setHistory] = useState(null)
   const [heatMapData, setHeatMapData] = useState(null)
   const [heatMapMetric, setHeatMapMetric] = useState('tasks')
@@ -203,8 +204,25 @@ export default function AnalyticsModal({ open, onClose, tasks = [], routines = [
             <span className="v2-analytics-summary-label">{metric === 'tasks' ? 'tasks' : 'points'} · last {range || 'all'} {range ? 'days' : 'time'}</span>
           </div>
 
+          {/* Section tabs */}
+          <div className="v2-analytics-tabs" role="tablist" aria-label="Analytics sections">
+            {[
+              { id: 'overview', label: 'Overview' },
+              { id: 'tasks', label: 'Tasks' },
+              { id: 'habits', label: 'Habits' },
+            ].map(t => (
+              <button
+                key={t.id}
+                role="tab"
+                aria-selected={tab === t.id}
+                className={`v2-analytics-tab${tab === t.id ? ' v2-analytics-tab-active' : ''}`}
+                onClick={() => setTab(t.id)}
+              >{t.label}</button>
+            ))}
+          </div>
+
           {/* Daily chart */}
-          {history.daily?.length > 0 && (
+          {tab === 'overview' && history.daily?.length > 0 && (
             <section className="v2-analytics-section">
               <h3 className="v2-analytics-heading">Daily completions</h3>
               <div className="v2-analytics-daily-chart">
@@ -222,7 +240,7 @@ export default function AnalyticsModal({ open, onClose, tasks = [], routines = [
           )}
 
           {/* Day-of-week pattern */}
-          {history.byDayOfWeek && (
+          {tab === 'tasks' && history.byDayOfWeek && (
             <section className="v2-analytics-section">
               <h3 className="v2-analytics-heading">By day of week</h3>
               <div className="v2-analytics-dow">
@@ -244,6 +262,7 @@ export default function AnalyticsModal({ open, onClose, tasks = [], routines = [
           )}
 
           {/* Balance radar */}
+          {tab === 'tasks' && (
           <section className="v2-analytics-section">
             <div className="v2-analytics-section-head">
               <h3 className="v2-analytics-heading">Balance</h3>
@@ -269,9 +288,10 @@ export default function AnalyticsModal({ open, onClose, tasks = [], routines = [
             </p>
             <BalanceRadar spokes={radarSpokes} size={300} />
           </section>
+          )}
 
           {/* Tag breakdown */}
-          {Object.keys(history.byTag || {}).length > 0 && (
+          {tab === 'tasks' && Object.keys(history.byTag || {}).length > 0 && (
             <section className="v2-analytics-section">
               <h3 className="v2-analytics-heading">By tag</h3>
               <ul className="v2-analytics-bd">
@@ -298,7 +318,7 @@ export default function AnalyticsModal({ open, onClose, tasks = [], routines = [
           )}
 
           {/* Energy breakdown */}
-          {Object.keys(history.byEnergy || {}).length > 0 && (
+          {tab === 'tasks' && Object.keys(history.byEnergy || {}).length > 0 && (
             <section className="v2-analytics-section">
               <h3 className="v2-analytics-heading">By energy type</h3>
               <ul className="v2-analytics-bd">
@@ -325,7 +345,7 @@ export default function AnalyticsModal({ open, onClose, tasks = [], routines = [
           )}
 
           {/* Size breakdown */}
-          {Object.keys(history.bySize || {}).length > 0 && (
+          {tab === 'tasks' && Object.keys(history.bySize || {}).length > 0 && (
             <section className="v2-analytics-section">
               <h3 className="v2-analytics-heading">By size</h3>
               <ul className="v2-analytics-bd">
@@ -349,7 +369,7 @@ export default function AnalyticsModal({ open, onClose, tasks = [], routines = [
           )}
 
           {/* 52-week heatmap */}
-          {heatMap.weeks.length > 0 && (
+          {tab === 'overview' && heatMap.weeks.length > 0 && (
             <section className="v2-analytics-section">
               <div className="v2-analytics-section-head">
                 <h3 className="v2-analytics-heading">52-week pattern</h3>
@@ -399,14 +419,18 @@ export default function AnalyticsModal({ open, onClose, tasks = [], routines = [
             </section>
           )}
 
+          {tab === 'overview' && (
           <section className="v2-analytics-section">
             <div className="v2-analytics-section-head">
               <h2 className="v2-analytics-section-title">Achievements</h2>
             </div>
             <BadgesGrid badges={badges} />
           </section>
+          )}
 
-          {throttleDecisions.filter(d => !d.feedback).length > 0 && (
+          {tab === 'habits' && <HabitsAnalytics routines={routines} />}
+
+          {tab === 'tasks' && throttleDecisions.filter(d => !d.feedback).length > 0 && (
             <section className="v2-analytics-section">
               <div className="v2-analytics-section-head">
                 <h2 className="v2-analytics-section-title">Adaptive throttle decisions</h2>
@@ -445,5 +469,63 @@ export default function AnalyticsModal({ open, onClose, tasks = [], routines = [
         </>
       )}
     </ModalShell>
+  )
+}
+
+// Habits tab — per-routine completion summary from data we already have
+// (routine.completed_history). No new endpoint. Theme-agnostic.
+function habitStreak(history) {
+  const days = new Set((history || []).map(ts => {
+    const d = new Date(ts)
+    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+  }))
+  const cur = new Date(); cur.setHours(0, 0, 0, 0)
+  const key = d => `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+  if (!days.has(key(cur))) cur.setDate(cur.getDate() - 1) // today optional
+  let n = 0
+  while (days.has(key(cur))) { n++; cur.setDate(cur.getDate() - 1) }
+  return n
+}
+
+function HabitsAnalytics({ routines = [] }) {
+  const rows = routines
+    .map(r => ({
+      id: r.id,
+      title: r.title,
+      total: (r.completed_history?.length || 0),
+      last: (r.completed_history || []).slice().sort().pop() || null,
+      streak: habitStreak(r.completed_history),
+    }))
+    .filter(r => r.total > 0)
+    .sort((a, b) => b.total - a.total)
+
+  if (rows.length === 0) {
+    return (
+      <section className="v2-analytics-section">
+        <p className="v2-analytics-section-sub">No habit completions yet — check a routine off to start tracking.</p>
+      </section>
+    )
+  }
+  const max = Math.max(...rows.map(r => r.total))
+  const ago = (ts) => {
+    if (!ts) return '—'
+    const days = Math.floor((Date.now() - new Date(ts)) / 86400000)
+    return days <= 0 ? 'today' : days === 1 ? 'yesterday' : `${days}d ago`
+  }
+  return (
+    <section className="v2-analytics-section">
+      <h3 className="v2-analytics-heading">By habit</h3>
+      <ul className="v2-analytics-bd v2-analytics-bd-habits">
+        {rows.map(r => (
+          <li key={r.id} className="v2-analytics-bd-row">
+            <span className="v2-analytics-bd-label">{r.title}</span>
+            <div className="v2-analytics-bd-track">
+              <div className="v2-analytics-bd-fill" style={{ width: `${(r.total / max) * 100}%` }} />
+            </div>
+            <span className="v2-analytics-bd-value">{r.total}×{r.streak > 1 ? ` · 🔥${r.streak}` : ''} · {ago(r.last)}</span>
+          </li>
+        ))}
+      </ul>
+    </section>
   )
 }

--- a/src/v2/terminal/init.css
+++ b/src/v2/terminal/init.css
@@ -1346,13 +1346,25 @@
 
 /* --- Analytics modal ---------------------------------------------- */
 :root[data-ui="v2"][data-theme^="terminal"] .v2-analytics-range-btn,
-:root[data-ui="v2"][data-theme^="terminal"] .v2-analytics-metric-btn {
+:root[data-ui="v2"][data-theme^="terminal"] .v2-analytics-metric-btn,
+:root[data-ui="v2"][data-theme^="terminal"] .v2-analytics-tab {
   background: transparent !important;
   border: none !important;
   border-radius: 0 !important;
   color: var(--v2-text-meta) !important;
   text-transform: lowercase;
   padding: 6px 10px !important;
+}
+
+:root[data-ui="v2"][data-theme^="terminal"] .v2-analytics-tabs {
+  background: transparent !important;
+  border: none !important;
+  padding: 0 !important;
+  border-bottom: 1px solid var(--v2-hairline);
+}
+:root[data-ui="v2"][data-theme^="terminal"] .v2-analytics-tab-active {
+  color: var(--v2-accent) !important;
+  text-shadow: var(--v2-glow);
 }
 
 :root[data-ui="v2"][data-theme^="terminal"] .v2-analytics-range-btn::before {

--- a/src/v2/wallaby/analytics.css
+++ b/src/v2/wallaby/analytics.css
@@ -58,6 +58,26 @@
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
 }
 
+/* Section tabs → contained segmented control, green active (matches Tasks). */
+[data-theme^="wallaby"] .v2-analytics-tabs {
+  background: var(--wb-card-2);
+  border: 1px solid var(--wb-hairline);
+  border-radius: 999px;
+  padding: 3px;
+  gap: 2px;
+}
+[data-theme^="wallaby"] .v2-analytics-tab {
+  border: none;
+  background: transparent;
+  border-radius: 999px;
+  color: var(--wb-text-meta);
+}
+[data-theme^="wallaby"] .v2-analytics-tab-active {
+  background: var(--wb-action-complete);
+  color: #fff;
+  border: none;
+}
+
 /* Chart fills pick up the Wallaby accent (purple) over the v2 orange */
 [data-theme^="wallaby"] .v2-analytics-daily-bar,
 [data-theme^="wallaby"] .v2-analytics-bd-fill,

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,9 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-07
 
+- feat(analytics): tabbed AnalyticsModal — Overview / Tasks / Habits (all skins) [M]
+  - The single long-scroll AnalyticsModal is now organized into three tabs (shared component, all skins): **Overview** (summary + daily completions + 52-week heatmap + Achievements), **Tasks** (by day of week + Balance radar + by tag/energy/size + adaptive-throttle decisions), and a new **Habits** tab — per-routine completion (count, current streak 🔥, last-done, bar relative to the busiest) derived from `routine.completed_history`, no new endpoint. Range + metric controls stay above the tabs. Implemented by gating existing sections on the active tab (no reorder), so it's low-risk. Base tab styling in `AnalyticsModal.css`; Wallaby override → green segmented control. Focus/mood tabs intentionally omitted (deferred features). Verified headless: tab switching shows the right sections; Habits shows 7 routines with full names.
+
 - feat(ui): swipe-to-reveal actions on Wallaby task rows [S]
   - Brings the Wallaby `TasksView` rows to parity with the v2 TaskCard: swipe a row left to reveal **Done/Reopen** (green) + **Delete** (red). Extracted the v2 TaskCard's gesture into a shared `src/hooks/useSwipeActions.js` (offset/threshold/vertical-cancel, returns `{x, open, swiping, close, handlers}`) and wired it into the Wallaby `TaskRow` (actions panel behind, row slides on `translateX`). Tapping the row still opens the action sheet; an open swipe closes on body tap. Verified headless (touch-emulated): drag-left settles at `translateX(-132)` with Done/Delete revealed. (Standard skin already had swipe via the v2 TaskCard.)
 

--- a/wiki/Wallaby-Ideas.md
+++ b/wiki/Wallaby-Ideas.md
@@ -40,6 +40,7 @@ Bottom nav (loggd): **Home · Habits · Tasks · Timer · More**.
 | Profile / dashboard | ✅ | avatar/bio/year-grid (Tasks/Points)/per-habit grids + **Records strip** (Best day / Best points / Longest streak, from `computeRecords`). Level/XP/badges = 🅿️ gamification; public/share intentionally omitted |
 | Home — daily agenda | ✅ | Pulse + **Daily-summary card** (N tasks·M habits done + day-streak + mini 14-week heatmap) + per-day tasks/habits + interactive date strip. Mood/vision parts = 🅿️ |
 | Settings (visual reskin) | ✅ | Account / Notifications / Preferences / Privacy / API; per-type Push/Email toggles (Boomerang already has the data) |
+| Analytics — tabbed (Overview/Tasks/Habits) | ✅ (2026-06-07) | shared AnalyticsModal split into Overview / Tasks / Habits tabs (new per-habit completion view). Focus/Goals/mood tabs deferred (gated by Timer/mood features). |
 | Analytics (visual reskin) | ✅ (reskin) / 🅿️ | Tabbed **Overview / Habits / Tasks / Goals / Focus**. Weekly **points** total + ‹week› nav, 🔥current/🏆best streak, stat cards (Habits checks, Tasks completed, Focus time, Check-ins), **Points Breakdown by activity type**, weekly **mood bar-chart** + **reflections** recap. Reskin-able: points/streak/habit+task counts (Boomerang has these). Deferred: focus-time, check-ins, mood, badge points (tied to new features). Reached via More/Profile. |
 
 ### Home "Today's Pulse" (richer Home — PDF 1)


### PR DESCRIPTION
## Quick win #5 (final): tabbed Analytics

The long-scroll AnalyticsModal is now organized into three tabs (shared component → **all skins**):

- **Overview** — summary + daily completions + 52-week heatmap + Achievements
- **Tasks** — by day of week + Balance radar + by tag/energy/size + adaptive-throttle decisions
- **Habits** (new) — per-routine completion: count, current streak 🔥, last-done, bar relative to the busiest. Derived from `routine.completed_history` — **no new endpoint**.

Range + metric controls stay above the tabs.

## Low-risk approach

Sections are **gated on the active tab in place** (no reordering of the existing JSX), so the change is additive and the existing charts are untouched. Base tab styling in `AnalyticsModal.css`; Wallaby override → green segmented control; terminal override added (kept the `check:terminal-buttons` gate green). **Focus/mood tabs intentionally omitted** (deferred features).

## Verified

Headless (wallaby-dark): tab switching shows the right sections — Overview {daily, 52-week, Achievements}, Tasks {dow, Balance, tag/energy/size}, Habits {7 routines, full names, count/streak/last-done}. `npm run lint` 0 errors; `check:terminal-titles` + `check:terminal-buttons` pass.

---

This completes **all five green-dot quick wins**: Terminal off · Badges · NL due dates · swipe gestures · tabbed Analytics.

https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk)_