### PR TITLE
feat(ui): wallaby header avatar → growth arrow + streak day-count

### DIFF
--- a/src/v2/wallaby/HomeView.css
+++ b/src/v2/wallaby/HomeView.css
@@ -253,6 +253,8 @@
 .wb-pulse-row:last-child { margin-bottom: 0; }
 .wb-pulse-row em { font-style: normal; color: var(--wb-text-meta); font-weight: 600; }
 .wb-pulse-risk { background: color-mix(in srgb, var(--wb-action-delete) 18%, transparent); color: var(--wb-action-primary); }
+.wb-pulse-risk em { color: inherit; opacity: 0.85; }
+.wb-pulse-risk strong { font-weight: 800; }
 .wb-pulse-habits { background: color-mix(in srgb, var(--wb-cat-purple) 16%, transparent); }
 .wb-pulse-tasks { background: var(--wb-card-2); }
 .wb-pulse-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--wb-cat-purple); flex: 0 0 auto; }

--- a/src/v2/wallaby/HomeView.jsx
+++ b/src/v2/wallaby/HomeView.jsx
@@ -44,8 +44,11 @@ export default function HomeView({
     return { routine: r, color: WALLABY_COLORS[i % WALLABY_COLORS.length], byDay, streak: currentStreak(byDay) }
   }), [habits])
 
-  // Streak at risk: a live streak not yet logged TODAY.
-  const atRisk = enriched.filter(h => !h.byDay[todayKey] && h.streak > 0)
+  // Streak at risk: a live streak not yet logged TODAY. Longest first, so the
+  // Pulse leads with the streak you most don't want to drop.
+  const atRisk = enriched
+    .filter(h => !h.byDay[todayKey] && h.streak > 0)
+    .sort((a, b) => b.streak - a.streak)
 
   // Week strip (Sunday-anchored), paged by weekOffset.
   const weekStart = new Date(today)
@@ -126,7 +129,10 @@ export default function HomeView({
           {atRisk.length > 0 && (
             <div className="wb-pulse-row wb-pulse-risk">
               <Flame size={16} strokeWidth={2.25} />
-              <span>{atRisk.length === 1 ? `${atRisk[0].routine.title} streak at risk` : `${atRisk.length} streaks at risk`}</span>
+              <span>
+                <strong>{atRisk[0].routine.title}</strong> streak at risk
+                {' '}<em>({atRisk[0].streak} day{atRisk[0].streak === 1 ? '' : 's'}{atRisk.length > 1 ? ` · +${atRisk.length - 1} more` : ''})</em>
+              </span>
             </div>
           )}
           <div className="wb-pulse-row wb-pulse-habits">

--- a/src/v2/wallaby/WallabyHeader.css
+++ b/src/v2/wallaby/WallabyHeader.css
@@ -64,6 +64,8 @@
   text-align: center;
 }
 .wb-header-avatar {
+  display: grid;
+  place-items: center;
   width: 32px;
   height: 32px;
   border-radius: 50%;

--- a/src/v2/wallaby/WallabyHeader.jsx
+++ b/src/v2/wallaby/WallabyHeader.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { Bell } from 'lucide-react'
+import { Bell, TrendingUp } from 'lucide-react'
 import Logo from '../../components/Logo'
 import './WallabyHeader.css'
 
@@ -62,7 +62,9 @@ export default function WallabyHeader({
           <Bell size={20} strokeWidth={1.9} />
           {unread > 0 && <span className="wb-header-badge">{unread > 99 ? '99+' : unread}</span>}
         </button>
-        <button className="wb-header-avatar" onClick={onAvatar} aria-label="Profile" />
+        <button className="wb-header-avatar" onClick={onAvatar} aria-label="Profile">
+          <TrendingUp size={17} strokeWidth={2.5} color="#fff" />
+        </button>
       </div>
     </header>
   )

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,10 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-07
 
+- feat(ui): Wallaby header avatar → growth arrow + streak day-count in Pulse [S]
+  - **Header avatar** (`WallabyHeader`): the plain gradient dot now holds an **up-and-right arrow** (`TrendingUp`) — it opens Profile/"Your year", so a growth arrow fits (no real users). (Review-pass req #3.)
+  - **Today's Pulse streak-at-risk** (`HomeView`): the row now names the habit AND shows the streak length, loggd-style — "🔥 **take meds** streak at risk (4 days)" — leading with the longest at-risk streak (`+N more` when several). Uses the already-computed `currentStreak`. (Review-pass req #2.) Verified headless.
+
 - docs: capture 2026-06-07 review-pass feature requests + reference [XS]
   - Saved 5 reference shots to `wiki/wallaby-reference/feature-requests-2026-06-07/` and recorded three paused requests in `wiki/Wallaby-Ideas.md` so they're not lost: (1) **Edit-task modal redesign** into loggd's pill-chip language (real work); (2) **streak-with-day-count** in Today's Pulse (new, easy); (3) **header avatar → ↗ arrow** (easy). No code changes — paused per user.
 


### PR DESCRIPTION
Two easy review-pass requests.

**#3 Header avatar → ↗ arrow** — the plain gradient dot in the top-right now holds an up-and-right arrow (`TrendingUp`). It opens Profile/"Your year", so a growth arrow reads better than a faux user avatar.

**#2 Streak day-count in Today's Pulse** — the streak-at-risk row now names the habit and shows the streak length, loggd-style: "🔥 **take meds** streak at risk (4 days)". Leads with the longest at-risk streak; appends `+N more` when several. Uses the already-computed `currentStreak` — no new data.

Verified headless (wallaby-dark): avatar shows the arrow icon; toggling a daily habit off surfaces "take meds streak at risk (4 days)" with bold name + dimmed count on the orange row. Lint clean.

(Edit-task modal redesign — review-pass #1 — coming as its own PR next.)

https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk)_