### PR TITLE
release: Kept stacks on Today (grouped members + trigger-time gating)

### DIFF
--- a/src/AppV2.jsx
+++ b/src/AppV2.jsx
@@ -1256,6 +1256,11 @@ export default function AppV2() {
           streak={streak}
           onCompleteTask={(task) => task.status === 'done' ? handleUncomplete(task) : handleComplete(task.id)}
           onOpenTask={(task) => setEditTarget(task)}
+          onSpawnStackToday={(routineId) => {
+            const spawned = spawnNow(routineId)
+            if (spawned && spawned.length) addSpawnedTasks(spawned)
+            return spawned
+          }}
           onToggleHabit={toggleHabitDay}
           onRescheduleTask={(task, ymd) => updateTask(task.id, { due_date: ymd })}
           onDeleteTask={(task) => handleDelete(task.id)}
@@ -1289,6 +1294,11 @@ export default function AppV2() {
           streak={streak}
           onCompleteTask={(task) => task.status === 'done' ? handleUncomplete(task) : handleComplete(task.id)}
           onOpenTask={(task) => setEditTarget(task)}
+          onSpawnStackToday={(routineId) => {
+            const spawned = spawnNow(routineId)
+            if (spawned && spawned.length) addSpawnedTasks(spawned)
+            return spawned
+          }}
           onToggleHabit={toggleHabitDay}
           onRescheduleTask={(task, ymd) => updateTask(task.id, { due_date: ymd })}
           onDeleteTask={(task) => handleDelete(task.id)}

--- a/src/kept/KeptDesktop.jsx
+++ b/src/kept/KeptDesktop.jsx
@@ -18,7 +18,7 @@ import './desktop.css'
 export default function KeptDesktop({
   tasks = [], routines = [], labels = [],
   dailyStats = {}, pointsGoal = 15, streak = 0,
-  onCompleteTask, onOpenTask, onToggleHabit, onRescheduleTask, onDeleteTask,
+  onCompleteTask, onOpenTask, onToggleHabit, onRescheduleTask, onDeleteTask, onSpawnStackToday,
   onThrow, onOpenFullAdd, onEditLoop, onAddLoop,
   onOpenQuokka, onOpenSettings, onOpenPackages, onOpenAnalytics,
   onOpenProjects, onOpenDone, onOpenActivity,
@@ -69,7 +69,7 @@ export default function KeptDesktop({
         tasks={tasks} routines={routines} labels={labels}
         dailyStats={dailyStats} pointsGoal={pointsGoal} streak={streak}
         onCompleteTask={onCompleteTask} onOpenTask={onOpenTask} onToggleHabit={onToggleHabit}
-        onDeleteTask={onDeleteTask} onEditLoop={onEditLoop}
+        onDeleteTask={onDeleteTask} onEditLoop={onEditLoop} onSpawnStackToday={onSpawnStackToday}
       />
     )
   }

--- a/src/kept/KeptShell.jsx
+++ b/src/kept/KeptShell.jsx
@@ -15,7 +15,7 @@ import './shell.css'
 export default function KeptShell({
   tasks = [], routines = [], labels = [],
   dailyStats = {}, pointsGoal = 15, streak = 0,
-  onCompleteTask, onOpenTask, onToggleHabit, onRescheduleTask, onDeleteTask,
+  onCompleteTask, onOpenTask, onToggleHabit, onRescheduleTask, onDeleteTask, onSpawnStackToday,
   onThrow, onOpenFullAdd, onEditLoop, onAddLoop,
   onOpenQuokka, onOpenSettings, onOpenPackages, onOpenAnalytics,
   onOpenProjects, onOpenDone, onOpenActivity, onOpenSuggestions,
@@ -50,7 +50,7 @@ export default function KeptShell({
         tasks={tasks} routines={routines} labels={labels}
         dailyStats={dailyStats} pointsGoal={pointsGoal} streak={streak}
         onCompleteTask={onCompleteTask} onOpenTask={onOpenTask} onToggleHabit={onToggleHabit}
-        onDeleteTask={onDeleteTask} onEditLoop={onEditLoop}
+        onDeleteTask={onDeleteTask} onEditLoop={onEditLoop} onSpawnStackToday={onSpawnStackToday}
       />
     )
   }

--- a/src/kept/TodayView.jsx
+++ b/src/kept/TodayView.jsx
@@ -17,19 +17,25 @@ const ACTIVE = ['not_started', 'doing', 'waiting', 'in_progress']
 export default function TodayView({
   tasks = [], routines = [], labels = [],
   dailyStats = {}, pointsGoal = 15, streak = 0,
-  onCompleteTask, onOpenTask, onToggleHabit, onDeleteTask, onEditLoop,
+  onCompleteTask, onOpenTask, onToggleHabit, onDeleteTask, onEditLoop, onSpawnStackToday,
 }) {
   const todayKey = localYMD()
   const labelsById = useMemo(() => { const m = {}; for (const l of labels) m[l.id] = l; return m }, [labels])
 
+  const stackRoutineIds = useMemo(() => new Set(
+    routines.filter(r => Array.isArray(r.members) && r.members.length > 0).map(r => r.id),
+  ), [routines])
+
   const dayTasks = useMemo(() => tasks.filter(t => {
     if (t.parent_id || t.gmail_pending) return false
+    // Stack members render grouped under their stack in the Loops section.
+    if (t.routine_id && stackRoutineIds.has(t.routine_id)) return false
     const doneToday = t.status === 'done' && t.completed_at && localYMD(new Date(t.completed_at)) === todayKey
     if (doneToday) return true
     if (!ACTIVE.includes(t.status)) return false
     if (isSnoozed(t)) return false
     return t.due_date ? String(t.due_date).slice(0, 10) <= todayKey : false
-  }).sort((a, b) => (a.status === 'done' ? 1 : 0) - (b.status === 'done' ? 1 : 0)), [tasks, todayKey])
+  }).sort((a, b) => (a.status === 'done' ? 1 : 0) - (b.status === 'done' ? 1 : 0)), [tasks, todayKey, stackRoutineIds])
 
   const returningSoon = useMemo(() => tasks.filter(t =>
     ACTIVE.includes(t.status) && !t.parent_id && !t.gmail_pending && isSnoozed(t) && !t.snooze_indefinite,
@@ -46,14 +52,22 @@ export default function TodayView({
       const byDay = historyByDay(r.completed_history)
       const next = getNextDueDate(r)
       const dueKey = next ? localYMD(next) : null
+      const isStack = Array.isArray(r.members) && r.members.length > 0
+      // A stack's live cycle = its member tasks due today or carried over
+      // (leftover members linger as the open cycle until cleared).
+      const memberTasks = isStack
+        ? tasks.filter(t => t.routine_id === r.id
+            && String(t.due_date || '').slice(0, 10) <= todayKey
+            && !['cancelled', 'backlog', 'project'].includes(t.status))
+        : []
       return {
-        r, color: feathers[r.id], byDay,
+        r, color: feathers[r.id], byDay, isStack, memberTasks,
         rally: currentStreak(byDay),
         doneToday: !!byDay[todayKey],
         dueToday: !!dueKey && dueKey <= todayKey,
       }
-    }).filter(l => l.dueToday || l.doneToday)
-  }, [routines, todayKey])
+    }).filter(l => l.dueToday || l.doneToday || l.memberTasks.length > 0)
+  }, [routines, tasks, todayKey])
   const loopsDone = loops.filter(l => l.doneToday).length
   const catches = dailyStats.tasksToday ?? 0
 
