### PR TITLE
fix(ui): wallaby — zero pills (de-pill every surface)

### DIFF
--- a/src/v2/wallaby/GoalsView.css
+++ b/src/v2/wallaby/GoalsView.css
@@ -28,7 +28,7 @@
   font-weight: 600;
   color: var(--tag, var(--wb-text-meta));
   background: color-mix(in srgb, var(--tag, #888) 18%, transparent);
-  border-radius: 999px;
+  border-radius: 10px;
   padding: 4px 11px;
 }
 .wb-goal-chip-soft {
@@ -72,14 +72,14 @@
 /* ── Progress bar ────────────────────────────────────────────────────────── */
 .wb-progress {
   height: 8px;
-  border-radius: 999px;
+  border-radius: 4px;
   background: var(--wb-card-2);
   overflow: hidden;
 }
 .wb-progress-big { height: 12px; }
 .wb-progress-fill {
   height: 100%;
-  border-radius: 999px;
+  border-radius: 4px;
   background: linear-gradient(90deg, var(--wb-action-primary), var(--wb-cat-pink));
   transition: width 240ms ease;
 }

--- a/src/v2/wallaby/HabitsView.css
+++ b/src/v2/wallaby/HabitsView.css
@@ -44,7 +44,7 @@
   display: inline-flex;
   background: var(--wb-card-2);
   border: 1px solid var(--wb-hairline);
-  border-radius: 999px;
+  border-radius: 10px;
   padding: 3px;
   gap: 2px;
 }
@@ -55,7 +55,7 @@
   color: var(--wb-text-meta);
   font: 600 12.5px/1 var(--v2-font-body);
   padding: 7px 13px;
-  border-radius: 999px;
+  border-radius: 10px;
   cursor: pointer;
   transition: background 140ms ease, color 140ms ease;
 }
@@ -147,7 +147,7 @@
   font-size: 11.5px;
   font-weight: 700;
   padding: 3px 8px;
-  border-radius: 999px;
+  border-radius: 10px;
   background: var(--wb-card-2);
   color: var(--wb-text-meta);
 }
@@ -280,7 +280,7 @@
   font-size: 13px;
   font-weight: 700;
   padding: 7px 13px;
-  border-radius: 999px;
+  border-radius: 10px;
   background: var(--wb-card-2);
   color: var(--wb-text-meta);
 }

--- a/src/v2/wallaby/HomeView.css
+++ b/src/v2/wallaby/HomeView.css
@@ -51,7 +51,7 @@
   font-weight: 700;
   color: var(--wb-action-complete);
   background: color-mix(in srgb, var(--wb-action-complete) 18%, transparent);
-  border-radius: 999px;
+  border-radius: 10px;
   padding: 4px 10px;
   flex: 0 0 auto;
 }
@@ -163,7 +163,7 @@
   font-weight: 700;
   color: var(--wb-text-meta);
   background: var(--wb-card-2);
-  border-radius: 999px;
+  border-radius: 10px;
   padding: 1px 8px;
 }
 .wb-home-habits { display: flex; flex-direction: column; gap: 9px; }
@@ -299,7 +299,7 @@
   font-weight: 800;
   color: var(--wb-action-primary);
   background: color-mix(in srgb, var(--wb-action-primary) 16%, transparent);
-  border-radius: 999px;
+  border-radius: 10px;
   padding: 4px 10px;
 }
 .wb-summary-heat { overflow: hidden; }
@@ -323,8 +323,8 @@
 .wb-home-card-count { font-size: 12.5px; font-weight: 700; color: var(--wb-text-meta); }
 .wb-home-empty-sm { color: var(--wb-text-meta); font-size: 13.5px; margin: 4px 0; }
 
-.wb-home-progress { height: 6px; border-radius: 999px; background: var(--wb-card-2); overflow: hidden; margin-bottom: 12px; }
-.wb-home-progress-fill { height: 100%; border-radius: 999px; background: var(--wb-action-complete); transition: width 240ms ease; }
+.wb-home-progress { height: 6px; border-radius: 4px; background: var(--wb-card-2); overflow: hidden; margin-bottom: 12px; }
+.wb-home-progress-fill { height: 100%; border-radius: 4px; background: var(--wb-action-complete); transition: width 240ms ease; }
 
 /* ── Task rows on Home ───────────────────────────────────────────────────── */
 .wb-home-tasks { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 4px; }
@@ -351,7 +351,7 @@
   font-size: 11px; font-weight: 600;
   color: var(--tag, var(--wb-text-meta));
   background: color-mix(in srgb, var(--tag, #888) 18%, transparent);
-  border-radius: 999px; padding: 2px 9px;
+  border-radius: 10px; padding: 2px 9px;
 }
 
 /* Habit rows inside the card — icon tile + title + streak + check on one line */

--- a/src/v2/wallaby/ProfileView.css
+++ b/src/v2/wallaby/ProfileView.css
@@ -146,7 +146,7 @@
   display: inline-flex;
   background: var(--wb-card-2);
   border: 1px solid var(--wb-hairline);
-  border-radius: 999px;
+  border-radius: 10px;
   padding: 3px;
   gap: 2px;
 }
@@ -157,7 +157,7 @@
   color: var(--wb-text-meta);
   font: 600 12px/1 var(--v2-font-body);
   padding: 6px 12px;
-  border-radius: 999px;
+  border-radius: 10px;
   cursor: pointer;
 }
 .wb-profile .wb-seg-btn.is-active {
@@ -185,6 +185,6 @@
   font-weight: 700;
   color: var(--wb-text-meta);
   background: var(--wb-card-2);
-  border-radius: 999px;
+  border-radius: 10px;
   padding: 2px 8px;
 }

