### PR TITLE
feat(ui): Kept K2 — canonical date module + signature viz components

### DIFF
--- a/kept-viz-preview.html
+++ b/kept-viz-preview.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<!-- Dev-only render harness for the Kept viz components (K2). Mounts all four
+     with seeded mock data via vite dev. NOT referenced by index.html. -->
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&family=Fraunces:opsz,wght@9..144,600;9..144,700&display=swap" rel="stylesheet" />
+    <title>Kept viz preview</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/kept-viz-preview.jsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "start": "node server.js",
     "lint": "eslint .",
-    "test": "sh scripts/smoke-test.sh",
+    "test": "node --test scripts/dates.test.mjs && sh scripts/smoke-test.sh",
     "prepare": "git config core.hooksPath .githooks || true",
     "preview": "vite preview"
   },

--- a/scripts/dates.test.mjs
+++ b/scripts/dates.test.mjs
@@ -1,0 +1,40 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { parseLocalDate, localYMD, addDays, weekStartMonday } from '../src/dates.js'
+
+test('YMD strings are local days (the UTC-midnight trap)', () => {
+  const d = parseLocalDate('2026-06-10')
+  assert.equal(d.getFullYear(), 2026)
+  assert.equal(d.getMonth(), 5)
+  assert.equal(d.getDate(), 10)        // bare new Date() gives 9 west of UTC
+  assert.equal(d.getHours(), 0)
+  assert.equal(localYMD('2026-06-10'), '2026-06-10')  // passthrough
+})
+
+test('localYMD handles Date, ISO timestamp, default', () => {
+  assert.equal(localYMD(new Date(2026, 0, 5)), '2026-01-05')
+  const iso = new Date(2026, 11, 31, 23, 30).toISOString()
+  assert.equal(localYMD(iso), localYMD(new Date(2026, 11, 31, 23, 30)))
+  assert.match(localYMD(), /^\d{4}-\d{2}-\d{2}$/)
+  assert.equal(localYMD('garbage'), null)
+})
+
+test('addDays crosses month boundaries on local calendar', () => {
+  assert.equal(localYMD(addDays('2026-01-31', 1)), '2026-02-01')
+  assert.equal(localYMD(addDays('2026-03-01', -1)), '2026-02-28')
+  assert.equal(localYMD(addDays('2024-02-28', 1)), '2024-02-29') // leap
+})
+
+test('streak chaining: consecutive YMD keys differ by exactly one addDays', () => {
+  const days = ['2026-06-08', '2026-06-09', '2026-06-10']
+  for (let i = 1; i < days.length; i++) {
+    assert.equal(localYMD(addDays(days[i - 1], 1)), days[i])
+  }
+})
+
+test('weekStartMonday anchors to Monday', () => {
+  const ws = weekStartMonday('2026-06-10') // a Wednesday
+  assert.equal(ws.getDay(), 1)
+  assert.equal(localYMD(ws), '2026-06-08')
+  assert.equal(localYMD(weekStartMonday('2026-06-08')), '2026-06-08') // Monday stays
+})

