### PR TITLE
feat(ui): Kept K5(v1) + K6 cutover — desktop command center + default flip

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1165,8 +1165,14 @@ canonical date module WITH unit tests in `npm test`; FlightTrail / MonthDots /
 DensityRibbon / DayArc in `src/kept/`) + K3 (KeptShell mobile IA — Today with
 Day Arc hero, Loops with trail cards, Tasks + action sheet, More, ThrowSheet;
 `useMobilePages` + `:is()`-gated modals.css serve both shells; shared
-`toggleHabitDay` handler) are MERGED. Kept on mobile is fully navigable.
-Remaining: K5 desktop command center, K6 cutover + Wallaby teardown.
+`toggleHabitDay` handler) + K5-v1 (KeptDesktop command center: sidebar +
+⌘K Throw + shared Kept views; Today rail / Board / Timeline modes are the
+K5 continuation) + K6 cutover (NEW installs default to Kept system-follow;
+existing themes untouched) are MERGED. **Kept is now the default experience
+for new installs on both mobile and desktop.** Remaining: K5 continuation
+(Today rail, Board/Timeline, detail panel), K4 polish (Arcs/Flight log as
+Kept-native surfaces), and the K6 completion — Wallaby teardown once the
+user confirms Kept as the daily driver.
 
 ## Additional Notes
 - Single developer (ryakel) — no PR review process needed.

--- a/src/AppV2.jsx
+++ b/src/AppV2.jsx
@@ -20,6 +20,7 @@ import ActivityLog from './components/ActivityLog'
 import RoutinesModal from './components/RoutinesModal'
 import WallabyShell from './wallaby/WallabyShell'
 import KeptShell from './kept/KeptShell'
+import KeptDesktop from './kept/KeptDesktop'
 import WallabyEditTask from './wallaby/WallabyEditTask'
 import SuggestionsModal from './components/SuggestionsModal'
 import PackagesModal from './components/PackagesModal'
@@ -1272,6 +1273,36 @@ export default function AppV2() {
         />
       )}
 