--- a/src/v2/wallaby/TasksView.css
+++ b/src/v2/wallaby/TasksView.css
@@ -45,7 +45,7 @@
   width: 100%;
   background: var(--wb-card-2);
   border: 1px solid var(--wb-hairline);
-  border-radius: 999px;
+  border-radius: 10px;
   padding: 3px;
   gap: 2px;
 }
@@ -57,7 +57,7 @@
   color: var(--wb-text-meta);
   font: 600 13px/1 var(--v2-font-body);
   padding: 9px 13px;
-  border-radius: 999px;
+  border-radius: 10px;
   cursor: pointer;
 }
 .wb-tasks .wb-seg-btn.is-active {
@@ -98,7 +98,7 @@
   font-weight: 700;
   color: var(--wb-text-meta);
   background: var(--wb-card-2);
-  border-radius: 999px;
+  border-radius: 10px;
   padding: 1px 7px;
 }
 
@@ -197,7 +197,7 @@
   font-weight: 600;
   color: var(--tag, var(--wb-text-meta));
   background: color-mix(in srgb, var(--tag, #888) 18%, transparent);
-  border-radius: 999px;
+  border-radius: 10px;
   padding: 2px 9px;
 }
 
@@ -353,6 +353,6 @@
   font-size: 11px;
   font-weight: 700;
   background: var(--wb-card-2);
-  border-radius: 999px;
+  border-radius: 10px;
   padding: 2px 8px;
 }

--- a/src/v2/wallaby/WallabyHeader.css
+++ b/src/v2/wallaby/WallabyHeader.css
@@ -55,7 +55,7 @@
   min-width: 16px;
   height: 16px;
   padding: 0 4px;
-  border-radius: 999px;
+  border-radius: 10px;
   background: var(--wb-action-delete);
   color: #fff;
   font-size: 10px;

--- a/src/v2/wallaby/analytics.css
+++ b/src/v2/wallaby/analytics.css
@@ -36,7 +36,7 @@
   gap: 2px;
   background: var(--wb-card-2);
   border: 1px solid var(--wb-hairline);
-  border-radius: 999px;
+  border-radius: 10px;
   padding: 3px;
   margin: 0 0 10px;
 }
@@ -45,7 +45,7 @@
   flex: 1 1 0;
   border: none;
   background: transparent;
-  border-radius: 999px;
+  border-radius: 10px;
   padding: 9px 8px;
   color: var(--wb-text-meta);
   font: 600 13px/1 var(--v2-font-body);
@@ -62,14 +62,14 @@
 [data-theme^="wallaby"] .v2-analytics-tabs {
   background: var(--wb-card-2);
   border: 1px solid var(--wb-hairline);
-  border-radius: 999px;
+  border-radius: 10px;
   padding: 3px;
   gap: 2px;
 }
 [data-theme^="wallaby"] .v2-analytics-tab {
   border: none;
   background: transparent;
-  border-radius: 999px;
+  border-radius: 10px;
   color: var(--wb-text-meta);
 }
 [data-theme^="wallaby"] .v2-analytics-tab-active {

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,9 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-07
 
+- fix(ui): Wallaby — zero pills (de-pill every surface) [S]
+  - Per user "Wallaby should have zero pills": swept all `border-radius: 999px` → `10px` rounded squares across every Wallaby surface — segmented controls (Tasks Upcoming/Backlog/Done, Habits Single/Month/Year, Profile Tasks/Points, Analytics Overview/Tasks/Habits + range/metric), tags/label chips, counts/badges (streak chip, section counts, habit counts, "Soon"/"Today" badges, header notification badge), goal chips. Progress bars softened to 4px (clearly non-pill). **True circles preserved** (avatars, the date circle, week dots, round checkboxes at 50%). Combined with the earlier editor de-pill, Wallaby now has no pill-shaped controls. (Shared modals like Snooze/WhatNow keep their own v2 styling — sweep on request.)
+
 - fix(ui): Wallaby editors use rounded-square controls, not iOS pills [XS]
   - The task editors' config controls were fully-rounded **pills** (999px) while the rest of Wallaby's cards/buttons (and the editors' own More-options/Delete buttons) are rounded **squares** (10–18px) — inconsistent. De-pilled both: the chip quick-editor (`.wb-edit-chip` / `-opt` / `-tag` → 11px) and the full editor's controls (`forms.css`: `.v2-form-seg` / `-energy-pill` / `-label-pill` / `-ai-pill` / misc edit chips → 10–11px). Now matches the Wallaby button/card language. (User: "More options still has the rounded pill look … so does the edit menu itself … doesn't the rest use rounded squares?")
 


### PR DESCRIPTION
**"Wallaby should have zero pills."** Done — swept every `border-radius: 999px` → `10px` rounded square across all Wallaby surfaces:

- **Segmented controls** — Tasks (Upcoming/Backlog/Done), Habits (Single/Month/Year), Profile (Tasks/Points), Analytics (Overview/Tasks/Habits + range/metric)
- **Tags / label chips**, **counts / badges** — streak chip ("🔥 1 day"), section counts, habit counts, "Soon"/"Today" badges, the header notification badge, goal chips
- **Progress bars** softened to 4px (clearly not pills)

**Preserved true circles** (50%): avatars, the ↗ header avatar, the date circle, week dots, round checkboxes — those aren't pills.

Combined with the earlier editor de-pill (#438), there are now no pill-shaped controls anywhere in Wallaby.

Verified headless: every `999px` is gone from `src/v2/wallaby/*.css`; spot-check shows no chip/tab radius > 50px; Home + Tasks screenshots confirm rounded-square chips/tabs. Lint clean; terminal-buttons passes.

Note: shared modals reachable from Wallaby (Snooze, WhatNow, Reframe, ConfirmDialog) still use their own v2 styling — I can sweep those too if you spot a pill there.

https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk)_