### PR TITLE
fix(ui): Kept Today — trigger-time stacks wait for their clock time

### DIFF
--- a/src/kept/TodayView.jsx
+++ b/src/kept/TodayView.jsx
@@ -38,8 +38,9 @@ export default function TodayView({
   }).sort((a, b) => (a.status === 'done' ? 1 : 0) - (b.status === 'done' ? 1 : 0)), [tasks, todayKey, stackRoutineIds])
 
   const returningSoon = useMemo(() => tasks.filter(t =>
-    ACTIVE.includes(t.status) && !t.parent_id && !t.gmail_pending && isSnoozed(t) && !t.snooze_indefinite,
-  ).slice(0, 3), [tasks])
+    ACTIVE.includes(t.status) && !t.parent_id && !t.gmail_pending && isSnoozed(t) && !t.snooze_indefinite
+    && !(t.routine_id && stackRoutineIds.has(t.routine_id)),
+  ).slice(0, 3), [tasks, stackRoutineIds])
 
   // Only loops that are actually DUE today (per the cadence engine — weekly/
   // monthly/quarterly stay hidden until their day), already done today (so a
@@ -55,18 +56,24 @@ export default function TodayView({
       const isStack = Array.isArray(r.members) && r.members.length > 0
       // A stack's live cycle = its member tasks due today or carried over
       // (leftover members linger as the open cycle until cleared).
-      const memberTasks = isStack
+      const cycleTasks = isStack
         ? tasks.filter(t => t.routine_id === r.id
             && String(t.due_date || '').slice(0, 10) <= todayKey
             && !['cancelled', 'backlog', 'project'].includes(t.status))
         : []
+      // Pre-trigger (trigger_time) members are snoozed — the stack shows as a
+      // single "returns tonight" row until they surface, per the trigger-time
+      // contract (don't show scheduled work before its clock time).
+      const memberTasks = cycleTasks.filter(t => t.status === 'done' || !isSnoozed(t))
+      const snoozedUntil = cycleTasks.find(t => t.status !== 'done' && isSnoozed(t))?.snoozed_until || null
+      const allSnoozed = isStack && memberTasks.length === 0 && !!snoozedUntil
       return {
-        r, color: feathers[r.id], byDay, isStack, memberTasks,
+        r, color: feathers[r.id], byDay, isStack, memberTasks, allSnoozed, snoozedUntil,
         rally: currentStreak(byDay),
         doneToday: !!byDay[todayKey],
         dueToday: !!dueKey && dueKey <= todayKey,
       }
-    }).filter(l => l.dueToday || l.doneToday || l.memberTasks.length > 0)
+    }).filter(l => l.dueToday || l.doneToday || l.memberTasks.length > 0 || l.allSnoozed)
   }, [routines, tasks, todayKey])
   const loopsDone = loops.filter(l => l.doneToday).length
   const catches = dailyStats.tasksToday ?? 0
@@ -132,7 +139,7 @@ export default function TodayView({
         <>
           <div className="bm-sec"><span className="bm-sec-tick" /> Loops <span className="bm-sec-n">{loopsDone}/{loops.length}</span></div>
           <div className="bm-rows">
-            {loops.map(({ r, color, byDay, rally, doneToday, isStack, memberTasks }) => {
+            {loops.map(({ r, color, byDay, rally, doneToday, isStack, memberTasks, allSnoozed, snoozedUntil }) => {
               if (isStack) {
                 // Stack: independent member tasks per cycle. Checks route
                 // through the REAL task path (onCompleteTask) so the 20%
@@ -143,10 +150,16 @@ export default function TodayView({
                       <span className="bm-loop-ring"><Repeat2 size={15} strokeWidth={2.2} /></span>
                       <button className="bm-loop-body" onClick={() => onEditLoop?.(r)}>
                         <div className="bm-loop-title">{r.title} <em className="bm-stack-count">· {r.members.length} items</em></div>
-                        <div className="bm-loop-sub">{doneToday ? 'cycle cleared today' : 'stack'}</div>
+                        <div className="bm-loop-sub">
+                          {doneToday ? 'cycle cleared today'
+                            : allSnoozed ? <span className="bm-return-chip">↩ returns {formatSnoozeLabel(snoozedUntil)}</span>
+                            : 'stack'}
+                        </div>
                       </button>
                       {doneToday ? (
                         <span className="bm-loop-chk is-done" style={{ '--loop': color }} aria-hidden="true"><Check size={15} strokeWidth={3.2} /></span>
+                      ) : allSnoozed ? (
+                        <span className="bm-chk is-muted" aria-hidden="true" />
                       ) : (
                         <button className="bm-btn bm-btn-tonal bm-stack-start" onClick={() => onSpawnStackToday?.(r.id)}>Start</button>
                       )}

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,9 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-11
 
+- fix(ui): Kept Today — trigger-time stacks stay "returns tonight" until their clock time [S]
+  - Prod screenshots (the "Bedtime" stack, trigger 8pm-ish) showed snoozed stack members leaking into Today as individual "↩ returns tonight" rows hours early. Pre-trigger, a stack now renders as ONE row — `Bedtime · 3 items · ↩ returns tonight` with a muted check, no Start button — per the trigger-time contract. Members surface grouped only once un-snoozed; `returningSoon` excludes stack members (the stack row represents them). Verified with a 23:45-trigger stack: single returns row, zero member leakage, no premature grouped block.
+
 - fix(ui): Kept Today — stack support (grouped member rows, Start affordance) [M]
   - Stacks were rendered as a single-toggle loop row on Kept's Today — tapping the check would have caught one arbitrary member per tap. Stacks now fan out properly: a grouped block (stack head + `done/total` progress + indented member rows with feather checks) when the cycle is spawned; a **Start** button when due but not yet spawned; a "cycle cleared today" state after the last member. Member checks route through the REAL task path (`onCompleteTask`) so the 20% clear-bonus and the lone last-member `completed_history` stamp hold — verified end-to-end: 3-member stack spawned, members grouped (not duplicated in the plain Tasks rows), full clear produced exactly ONE history stamp + the bonus toast.
   - `onSpawnStackToday` threaded into KeptShell + KeptDesktop; stack members excluded from Today's plain task rows.


### PR DESCRIPTION
Follow-up to last night's stack support, driven by the prod Bedtime-stack screenshots: **trigger-time stacks were leaking their snoozed members into Today hours early** — both as individual "↩ returns tonight" rows and (on dev) as a prematurely-grouped member block.

Pre-trigger, a stack now renders as **one row**: `Bedtime · 3 items · ↩ returns tonight`, muted check, no Start button — honoring the trigger-time contract (scheduled work stays hidden until its clock time). Members surface grouped only once un-snoozed, and `returningSoon` excludes stack members since the stack row represents them.

Verified with a 23:45-trigger 3-member stack: single returns row, zero member leakage into the task/returns rows, no premature grouped block, zero page errors. Lint 0; tests + build + smoke pass.

https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR)_