### PR TITLE
release: Today cadence-due loops hotfix + pinned-control fade

### DIFF
--- a/src/kept/TodayView.jsx
+++ b/src/kept/TodayView.jsx
@@ -4,7 +4,7 @@ import DayArc from './DayArc'
 import FlightTrail from './FlightTrail'
 import { localYMD } from '../dates'
 import { historyByDay, currentStreak } from '../wallaby/heatmapUtils'
-import { isSnoozed, formatSnoozeLabel } from '../store'
+import { isSnoozed, formatSnoozeLabel, getNextDueDate } from '../store'
 import { routineFeathers } from './feathers'
 import RowSwipe from './RowSwipe'
 import './shell.css'
@@ -35,12 +35,24 @@ export default function TodayView({
     ACTIVE.includes(t.status) && !t.parent_id && !t.gmail_pending && isSnoozed(t) && !t.snooze_indefinite,
   ).slice(0, 3), [tasks])
 
+  // Only loops that are actually DUE today (per the cadence engine — weekly/
+  // monthly/quarterly stay hidden until their day), already done today (so a
+  // checked loop doesn't vanish), or overdue from an earlier cycle. The full
+  // library lives on the Loops tab. (Prod bug: every non-paused loop was
+  // listed daily — loggd's all-habits-are-daily assumption.)
   const loops = useMemo(() => {
     const feathers = routineFeathers(routines)
     return routines.filter(r => !r.paused).map(r => {
       const byDay = historyByDay(r.completed_history)
-      return { r, color: feathers[r.id], byDay, rally: currentStreak(byDay), doneToday: !!byDay[todayKey] }
-    })
+      const next = getNextDueDate(r)
+      const dueKey = next ? localYMD(next) : null
+      return {
+        r, color: feathers[r.id], byDay,
+        rally: currentStreak(byDay),
+        doneToday: !!byDay[todayKey],
+        dueToday: !!dueKey && dueKey <= todayKey,
+      }
+    }).filter(l => l.dueToday || l.doneToday)
   }, [routines, todayKey])
   const loopsDone = loops.filter(l => l.doneToday).length
   const catches = dailyStats.tasksToday ?? 0

--- a/src/wallaby/modals.css
+++ b/src/wallaby/modals.css
@@ -48,6 +48,18 @@
   :is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-modal-header {
     padding: calc(60px + env(safe-area-inset-top)) 20px 16px;
   }
+  /* Pinned-control underlay: scrolled content fades out under the top strip
+   * instead of colliding with the fixed back button (the "it loop" clipped-
+   * title report). Gradient from the page bg; clicks pass through. */
+  :is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-modal::before {
+    content: "";
+    position: fixed;
+    top: 0; left: 0; right: 0;
+    height: calc(64px + env(safe-area-inset-top));
+    background: linear-gradient(to bottom, var(--v2-bg) 55%, transparent);
+    z-index: 4;
+    pointer-events: none;
+  }
   :is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-modal-back {
     /* .v2-modal is the page SCROLLER — absolute positioning rode along with
      * the content, so the back button scrolled off-screen on long pages.

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -4,7 +4,11 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ---
 
-## 2026-06-10
+## 2026-06-11
+
+- fix(ui): Kept Today — only cadence-due loops; modal-top fade strip [S]
+  - **Prod bug:** Today listed EVERY non-paused loop daily (loggd's all-habits-are-daily assumption carried into TodayView) — weekly/monthly/quarterly routines like "Mow · weekly · Fri" surfaced days early. The loops list now filters through `getNextDueDate`: a loop shows only when cadence-due today (or overdue), or already done today so a checked loop doesn't vanish. The full library stays on the Loops tab. Verified with a Friday-anchored weekly loop completed last Friday: hidden from Today, present in Loops.
+  - **Edit-modal title collision:** with the back button pinned (previous fix), scrolled content slid UNDER it — the "Edit loop" title read "it loop" mid-scroll. A fixed gradient strip (page bg → transparent, click-through) now fades content out under the pinned controls.
 
 - feat(ui): Kept palette revision — "Smoke + Ember" replaces Nightgum + Ochre [M]
   - The green-ink + gold direction read *earthy* in daily use. From a 4-direction live exploration (same Today screen re-skinned via token injection) the user picked a blend of "Warm Ink + Ember" and "Graphite + Gold": **Smoke** — a warm-neutral de-greened canvas (`#16140F` dark / `#F8F4ED` light) — with the brand's original **ember orange** (`#F26640`/`#D9512B`) as THE hero, and **gold demoted to the warm companion accent** (`--bm-gold`, rally chips + the ochre feather). Danger shifts to crimson so it can't collide with the ember hero.


### PR DESCRIPTION
Hotfix promotion for the prod-reported Today bug. **Merge with the merge-commit method only.**

- **Today shows only cadence-due loops:** weekly/monthly/quarterly loops no longer appear daily — the list filters through `getNextDueDate` (due today / overdue / already done today). "Mow · weekly · Fri" stays hidden until Friday. The full library remains on the Loops tab.
- **Pinned-control fade strip:** scrolled modal content no longer collides with the pinned back button (the "it loop" clipped title).

Single commit on top of the Kept release; verified live with a controlled Friday-anchored loop + scrolled-modal screenshots; lint 0, tests + build + smoke pass.

https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR)_