### PR TITLE
release: wallaby bug fixes (snooze leak, notif scroll, Spaces gate)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1090,8 +1090,12 @@ Tapping a task → `EditTaskModal`, checkbox → `handleComplete`, subtask →
 `updateTask({checklists})`, Home check → toggle `completed_history` today, Goals
 Log session → `logProjectSession` etc. Desktop keeps Kanban + drawer. The old
 `.v2-habits-overlay` Spaces entries (`showHabits`/`showTasks`/`showProfile`/
-`showGoals`) remain wired but are unreachable in Wallaby (the shell covers the
-Spaces hub) — kept as a fallback until the shell fully subsumes them.
+`showGoals`) remain wired but are now fully unreachable — the shell covers the
+Spaces hub in Wallaby, and the four Wallaby-native launcher rows
+(Dashboard/Habits/Tasks/Goals) were removed from `SpacesHub` (2026-06-07) because
+they leaked Wallaby surfaces into the **Standard** theme's hub. The Standard hub
+is back to Projects / Routines / Knowledge; the dead overlay blocks are kept as a
+fallback until the shell fully subsumes them.
 
 **Dev-only render harness.** `wallaby-preview.html` + `src/wallaby-preview.jsx`
 mount `HabitsView` in isolation (mock or API-injected routines) for

--- a/src/v2/AppV2.jsx
+++ b/src/v2/AppV2.jsx
@@ -1238,10 +1238,6 @@ export default function AppV2() {
         }}
         onOpenProjects={() => setShowProjects(true)}
         onOpenRoutines={() => setShowRoutines(true)}