@@ -118,7 +132,55 @@ export default function TodayView({
         <>
           <div className="bm-sec"><span className="bm-sec-tick" /> Loops <span className="bm-sec-n">{loopsDone}/{loops.length}</span></div>
           <div className="bm-rows">
-            {loops.map(({ r, color, byDay, rally, doneToday }) => (
+            {loops.map(({ r, color, byDay, rally, doneToday, isStack, memberTasks }) => {
+              if (isStack) {
+                // Stack: independent member tasks per cycle. Checks route
+                // through the REAL task path (onCompleteTask) so the 20%
+                // clear-bonus and the lone last-member history stamp hold.
+                if (memberTasks.length === 0) {
+                  return (
+                    <div key={r.id} className="bm-loop" style={{ '--loop': color }}>
+                      <span className="bm-loop-ring"><Repeat2 size={15} strokeWidth={2.2} /></span>
+                      <button className="bm-loop-body" onClick={() => onEditLoop?.(r)}>
+                        <div className="bm-loop-title">{r.title} <em className="bm-stack-count">· {r.members.length} items</em></div>
+                        <div className="bm-loop-sub">{doneToday ? 'cycle cleared today' : 'stack'}</div>
+                      </button>
+                      {doneToday ? (
+                        <span className="bm-loop-chk is-done" style={{ '--loop': color }} aria-hidden="true"><Check size={15} strokeWidth={3.2} /></span>
+                      ) : (
+                        <button className="bm-btn bm-btn-tonal bm-stack-start" onClick={() => onSpawnStackToday?.(r.id)}>Start</button>
+                      )}
+                    </div>
+                  )
+                }
+                const done = memberTasks.filter(t => t.status === 'done').length
+                return (
+                  <div key={r.id} className="bm-stack" style={{ '--loop': color }}>
+                    <div className="bm-stack-head">
+                      <span className="bm-loop-ring" style={{ width: 26, height: 26 }}><Repeat2 size={13} strokeWidth={2.2} /></span>
+                      <button className="bm-stack-title" onClick={() => onEditLoop?.(r)}>{r.title}</button>
+                      <span className="bm-stack-progress">{done}/{memberTasks.length}</span>
+                    </div>
+                    {memberTasks.map(t => {
+                      const mdone = t.status === 'done'
+                      return (
+                        <div key={t.id} className="bm-stack-member">
+                          <button
+                            className={`bm-chk${mdone ? ' is-done' : ''}`}
+                            style={mdone ? { background: color, borderColor: color } : { borderColor: color }}
+                            onClick={() => onCompleteTask?.(t)}
+                            aria-label={mdone ? 'Reopen' : 'Catch it'}
+                          >{mdone && <Check size={13} strokeWidth={3.4} color="var(--bm-on-ember)" />}</button>
+                          <button className="bm-row-body" onClick={() => onOpenTask?.(t)}>
+                            <span className={`bm-row-title${mdone ? ' is-done' : ''}`}>{t.title}</span>
+                          </button>
+                        </div>
+                      )
+                    })}
+                  </div>
+                )
+              }
+              return (
               <div key={r.id} className="bm-loop" style={{ '--loop': color }}>
                 <span className="bm-loop-ring"><Repeat2 size={15} strokeWidth={2.2} /></span>
                 <button className="bm-loop-body" onClick={() => onEditLoop?.(r)} aria-label={`Edit ${r.title}`}>
@@ -134,7 +196,8 @@ export default function TodayView({
                   aria-label={doneToday ? 'Mark not done' : 'Mark done'}
                 >{doneToday && <Check size={15} strokeWidth={3.2} />}</button>
               </div>
-            ))}
+              )
+            })}
           </div>
         </>
       )}

--- a/src/kept/TodayView.jsx
+++ b/src/kept/TodayView.jsx
@@ -38,8 +38,9 @@ export default function TodayView({
   }).sort((a, b) => (a.status === 'done' ? 1 : 0) - (b.status === 'done' ? 1 : 0)), [tasks, todayKey, stackRoutineIds])
 
   const returningSoon = useMemo(() => tasks.filter(t =>
-    ACTIVE.includes(t.status) && !t.parent_id && !t.gmail_pending && isSnoozed(t) && !t.snooze_indefinite,
-  ).slice(0, 3), [tasks])
+    ACTIVE.includes(t.status) && !t.parent_id && !t.gmail_pending && isSnoozed(t) && !t.snooze_indefinite
+    && !(t.routine_id && stackRoutineIds.has(t.routine_id)),
+  ).slice(0, 3), [tasks, stackRoutineIds])
 
   // Only loops that are actually DUE today (per the cadence engine — weekly/
   // monthly/quarterly stay hidden until their day), already done today (so a
