### PR TITLE
feat(ui): Kept — bouncing wordmark, shared sync hook, matching modal titles

### DIFF
--- a/src/AppV2.jsx
+++ b/src/AppV2.jsx
@@ -1270,6 +1270,8 @@ export default function AppV2() {
           onOpenDone={() => setShowDone(true)}
           onOpenActivity={() => setShowActivityLog(true)}
           onOpenSuggestions={() => setShowSuggestions(true)}
+          syncStatus={syncStatus}
+          queueLength={queueLength}
         />
       )}
 
@@ -1300,6 +1302,8 @@ export default function AppV2() {
           onOpenProjects={() => setShowProjects(true)}
           onOpenDone={() => setShowDone(true)}
           onOpenActivity={() => setShowActivityLog(true)}
+          syncStatus={syncStatus}
+          queueLength={queueLength}
         />
       )}
 

--- a/src/AppV2.jsx
+++ b/src/AppV2.jsx
@@ -1447,6 +1447,7 @@ export default function AppV2() {
       />
       <ProjectsView
         open={showProjects}
+        title={isKept ? 'Arcs' : 'Projects'}
         tasks={tasks}
         onClose={() => setShowProjects(false)}
         onComplete={handleComplete}
@@ -1460,6 +1461,7 @@ export default function AppV2() {
       />
       <DoneList
         open={showDone}
+        title={isKept ? 'Caught' : 'Done'}
         onClose={() => setShowDone(false)}
         onUncomplete={handleUncomplete}
       />
@@ -1470,6 +1472,8 @@ export default function AppV2() {
       />
       <RoutinesModal
         open={showRoutines}
+        title={isKept ? 'Loops' : 'Routines'}
+        noun={isKept ? 'loop' : 'routine'}
         routines={routines}
         tasks={tasks}
         onAdd={addRoutine}

--- a/src/components/DoneList.jsx
+++ b/src/components/DoneList.jsx
@@ -20,7 +20,7 @@ function daysOnList(task) {
   ))
 }
 
-export default function DoneList({ open, onClose, onUncomplete }) {
+export default function DoneList({ open, onClose, onUncomplete, title = 'Done' }) {
   const [doneTasks, setDoneTasks] = useState([])
   const [loading, setLoading] = useState(true)
   const [hasMore, setHasMore] = useState(true)
@@ -143,7 +143,7 @@ export default function DoneList({ open, onClose, onUncomplete }) {
   )
 
   return (
-    <ModalShell open={open} onClose={onClose} title="Done" width="wide">
+    <ModalShell open={open} onClose={onClose} title={title} width="wide">
       {/* Search bar */}
       <div className="v2-smart-search">
         <Search size={15} className="v2-smart-search-icon" />

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,25 +1,11 @@
-import { useEffect, useRef, useState } from 'react'
+import { useRef, useState } from 'react'
 import { Sparkles, Package, Settings as SettingsIcon } from 'lucide-react'
 import Logo from './Logo'
 import { MiniRings } from './Rings'
+import { useSyncBounce } from '../hooks/useSyncBounce'
 import './Header.css'
 
 const WORDMARK_LETTERS = 'BOOMERANG'.split('')
-
-// Sync-state derivation. Maps useServerSync's syncStatus + the local
-// `animState` (saving / just-synced / idle, with minimum hold enforcement)
-// + queue length into the visual states the wordmark reflects. Permanent
-// states (offline / degraded) fade ambient stress into the brand instead
-// of using a separate icon. animState wins over instantaneous syncStatus
-// for the saving / just-synced phases so a fast sync still gets a full
-// wave + flash.
-function deriveSyncVisualState(syncStatus, queueLength, animState) {
-  if (syncStatus === 'offline') return 'offline'
-  if (animState === 'saving') return 'saving'
-  if (animState === 'just-synced') return 'just-synced'
-  if (queueLength > 0) return 'degraded'
-  return 'idle'
-}
 
 export default function Header({
   onOpenAdviser, onOpenPackages, onOpenSystemMenu, systemMenuOpen,
@@ -34,67 +20,7 @@ export default function Header({
   const popoverRef = useRef(null)
   const brandRef = useRef(null)
 
-  // Just-synced pulse — flashes green for ~700ms after a save completes,
-  // then decays. Ambient by design: if everything's working you see the
-  // flash once and forget about it.
-  //
-  // We also enforce a minimum saving-hold (1300ms) so a fast sync doesn't
-  // strand the bounce on the B before the wave reaches the G. The wave
-  // takes ~1140ms to traverse all nine letters at 60ms stagger; rounding
-  // up to 1300 gives margin without feeling sluggish. If saving completes
-  // mid-wave, the green flash queues to fire after the hold expires.
-  const SAVING_MIN_HOLD = 1300
-  const FLASH_MS = 700
-  const [animState, setAnimState] = useState('idle')
-  const allowFlashRef = useRef(false)
-  const timerRef = useRef(null)
-
-  useEffect(() => {
-    return () => { if (timerRef.current) clearTimeout(timerRef.current) }
-  }, [])
-
-  useEffect(() => {
-    if (syncStatus === 'saving') {
-      // Start (or restart) the wave. Clear any pending flash.
-      allowFlashRef.current = false
-      setAnimState('saving')
-      if (timerRef.current) clearTimeout(timerRef.current)
-      timerRef.current = setTimeout(() => {
-        timerRef.current = null
-        if (allowFlashRef.current) {
-          setAnimState('just-synced')
-          timerRef.current = setTimeout(() => {
-            timerRef.current = null
-            setAnimState('idle')
-          }, FLASH_MS)
-        } else {
-          setAnimState('idle')
-        }
-      }, SAVING_MIN_HOLD)
-    } else if (syncStatus === 'synced' && animState === 'saving') {
-      // Saving completed mid-wave — queue the green flash for when the hold
-      // timer fires. Don't transition yet; wave finishes first.
-      allowFlashRef.current = true
-    }
-  }, [syncStatus, animState])
-
-  // Click outside closes the brand popover.
-  useEffect(() => {
-    if (!popoverOpen) return
-    const onClick = (e) => {
-      if (popoverRef.current?.contains(e.target)) return
-      if (brandRef.current?.contains(e.target)) return
-      setPopoverOpen(false)
-    }
-    document.addEventListener('mousedown', onClick)
-    document.addEventListener('touchstart', onClick)
-    return () => {
-      document.removeEventListener('mousedown', onClick)
-      document.removeEventListener('touchstart', onClick)
-    }
-  }, [popoverOpen])
-
-  const syncVisualState = deriveSyncVisualState(syncStatus, queueLength, animState)
+  const syncVisualState = useSyncBounce(syncStatus, queueLength)
   const syncLabel =
     syncVisualState === 'offline' ? `Offline${queueLength ? ` · ${queueLength} pending` : ''}` :
     syncVisualState === 'degraded' ? `Working through ${queueLength} pending change${queueLength === 1 ? '' : 's'}` :

--- a/src/components/ProjectsView.jsx
+++ b/src/components/ProjectsView.jsx
@@ -19,6 +19,7 @@ import './ProjectsView.css'
 export default function ProjectsView({
   open, tasks, onClose, onComplete, onEdit, onSnooze, weatherByDate, 
   onTogglePin, onAddChild, onSetChildVisibility, onCreateProject,
+  title = 'Projects',
 }) {
   const [expandedTaskId, setExpandedTaskId] = useState(null)
   const [expandedProjectId, setExpandedProjectId] = useState(null)
@@ -38,7 +39,7 @@ export default function ProjectsView({
     <ModalShell
       open={open}
       onClose={onClose}
-      title="Projects"
+      title={title}
       subtitle={projectTasks.length > 0
         ? `${projectTasks.length} project${projectTasks.length !== 1 ? 's' : ''} · no nagging unless you opt in`
         : undefined}

--- a/src/components/RoutinesModal.jsx
+++ b/src/components/RoutinesModal.jsx
@@ -996,6 +996,7 @@ function RoutineForm({ initial, onSave, onCancel }) {
 export default function RoutinesModal({
   open, routines, tasks = [], onAdd, onDelete, onTogglePause, onUpdate, onSpawnNow, onLogHabit, onSkipCycle, onClose,
   editRoutineId, onClearEditRoutineId, activeRoutineIds,
+  title = 'Routines', noun = 'routine',
 }) {
   const [view, setView] = useState('list')  // 'list' | 'form'
   const [editing, setEditing] = useState(null)  // routine being edited; null = new
@@ -1074,7 +1075,7 @@ export default function RoutinesModal({
     <ModalShell
       open={open}
       onClose={onClose}
-      title={view === 'form' ? (editing ? 'Edit routine' : 'New routine') : 'Routines'}
+      title={view === 'form' ? (editing ? `Edit ${noun}` : `New ${noun}`) : title}
       subtitle={view === 'list' && routines.length > 0
         ? `${active.length} active${paused.length ? ` · ${paused.length} paused` : ''}`
         : undefined}

--- a/src/hooks/useSyncBounce.js
+++ b/src/hooks/useSyncBounce.js
@@ -1,0 +1,47 @@
+import { useEffect, useRef, useState } from 'react'
+
+// Wordmark sync-state machine — shared by the standard Header, WallabyHeader,
+// and KeptHeader (it lived as three copies before Kept). Maps useServerSync's
+// syncStatus + queue length into the visual states the bouncing wordmark
+// reflects, enforcing a minimum saving-hold so a fast sync still plays a full
+// letter-wave, and queueing the green "just-synced" flash to fire after the
+// hold expires.
+//
+//   idle | saving (bounce wave) | just-synced (green flash) |
+//   degraded (queue backlog) | offline
+const SAVING_MIN_HOLD = 1300 // full wave across the letters + margin
+const FLASH_MS = 700
+
+export function useSyncBounce(syncStatus, queueLength = 0) {
+  const [animState, setAnimState] = useState('idle')
+  const allowFlashRef = useRef(false)
+  const timerRef = useRef(null)
+
+  useEffect(() => () => { if (timerRef.current) clearTimeout(timerRef.current) }, [])
+
+  useEffect(() => {
+    if (syncStatus === 'saving') {
+      allowFlashRef.current = false
+      setAnimState('saving')
+      if (timerRef.current) clearTimeout(timerRef.current)
+      timerRef.current = setTimeout(() => {
+        timerRef.current = null
+        if (allowFlashRef.current) {
+          setAnimState('just-synced')
+          timerRef.current = setTimeout(() => { timerRef.current = null; setAnimState('idle') }, FLASH_MS)
+        } else {
+          setAnimState('idle')
+        }
+      }, SAVING_MIN_HOLD)
+    } else if (syncStatus === 'synced' && animState === 'saving') {
+      // Saving completed mid-wave — queue the flash for when the hold expires.
+      allowFlashRef.current = true
+    }
+  }, [syncStatus, animState])
+
+  if (syncStatus === 'offline') return 'offline'
+  if (animState === 'saving') return 'saving'
+  if (animState === 'just-synced') return 'just-synced'
+  if (queueLength > 0) return 'degraded'
+  return 'idle'
+}

--- a/src/kept/KeptDesktop.jsx
+++ b/src/kept/KeptDesktop.jsx
@@ -4,6 +4,7 @@ import {
   Sparkles, Plus, CheckCircle2, ScrollText,
 } from 'lucide-react'
 import Logo from '../components/Logo'
+import { useSyncBounce } from '../hooks/useSyncBounce'
 import TodayView from './TodayView'
 import TasksViewKept from './TasksViewKept'
 import LoopsView from './LoopsView'
@@ -21,8 +22,10 @@ export default function KeptDesktop({
   onThrow, onOpenFullAdd, onEditLoop, onAddLoop,
   onOpenQuokka, onOpenSettings, onOpenPackages, onOpenAnalytics,
   onOpenProjects, onOpenDone, onOpenActivity,
+  syncStatus = 'synced', queueLength = 0,
 }) {
   const [tab, setTab] = useState('today')
+  const syncVisualState = useSyncBounce(syncStatus, queueLength)
   const [throwOpen, setThrowOpen] = useState(false)
 
   useEffect(() => {
@@ -75,7 +78,11 @@ export default function KeptDesktop({
       <aside className="bm-side">
         <div className="bm-side-brand">
           <Logo size={22} />
-          <span className="bm-header-mark">boomerang<i>.</i></span>
+          <span className="v2-header-wordmark bm-header-mark" data-sync-state={syncVisualState}>
+            {'boomerang.'.split('').map((ch, i) => (
+              <span key={i} className="v2-header-wordmark-letter" style={{ '--letter-index': i }}>{ch}</span>
+            ))}
+          </span>
         </div>
         <button className="bm-side-throw" onClick={() => setThrowOpen(true)}>
           <Plus size={15} strokeWidth={2.4} /> Throw a task <kbd>⌘K</kbd>

--- a/src/kept/KeptHeader.jsx
+++ b/src/kept/KeptHeader.jsx
@@ -1,15 +1,25 @@
 import { Bell, Sparkles, TrendingUp } from 'lucide-react'
 import Logo from '../components/Logo'
+import { useSyncBounce } from '../hooks/useSyncBounce'
 import './shell.css'
 
-// Kept top bar: mark + `boomerang.` wordmark · Quokka (gold-tinted, always one
-// tap away — it is NOT a nav tab in Kept) · bell · avatar (spec §6).
-export default function KeptHeader({ onQuokka, onBell, onAvatar, unread = 0 }) {
+const WORDMARK_LETTERS = 'boomerang.'.split('')
+
+// Kept top bar: mark + bouncing `boomerang.` wordmark (the save-wave from the
+// standard header — letters bounce while syncing, flash green on save, the
+// gold period rides the wave) · Quokka (one tap from every screen — it is NOT
+// a nav tab in Kept) · bell · avatar (spec §6).
+export default function KeptHeader({ onQuokka, onBell, onAvatar, unread = 0, syncStatus = 'synced', queueLength = 0 }) {
+  const syncVisualState = useSyncBounce(syncStatus, queueLength)
   return (
     <header className="bm-header">
       <div className="bm-header-brand">
         <Logo size={24} />
-        <span className="bm-header-mark">boomerang<i>.</i></span>
+        <span className="v2-header-wordmark bm-header-mark" data-sync-state={syncVisualState}>
+          {WORDMARK_LETTERS.map((ch, i) => (
+            <span key={i} className="v2-header-wordmark-letter" style={{ '--letter-index': i }}>{ch}</span>
+          ))}
+        </span>
       </div>
       <div className="bm-header-actions">
         <button className="bm-header-btn bm-header-quokka" onClick={onQuokka} aria-label="Quokka">

--- a/src/kept/KeptShell.jsx
+++ b/src/kept/KeptShell.jsx
@@ -19,6 +19,7 @@ export default function KeptShell({
   onThrow, onOpenFullAdd, onEditLoop, onAddLoop,
   onOpenQuokka, onOpenSettings, onOpenPackages, onOpenAnalytics,
   onOpenProjects, onOpenDone, onOpenActivity, onOpenSuggestions,
+  syncStatus = 'synced', queueLength = 0,
 }) {
   const [tab, setTab] = useState('today')
   const [throwOpen, setThrowOpen] = useState(false)
@@ -59,6 +60,8 @@ export default function KeptShell({
         onQuokka={onOpenQuokka}
         onBell={onOpenActivity}
         onAvatar={onOpenAnalytics}
+        syncStatus={syncStatus}
+        queueLength={queueLength}
       />
       <div className="bm-shell-surface">{surface}</div>
       <KeptNav active={tab} onChange={setTab} onThrow={() => setThrowOpen(true)} />

--- a/src/kept/shell.css
+++ b/src/kept/shell.css
@@ -34,13 +34,18 @@
 }
 .bm-header-brand { display: flex; align-items: center; gap: 9px; min-width: 0; }
 .bm-header-mark {
-  font-family: var(--v2-font-display);
-  font-weight: 700;
-  font-size: 18px;
+  font: 700 18px/1 var(--v2-font-display);
   letter-spacing: 0.01em;
+  gap: 0.01em;   /* matches letter-spacing for the per-letter spans */
   color: var(--bm-text);
 }
 .bm-header-mark i { color: var(--bm-gold); font-style: normal; }
+/* The gold period (the caught dot) keeps its color through the idle/degraded
+ * sync states — boosted specificity to outrank Header.css's state rules; the
+ * bounce/flash ANIMATIONS still apply on top (animations win the cascade). */
+.bm-header-mark.v2-header-wordmark[data-sync-state] .v2-header-wordmark-letter:last-child {
+  color: var(--bm-gold);
+}
 .bm-header-actions { margin-left: auto; display: flex; gap: 8px; }
 .bm-header-btn {
   position: relative;

--- a/src/wallaby/WallabyHeader.jsx
+++ b/src/wallaby/WallabyHeader.jsx
@@ -1,18 +1,9 @@
-import { useEffect, useRef, useState } from 'react'
 import { Bell, TrendingUp } from 'lucide-react'
 import Logo from '../components/Logo'
+import { useSyncBounce } from '../hooks/useSyncBounce'
 import './WallabyHeader.css'
 
 const WORDMARK_LETTERS = 'BOOMERANG'.split('')
-
-// Mirrors Header.jsx so the wordmark bounces on save the same way.
-function deriveSyncVisualState(syncStatus, queueLength, animState) {
-  if (syncStatus === 'offline') return 'offline'
-  if (animState === 'saving') return 'saving'
-  if (animState === 'just-synced') return 'just-synced'
-  if (queueLength > 0) return 'degraded'
-  return 'idle'
-}
 
 // Wallaby persistent top app bar: bouncing BOOMERANG wordmark + logo (to the
 // right of the text), then Quokka · Packages · notifications bell · avatar.
@@ -20,32 +11,7 @@ export default function WallabyHeader({
   unread = 0, onBell, onAvatar,
   syncStatus = 'synced', queueLength = 0,
 }) {
-  const SAVING_MIN_HOLD = 1300
-  const FLASH_MS = 700
-  const [animState, setAnimState] = useState('idle')
-  const allowFlashRef = useRef(false)
-  const timerRef = useRef(null)
-
-  useEffect(() => () => { if (timerRef.current) clearTimeout(timerRef.current) }, [])
-
-  useEffect(() => {
-    if (syncStatus === 'saving') {
-      allowFlashRef.current = false
-      setAnimState('saving')
-      if (timerRef.current) clearTimeout(timerRef.current)
-      timerRef.current = setTimeout(() => {
-        timerRef.current = null
-        if (allowFlashRef.current) {
-          setAnimState('just-synced')
-          timerRef.current = setTimeout(() => { timerRef.current = null; setAnimState('idle') }, FLASH_MS)
-        } else { setAnimState('idle') }
-      }, SAVING_MIN_HOLD)
-    } else if (syncStatus === 'synced' && animState === 'saving') {
-      allowFlashRef.current = true
-    }
-  }, [syncStatus, animState])
-
-  const syncVisualState = deriveSyncVisualState(syncStatus, queueLength, animState)
+  const syncVisualState = useSyncBounce(syncStatus, queueLength)
 
   return (
     <header className="wb-header">

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,11 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-10
 
+- feat(ui): Kept — bouncing wordmark + shared sync-bounce hook [S]
+  - The save-wave is back on the brand: the Kept `boomerang.` wordmark (mobile header + desktop sidebar) renders per-letter spans driven by the same sync states as the standard header — letters bounce while saving, flash green on sync, dim on degraded/offline. The gold period rides the wave (boosted-specificity rule keeps it gold through the state colors; animations still apply on top).
+  - **Dedupe:** the hold/flash state machine existed as identical copies in `Header.jsx` and `WallabyHeader.jsx` (a third was about to land) — extracted to `src/hooks/useSyncBounce.js`; all three headers now consume it. `syncStatus`/`queueLength` threaded into KeptShell + KeptDesktop.
+  - Verified live: header captured mid-wave in `saving` state; idle → saving → idle cycle confirmed on a real task completion.
+
 - feat(ui): Kept K5(v1) + K6 cutover — desktop command center + new-install default [L]
   - **KeptDesktop** (`src/kept/KeptDesktop.jsx` + `desktop.css`): the command-center layout for kept themes on desktop — persistent sidebar (brand, gold **"Throw a task ⌘K"** pill, Today/Tasks/Loops nav, Review section routing to Arcs/Caught/Analytics/Packages/Activity, Quokka card, Settings) over a centered work surface rendering the shared Kept views. **⌘K** opens the Throw sheet (centered dialog treatment on desktop). FloatingCapture FABs gated out of kept desktop. K5 continuation (Today rail, Board/Timeline view modes, detail panel) tracked in the spec.
   - **K6 cutover (new installs):** an unset theme now defaults to **Kept following the system color scheme** (`kept-dark`/`kept-light` via `prefers-color-scheme`, persisted on first load). Existing users keep their stored theme — nothing migrates. Wallaby remains in the picker; its teardown is the K6 completion step once Kept is accepted as the daily driver.

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,9 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-10
 
+- fix(ui): Kept — shared-modal titles follow the Kept naming layer [S]
+  - The More menu said Arcs / Caught / Loops but the modals opened as "Projects" / "Done" / "Routines". `ProjectsView`, `DoneList`, and `RoutinesModal` now take a `title` override (+ `noun` on RoutinesModal so the form reads "New loop"/"Edit loop"); AppV2 passes the Kept names when a kept theme is active. Standard + Wallaby keep their existing titles. Verified live: all three open under their menu names.
+
 - feat(ui): Kept — bouncing wordmark + shared sync-bounce hook [S]
   - The save-wave is back on the brand: the Kept `boomerang.` wordmark (mobile header + desktop sidebar) renders per-letter spans driven by the same sync states as the standard header — letters bounce while saving, flash green on sync, dim on degraded/offline. The gold period rides the wave (boosted-specificity rule keeps it gold through the state colors; animations still apply on top).
   - **Dedupe:** the hold/flash state machine existed as identical copies in `Header.jsx` and `WallabyHeader.jsx` (a third was about to land) — extracted to `src/hooks/useSyncBounce.js`; all three headers now consume it. `syncStatus`/`queueLength` threaded into KeptShell + KeptDesktop.


### PR DESCRIPTION
Two Kept polish items:

## The bounce is back 🪃

The Kept `boomerang.` wordmark (mobile header **and** desktop sidebar) now plays the save-wave: per-letter bounce while syncing, green flash on save, dim on degraded/offline — with the gold period riding the wave (a boosted-specificity rule keeps it gold through the sync-state colors; the animations still apply on top).

**Dedupe along the way:** the hold/flash state machine existed as identical copies in `Header.jsx` and `WallabyHeader.jsx`, and a third copy was about to land — extracted to `src/hooks/useSyncBounce.js`, now consumed by all three headers. `syncStatus`/`queueLength` threaded into KeptShell + KeptDesktop.

## Menu titles match their pages

The More menu said **Arcs / Caught / Loops** but the modals opened titled "Projects" / "Done" / "Routines". `ProjectsView`, `DoneList`, and `RoutinesModal` take a `title` override (plus a `noun` prop so the routine form reads "New loop" / "Edit loop"); AppV2 passes the Kept names when a kept theme is active. Standard and Wallaby keep their existing titles.

## Verified

Live headless: wordmark captured mid-wave in `saving` on a real task completion, idle→saving→idle cycle confirmed; Arcs/Caught/Loops all open under their menu names. Lint 0; dates tests + build + smoke pass.

https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR)_