--- a/src/dates.js
+++ b/src/dates.js
@@ -1,0 +1,57 @@
+// Canonical date helpers — THE one date module (Kept K2). Merges the two
+// historical localYMD implementations (store.js expected a Date;
+// wallaby/heatmapUtils accepted anything) into one contract:
+//
+//   * 'YYYY-MM-DD' strings are LOCAL calendar days. Never feed them to bare
+//     new Date(): the spec parses them as UTC midnight, which is the
+//     PREVIOUS local day anywhere west of UTC (the bug class behind tasks
+//     due today grouping as Overdue, off-by-one target dates, and broken
+//     streak chains — three separate incidents).
+//   * Full ISO timestamps and Date objects parse normally.
+//
+// Tested by scripts/dates.test.mjs (runs in `npm test`).
+
+const YMD_RE = /^\d{4}-\d{2}-\d{2}$/
+
+// → Date at LOCAL midnight for date-only strings; normal parse otherwise.
+//   Returns null for unparseable input.
+export function parseLocalDate(d) {
+  if (typeof d === 'string' && YMD_RE.test(d)) {
+    const [y, m, day] = d.split('-').map(Number)
+    return new Date(y, m - 1, day)
+  }
+  const x = new Date(d)
+  return Number.isNaN(x.getTime()) ? null : x
+}
+
+// → 'YYYY-MM-DD' local day key. Date-only strings pass through unchanged
+//   (they already ARE local day keys). Defaults to today.
+export function localYMD(d = new Date()) {
+  if (typeof d === 'string' && YMD_RE.test(d)) return d
+  const x = parseLocalDate(d)
+  if (!x) return null
+  return `${x.getFullYear()}-${String(x.getMonth() + 1).padStart(2, '0')}-${String(x.getDate()).padStart(2, '0')}`
+}
+
+// → new Date offset by n days (local-calendar aware via setDate).
+export function addDays(d, n) {
+  const x = parseLocalDate(d)
+  x.setDate(x.getDate() + n)
+  return x
+}
+
+// → Monday-anchored start of the week containing `ref` (+ weekOffset weeks).
+export function weekStartMonday(ref, weekOffset = 0) {
+  const d = parseLocalDate(ref)
+  d.setHours(0, 0, 0, 0)
+  const dow = (d.getDay() + 6) % 7 // 0 = Monday
+  d.setDate(d.getDate() - dow + weekOffset * 7)
+  return d
+}
+
+const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+export function fmtMonthDay(d) {
+  const x = parseLocalDate(d)
+  return `${MONTHS[x.getMonth()]} ${x.getDate()}`
+}
+export function monthShort(i) { return MONTHS[i] }

--- a/src/kept-viz-preview.jsx
+++ b/src/kept-viz-preview.jsx
@@ -1,0 +1,36 @@
+// Dev-only harness mounting the Kept K2 viz components with mock data so they
+// can be screenshot-verified in isolation. Never shipped (not in index.html).
+import { createRoot } from 'react-dom/client'
+import './index.css'
+import './tokens.css'
+import './kept/palette.css'
+import FlightTrail from './kept/FlightTrail'
+import MonthDots from './kept/MonthDots'
+import DensityRibbon from './kept/DensityRibbon'
+import DayArc from './kept/DayArc'
+import { localYMD, addDays } from './dates'
+
+const root = document.documentElement
+root.setAttribute('data-ui', 'v2')
+root.setAttribute('data-theme', new URLSearchParams(location.search).get('mode') === 'light' ? 'kept-light' : 'kept-dark')
+
+// Deterministic mock history: ~68% done-rate over the past year.
+let seed = 42
+const rnd = () => (seed = (seed * 16807) % 2147483647) / 2147483647
+const byDay = {}
+for (let i = 0; i < 366; i++) {
+  if (rnd() > 0.32) byDay[localYMD(addDays(new Date(), -i))] = 1 + Math.floor(rnd() * 3)
+}
+
+const card = { background: 'var(--bm-card)', border: '1px solid var(--bm-hairline)', borderRadius: 16, padding: 16, marginBottom: 14 }
+const label = { font: '700 11px DM Sans', letterSpacing: '0.1em', textTransform: 'uppercase', color: 'var(--bm-text-meta)', marginBottom: 10 }
+
+createRoot(document.getElementById('root')).render(
+  <div style={{ width: 390, margin: '0 auto', padding: 16, background: 'var(--bm-bg)', minHeight: '100vh', fontFamily: 'DM Sans' }}>
+    <div style={card}><div style={label}>Day Arc</div><DayArc value={21} goal={30} /></div>
+    <div style={card}><div style={label}>Flight Trail (10 weeks)</div><FlightTrail valueByDay={byDay} color="var(--bm-f-eucalypt)" /></div>
+    <div style={card}><div style={label}>Flight Trail (mini)</div><FlightTrail valueByDay={byDay} color="var(--bm-f-ironbark)" mini /></div>
+    <div style={card}><div style={label}>Month Dots</div><MonthDots valueByDay={byDay} color="var(--bm-f-billabong)" /></div>
+    <div style={card}><div style={label}>Density Ribbon (year)</div><DensityRibbon valueByDay={byDay} color="var(--bm-f-heath)" /></div>
+  </div>,
+)