@@ -55,18 +56,24 @@ export default function TodayView({
       const isStack = Array.isArray(r.members) && r.members.length > 0
       // A stack's live cycle = its member tasks due today or carried over
       // (leftover members linger as the open cycle until cleared).
-      const memberTasks = isStack
+      const cycleTasks = isStack
         ? tasks.filter(t => t.routine_id === r.id
             && String(t.due_date || '').slice(0, 10) <= todayKey
             && !['cancelled', 'backlog', 'project'].includes(t.status))
         : []
+      // Pre-trigger (trigger_time) members are snoozed — the stack shows as a
+      // single "returns tonight" row until they surface, per the trigger-time
+      // contract (don't show scheduled work before its clock time).
+      const memberTasks = cycleTasks.filter(t => t.status === 'done' || !isSnoozed(t))
+      const snoozedUntil = cycleTasks.find(t => t.status !== 'done' && isSnoozed(t))?.snoozed_until || null
+      const allSnoozed = isStack && memberTasks.length === 0 && !!snoozedUntil
       return {
-        r, color: feathers[r.id], byDay, isStack, memberTasks,
+        r, color: feathers[r.id], byDay, isStack, memberTasks, allSnoozed, snoozedUntil,
         rally: currentStreak(byDay),
         doneToday: !!byDay[todayKey],
         dueToday: !!dueKey && dueKey <= todayKey,
       }
-    }).filter(l => l.dueToday || l.doneToday || l.memberTasks.length > 0)
+    }).filter(l => l.dueToday || l.doneToday || l.memberTasks.length > 0 || l.allSnoozed)
   }, [routines, tasks, todayKey])
   const loopsDone = loops.filter(l => l.doneToday).length
   const catches = dailyStats.tasksToday ?? 0