+      {/* Kept desktop command center (K5 v1) — sidebar + work surface over
+        * the shared Kept views; cmd-K Throw. Covers the standard layout the
+        * same way the mobile shells do; modals open above it. */}
+      {isKept && isDesktop && (
+        <KeptDesktop
+          tasks={tasks}
+          routines={routines}
+          labels={labels}
+          dailyStats={dailyStats}
+          pointsGoal={settingsForRings.daily_points_goal || 15}
+          streak={streak}
+          onCompleteTask={(task) => task.status === 'done' ? handleUncomplete(task) : handleComplete(task.id)}
+          onOpenTask={(task) => setEditTarget(task)}
+          onToggleHabit={toggleHabitDay}
+          onRescheduleTask={(task, ymd) => updateTask(task.id, { due_date: ymd })}
+          onDeleteTask={(task) => handleDelete(task.id)}
+          onThrow={({ title, dueDate }) => handleAddTask({ title, dueDate })}
+          onOpenFullAdd={() => setShowAdd(true)}
+          onEditLoop={(r) => { setEditRoutineId(r.id); setShowRoutines(true) }}
+          onAddLoop={() => setShowRoutines(true)}
+          onOpenQuokka={() => setShowAdviser(true)}
+          onOpenSettings={() => setShowSettings(true)}
+          onOpenPackages={() => setShowPackages(true)}
+          onOpenAnalytics={() => setShowAnalytics(true)}
+          onOpenProjects={() => setShowProjects(true)}
+          onOpenDone={() => setShowDone(true)}
+          onOpenActivity={() => setShowActivityLog(true)}
+        />
+      )}
+
       {/* Spaces hub — picker for Projects / Routines / Knowledge. Each
        * row launches the existing dedicated modal and resets activeTab
        * to 'today' on that sub-modal close, so the tab indicator never
@@ -1510,7 +1541,7 @@ export default function AppV2() {
         streak={streak}
       />
 
-      {isDesktop && (
+      {isDesktop && !isKept && (
         <FloatingCapture
           onAddTask={(title) => {
             const id = addTask({ title })

--- a/src/kept/KeptDesktop.jsx
+++ b/src/kept/KeptDesktop.jsx
@@ -1,0 +1,118 @@
+import { useEffect, useState } from 'react'
+import {
+  Home, ListTodo, Repeat2, FolderKanban, BarChart3, Package, Settings,
+  Sparkles, Plus, CheckCircle2, ScrollText,
+} from 'lucide-react'
+import Logo from '../components/Logo'
+import TodayView from './TodayView'
+import TasksViewKept from './TasksViewKept'
+import LoopsView from './LoopsView'
+import ThrowSheet from './ThrowSheet'
+import './shell.css'
+import './desktop.css'
+
+// Kept desktop command center (spec §7) — v1: persistent sidebar nav over the
+// shared Kept surfaces, ⌘K Throw. The Today rail + Board/Timeline view modes
+// are the K5 continuation; Kanban remains available via the standard themes.
+export default function KeptDesktop({
+  tasks = [], routines = [], labels = [],
+  dailyStats = {}, pointsGoal = 15, streak = 0,
+  onCompleteTask, onOpenTask, onToggleHabit, onRescheduleTask, onDeleteTask,
+  onThrow, onOpenFullAdd, onEditLoop, onAddLoop,
+  onOpenQuokka, onOpenSettings, onOpenPackages, onOpenAnalytics,
+  onOpenProjects, onOpenDone, onOpenActivity,
+}) {
+  const [tab, setTab] = useState('today')
+  const [throwOpen, setThrowOpen] = useState(false)
+
+  useEffect(() => {
+    const onKey = (e) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+        e.preventDefault()
+        setThrowOpen(o => !o)
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [])
+
+  const navMain = [
+    { id: 'today', label: 'Today', icon: Home },
+    { id: 'tasks', label: 'Tasks', icon: ListTodo },
+    { id: 'loops', label: 'Loops', icon: Repeat2 },
+  ]
+  const navReview = [
+    { label: 'Arcs', icon: FolderKanban, onClick: onOpenProjects },
+    { label: 'Caught', icon: CheckCircle2, onClick: onOpenDone },
+    { label: 'Analytics', icon: BarChart3, onClick: onOpenAnalytics },
+    { label: 'Packages', icon: Package, onClick: onOpenPackages },
+    { label: 'Activity log', icon: ScrollText, onClick: onOpenActivity },
+  ]
+
+  let surface
+  if (tab === 'tasks') {
+    surface = (
+      <TasksViewKept
+        tasks={tasks} labels={labels}
+        onToggleComplete={onCompleteTask} onOpenTask={onOpenTask}
+        onDelete={onDeleteTask} onReschedule={onRescheduleTask}
+      />
+    )
+  } else if (tab === 'loops') {
+    surface = <LoopsView routines={routines} onEditLoop={onEditLoop} onAddLoop={onAddLoop} />
+  } else {
+    surface = (
+      <TodayView
+        tasks={tasks} routines={routines} labels={labels}
+        dailyStats={dailyStats} pointsGoal={pointsGoal} streak={streak}
+        onCompleteTask={onCompleteTask} onOpenTask={onOpenTask} onToggleHabit={onToggleHabit}
+      />
+    )
+  }
+
+  return (
+    <div className="bm-desktop bm-desktop-sheets">
+      <aside className="bm-side">
+        <div className="bm-side-brand">
+          <Logo size={22} />
+          <span className="bm-header-mark">boomerang<i>.</i></span>
+        </div>
+        <button className="bm-side-throw" onClick={() => setThrowOpen(true)}>
+          <Plus size={15} strokeWidth={2.4} /> Throw a task <kbd>⌘K</kbd>
+        </button>
+        {navMain.map(t => {
+          const Icon = t.icon
+          return (
+            <button key={t.id} className={`bm-side-item${tab === t.id ? ' is-active' : ''}`} onClick={() => setTab(t.id)}>
+              <Icon size={17} strokeWidth={2} /> {t.label}
+            </button>
+          )
+        })}
+        <div className="bm-side-sec">Review</div>
+        {navReview.map(t => {
+          const Icon = t.icon
+          return (
+            <button key={t.label} className="bm-side-item" onClick={t.onClick}>
+              <Icon size={17} strokeWidth={2} /> {t.label}
+            </button>
+          )
+        })}
+        <div className="bm-side-spacer" />
+        <button className="bm-side-quokka" onClick={onOpenQuokka}>
+          <Sparkles size={18} strokeWidth={2} style={{ color: 'var(--bm-gold)', flex: '0 0 auto' }} />
+          <span><b>Quokka</b><span>ask anything, change anything</span></span>
+        </button>
+        <button className="bm-side-item" onClick={onOpenSettings}>
+          <Settings size={17} strokeWidth={2} /> Settings
+        </button>
+      </aside>
+      <main className="bm-main">{surface}</main>
+      <ThrowSheet
+        open={throwOpen}
+        onClose={() => setThrowOpen(false)}
+        onThrow={onThrow}
+        onMoreOptions={onOpenFullAdd}
+      />
+    </div>
+  )
+}

--- a/src/kept/desktop.css
+++ b/src/kept/desktop.css
@@ -1,0 +1,82 @@
+/* Kept desktop command center — sidebar + work surface (spec §7).
+ * v1 scope: sidebar nav over the Kept surfaces; Today rail + Board/Timeline
+ * view modes are the K5 continuation. */
+
+.bm-desktop {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+  display: flex;
+  background: var(--bm-bg);
+  color: var(--bm-text);
+  font-family: var(--v2-font-body);
+  -webkit-font-smoothing: antialiased;
+}
+.bm-side {
+  flex: 0 0 224px;
+  display: flex;
+  flex-direction: column;
+  padding: 18px 12px 14px;
+  border-right: 1px solid var(--bm-hairline);
+}
+.bm-side-brand { display: flex; align-items: center; gap: 9px; padding: 2px 10px 18px; }
+.bm-side-throw {
+  display: flex; align-items: center; justify-content: center; gap: 9px;
+  background: var(--bm-gold); color: var(--bm-on-gold);
+  border: none; border-radius: 12px;
+  padding: 11px 12px;
+  font-size: 13.5px; font-weight: 700; font-family: var(--v2-font-body);
+  margin: 0 4px 16px;
+  cursor: pointer;
+  box-shadow: 0 6px 18px color-mix(in srgb, var(--bm-gold) 28%, transparent);
+}
+.bm-side-throw kbd {
+  font-family: inherit; font-size: 10.5px; opacity: 0.65;
+  border: 1px solid color-mix(in srgb, var(--bm-on-gold) 35%, transparent);
+  border-radius: 5px; padding: 1px 5px;
+}
+.bm-side-item {
+  display: flex; align-items: center; gap: 11px;
+  width: 100%;
+  background: none; border: none;
+  padding: 9px 10px; border-radius: 10px;
+  font-size: 13.5px; font-weight: 600; font-family: var(--v2-font-body);
+  color: var(--bm-text-meta);
+  cursor: pointer; text-align: left;
+  margin-bottom: 1px;
+}
+.bm-side-item.is-active { color: var(--bm-text); background: var(--bm-card-2); }
+.bm-side-item.is-active svg { color: var(--bm-gold); }
+.bm-side-sec {
+  font-size: 10px; font-weight: 700;
+  letter-spacing: 0.12em; text-transform: uppercase;
+  color: var(--bm-text-faint);
+  padding: 16px 10px 6px;
+}
+.bm-side-spacer { flex: 1 1 auto; }
+.bm-side-quokka {
+  display: flex; align-items: center; gap: 10px;
+  margin: 0 4px 8px;
+  border: 1px solid var(--bm-hairline);
+  border-radius: 13px;
+  background: var(--bm-card);
+  padding: 11px 12px;
+  cursor: pointer;
+  text-align: left;
+  color: var(--bm-text);
+}
+.bm-side-quokka b { font-size: 12.5px; display: block; font-family: var(--v2-font-body); }
+.bm-side-quokka span { font-size: 11px; color: var(--bm-text-meta); }
+.bm-main {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow-y: auto;
+}
+.bm-desktop .bm-surface {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 22px 28px 60px;
+}
+/* Centered dialog treatment for sheets on desktop */
+.bm-desktop-sheets .bm-sheet-backdrop { align-items: center; justify-content: center; }
+.bm-desktop-sheets .bm-sheet { max-width: 480px; border-radius: 22px; border: 1px solid var(--bm-hairline); }

--- a/src/store.js
+++ b/src/store.js
@@ -273,6 +273,16 @@ export function loadSettings() {
     saved.theme = saved.theme === 'terminal-light' ? 'wallaby-light' : 'wallaby-dark'
     save(SETTINGS_KEY, saved)
   }
+
+  // Kept cutover (K6, 2026-06-10): NEW installs default to Kept, following
+  // the system color scheme at first load. Existing users keep whatever
+  // theme they had — only an unset theme gets the default.
+  if (!saved.theme) {
+    const prefersDark = typeof window !== 'undefined'
+      && window.matchMedia?.('(prefers-color-scheme: dark)')?.matches
+    saved.theme = prefersDark ? 'kept-dark' : 'kept-light'
+    save(SETTINGS_KEY, saved)
+  }
   return { ...DEFAULT_SETTINGS, ...saved }
 }
 export function saveSettings(settings) { save(SETTINGS_KEY, settings); touchModified() }

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,11 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-10
 
