### PR TITLE
fix(ui): wallaby — de-pill the shared modals (Snooze/WhatNow/Confirm/…)

### DIFF
--- a/src/v2/AppV2.css
+++ b/src/v2/AppV2.css
@@ -5,6 +5,7 @@
 @import './wallaby/analytics.css';
 @import './wallaby/modals.css';
 @import './wallaby/forms.css';
+@import './wallaby/shared.css';
 
 /* Wallaby "Habits" surface mounts as a full-screen overlay above the app. */
 .v2-habits-overlay {

--- a/src/v2/wallaby/shared.css
+++ b/src/v2/wallaby/shared.css
@@ -1,0 +1,34 @@
+/* ════════════════════════════════════════════════════════════════════════
+ * Wallaby de-pill for SHARED v2 components (modals reached from Wallaby:
+ * Snooze, WhatNow, Reframe, Confirm, Suggestions, Packages, Settings, Done,
+ * Activity, Routines, Adviser, …). Most of their pill controls use the
+ * --v2-radius-pill token, so redefining it for Wallaby de-pills them all at
+ * once → rounded squares, matching the Wallaby surfaces.
+ * (User: "Wallaby should have zero pills … wallaby gate those controls.")
+ * ════════════════════════════════════════════════════════════════════════ */
+
+:root[data-ui="v2"][data-theme^="wallaby"] {
+  --v2-radius-pill: 10px;
+}
+
+/* Toggle switches keep a pill track — a switch with a square track + round
+ * thumb reads as broken, and a switch isn't a "pill" control. */
+:root[data-ui="v2"][data-theme^="wallaby"] .v2-settings-toggle-track {
+  border-radius: 999px;
+}
+
+/* Literal-999px badges/chips (the token override can't reach these) → squares. */
+:root[data-ui="v2"][data-theme^="wallaby"] .v2-stack-bonus,
+:root[data-ui="v2"][data-theme^="wallaby"] .v2-form-date-preview {
+  border-radius: 10px !important;
+}
+
+/* Literal-999px progress/indicator BARS → small radius (clearly not pills). */
+:root[data-ui="v2"][data-theme^="wallaby"] .v2-analytics-dow-track,
+:root[data-ui="v2"][data-theme^="wallaby"] .v2-analytics-dow-fill,
+:root[data-ui="v2"][data-theme^="wallaby"] .v2-analytics-bd-track,
+:root[data-ui="v2"][data-theme^="wallaby"] .v2-analytics-bd-fill,
+:root[data-ui="v2"][data-theme^="wallaby"] .v2-badge-progress,
+:root[data-ui="v2"][data-theme^="wallaby"] .v2-edit-checklist-progress {
+  border-radius: 4px !important;
+}

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,9 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-07
 
+- fix(ui): Wallaby — de-pill the shared modals too (Snooze/WhatNow/Confirm/…) [S]
+  - New `src/v2/wallaby/shared.css` (via `AppV2.css`) Wallaby-gates the **shared** v2 components reachable from Wallaby. Most of their pill controls use the `--v2-radius-pill` token, so it's redefined `999px → 10px` for `:root[data-ui="v2"][data-theme^="wallaby"]` — de-pilling Snooze, WhatNow, Reframe, ConfirmDialog, Suggestions, Packages, Settings (segmented + buttons), Adviser, etc. in one shot. **Toggle switches are protected** (`.v2-settings-toggle-track` restored to a pill track — a switch isn't a "pill"). Literal-`999px` stragglers handled too: `.v2-stack-bonus` / `.v2-form-date-preview` → 10px; indicator bars (`.v2-analytics-dow/-bd-track/-fill`, `.v2-badge-progress`, `.v2-edit-checklist-progress`) → 4px. Verified: token = 10px in Wallaby, toggle track = 999px, Settings segmented controls render as rounded squares.
+
 - fix(ui): Wallaby — zero pills (de-pill every surface) [S]
   - Per user "Wallaby should have zero pills": swept all `border-radius: 999px` → `10px` rounded squares across every Wallaby surface — segmented controls (Tasks Upcoming/Backlog/Done, Habits Single/Month/Year, Profile Tasks/Points, Analytics Overview/Tasks/Habits + range/metric), tags/label chips, counts/badges (streak chip, section counts, habit counts, "Soon"/"Today" badges, header notification badge), goal chips. Progress bars softened to 4px (clearly non-pill). **True circles preserved** (avatars, the date circle, week dots, round checkboxes at 50%). Combined with the earlier editor de-pill, Wallaby now has no pill-shaped controls. (Shared modals like Snooze/WhatNow keep their own v2 styling — sweep on request.)
 


### PR DESCRIPTION
Follow-up to the zero-pills sweep: the **shared** modals reachable from Wallaby (Snooze, What-now, Reframe, confirm dialogs, Suggestions, Packages, Settings, Adviser) still used their own v2 pill styling. Now Wallaby-gated and de-pilled.

## How
New `src/v2/wallaby/shared.css` (via `AppV2.css`). Most of those controls use the `--v2-radius-pill` **token**, so it's redefined `999px → 10px` for `:root[data-ui="v2"][data-theme^="wallaby"]` — de-pilling all of them at once (only affects shared components in Wallaby; no Wallaby surface uses the token, and Standard/Terminal are untouched).

**Protected:** toggle switches keep a pill track (`.v2-settings-toggle-track` → 999px) — a switch with a square track + round thumb reads as broken, and a switch isn't a "pill."

**Literal-`999px` stragglers** the token can't reach:
- badges/chips → 10px: `.v2-stack-bonus`, `.v2-form-date-preview`
- indicator bars → 4px: `.v2-analytics-dow/-bd-track/-fill`, `.v2-badge-progress`, `.v2-edit-checklist-progress`

## Verified (headless, wallaby-dark)
- `--v2-radius-pill` = `10px` in Wallaby; `.v2-settings-toggle-track` = `999px` (protected).
- Settings screenshot: Standard/Wallaby + Light/Dark segmented controls render as rounded squares, tabs underline-style, no pills.
- Lint 0 errors; `check:terminal-buttons` + `check:terminal-titles` pass.

https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEBKLe7RnZCv9eX9W7q6nk)_