--- a/src/kept/DayArc.jsx
+++ b/src/kept/DayArc.jsx
@@ -1,0 +1,39 @@
+import './viz.css'
+
+// Day Arc — the Kept daily hero gauge (spec §5.4): a semicircular gold sweep
+// from 0 to the day's points goal, hairline ticks at tenths, a tip dot, the
+// count in the display face beneath the apex.
+export default function DayArc({ value = 0, goal = 1, caption = 'points today' }) {
+  const W = 250, H = 118, cx = W / 2, cy = H - 4, r = 88
+  const pct = Math.max(0, Math.min(1, goal > 0 ? value / goal : 0))
+  const pt = a => [cx + r * Math.cos(Math.PI * (1 - a)), cy - r * Math.sin(Math.PI * (1 - a))]
+  const arc = (a0, a1) => {
+    const [x0, y0] = pt(a0); const [x1, y1] = pt(a1)
+    return `M ${x0.toFixed(1)} ${y0.toFixed(1)} A ${r} ${r} 0 0 1 ${x1.toFixed(1)} ${y1.toFixed(1)}`
+  }
+  const ticks = []
+  for (let i = 1; i < 10; i++) {
+    const a = i / 10
+    const [x, y] = pt(a)
+    const x2 = cx + (r - 7) * Math.cos(Math.PI * (1 - a))
+    const y2 = cy - (r - 7) * Math.sin(Math.PI * (1 - a))
+    ticks.push(<line key={i} x1={x} y1={y} x2={x2} y2={y2} stroke="var(--bm-hairline-strong)" strokeWidth="1.5" />)
+  }
+  const tip = pt(pct)
+
+  return (
+    <div className="bm-dayarc" role="img" aria-label={`${value} of ${goal} ${caption}`}>
+      <svg viewBox={`0 0 ${W} ${H}`}>
+        <path d={arc(0, 1)} stroke="var(--bm-trail-empty)" strokeWidth="10" strokeLinecap="round" fill="none" />
+        {ticks}
+        {pct > 0 && <path d={arc(0, pct)} stroke="var(--bm-gold)" strokeWidth="10" strokeLinecap="round" fill="none" />}
+        <circle cx={tip[0]} cy={tip[1]} r="7" fill="var(--bm-gold)" />
+        <circle cx={tip[0]} cy={tip[1]} r="2.8" fill="var(--bm-on-gold)" />
+      </svg>
+      <div className="bm-dayarc-center">
+        <div className="bm-dayarc-num">{value}<span className="bm-dayarc-goal"> / {goal}</span></div>
+        <div className="bm-dayarc-cap">{caption}</div>
+      </div>
+    </div>
+  )
+}

--- a/src/kept/DensityRibbon.jsx
+++ b/src/kept/DensityRibbon.jsx
@@ -1,0 +1,51 @@
+import { useId, useMemo } from 'react'
+import { localYMD, addDays, weekStartMonday, monthShort } from '../dates'
+import './viz.css'
+
+// Density Ribbon — the Kept year view (spec §5.3): weekly totals as a smooth
+// gradient-filled area curve. Replaces the 53-week contribution grid.
+export default function DensityRibbon({ valueByDay = {}, color = 'var(--bm-gold)', weeks = 52 }) {
+  const gid = useId()
+  const { path, area, labels } = useMemo(() => {
+    const end = weekStartMonday(new Date())
+    const totals = []
+    const labels = []
+    // ~6 evenly-spaced month labels across the window.
+    const labelEvery = Math.max(1, Math.round(weeks / 6))
+    for (let w = weeks - 1; w >= 0; w--) {
+      const ws = addDays(end, -7 * w)
+      let t = 0
+      for (let d = 0; d < 7; d++) t += valueByDay[localYMD(addDays(ws, d))] || 0
+      totals.push(t)
+      if ((weeks - 1 - w) % labelEvery === Math.floor(labelEvery / 2)) labels.push(monthShort(ws.getMonth()))
+    }
+    const W = 320, H = 64
+    const max = Math.max(1, ...totals)
+    const x = i => (i / (totals.length - 1)) * W
+    const y = v => H - 8 - (v / max) * (H - 18)
+    let d = `M 0 ${y(totals[0]).toFixed(1)}`
+    for (let i = 1; i < totals.length; i++) {
+      const xm = ((x(i - 1) + x(i)) / 2).toFixed(1)
+      d += ` C ${xm} ${y(totals[i - 1]).toFixed(1)}, ${xm} ${y(totals[i]).toFixed(1)}, ${x(i).toFixed(1)} ${y(totals[i]).toFixed(1)}`
+    }
+    return { path: d, area: `${d} L ${W} ${H} L 0 ${H} Z`, labels }
+  }, [valueByDay, weeks])
+
+  return (
+    <div className="bm-ribbon" role="img" aria-label="Yearly completion density">
+      <svg viewBox="0 0 320 64">
+        <defs>
+          <linearGradient id={gid} x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0" stopColor={color} stopOpacity="0.45" />
+            <stop offset="1" stopColor={color} stopOpacity="0" />
+          </linearGradient>
+        </defs>
+        <path d={area} fill={`url(#${gid})`} />
+        <path d={path} stroke={color} strokeWidth="2" fill="none" strokeLinecap="round" />
+      </svg>
+      {labels.length > 1 && (
+        <div className="bm-ribbon-months">{labels.map((l, i) => <span key={i}>{l.toUpperCase()}</span>)}</div>
+      )}
+    </div>
+  )
+}