@@ -132,7 +139,7 @@ export default function TodayView({
         <>
           <div className="bm-sec"><span className="bm-sec-tick" /> Loops <span className="bm-sec-n">{loopsDone}/{loops.length}</span></div>
           <div className="bm-rows">
-            {loops.map(({ r, color, byDay, rally, doneToday, isStack, memberTasks }) => {
+            {loops.map(({ r, color, byDay, rally, doneToday, isStack, memberTasks, allSnoozed, snoozedUntil }) => {
               if (isStack) {
                 // Stack: independent member tasks per cycle. Checks route
                 // through the REAL task path (onCompleteTask) so the 20%
@@ -143,10 +150,16 @@ export default function TodayView({
                       <span className="bm-loop-ring"><Repeat2 size={15} strokeWidth={2.2} /></span>
                       <button className="bm-loop-body" onClick={() => onEditLoop?.(r)}>
                         <div className="bm-loop-title">{r.title} <em className="bm-stack-count">· {r.members.length} items</em></div>
-                        <div className="bm-loop-sub">{doneToday ? 'cycle cleared today' : 'stack'}</div>
+                        <div className="bm-loop-sub">
+                          {doneToday ? 'cycle cleared today'
+                            : allSnoozed ? <span className="bm-return-chip">↩ returns {formatSnoozeLabel(snoozedUntil)}</span>
+                            : 'stack'}
+                        </div>
                       </button>
                       {doneToday ? (
                         <span className="bm-loop-chk is-done" style={{ '--loop': color }} aria-hidden="true"><Check size={15} strokeWidth={3.2} /></span>
+                      ) : allSnoozed ? (
+                        <span className="bm-chk is-muted" aria-hidden="true" />
                       ) : (
                         <button className="bm-btn bm-btn-tonal bm-stack-start" onClick={() => onSpawnStackToday?.(r.id)}>Start</button>
                       )}

--- a/src/kept/shell.css
+++ b/src/kept/shell.css
@@ -376,3 +376,21 @@
   transition: transform 200ms ease;
   will-change: transform;
 }
+
+/* Stacks on Today — grouped member rows under a stack head */
+.bm-stack { padding: 9px 2px 6px; border-bottom: 1px solid var(--bm-hairline); }
+.bm-stack:last-child { border-bottom: none; }
+.bm-stack-head { display: flex; align-items: center; gap: 10px; margin-bottom: 4px; }
+.bm-stack-title {
+  flex: 1 1 auto; min-width: 0;
+  background: none; border: none; padding: 0;
+  text-align: left; cursor: pointer;
+  font-size: 12.5px; font-weight: 700;
+  letter-spacing: 0.04em; text-transform: uppercase;
+  color: var(--bm-text-meta);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.bm-stack-progress { flex: 0 0 auto; font-size: 12px; font-weight: 650; color: var(--bm-text-meta); }
+.bm-stack-member { display: flex; align-items: center; gap: 12px; padding: 7px 0 7px 14px; }
+.bm-stack-count { font-style: normal; font-weight: 500; color: var(--bm-text-meta); }
+.bm-stack-start { padding: 8px 16px; flex: 0 0 auto; }

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,9 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-11
 
+- fix(ui): Kept Today — trigger-time stacks stay "returns tonight" until their clock time [S]
+  - Prod screenshots (the "Bedtime" stack, trigger 8pm-ish) showed snoozed stack members leaking into Today as individual "↩ returns tonight" rows hours early. Pre-trigger, a stack now renders as ONE row — `Bedtime · 3 items · ↩ returns tonight` with a muted check, no Start button — per the trigger-time contract. Members surface grouped only once un-snoozed; `returningSoon` excludes stack members (the stack row represents them). Verified with a 23:45-trigger stack: single returns row, zero member leakage, no premature grouped block.
+
 - fix(ui): Kept Today — stack support (grouped member rows, Start affordance) [M]
   - Stacks were rendered as a single-toggle loop row on Kept's Today — tapping the check would have caught one arbitrary member per tap. Stacks now fan out properly: a grouped block (stack head + `done/total` progress + indented member rows with feather checks) when the cycle is spawned; a **Start** button when due but not yet spawned; a "cycle cleared today" state after the last member. Member checks route through the REAL task path (`onCompleteTask`) so the 20% clear-bonus and the lone last-member `completed_history` stamp hold — verified end-to-end: 3-member stack spawned, members grouped (not duplicated in the plain Tasks rows), full clear produced exactly ONE history stamp + the bonus toast.
   - `onSpawnStackToday` threaded into KeptShell + KeptDesktop; stack members excluded from Today's plain task rows.

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,10 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-11
 
+- fix(ui): Kept Today — stack support (grouped member rows, Start affordance) [M]
+  - Stacks were rendered as a single-toggle loop row on Kept's Today — tapping the check would have caught one arbitrary member per tap. Stacks now fan out properly: a grouped block (stack head + `done/total` progress + indented member rows with feather checks) when the cycle is spawned; a **Start** button when due but not yet spawned; a "cycle cleared today" state after the last member. Member checks route through the REAL task path (`onCompleteTask`) so the 20% clear-bonus and the lone last-member `completed_history` stamp hold — verified end-to-end: 3-member stack spawned, members grouped (not duplicated in the plain Tasks rows), full clear produced exactly ONE history stamp + the bonus toast.
+  - `onSpawnStackToday` threaded into KeptShell + KeptDesktop; stack members excluded from Today's plain task rows.
+
 - fix(ui): Kept Today — only cadence-due loops; modal-top fade strip [S]
   - **Prod bug:** Today listed EVERY non-paused loop daily (loggd's all-habits-are-daily assumption carried into TodayView) — weekly/monthly/quarterly routines like "Mow · weekly · Fri" surfaced days early. The loops list now filters through `getNextDueDate`: a loop shows only when cadence-due today (or overdue), or already done today so a checked loop doesn't vanish. The full library stays on the Loops tab. Verified with a Friday-anchored weekly loop completed last Friday: hidden from Today, present in Loops.
   - **Edit-modal title collision:** with the back button pinned (previous fix), scrolled content slid UNDER it — the "Edit loop" title read "it loop" mid-scroll. A fixed gradient strip (page bg → transparent, click-through) now fades content out under the pinned controls.


### PR DESCRIPTION
Promotes the stack work to prod (user-approved). **Merge with the merge-commit method only.**

Two commits on top of the current prod release:

1. **Stacks fan out on Today** — grouped block (stack head · `done/total` · indented member rows with feather checks), a **Start** affordance when due-but-unspawned, "cycle cleared today" after the last member. Checks route through the real task path: the 20% clear-bonus and the single last-member `completed_history` stamp verified end-to-end. Members no longer double-display in plain task rows.
2. **Trigger-time stacks wait for their clock time** — pre-trigger, the Bedtime-style stack shows as ONE `↩ returns tonight` row (no Start, no member rows, no individual returns-row leakage), exactly matching the reported prod screenshots. Members surface grouped once un-snoozed.

Both verified live on seeded stacks (with and without trigger_time); lint 0; tests + build + smoke pass.

https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR)_