+- feat(ui): Kept K5(v1) + K6 cutover — desktop command center + new-install default [L]
+  - **KeptDesktop** (`src/kept/KeptDesktop.jsx` + `desktop.css`): the command-center layout for kept themes on desktop — persistent sidebar (brand, gold **"Throw a task ⌘K"** pill, Today/Tasks/Loops nav, Review section routing to Arcs/Caught/Analytics/Packages/Activity, Quokka card, Settings) over a centered work surface rendering the shared Kept views. **⌘K** opens the Throw sheet (centered dialog treatment on desktop). FloatingCapture FABs gated out of kept desktop. K5 continuation (Today rail, Board/Timeline view modes, detail panel) tracked in the spec.
+  - **K6 cutover (new installs):** an unset theme now defaults to **Kept following the system color scheme** (`kept-dark`/`kept-light` via `prefers-color-scheme`, persisted on first load). Existing users keep their stored theme — nothing migrates. Wallaby remains in the picker; its teardown is the K6 completion step once Kept is accepted as the daily driver.
+  - Verified headless: fresh install lands on kept-light (headless prefers light); desktop Today/Tasks/Loops navigation, ⌘K throw dialog, matched-version hero data. The transient "3650-day rally" seen during verification was the pre-existing computeStreak iteration guard surfacing on an EMPTY task list (blocked hydration) — not a Kept regression.
+
 - feat(ui): Kept K3 — the KeptShell mobile IA (Today / Loops / Throw / Tasks / More) [XL]
   - **KeptShell** renders for kept themes on mobile: `KeptHeader` (mark + `boomerang.` wordmark, gold Quokka button — Quokka is one tap from every screen, not a nav tab — bell, avatar), `KeptNav` (Today · Loops · **Throw** · Tasks · More; one gold accent, active dot), and the **ThrowSheet** (title + Today/Tomorrow/Weekend/No-date chips; "More options" hands off to the full AddTaskModal).
   - **TodayView:** wing-corner Day Arc hero (points vs goal, catches / loops / pts-left meta, `↻ rally` chip) + today's tasks as hairline rows (gold circle checks, dot-tags, `↩ returns` chips for snoozed) + Loops rows with mini Flight Trails and feather checks.