--- a/src/kept/FlightTrail.jsx
+++ b/src/kept/FlightTrail.jsx
@@ -1,0 +1,80 @@
+import { useMemo } from 'react'
+import { localYMD, addDays, weekStartMonday } from '../dates'
+import './viz.css'
+
+// Flight Trail — the Kept signature loop-history viz (spec §5.1). Rows of 14
+// round day-dots (2 weeks per row); consecutive done-days are bridged by a
+// low ARC stroke, so streaks literally read as flights. `mini` renders a
+// single trailing-14-day row for list rows.
+export default function FlightTrail({ valueByDay = {}, color = 'var(--bm-gold)', weeks = 10, mini = false }) {
+  const { rows, COLS, max } = useMemo(() => {
+    const COLS = 14
+    const nRows = mini ? 1 : Math.ceil(weeks / 2)
+    const today = new Date(); today.setHours(0, 0, 0, 0)
+    // End on the Sunday closing the current Monday-anchored week so rows align.
+    const end = addDays(weekStartMonday(today), 13)
+    const start = addDays(end, -(nRows * COLS) + 1)
+    let max = 1
+    const rows = []
+    for (let r = 0; r < nRows; r++) {
+      const row = []
+      for (let c = 0; c < COLS; c++) {
+        const d = addDays(start, r * COLS + c)
+        const key = localYMD(d)
+        const v = valueByDay[key] || 0
+        if (v > max) max = v
+        row.push({ key, v, future: d > today })
+      }
+      rows.push(row)
+    }
+    return { rows, COLS, max }
+  }, [valueByDay, weeks, mini])
+
+  const step = 23, rstep = 30, r = 4
+  const W = COLS * step, H = rows.length * rstep + 4
+  const els = []
+  rows.forEach((row, ri) => {
+    const y = ri * rstep + 22
+    row.forEach((c, i) => {
+      const x = i * step + step / 2
+      els.push(
+        <circle
+          key={c.key}
+          cx={x} cy={y} r={r}
+          fill={c.v > 0 && !c.future ? color : 'var(--bm-trail-empty)'}
+          opacity={c.v > 0 ? 0.55 + 0.45 * (c.v / max) : c.future ? 0.35 : 1}
+        >
+          <title>{`${c.key}: ${c.v}`}</title>
+        </circle>,
+      )
+    })
+    // streak arcs over consecutive runs
+    let i = 0
+    while (i < row.length) {
+      if (row[i].v > 0 && !row[i].future) {
+        let j = i
+        while (j + 1 < row.length && row[j + 1].v > 0 && !row[j + 1].future) j++
+        if (j > i) {
+          const x0 = i * step + step / 2, x1 = j * step + step / 2
+          const lift = Math.min(13, 5 + (j - i) * 1.7)
+          els.push(
+            <path
+              key={`arc-${ri}-${i}`}
+              d={`M ${x0} ${y - 6} Q ${(x0 + x1) / 2} ${y - 6 - lift} ${x1} ${y - 6}`}
+              stroke={color} strokeWidth="1.8" fill="none" opacity="0.8"
+            />,
+          )
+        }
+        i = j + 1
+      } else i++
+    }
+  })
+
+  return (
+    <div className="bm-trail" role="img" aria-label="Completion trail">
+      <svg viewBox={`0 0 ${W} ${H}`} style={mini ? { width: COLS * 9, height: H * (9 / step) } : undefined}>
+        {els}
+      </svg>
+    </div>
+  )
+}