-        onOpenHabits={() => setShowHabits(true)}
-        onOpenTasks={() => setShowTasks(true)}
-        onOpenProfile={() => setShowProfile(true)}
-        onOpenGoals={() => setShowGoals(true)}
         onOpenKnowledge={() => {
           setAdviserDraftSeed("What's in my knowledge base?")
           setShowAdviser(true)

--- a/src/v2/components/SpacesHub.jsx
+++ b/src/v2/components/SpacesHub.jsx
@@ -1,57 +1,26 @@
-import { FolderKanban, RotateCw, BookOpen, Activity, ListTodo, LayoutDashboard, Target, ChevronRight } from 'lucide-react'
+import { FolderKanban, RotateCw, BookOpen, ChevronRight } from 'lucide-react'
 import ModalShell from './ModalShell'
 import './SpacesHub.css'
 
-// Spaces tab destination. Hub of the three "not-today" surfaces:
-// Projects, Routines, Knowledge. Each row is a tappable launcher that
-// opens the existing dedicated modal — we don't embed the modals
-// inline. Reason: ProjectsView and RoutinesModal both ship their own
-// ModalShell, and refactoring them to render bodyless is more risk
-// than reward for D. C-upgrade replaces this row list with rich
+// Spaces tab destination (Standard / non-Wallaby UI). Hub of the three
+// "not-today" surfaces: Projects, Routines, Knowledge. Each row is a
+// tappable launcher that opens the existing dedicated modal — we don't
+// embed the modals inline. Reason: ProjectsView and RoutinesModal both
+// ship their own ModalShell, and refactoring them to render bodyless is
+// more risk than reward for D. C-upgrade replaces this row list with rich
 // preview cards (live session counts, last-edited timestamps, etc.)
 // without changing the launcher contract — `useSpaces()` will feed
 // the same hub a richer data shape.
+//
+// The Wallaby-native surfaces (Dashboard/Habits/Tasks/Goals) live in the
+// WallabyShell, NOT here — they're reached via the Wallaby bottom nav. They
+// used to be listed here as a fallback, but that leaked Wallaby views into the
+// Standard theme's hub, so they were removed (the Wallaby gate must hold).
 export default function SpacesHub({
   open, onClose,
-  onOpenProjects, onOpenRoutines, onOpenHabits, onOpenTasks, onOpenProfile, onOpenGoals, onOpenKnowledge,
+  onOpenProjects, onOpenRoutines, onOpenKnowledge,
 }) {
   const rows = [
-    {
-      key: 'dashboard',
-      icon: LayoutDashboard,
-      tint: 'projects',
-      label: 'Dashboard',
-      subtitle: 'Stats + your activity year',
-      terminalCmd: '> dashboard',
-      onClick: onOpenProfile,
-    },
-    {
-      key: 'habits',
-      icon: Activity,
-      tint: 'routines',
-      label: 'Habits',
-      subtitle: 'Routines as contribution heatmaps',
-      terminalCmd: '> habits',
-      onClick: onOpenHabits,
-    },
-    {
-      key: 'tasks',
-      icon: ListTodo,
-      tint: 'projects',
-      label: 'Tasks',
-      subtitle: 'Upcoming + backlog · subtasks',
-      terminalCmd: '> tasks',
-      onClick: onOpenTasks,
-    },
-    {
-      key: 'goals',
-      icon: Target,
-      tint: 'projects',
-      label: 'Goals',
-      subtitle: 'Projects · progress + sessions',
-      terminalCmd: '> goals',
-      onClick: onOpenGoals,
-    },
     {
       key: 'projects',
       icon: FolderKanban,

--- a/src/v2/wallaby/HomeView.jsx
+++ b/src/v2/wallaby/HomeView.jsx
@@ -5,6 +5,7 @@ import {
 } from 'lucide-react'
 import ContributionHeatmap from './ContributionHeatmap'
 import { WALLABY_COLORS, historyByDay, currentStreak, localYMD } from './heatmapUtils'
+import { isSnoozed } from '../../store'
 import './HomeView.css'
 
 const ENERGY_ICONS = { desk: Monitor, people: Users, errand: MapPin, creative: Palette, physical: Dumbbell }
@@ -77,6 +78,9 @@ export default function HomeView({
       const dueKey = t.due_date ? String(t.due_date).slice(0, 10) : null
       const doneKey = (t.status === 'done' && t.completed_at) ? localYMD(new Date(t.completed_at)) : null
       if (doneKey === selectedKey) return true
+      // Snoozed tasks (incl. routine spawns waiting on their trigger time, and
+      // "set aside" tasks) aren't actionable yet — keep them out of the day list.
+      if (isSnoozed(t)) return false
       if (ACTIVE.includes(t.status)) return isToday ? (dueKey ? dueKey <= todayKey : false) : dueKey === selectedKey
       return false
     }).sort((a, b) => (a.status === 'done' ? 1 : 0) - (b.status === 'done' ? 1 : 0))

--- a/src/v2/wallaby/NotificationsView.css
+++ b/src/v2/wallaby/NotificationsView.css
@@ -1,11 +1,15 @@
 /* Wallaby notifications center — reads the existing notification_log. */
 .wb-notifs {
-  min-height: 100vh;
+  /* Fill the scroll surface exactly (it already sits below the 52px header), not
+   * the full viewport — `100vh` overflowed the container by the header height,
+   * so even an empty notifications list scrolled ~52px of dead space. */
+  min-height: 100%;
   background: var(--wb-bg);
   color: var(--wb-text);
   padding: 16px 16px 120px;
   font-family: var(--v2-font-body);
   -webkit-font-smoothing: antialiased;
+  overflow-wrap: anywhere;
 }
 .wb-notifs-title { font-size: 24px; margin-right: auto; }
 .wb-notifs-markall {

--- a/src/v2/wallaby/TasksView.jsx
+++ b/src/v2/wallaby/TasksView.jsx
@@ -4,6 +4,7 @@ import {
   Inbox, CheckCircle2, Archive, Pencil, Trash2, Timer, X, Calendar,
 } from 'lucide-react'
 import { localYMD } from './heatmapUtils'
+import { isSnoozed } from '../../store'
 import { useSwipeActions } from '../../hooks/useSwipeActions'
 import './TasksView.css'
 
@@ -34,7 +35,9 @@ export default function TasksView({
   }, [labels])
 
   const counts = useMemo(() => ({
-    upcoming: tasks.filter(t => ACTIVE.includes(t.status) && !t.gmail_pending && !t.parent_id).length,
+    // Upcoming excludes snoozed tasks (routine spawns waiting on a trigger time,
+    // "set aside" tasks) — they aren't actionable yet.
+    upcoming: tasks.filter(t => ACTIVE.includes(t.status) && !t.gmail_pending && !t.parent_id && !isSnoozed(t)).length,
     backlog: tasks.filter(t => t.status === 'backlog' && !t.gmail_pending && !t.parent_id).length,
     done: tasks.filter(t => t.status === 'done').length,
   }), [tasks])
@@ -45,7 +48,7 @@ export default function TasksView({
       if (t.gmail_pending || t.parent_id) return false
       if (tab === 'done') { if (t.status !== 'done') return false }
       else if (tab === 'backlog') { if (t.status !== 'backlog') return false }
-      else if (!ACTIVE.includes(t.status)) return false
+      else if (!ACTIVE.includes(t.status) || isSnoozed(t)) return false
       if (q && !t.title.toLowerCase().includes(q)) return false
       return true
     })

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,11 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-07
 
+- fix(ui): Wallaby — three post-promotion bug fixes (snooze leak / notif scroll / Spaces gate) [S]
+  - **Routine spawns showing before their trigger time** (Home + Tasks): the Wallaby `HomeView` daily list and `TasksView` Upcoming list filtered on active status but never excluded snoozed tasks — so routine-spawned tasks waiting on a `trigger_time` (snoozed until, e.g., 8pm) and "set aside" tasks surfaced hours early. Both now exclude `isSnoozed(task)` (shared `store.js` helper), matching the standard v2 list, which keeps snoozed tasks out of the active sections. Verified headless: a task due today but snoozed +3h is absent from Home and from the Upcoming count.
+  - **Weird scrolling in Notifications**: `.wb-notifs` used `min-height: 100vh`, but the surface scroll container already sits below the 52px header — so the content was 52px taller than its container and even an empty notifications list scrolled ~52px of dead space. Changed to `min-height: 100%` (fills the surface exactly) + `overflow-wrap: anywhere` (defensive against long bodies). Verified: scrollHeight now equals clientHeight (no phantom scroll).
+  - **Wallaby gate not holding in the Standard Spaces hub**: `SpacesHub` listed the four Wallaby-native surfaces (Dashboard/Habits/Tasks/Goals) as launcher rows. They're unreachable in Wallaby (the shell covers the hub) and conceptually wrong in Standard, so they leaked Wallaby views into the Standard theme. Removed those four rows (+ now-unused icon imports and `onOpen*` props at the `AppV2` callsite); the hub is back to Projects / Routines / Knowledge. The dead `.v2-habits-overlay` blocks remain as documented unreachable fallback. Verified: Standard hub renders exactly `[Projects, Routines, Knowledge]`.
+
 - chore(release): delete `wiki/wallaby-reference/` ahead of prod promotion [XS]
   - Removed the 9.9 MB of external loggd reference PDFs/screenshots (+ the 2026-06-07 feature-request shots) — they must not ship to prod, per the dev→main ritual. Recoverable from git history. Doc links updated to note the removal.
 


### PR DESCRIPTION
Promotes the three Wallaby bug fixes from `dev` to production.

## Included
- **fix(ui): wallaby — snooze leak, notif scroll, Spaces gate** (`d46919e`)
  - Home/Tasks snooze leak: routine spawns no longer surface before their `trigger_time`; "set aside" tasks stay hidden.
  - Notifications scroll: `.wb-notifs` `min-height:100%` so an empty list no longer scrolls ~52px.
  - Spaces hub Wallaby-leak: Standard theme's hub is back to Projects / Routines / Knowledge.

## Release mechanics
- Head is a fresh release branch (`claude/release-wallaby-bugfix`), **not `dev`** — so the auto-delete on merge can't touch `dev`.
- Merge method must be **`merge`** (merge commit, NOT rebase/squash) to keep `main` an ancestor-subset of `dev`.
- `wiki/wallaby-reference/` confirmed absent (already removed in the prior release).

https://claude.ai/code/session_01XknMCTidXtBkDpUz1hhoKR

---
_Generated by [Claude Code](https://claude.ai/code/session_01XknMCTidXtBkDpUz1hhoKR)_