### PR DESCRIPTION
**Kept K5(v1) + K6 cutover** — the final phase of this session's go-for-broke run (`wiki/Kept-Design-Language.md` §7, §12).

## KeptDesktop — the command center (v1)

For kept themes on desktop: persistent sidebar (brand, gold **"Throw a task ⌘K"** pill, Today/Tasks/Loops nav, a Review section routing to Arcs/Caught/Analytics/Packages/Activity, the Quokka card, Settings) over a centered work surface rendering the **same Kept views as mobile** — the cross-platform coherence contract in action. **⌘K** opens the Throw sheet (centered-dialog treatment on desktop). FloatingCapture FABs are gated out of kept desktop.

K5 continuation (Today rail, Board/Timeline view modes, selected-row detail panel) is tracked in the spec — the standard themes keep Kanban untouched meanwhile.

## K6 cutover — new installs default to Kept

An unset theme now resolves to **Kept following the system color scheme** (`prefers-color-scheme` → `kept-dark`/`kept-light`, persisted on first load). Existing users keep whatever they have — nothing migrates. Wallaby stays in the picker; its teardown is the K6 completion step once Kept is confirmed as the daily driver.

## Verified

Headless: a storage-cleared "fresh install" lands on `kept-light`; desktop Today/Tasks/Loops navigation + ⌘K throw with matched client/server versions. (The "3650-day rally" seen mid-verification was the pre-existing `computeStreak` iteration guard on an empty task list during a version-mismatch overlay — not a Kept regression.) Lint 0; dates tests + build + smoke pass.

https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR)_