--- a/src/kept/MonthDots.jsx
+++ b/src/kept/MonthDots.jsx
@@ -1,0 +1,56 @@
+import { useMemo } from 'react'
+import { localYMD } from '../dates'
+import './viz.css'
+
+// Month Dots — Kept calendar view (spec §5.2): numbered circle cells, done
+// days filled with the loop's feather, adjacent done-days bridged by arcs.
+const DOW = ['M', 'T', 'W', 'T', 'F', 'S', 'S']
+
+export default function MonthDots({ monthRef = new Date(), valueByDay = {}, color = 'var(--bm-gold)' }) {
+  const cells = useMemo(() => {
+    const first = new Date(monthRef.getFullYear(), monthRef.getMonth(), 1)
+    const startPad = (first.getDay() + 6) % 7
+    const daysInMonth = new Date(first.getFullYear(), first.getMonth() + 1, 0).getDate()
+    const out = []
+    for (let i = 0; i < startPad; i++) out.push(null)
+    for (let d = 1; d <= daysInMonth; d++) {
+      const key = localYMD(new Date(first.getFullYear(), first.getMonth(), d))
+      out.push({ d, key, done: (valueByDay[key] || 0) > 0 })
+    }
+    return out
+  }, [monthRef, valueByDay])
+
+  const step = 32, rstep = 30, r = 7.5
+  const rows = Math.ceil(cells.length / 7)
+  const W = 7 * step, H = rows * rstep + 16
+  const els = DOW.map((d, i) => (
+    <text key={`h${i}`} x={i * step + step / 2} y={9} textAnchor="middle"
+      fontSize="8.5" fontWeight="700" fill="var(--bm-text-faint)" fontFamily="inherit">{d}</text>
+  ))
+  cells.forEach((c, idx) => {
+    if (!c) return
+    const i = idx % 7, ri = Math.floor(idx / 7)
+    const x = i * step + step / 2, y = ri * rstep + 26
+    els.push(
+      <circle key={c.key} cx={x} cy={y} r={r}
+        fill={c.done ? color : 'transparent'}
+        stroke={c.done ? color : 'var(--bm-hairline-strong)'} strokeWidth="1.4" />,
+      <text key={`t${c.key}`} x={x} y={y + 3} textAnchor="middle" fontSize="8.5"
+        fontWeight="650" fill={c.done ? 'var(--bm-on-gold)' : 'var(--bm-text-meta)'} fontFamily="inherit">{c.d}</text>,
+    )
+    const next = cells[idx + 1]
+    if (c.done && next && next.done && i < 6) {
+      const x1 = (i + 1) * step + step / 2
+      els.push(
+        <path key={`a${c.key}`} d={`M ${x + 4} ${y - 8} Q ${(x + x1) / 2} ${y - 16} ${x1 - 4} ${y - 8}`}
+          stroke={color} strokeWidth="1.6" fill="none" opacity="0.75" />,
+      )
+    }
+  })
+
+  return (
+    <div className="bm-month" role="img" aria-label="Month completion calendar">
+      <svg viewBox={`0 0 ${W} ${H}`}>{els}</svg>
+    </div>
+  )
+}

