### PR TITLE
chore(deps): override hono to ^4.12.23 to clear 4 moderate advisories [XS]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4815,9 +4815,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.18",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
-      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "version": "4.12.23",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
+      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   },
   "overrides": {
     "lodash": "4.18.1",
-    "serialize-javascript": "^7.0.5"
+    "serialize-javascript": "^7.0.5",
+    "hono": "^4.12.23"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -4,6 +4,13 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ---
 
+## 2026-06-08
+
+- chore(deps): override `hono` to `^4.12.23` to clear 4 moderate advisories [XS]
+  - Dependabot flagged 4 moderate `hono` advisories (IPv6 deny-rule bypass GHSA-xrhx-7g5j-rcj5, Set-Cookie injection GHSA-3hrh-pfw6-9m5x, JWT non-Bearer scheme GHSA-f577-qrjj-4474, `app.mount()` percent-encoded routing GHSA-2gcr-mfcq-wcc3). `hono` is a transitive dep only — pulled by `@modelcontextprotocol/sdk` (`^4.11.4`) and the `@hono/node-server` peer (`^4`); it's not imported anywhere in Boomerang's own code. Added a `hono: "^4.12.23"` entry to the existing `overrides` block, bumping the locked version `4.12.18 → 4.12.23` (latest 4.x). Both dependents accept `^4`, so no breaking change. `npm audit` now reports **0 vulnerabilities**; smoke test passes (server boots, MCP SDK loads, JS bundle builds clean).
+
+---
+
 ## 2026-06-07
 
 - fix(ui): Wallaby — three post-promotion bug fixes (snooze leak / notif scroll / Spaces gate) [S]


### PR DESCRIPTION
Clears the 4 moderate Dependabot advisories on `hono`.

## What
`hono` is a **transitive dep only** — pulled by `@modelcontextprotocol/sdk` (`^4.11.4`) and the `@hono/node-server` peer (`^4`); it is **not imported anywhere in Boomerang's own code**. Added a `hono: "^4.12.23"` entry to the existing `overrides` block, bumping the locked version `4.12.18 → 4.12.23` (latest 4.x).

## Advisories cleared
- IPv6 deny-rule bypass — GHSA-xrhx-7g5j-rcj5
- Set-Cookie injection via cookie helper — GHSA-3hrh-pfw6-9m5x
- JWT middleware accepts any Authorization scheme — GHSA-f577-qrjj-4474
- `app.mount()` percent-encoded routing — GHSA-2gcr-mfcq-wcc3

## Safety
- Both dependents accept `^4`, so no breaking change.
- Lockfile diff is **only** the `hono` version bump (3 lines).
- `npm audit` → **0 vulnerabilities**.

## Testing
- Smoke test passes: production bundle builds, server boots, MCP SDK loads, JS bundle parses.
- Lint: 0 errors (only pre-existing warnings).

Merge method: **rebase** (linear history on `dev`).

https://claude.ai/code/session_01XknMCTidXtBkDpUz1hhoKR

---
_Generated by [Claude Code](https://claude.ai/code/session_01XknMCTidXtBkDpUz1hhoKR)_