### PR TITLE
fix(ui): Kept round-1 polish — editors, swipe, clickable loops, pinned back

### DIFF
--- a/src/AppV2.jsx
+++ b/src/AppV2.jsx
@@ -430,9 +430,10 @@ export default function AppV2() {
   // mount. Falls back to the snapshot for tasks not in local state (e.g.
   // server search results).
   const liveEditTarget = editTarget ? (tasks.find(t => t.id === editTarget.id) || editTarget) : null
-  // Use the Wallaby chip-language quick editor for regular tasks on mobile;
+  // Use the chip-language quick editor for regular tasks on mobile (Wallaby
+  // AND Kept — the editor's --wb-* tokens bridge to the Kept palette);
   // projects/subs and "More options" fall through to the full EditTaskModal.
-  const useWallabyEditor = !!liveEditTarget && isWallaby && !isDesktop && !editFull
+  const useWallabyEditor = !!liveEditTarget && (isWallaby || isKept) && !isDesktop && !editFull
     && liveEditTarget.status !== 'project' && !liveEditTarget.parent_id
   // Flat ordered list for desktop keyboard nav (j/k). Mirrors the visual order:
   // doing → stale → up next → waiting → snoozed → backlog → projects.

--- a/src/kept/KeptDesktop.jsx
+++ b/src/kept/KeptDesktop.jsx
@@ -69,6 +69,7 @@ export default function KeptDesktop({
         tasks={tasks} routines={routines} labels={labels}
         dailyStats={dailyStats} pointsGoal={pointsGoal} streak={streak}
         onCompleteTask={onCompleteTask} onOpenTask={onOpenTask} onToggleHabit={onToggleHabit}
+        onDeleteTask={onDeleteTask} onEditLoop={onEditLoop}
       />
     )
   }

--- a/src/kept/KeptShell.jsx
+++ b/src/kept/KeptShell.jsx
@@ -50,6 +50,7 @@ export default function KeptShell({
         tasks={tasks} routines={routines} labels={labels}
         dailyStats={dailyStats} pointsGoal={pointsGoal} streak={streak}
         onCompleteTask={onCompleteTask} onOpenTask={onOpenTask} onToggleHabit={onToggleHabit}
+        onDeleteTask={onDeleteTask} onEditLoop={onEditLoop}
       />
     )
   }

--- a/src/kept/LoopsView.jsx
+++ b/src/kept/LoopsView.jsx
@@ -43,7 +43,10 @@ export default function LoopsView({ routines = [], onEditLoop, onAddLoop }) {
         <div key={r.id} className="bm-card" style={{ '--loop': color }}>
           <div className="bm-card-title">
             <span className="bm-loop-ring" style={{ width: 28, height: 28 }}><Repeat2 size={13} strokeWidth={2.2} /></span>
-            <span style={{ flex: '1 1 auto', minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{r.title}</span>
+            <button
+              style={{ flex: '1 1 auto', minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', background: 'none', border: 'none', padding: 0, font: 'inherit', color: 'inherit', textAlign: 'left', cursor: 'pointer' }}
+              onClick={() => onEditLoop?.(r)}
+            >{r.title}</button>
             {rally > 0 && <span className="bm-loop-rally" style={{ fontSize: 11.5 }}>↻ {rally}</span>}
             <span style={{ fontSize: 11.5, fontWeight: 700, color: 'var(--bm-text-meta)' }}>{total}×</span>
             <button className="bm-back" style={{ width: 28, height: 28 }} onClick={() => onEditLoop?.(r)} aria-label="Edit loop">

--- a/src/kept/RowSwipe.jsx
+++ b/src/kept/RowSwipe.jsx
@@ -1,0 +1,31 @@
+import { Check, Trash2 } from 'lucide-react'
+import { useSwipeActions } from '../hooks/useSwipeActions'
+import './shell.css'
+
+// Swipe-left-to-reveal wrapper for Kept hairline rows (parity with the v2
+// TaskCard / Wallaby TaskRow gesture): Catch (gold) + Delete behind the row.
+export default function RowSwipe({ done = false, onCatch, onDelete, children }) {
+  const swipe = useSwipeActions({ openOffset: -132 })
+  return (
+    <div className="bm-row-swipe">
+      <div className="bm-row-swipe-actions">
+        <button
+          className="bm-row-swipe-act bm-row-swipe-catch"
+          onClick={() => { onCatch?.(); swipe.close() }}
+        ><Check size={16} strokeWidth={2.5} />{done ? 'Reopen' : 'Catch'}</button>
+        <button
+          className="bm-row-swipe-act bm-row-swipe-del"
+          onClick={() => { onDelete?.(); swipe.close() }}
+        ><Trash2 size={16} strokeWidth={2} />Delete</button>
+      </div>
+      <div
+        className="bm-row-swipe-body"
+        style={{ transform: swipe.x !== 0 ? `translateX(${swipe.x}px)` : undefined }}
+        {...swipe.handlers}
+        onClickCapture={(e) => { if (swipe.open || swipe.swiping) { e.stopPropagation(); swipe.close() } }}
+      >
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/src/kept/TasksViewKept.jsx
+++ b/src/kept/TasksViewKept.jsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react'
 import { Check, Search, Pencil, Trash2, Calendar, X } from 'lucide-react'
 import { localYMD, parseLocalDate, addDays } from '../dates'
 import { isSnoozed } from '../store'
+import RowSwipe from './RowSwipe'
 import './shell.css'
 
 const ACTIVE = ['not_started', 'doing', 'waiting', 'in_progress']
@@ -71,24 +72,26 @@ export default function TasksViewKept({ tasks = [], labels = [], onToggleComplet
               const due = dueMeta(t.due_date)
               const chips = (t.tags || []).map(id => labelsById[id]).filter(Boolean)
               return (
-                <div key={t.id} className="bm-row">
-                  <button
-                    className={`bm-chk${done ? ' is-done' : ''}`}
-                    onClick={() => onToggleComplete?.(t)}
-                    aria-label={done ? 'Reopen' : 'Catch it'}
-                  >{done && <Check size={13} strokeWidth={3.4} />}</button>
-                  <button className="bm-row-body" onClick={() => setSheetTask(t)}>
-                    <span className={`bm-row-title${done ? ' is-done' : ''}`}>{t.title}</span>
-                    {!done && (due || chips.length > 0) && (
-                      <span className="bm-row-meta">
-                        {due && <span className={due.tone === 'over' ? 'bm-due-over' : due.tone === 'hot' ? 'bm-due-hot' : undefined}>{due.label}</span>}
-                        {chips.slice(0, 3).map(l => (
-                          <span key={l.id} className="bm-tagdot" style={{ '--tag': l.color }}><i />{l.name}</span>
-                        ))}
-                      </span>
-                    )}
-                  </button>
-                </div>
+                <RowSwipe key={t.id} done={done} onCatch={() => onToggleComplete?.(t)} onDelete={() => onDelete?.(t)}>
+                  <div className="bm-row">
+                    <button
+                      className={`bm-chk${done ? ' is-done' : ''}`}
+                      onClick={() => onToggleComplete?.(t)}
+                      aria-label={done ? 'Reopen' : 'Catch it'}
+                    >{done && <Check size={13} strokeWidth={3.4} />}</button>
+                    <button className="bm-row-body" onClick={() => setSheetTask(t)}>
+                      <span className={`bm-row-title${done ? ' is-done' : ''}`}>{t.title}</span>
+                      {!done && (due || chips.length > 0) && (
+                        <span className="bm-row-meta">
+                          {due && <span className={due.tone === 'over' ? 'bm-due-over' : due.tone === 'hot' ? 'bm-due-hot' : undefined}>{due.label}</span>}
+                          {chips.slice(0, 3).map(l => (
+                            <span key={l.id} className="bm-tagdot" style={{ '--tag': l.color }}><i />{l.name}</span>
+                          ))}
+                        </span>
+                      )}
+                    </button>
+                  </div>
+                </RowSwipe>
               )
             })}
           </div>

--- a/src/kept/TodayView.jsx
+++ b/src/kept/TodayView.jsx
@@ -6,6 +6,7 @@ import { localYMD } from '../dates'
 import { historyByDay, currentStreak } from '../wallaby/heatmapUtils'
 import { isSnoozed, formatSnoozeLabel } from '../store'
 import { routineFeathers } from './feathers'
+import RowSwipe from './RowSwipe'
 import './shell.css'
 
 const ACTIVE = ['not_started', 'doing', 'waiting', 'in_progress']
@@ -16,7 +17,7 @@ const ACTIVE = ['not_started', 'doing', 'waiting', 'in_progress']
 export default function TodayView({
   tasks = [], routines = [], labels = [],
   dailyStats = {}, pointsGoal = 15, streak = 0,
-  onCompleteTask, onOpenTask, onToggleHabit,
+  onCompleteTask, onOpenTask, onToggleHabit, onDeleteTask, onEditLoop,
 }) {
   const todayKey = localYMD()
   const labelsById = useMemo(() => { const m = {}; for (const l of labels) m[l.id] = l; return m }, [labels])
@@ -68,24 +69,26 @@ export default function TodayView({
           const overdue = !done && t.due_date && String(t.due_date).slice(0, 10) < todayKey
           const chips = (t.tags || []).map(id => labelsById[id]).filter(Boolean)
           return (
-            <div key={t.id} className="bm-row">
-              <button
-                className={`bm-chk${done ? ' is-done' : ''}`}
-                onClick={() => onCompleteTask?.(t)}
-                aria-label={done ? 'Reopen' : 'Catch it'}
-              >{done && <Check size={13} strokeWidth={3.4} />}</button>
-              <button className="bm-row-body" onClick={() => onOpenTask?.(t)}>
-                <span className={`bm-row-title${done ? ' is-done' : ''}`}>{t.title}</span>
-                {!done && (overdue || chips.length > 0) && (
-                  <span className="bm-row-meta">
-                    {overdue && <span className="bm-due-over">overdue</span>}
-                    {chips.slice(0, 3).map(l => (
-                      <span key={l.id} className="bm-tagdot" style={{ '--tag': l.color }}><i />{l.name}</span>
-                    ))}
-                  </span>
-                )}
-              </button>
-            </div>
+            <RowSwipe key={t.id} done={done} onCatch={() => onCompleteTask?.(t)} onDelete={() => onDeleteTask?.(t)}>
+              <div className="bm-row">
+                <button
+                  className={`bm-chk${done ? ' is-done' : ''}`}
+                  onClick={() => onCompleteTask?.(t)}
+                  aria-label={done ? 'Reopen' : 'Catch it'}
+                >{done && <Check size={13} strokeWidth={3.4} />}</button>
+                <button className="bm-row-body" onClick={() => onOpenTask?.(t)}>
+                  <span className={`bm-row-title${done ? ' is-done' : ''}`}>{t.title}</span>
+                  {!done && (overdue || chips.length > 0) && (
+                    <span className="bm-row-meta">
+                      {overdue && <span className="bm-due-over">overdue</span>}
+                      {chips.slice(0, 3).map(l => (
+                        <span key={l.id} className="bm-tagdot" style={{ '--tag': l.color }}><i />{l.name}</span>
+                      ))}
+                    </span>
+                  )}
+                </button>
+              </div>
+            </RowSwipe>
           )
         })}
         {returningSoon.map(t => (
@@ -106,12 +109,12 @@ export default function TodayView({
             {loops.map(({ r, color, byDay, rally, doneToday }) => (
               <div key={r.id} className="bm-loop" style={{ '--loop': color }}>
                 <span className="bm-loop-ring"><Repeat2 size={15} strokeWidth={2.2} /></span>
-                <div className="bm-loop-body">
+                <button className="bm-loop-body" onClick={() => onEditLoop?.(r)} aria-label={`Edit ${r.title}`}>
                   <div className="bm-loop-title">{r.title}</div>
                   <div className="bm-loop-sub">
                     {r.cadence || 'routine'}{rally > 0 && <> · <span className="bm-loop-rally">↻ {rally}</span></>}
                   </div>
-                </div>
+                </button>
                 <span className="bm-loop-trail"><FlightTrail valueByDay={byDay} color={color} mini /></span>
                 <button
                   className={`bm-loop-chk${doneToday ? ' is-done' : ''}`}

--- a/src/kept/palette.css
+++ b/src/kept/palette.css
@@ -56,6 +56,39 @@
   --energy-errand: var(--bm-f-eucalypt);
   --energy-creative: var(--bm-f-heath);
   --energy-physical: var(--bm-f-clay);
+  /* ── Wallaby-token bridge ─────────────────────────────────────────────
+   * Components built against --wb-* (the chip task editor, the shared
+   * forms/settings/analytics override layers) resolve to the Kept palette
+   * inside kept themes. This bridge dies with Wallaby at the K6 teardown,
+   * when those components are re-tokened to --bm-* directly. */
+  --wb-bg: var(--bm-bg);
+  --wb-card: var(--bm-card);
+  --wb-card-2: var(--bm-card-2);
+  --wb-card-3: var(--bm-card-2);
+  --wb-hairline: var(--bm-hairline);
+  --wb-hairline-strong: var(--bm-hairline-strong);
+  --wb-text: var(--bm-text);
+  --wb-text-meta: var(--bm-text-meta);
+  --wb-shadow: var(--bm-shadow);
+  --wb-shadow-pop: var(--bm-shadow-pop);
+  --wb-shadow-press: var(--bm-shadow-press);
+  --wb-scrim: var(--bm-scrim);
+  --wb-heat-empty: var(--bm-trail-empty);
+  --wb-heat-border: transparent;
+  --wb-cat-blue: var(--bm-f-billabong);
+  --wb-cat-purple: var(--bm-f-ironbark);
+  --wb-cat-green: var(--bm-f-eucalypt);
+  --wb-cat-orange: var(--bm-f-ochre);
+  --wb-cat-pink: var(--bm-f-heath);
+  --wb-action-primary: var(--bm-gold);
+  --wb-action-complete: var(--bm-gold);
+  --wb-action-pause: var(--bm-gold-soft);
+  --wb-action-delete: var(--bm-danger);
+  --wb-action-secondary: var(--bm-card-2);
+  --wb-on-action: var(--bm-on-gold);
+  --wb-on-pause: var(--bm-gold);
+  --wb-fab-habits: var(--bm-gold);
+  --wb-fab-tasks: var(--bm-gold);
 }
 
 /* ── Kept light — "Linen" ──────────────────────────────────────────────── */
@@ -100,4 +133,37 @@
   --energy-errand: var(--bm-f-eucalypt);
   --energy-creative: var(--bm-f-heath);
   --energy-physical: var(--bm-f-clay);
+  /* ── Wallaby-token bridge ─────────────────────────────────────────────
+   * Components built against --wb-* (the chip task editor, the shared
+   * forms/settings/analytics override layers) resolve to the Kept palette
+   * inside kept themes. This bridge dies with Wallaby at the K6 teardown,
+   * when those components are re-tokened to --bm-* directly. */
+  --wb-bg: var(--bm-bg);
+  --wb-card: var(--bm-card);
+  --wb-card-2: var(--bm-card-2);
+  --wb-card-3: var(--bm-card-2);
+  --wb-hairline: var(--bm-hairline);
+  --wb-hairline-strong: var(--bm-hairline-strong);
+  --wb-text: var(--bm-text);
+  --wb-text-meta: var(--bm-text-meta);
+  --wb-shadow: var(--bm-shadow);
+  --wb-shadow-pop: var(--bm-shadow-pop);
+  --wb-shadow-press: var(--bm-shadow-press);
+  --wb-scrim: var(--bm-scrim);
+  --wb-heat-empty: var(--bm-trail-empty);
+  --wb-heat-border: transparent;
+  --wb-cat-blue: var(--bm-f-billabong);
+  --wb-cat-purple: var(--bm-f-ironbark);
+  --wb-cat-green: var(--bm-f-eucalypt);
+  --wb-cat-orange: var(--bm-f-ochre);
+  --wb-cat-pink: var(--bm-f-heath);
+  --wb-action-primary: var(--bm-gold);
+  --wb-action-complete: var(--bm-gold);
+  --wb-action-pause: var(--bm-gold-soft);
+  --wb-action-delete: var(--bm-danger);
+  --wb-action-secondary: var(--bm-card-2);
+  --wb-on-action: var(--bm-on-gold);
+  --wb-on-pause: var(--bm-gold);
+  --wb-fab-habits: var(--bm-gold);
+  --wb-fab-tasks: var(--bm-gold);
 }

--- a/src/kept/shell.css
+++ b/src/kept/shell.css
@@ -351,3 +351,28 @@
   font-size: 12px; color: var(--bm-text-meta);
 }
 .bm-hero-meta b { color: var(--bm-text); font-weight: 700; }
+
+/* Swipe-to-reveal on hairline rows */
+.bm-row-swipe { position: relative; overflow: hidden; }
+.bm-row-swipe-actions {
+  position: absolute;
+  inset: 0 0 1px auto;   /* keep the hairline visible below */
+  display: flex;
+}
+.bm-row-swipe-act {
+  width: 66px;
+  border: none;
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: center; gap: 3px;
+  font-size: 11px; font-weight: 700;
+  font-family: var(--v2-font-body);
+  cursor: pointer;
+}
+.bm-row-swipe-catch { background: var(--bm-gold); color: var(--bm-on-gold); }
+.bm-row-swipe-del { background: var(--bm-danger); color: var(--bm-on-gold); }
+.bm-row-swipe-body {
+  position: relative; z-index: 1;
+  background: var(--bm-bg);
+  transition: transform 200ms ease;
+  will-change: transform;
+}

--- a/src/wallaby/analytics.css
+++ b/src/wallaby/analytics.css
@@ -1,11 +1,11 @@
 /* ════════════════════════════════════════════════════════════════════════
- * Wallaby Analytics reskin — visual only, gated on [data-theme^="wallaby"].
+ * Wallaby Analytics reskin — visual only, gated on :is([data-theme^="wallaby"], [data-theme^="kept"]).
  * Cards Boomerang's existing analytics sections + greens the accents, without
  * touching the markup or the rich charts (daily bars / DOW / breakdown / heatmap).
  * ════════════════════════════════════════════════════════════════════════ */
 
 /* Sections → grouped navy cards */
-[data-theme^="wallaby"] .v2-analytics-section {
+:is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-analytics-section {
   background: var(--wb-card);
   border: 1px solid var(--wb-hairline);
   border-radius: 16px;
@@ -15,7 +15,7 @@
 }
 
 /* Summary "big number" band → its own card + green hero number */
-[data-theme^="wallaby"] .v2-analytics-summary {
+:is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-analytics-summary {
   background: var(--wb-card);
   border: 1px solid var(--wb-hairline);
   border-radius: 16px;
@@ -23,14 +23,14 @@
   margin: 4px 0 12px;
   box-shadow: var(--wb-shadow);
 }
-[data-theme^="wallaby"] .v2-analytics-summary-num { color: var(--wb-action-complete); }
+:is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-analytics-summary-num { color: var(--wb-action-complete); }
 
 /* Range / metric toggles → full-width segmented controls, matching the Tasks
  * header (`.wb-tasks .wb-seg`): contained pill track, subtle card-3 active fill.
  * (User: selectors looked awkward as small left-floating pills → "use the way
  * tasks does this for analytics.") */
-[data-theme^="wallaby"] .v2-analytics-range,
-[data-theme^="wallaby"] .v2-analytics-metric {
+:is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-analytics-range,
+:is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-analytics-metric {
   display: flex;
   width: 100%;
   gap: 2px;
@@ -40,8 +40,8 @@
   padding: 3px;
   margin: 0 0 10px;
 }
-[data-theme^="wallaby"] .v2-analytics-range-btn,
-[data-theme^="wallaby"] .v2-analytics-metric-btn {
+:is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-analytics-range-btn,
+:is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-analytics-metric-btn {
   flex: 1 1 0;
   border: none;
   background: transparent;
@@ -51,8 +51,8 @@
   font: 600 13px/1 var(--v2-font-body);
   cursor: pointer;
 }
-[data-theme^="wallaby"] .v2-analytics-range-btn-active,
-[data-theme^="wallaby"] .v2-analytics-metric-btn-active {
+:is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-analytics-range-btn-active,
+:is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-analytics-metric-btn-active {
   background: var(--wb-card-3);
   color: var(--wb-text);
   box-shadow: var(--wb-shadow-press);
@@ -61,20 +61,20 @@
 /* Section tabs → contained segmented control. View tabs take the slate
  * (card-3) active fill like every other Wallaby view/range tab — green is
  * reserved for form value-pick segments (see shared.css convention). */
-[data-theme^="wallaby"] .v2-analytics-tabs {
+:is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-analytics-tabs {
   background: var(--wb-card-2);
   border: 1px solid var(--wb-hairline);
   border-radius: 10px;
   padding: 3px;
   gap: 2px;
 }
-[data-theme^="wallaby"] .v2-analytics-tab {
+:is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-analytics-tab {
   border: none;
   background: transparent;
   border-radius: 10px;
   color: var(--wb-text-meta);
 }
-[data-theme^="wallaby"] .v2-analytics-tab-active {
+:is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-analytics-tab-active {
   background: var(--wb-card-3);
   color: var(--wb-text);
   box-shadow: var(--wb-shadow-press);
@@ -82,12 +82,12 @@
 }
 
 /* Chart fills pick up the Wallaby accent (purple) over the v2 orange */
-[data-theme^="wallaby"] .v2-analytics-daily-bar,
-[data-theme^="wallaby"] .v2-analytics-bd-fill,
-[data-theme^="wallaby"] .v2-analytics-dow-fill {
+:is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-analytics-daily-bar,
+:is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-analytics-bd-fill,
+:is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-analytics-dow-fill {
   background: var(--wb-cat-purple);
 }
-[data-theme^="wallaby"] .v2-analytics-bd-track,
-[data-theme^="wallaby"] .v2-analytics-dow-track {
+:is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-analytics-bd-track,
+:is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-analytics-dow-track {
   background: var(--wb-card-2);
 }

--- a/src/wallaby/forms.css
+++ b/src/wallaby/forms.css
@@ -10,49 +10,49 @@
  * ════════════════════════════════════════════════════════════════════════ */
 
 /* Inputs / textareas / selects → card surface (was the page bg). */
-[data-theme^="wallaby"] .v2-form-input,
-[data-theme^="wallaby"] .v2-form-textarea,
-[data-theme^="wallaby"] .v2-form-pri-toggle,
-[data-theme^="wallaby"] .v2-edit-duration-input,
-[data-theme^="wallaby"] .v2-edit-checklist-add-input,
-[data-theme^="wallaby"] .v2-edit-comment-input-row input {
+:is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-form-input,
+:is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-form-textarea,
+:is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-form-pri-toggle,
+:is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-edit-duration-input,
+:is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-edit-checklist-add-input,
+:is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-edit-comment-input-row input {
   background: var(--wb-card);
   border-color: var(--wb-hairline);
 }
-[data-theme^="wallaby"] .v2-form-input:focus,
-[data-theme^="wallaby"] .v2-form-textarea:focus,
-[data-theme^="wallaby"] .v2-edit-duration-input:focus {
+:is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-form-input:focus,
+:is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-form-textarea:focus,
+:is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-edit-duration-input:focus {
   border-color: var(--wb-cat-purple);
 }
 
 /* Segmented pills — Status, Size, Energy drain. Navy card, GREEN active. */
-[data-theme^="wallaby"] .v2-form-seg {
+:is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-form-seg {
   background: var(--wb-card);
   border-color: var(--wb-hairline);
   color: var(--wb-text-meta);
   border-radius: 11px;
 }
-[data-theme^="wallaby"] .v2-form-seg-active {
+:is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-form-seg-active {
   background: var(--wb-action-complete) !important;
   border-color: var(--wb-action-complete) !important;
   color: var(--wb-on-action) !important;
 }
 
 /* Energy type pills — navy card; active = purple tint (matches chip editor). */
-[data-theme^="wallaby"] .v2-form-energy-pill {
+:is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-form-energy-pill {
   background: var(--wb-card);
   border-color: var(--wb-hairline);
   color: var(--wb-text);
   border-radius: 11px;
 }
-[data-theme^="wallaby"] .v2-form-energy-pill-active {
+:is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-form-energy-pill-active {
   background: color-mix(in srgb, var(--wb-cat-purple) 22%, transparent) !important;
   border-color: var(--wb-cat-purple) !important;
   color: var(--wb-text) !important;
 }
 
 /* Label / tag pills — navy card; active keeps the label color. */
-[data-theme^="wallaby"] .v2-form-label-pill {
+:is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-form-label-pill {
   background: var(--wb-card);
   border-color: var(--wb-hairline);
   color: var(--wb-text);
@@ -60,17 +60,17 @@
 }
 
 /* AI helper pills (Auto / Research / Infer) — purple-tinted chip. */
-[data-theme^="wallaby"] .v2-form-ai-pill {
+:is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-form-ai-pill {
   background: var(--wb-card-2);
   color: var(--wb-cat-purple);
   border-radius: 10px;
 }
 
 /* Misc edit chips/pills that should read as Wallaby cards. */
-[data-theme^="wallaby"] .v2-edit-add-pill,
-[data-theme^="wallaby"] .v2-edit-connection-pill,
-[data-theme^="wallaby"] .v2-edit-knowledge-chip,
-[data-theme^="wallaby"] .v2-edit-blocker-chip {
+:is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-edit-add-pill,
+:is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-edit-connection-pill,
+:is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-edit-knowledge-chip,
+:is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-edit-blocker-chip {
   background: var(--wb-card);
   border-color: var(--wb-hairline);
   color: var(--wb-text);
@@ -78,17 +78,17 @@
 }
 
 /* Primary action buttons inside the editor → green; danger → red. */
-[data-theme^="wallaby"] .v2-edit-action-primary {
+:is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-edit-action-primary {
   background: var(--wb-action-complete);
   border-color: var(--wb-action-complete);
   color: var(--wb-on-action);
 }
-[data-theme^="wallaby"] .v2-edit-action-danger {
+:is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-edit-action-danger {
   color: var(--wb-action-delete);
   border-color: color-mix(in srgb, var(--wb-action-delete) 40%, transparent);
 }
 
 /* Checklist progress fill → green. */
-[data-theme^="wallaby"] .v2-edit-checklist-progress-fill {
+:is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-edit-checklist-progress-fill {
   background: var(--wb-action-complete);
 }

--- a/src/wallaby/modals.css
+++ b/src/wallaby/modals.css
@@ -49,6 +49,11 @@
     padding: calc(60px + env(safe-area-inset-top)) 20px 16px;
   }
   :is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-modal-back {
+    /* .v2-modal is the page SCROLLER — absolute positioning rode along with
+     * the content, so the back button scrolled off-screen on long pages.
+     * The page covers the viewport, so fixed = pinned top-left. */
+    position: fixed;
+    z-index: 5;
     top: calc(14px + env(safe-area-inset-top));
     left: 16px;
     right: auto;
@@ -59,7 +64,7 @@
     border: 1px solid var(--wb-hairline);
     color: var(--wb-text);
   }
-  :is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-modal-header-slot { top: calc(22px + env(safe-area-inset-top)); }
+  :is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-modal-header-slot { position: fixed; z-index: 5; top: calc(22px + env(safe-area-inset-top)); }
   :is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-modal-title { font-size: 26px; }
   /* Give the body bottom safe-area room so the last controls clear the home bar. */
   :is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-modal-body { padding-bottom: calc(24px + env(safe-area-inset-bottom)); }

--- a/src/wallaby/settings.css
+++ b/src/wallaby/settings.css
@@ -1,5 +1,5 @@
 /* ════════════════════════════════════════════════════════════════════════
- * Wallaby Settings reskin — visual only, gated on [data-theme^="wallaby"].
+ * Wallaby Settings reskin — visual only, gated on :is([data-theme^="wallaby"], [data-theme^="kept"]).
  * The SettingsModal already consumes --v2-* tokens (so it's navy in Wallaby);
  * this layers the loggd card/toggle/tab aesthetic on top WITHOUT touching the
  * markup. Every Boomerang setting is preserved. Notifications get the loggd
@@ -7,15 +7,15 @@
  * ════════════════════════════════════════════════════════════════════════ */
 
 /* ── Tabs → underline style, single scrollable row ───────────────────────── */
-[data-theme^="wallaby"] .v2-settings-tabs {
+:is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-settings-tabs {
   flex-wrap: nowrap;
   overflow-x: auto;
   gap: 2px;
   border-bottom-color: var(--wb-hairline);
   scrollbar-width: none;
 }
-[data-theme^="wallaby"] .v2-settings-tabs::-webkit-scrollbar { display: none; }
-[data-theme^="wallaby"] .v2-settings-tab {
+:is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-settings-tabs::-webkit-scrollbar { display: none; }
+:is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-settings-tab {
   flex: 0 0 auto;
   border: none;
   border-radius: 0;
@@ -23,8 +23,8 @@
   padding: 8px 12px 10px;
   font-weight: 700;
 }
-[data-theme^="wallaby"] .v2-settings-tab-active,
-[data-theme^="wallaby"] .v2-settings-tab.v2-settings-tab-active {
+:is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-settings-tab-active,
+:is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-settings-tab.v2-settings-tab-active {
   background: transparent;
   color: var(--wb-text);
   border: none;
@@ -32,7 +32,7 @@
 }
 
 /* ── Blocks → grouped navy cards ─────────────────────────────────────────── */
-[data-theme^="wallaby"] .v2-settings-block {
+:is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-settings-block {
   background: var(--wb-card);
   border: 1px solid var(--wb-hairline);
   border-radius: 16px;
@@ -40,28 +40,28 @@
   margin-bottom: 12px;
   box-shadow: var(--wb-shadow);
 }
-[data-theme^="wallaby"] .v2-settings-block + .v2-settings-block { padding-top: 16px; }
-[data-theme^="wallaby"] .v2-settings-block:last-child { padding-bottom: 16px; }
+:is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-settings-block + .v2-settings-block { padding-top: 16px; }
+:is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-settings-block:last-child { padding-bottom: 16px; }
 
 /* ── Toggles → loggd green ───────────────────────────────────────────────── */
-[data-theme^="wallaby"] .v2-settings-toggle input:checked + .v2-settings-toggle-track {
+:is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-settings-toggle input:checked + .v2-settings-toggle-track {
   background: var(--wb-action-complete);
 }
 
 /* ── Segmented controls → green active (form value-picks, per the shared.css
  * convention: view tabs are slate, value segments are green). ──────────── */
-[data-theme^="wallaby"] .v2-settings-segment-btn-active {
+:is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-settings-segment-btn-active {
   background: var(--wb-action-complete);
   color: var(--wb-on-action);
 }
 
 /* ── Inputs / buttons → navy surfaces ────────────────────────────────────── */
-[data-theme^="wallaby"] .v2-form-input,
-[data-theme^="wallaby"] .v2-settings-compact-input {
+:is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-form-input,
+:is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-settings-compact-input {
   background: var(--wb-card-2);
   border-color: var(--wb-hairline);
 }
-[data-theme^="wallaby"] .v2-settings-btn {
+:is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-settings-btn {
   background: var(--wb-card-2);
   border-color: var(--wb-hairline);
 }
@@ -69,29 +69,29 @@
 /* ── Notifications: the "fire" treatment ─────────────────────────────────── */
 /* Cards sit inside a block-card, so use the elevated surface for contrast and
  * lay the three channels out as clean toggle tiles. */
-[data-theme^="wallaby"] .v2-notif-cards {
+:is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-notif-cards {
   display: flex;
   flex-direction: column;
   gap: 10px;
 }
-[data-theme^="wallaby"] .v2-notif-card {
+:is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-notif-card {
   background: var(--wb-card-2);
   border: 1px solid var(--wb-hairline);
   border-radius: 14px;
   padding: 14px;
 }
-[data-theme^="wallaby"] .v2-notif-card-label {
+:is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-notif-card-label {
   font-weight: 700;
   color: var(--wb-text);
 }
-[data-theme^="wallaby"] .v2-notif-card-channel {
+:is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-notif-card-channel {
   background: var(--wb-card-3);
   border: 1px solid var(--wb-hairline);
   border-radius: 11px;
   padding: 10px 4px;
 }
-[data-theme^="wallaby"] .v2-notif-card-channel:hover { background: var(--wb-card); }
-[data-theme^="wallaby"] .v2-notif-card-freq-input {
+:is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-notif-card-channel:hover { background: var(--wb-card); }
+:is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-notif-card-freq-input {
   background: var(--wb-card-3);
   border-color: var(--wb-hairline);
 }

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,13 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-10
 
+- fix(ui): Kept tire-kicking round 1 — editors, swipe, clickable loops, pinned back button [M]
+  - **Editors now speak Kept.** A `--wb-*` → `--bm-*` token bridge inside the kept theme blocks means every wallaby-built component resolves to the Kept palette, and the forms/settings/analytics override layers are `:is()`-extended to kept — so the chip task editor (now enabled for kept themes, it was wallaby-gated), the full EditTaskModal's form controls, AddTaskModal, and the Settings/Analytics internals all render gold-on-Nightgum instead of raw v2. The bridge is explicitly temporary: it dies at the K6 Wallaby teardown when those components re-token to `--bm-*` directly.
+  - **Swipe is back:** new `RowSwipe` wrapper (shared `useSwipeActions` gesture) on Today + Tasks rows — swipe left reveals Catch (gold) / Delete.
+  - **Loops are tappable:** loop rows on Today and loop-card titles on Loops open the loop editor (previously only the pencil icon was interactive).
+  - **Back button pinned:** the full-page modal back arrow (and the autosave chip) were absolutely positioned inside `.v2-modal` — the page SCROLLER — so they scrolled off-screen on long pages. Now `position: fixed`.
+  - Verified live: chip editor opens in Kept palette from the task action sheet; loop tap opens "Edit loop"; back arrow at top after an 800px scroll; swipe wrappers on every row.
+
 - fix(ui): Kept — shared-modal titles follow the Kept naming layer [S]
   - The More menu said Arcs / Caught / Loops but the modals opened as "Projects" / "Done" / "Routines". `ProjectsView`, `DoneList`, and `RoutinesModal` now take a `title` override (+ `noun` on RoutinesModal so the form reads "New loop"/"Edit loop"); AppV2 passes the Kept names when a kept theme is active. Standard + Wallaby keep their existing titles. Verified live: all three open under their menu names.
 


### PR DESCRIPTION
Kept tire-kicking round 1 — four reports from live use, all fixed and verified:

## 1. Editors actually speak Kept now

They were functionally untouched v2 — honest miss. Two moves fix it:
- A **`--wb-*` → `--bm-*` token bridge** inside the kept theme blocks: every wallaby-built component resolves to the Kept palette (gold actions, Nightgum surfaces, feather category colors).
- The forms/settings/analytics override layers are `:is()`-extended to kept, and the **chip task editor is enabled for kept themes** (it was wallaby-gated, so Kept was falling through to the raw full editor).

Net: the quick chip editor, the full EditTaskModal's controls, AddTaskModal, and Settings/Analytics internals all render gold-on-Nightgum. The bridge is explicitly temporary — it dies at the K6 Wallaby teardown when these components re-token to `--bm-*` directly.

## 2. Swipe is back

New `RowSwipe` wrapper (the shared `useSwipeActions` gesture from TaskCard/Wallaby) on Today + Tasks rows — swipe left reveals **Catch** (gold) / **Delete**.

## 3. Loops are tappable

Loop rows on Today and loop-card titles on Loops open the loop editor — previously only the tiny pencil icon was interactive.

## 4. Back button stays put

The full-page modal back arrow (and the autosave chip) were absolutely positioned inside `.v2-modal` — which is the page *scroller* — so they rode the content off-screen on long pages. Now `position: fixed`, pinned through any scroll.

## Verified

Live headless: chip editor opens in the Kept palette from the action sheet; loop tap opens "Edit loop"; back arrow at `top: 14px` after an 800px scroll; swipe wrappers on every row. Lint 0; tests + build + smoke pass.

https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR)_