--- a/src/kept/viz.css
+++ b/src/kept/viz.css
@@ -1,0 +1,34 @@
+/* Kept signature data-viz (wiki/Kept-Design-Language.md §5).
+ * Arcs, not grids: FlightTrail / MonthDots / DensityRibbon / DayArc.
+ * All colors via --bm-* tokens or the feather `color` prop. */
+
+.bm-trail { width: 100%; }
+.bm-trail svg { display: block; width: 100%; height: auto; }
+
+.bm-month { width: 100%; }
+.bm-month svg { display: block; width: 100%; height: auto; }
+
+.bm-ribbon { width: 100%; }
+.bm-ribbon svg { display: block; width: 100%; height: auto; }
+.bm-ribbon-months {
+  display: flex;
+  justify-content: space-between;
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  color: var(--bm-text-faint);
+  padding: 4px 2px 0;
+}
+
+.bm-dayarc { position: relative; width: 100%; }
+.bm-dayarc svg { display: block; width: 100%; height: auto; }
+.bm-dayarc-center { position: absolute; inset: auto 0 4px 0; text-align: center; }
+.bm-dayarc-num {
+  font-family: var(--v2-font-display);
+  font-weight: 700;
+  font-size: 30px;
+  line-height: 1;
+  color: var(--bm-text);
+}
+.bm-dayarc-goal { font-size: 14px; color: var(--bm-text-meta); }
+.bm-dayarc-cap { font-size: 10.5px; color: var(--bm-text-meta); margin-top: 2px; }

--- a/src/store.js
+++ b/src/store.js
@@ -1,3 +1,4 @@
+import { localYMD, parseLocalDate } from './dates'
 // crypto.randomUUID is unavailable over plain HTTP (non-secure context)
 export const uuid = () =>
   typeof crypto !== 'undefined' && crypto.randomUUID
@@ -225,12 +226,9 @@ function touchModified() {
 // first — for a user in Central time, after ~6pm CST that flips the key to
 // the next calendar day and causes subtle off-by-one bugs across the UI.
 // Pass no argument to get today's local key.
-export function localYMD(d = new Date()) {
-  const y = d.getFullYear()
-  const m = String(d.getMonth() + 1).padStart(2, '0')
-  const day = String(d.getDate()).padStart(2, '0')
-  return `${y}-${m}-${day}`
-}
+// Delegates to the canonical date module (src/dates.js) — kept as a
+// re-export so the dozens of existing `from './store'` imports keep working.
+export { localYMD, parseLocalDate }
 
 export function getLocalModified() {
   return parseInt(localStorage.getItem(MODIFIED_KEY) || '0', 10)

--- a/src/wallaby/heatmapUtils.js
+++ b/src/wallaby/heatmapUtils.js
@@ -19,28 +19,11 @@ export function routineColors(routines) {
   return m
 }
 
-// Date-only strings ('YYYY-MM-DD') must be treated as LOCAL dates. Naive
-// `new Date('YYYY-MM-DD')` parses as UTC midnight, which lands on the
-// PREVIOUS local day anywhere west of UTC — that bug made a task due today
-// read as overdue. Anything else (Date, full ISO timestamp) parses normally.
-const YMD_RE = /^\d{4}-\d{2}-\d{2}$/
-
-export function parseLocalDate(d) {
-  if (typeof d === 'string' && YMD_RE.test(d)) {
-    const [y, m, day] = d.split('-').map(Number)
-    return new Date(y, m - 1, day)
-  }
-  const x = new Date(d)
-  return Number.isNaN(x.getTime()) ? null : x
-}
-
-export function localYMD(d) {
-  // A date-only string already IS a local day key.
-  if (typeof d === 'string' && YMD_RE.test(d)) return d
-  const x = parseLocalDate(d)
-  if (!x) return null
-  return `${x.getFullYear()}-${String(x.getMonth() + 1).padStart(2, '0')}-${String(x.getDate()).padStart(2, '0')}`
-}
+// Date helpers come from the canonical module — see src/dates.js for the
+// date-only-string contract (local days, never bare new Date()).
+import { parseLocalDate, localYMD, addDays, weekStartMonday } from '../dates'
+export { parseLocalDate, localYMD, addDays }
+export const weekStart = weekStartMonday
 
 // completed_history (array of ISO timestamps) → { 'YYYY-MM-DD': count }
 export function historyByDay(history) {
@@ -81,22 +64,4 @@ export function longestStreak(valueByDay) {
   return best
 }
 
-// Monday-anchored start of the week containing `ref` (+ weekOffset weeks).
-export function weekStart(ref, weekOffset = 0) {
-  const d = new Date(ref)
-  d.setHours(0, 0, 0, 0)
-  const dow = (d.getDay() + 6) % 7 // 0 = Monday
-  d.setDate(d.getDate() - dow + weekOffset * 7)
-  return d
-}
-
-export function addDays(d, n) {
-  const x = new Date(d)
-  x.setDate(x.getDate() + n)
-  return x
-}
-
-const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
-export function fmtMonthDay(d) {
-  return `${MONTHS[d.getMonth()]} ${d.getDate()}`
-}
+export { fmtMonthDay } from '../dates'

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,11 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-10
 
+- feat(ui): Kept K2 — canonical date module + the four signature viz components [L]
+  - **`src/dates.js`** is now THE date module: `parseLocalDate` / `localYMD` (date-only strings are LOCAL days — the documented contract behind three past timezone-bug incidents), `addDays`, `weekStartMonday`, `fmtMonthDay`. `store.js` and `wallaby/heatmapUtils.js` delegate to it (re-exports keep every existing import working). **First real unit tests:** `scripts/dates.test.mjs` (node:test) covers the UTC-midnight trap, passthrough, month/leap boundaries, streak chaining, week anchoring — wired into `npm test` ahead of the smoke test.
+  - **`src/kept/` viz components** (spec §5, shared mobile+desktop): `FlightTrail` (rows of 14 round day-dots, consecutive done-days bridged by literal streak ARCS; `mini` variant for list rows), `MonthDots` (numbered circle calendar + arcs), `DensityRibbon` (weekly totals as a smooth gradient area curve — the year view that replaces contribution grids), `DayArc` (semicircular gold gauge with tenth-ticks + tip dot). All colors via `--bm-*` tokens / feather props; intensity-scaled opacity; `<title>`/aria labels.
+  - Dev harness `kept-viz-preview.html` + `src/kept-viz-preview.jsx` (vite-dev only, never shipped) — all four screenshot-verified in kept-dark and kept-light with deterministic mock history.
+
 - feat(ui): Kept K1 — brand assets + palettes + theme registration + energy single-source [L]
   - **New brand shipped:** Kept arc-into-catch mark replaces the V-swoosh everywhere — `Logo.jsx` (gold arc + ink-aware catch curve via `--v2-text`), `favicon.svg`, `icon-192/512.svg`, regenerated `icon-192/512.png` + `apple-touch-icon.png` (sharp, Nightgum-gradient tile).
   - **`src/kept/palette.css`:** full `--bm-*` token set (Nightgum defaults for every theme + `kept-dark`/`kept-light` blocks overriding `--v2-*`), gold hero, feathers, scrim/shadows. Kept themes also swap `--v2-font-display` to Fraunces (loaded in index.html, replacing the orphaned JetBrains Mono terminal font).


### PR DESCRIPTION
**Kept K2 — canonical date module + the four signature viz components** (`wiki/Kept-Design-Language.md` §12).

## One date module, with tests

`src/dates.js` is now THE date module: `parseLocalDate` / `localYMD` (date-only strings are **local days** — the documented contract behind three separate past timezone-bug incidents), `addDays`, `weekStartMonday`, `fmtMonthDay`. `store.js` and `wallaby/heatmapUtils.js` delegate via re-exports, so every existing `from './store'` / heatmapUtils import keeps working — the two divergent `localYMD` implementations are gone.

**First real unit tests in the repo:** `scripts/dates.test.mjs` (node:test) — the UTC-midnight trap, YMD passthrough, month/leap boundaries, streak chaining, Monday anchoring. Wired into `npm test` ahead of the smoke test (and therefore into the pre-push hook).

## The Kept viz layer (shared mobile + desktop)

Four components in `src/kept/`, all token-driven (no raw hex), aria-labeled:
- **FlightTrail** — rows of 14 round day-dots; consecutive done-days bridged by literal streak **arcs**; intensity-scaled opacity; `mini` single-row variant for list rows
- **MonthDots** — numbered circle calendar with the same arc bridges
- **DensityRibbon** — weekly totals as a smooth gradient area curve (the year view that replaces every contribution grid)
- **DayArc** — semicircular gold gauge, tenth-ticks, tip dot, display-face count

Render-verified in kept-dark + kept-light via the new `kept-viz-preview.html` dev harness (vite-dev only, never shipped). Consumed for real starting K3.

Lint 0 errors; dates tests + build + smoke pass.

https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR)_