### PR TITLE
fix(ui): Kept stacks are folders — v2-parity display, no history ghosts

### DIFF
--- a/src/AppV2.jsx
+++ b/src/AppV2.jsx
@@ -1256,11 +1256,6 @@ export default function AppV2() {
           streak={streak}
           onCompleteTask={(task) => task.status === 'done' ? handleUncomplete(task) : handleComplete(task.id)}
           onOpenTask={(task) => setEditTarget(task)}
-          onSpawnStackToday={(routineId) => {
-            const spawned = spawnNow(routineId)
-            if (spawned && spawned.length) addSpawnedTasks(spawned)
-            return spawned
-          }}
           onToggleHabit={toggleHabitDay}
           onRescheduleTask={(task, ymd) => updateTask(task.id, { due_date: ymd })}
           onDeleteTask={(task) => handleDelete(task.id)}
@@ -1294,11 +1289,6 @@ export default function AppV2() {
           streak={streak}
           onCompleteTask={(task) => task.status === 'done' ? handleUncomplete(task) : handleComplete(task.id)}
           onOpenTask={(task) => setEditTarget(task)}
-          onSpawnStackToday={(routineId) => {
-            const spawned = spawnNow(routineId)
-            if (spawned && spawned.length) addSpawnedTasks(spawned)
-            return spawned
-          }}
           onToggleHabit={toggleHabitDay}
           onRescheduleTask={(task, ymd) => updateTask(task.id, { due_date: ymd })}
           onDeleteTask={(task) => handleDelete(task.id)}

--- a/src/kept/KeptDesktop.jsx
+++ b/src/kept/KeptDesktop.jsx
@@ -18,7 +18,7 @@ import './desktop.css'
 export default function KeptDesktop({
   tasks = [], routines = [], labels = [],
   dailyStats = {}, pointsGoal = 15, streak = 0,
-  onCompleteTask, onOpenTask, onToggleHabit, onRescheduleTask, onDeleteTask, onSpawnStackToday,
+  onCompleteTask, onOpenTask, onToggleHabit, onRescheduleTask, onDeleteTask,
   onThrow, onOpenFullAdd, onEditLoop, onAddLoop,
   onOpenQuokka, onOpenSettings, onOpenPackages, onOpenAnalytics,
   onOpenProjects, onOpenDone, onOpenActivity,
@@ -69,7 +69,7 @@ export default function KeptDesktop({
         tasks={tasks} routines={routines} labels={labels}
         dailyStats={dailyStats} pointsGoal={pointsGoal} streak={streak}
         onCompleteTask={onCompleteTask} onOpenTask={onOpenTask} onToggleHabit={onToggleHabit}
-        onDeleteTask={onDeleteTask} onEditLoop={onEditLoop} onSpawnStackToday={onSpawnStackToday}
+        onDeleteTask={onDeleteTask} onEditLoop={onEditLoop}
       />
     )
   }

--- a/src/kept/KeptShell.jsx
+++ b/src/kept/KeptShell.jsx
@@ -15,7 +15,7 @@ import './shell.css'
 export default function KeptShell({
   tasks = [], routines = [], labels = [],
   dailyStats = {}, pointsGoal = 15, streak = 0,
-  onCompleteTask, onOpenTask, onToggleHabit, onRescheduleTask, onDeleteTask, onSpawnStackToday,
+  onCompleteTask, onOpenTask, onToggleHabit, onRescheduleTask, onDeleteTask,
   onThrow, onOpenFullAdd, onEditLoop, onAddLoop,
   onOpenQuokka, onOpenSettings, onOpenPackages, onOpenAnalytics,
   onOpenProjects, onOpenDone, onOpenActivity, onOpenSuggestions,
@@ -50,7 +50,7 @@ export default function KeptShell({
         tasks={tasks} routines={routines} labels={labels}
         dailyStats={dailyStats} pointsGoal={pointsGoal} streak={streak}
         onCompleteTask={onCompleteTask} onOpenTask={onOpenTask} onToggleHabit={onToggleHabit}
-        onDeleteTask={onDeleteTask} onEditLoop={onEditLoop} onSpawnStackToday={onSpawnStackToday}
+        onDeleteTask={onDeleteTask} onEditLoop={onEditLoop}
       />
     )
   }

--- a/src/kept/TodayView.jsx
+++ b/src/kept/TodayView.jsx
@@ -17,7 +17,7 @@ const ACTIVE = ['not_started', 'doing', 'waiting', 'in_progress']
 export default function TodayView({
   tasks = [], routines = [], labels = [],
   dailyStats = {}, pointsGoal = 15, streak = 0,
-  onCompleteTask, onOpenTask, onToggleHabit, onDeleteTask, onEditLoop, onSpawnStackToday,
+  onCompleteTask, onOpenTask, onToggleHabit, onDeleteTask, onEditLoop,
 }) {
   const todayKey = localYMD()
   const labelsById = useMemo(() => { const m = {}; for (const l of labels) m[l.id] = l; return m }, [labels])
@@ -54,26 +54,37 @@ export default function TodayView({
       const next = getNextDueDate(r)
       const dueKey = next ? localYMD(next) : null
       const isStack = Array.isArray(r.members) && r.members.length > 0
-      // A stack's live cycle = its member tasks due today or carried over
-      // (leftover members linger as the open cycle until cleared).
-      const cycleTasks = isStack
-        ? tasks.filter(t => t.routine_id === r.id
-            && String(t.due_date || '').slice(0, 10) <= todayKey
-            && !['cancelled', 'backlog', 'project'].includes(t.status))
-        : []
-      // Pre-trigger (trigger_time) members are snoozed — the stack shows as a
-      // single "returns tonight" row until they surface, per the trigger-time
-      // contract (don't show scheduled work before its clock time).
-      const memberTasks = cycleTasks.filter(t => t.status === 'done' || !isSnoozed(t))
-      const snoozedUntil = cycleTasks.find(t => t.status !== 'done' && isSnoozed(t))?.snoozed_until || null
-      const allSnoozed = isStack && memberTasks.length === 0 && !!snoozedUntil
+      // v2-parity stack model: the stack is a FOLDER. Group this routine's
+      // member tasks into cycles by due_date; a cycle is shown only while it
+      // has open, un-snoozed members. Done members drop out of the display
+      // (the done/total header carries the progress); pre-trigger (snoozed)
+      // cycles show NOTHING; fully-cleared cycles disappear.
+      let cycles = []
+      if (isStack) {
+        const byCycle = new Map()
+        for (const t of tasks) {
+          if (t.routine_id !== r.id) continue
+          if (['cancelled', 'backlog', 'project'].includes(t.status)) continue
+          const dueKey2 = String(t.due_date || '').slice(0, 10)
+          if (!dueKey2 || dueKey2 > todayKey) continue
+          if (!byCycle.has(dueKey2)) byCycle.set(dueKey2, { due: dueKey2, open: [], total: 0, done: 0 })
+          const c = byCycle.get(dueKey2)
+          c.total++
+          if (t.status === 'done') c.done++
+          else if (!isSnoozed(t)) c.open.push(t)
+        }
+        cycles = [...byCycle.values()].filter(c => c.open.length > 0)
+          .sort((a, b) => a.due.localeCompare(b.due))
+      }
       return {
-        r, color: feathers[r.id], byDay, isStack, memberTasks, allSnoozed, snoozedUntil,
+        r, color: feathers[r.id], byDay, isStack, cycles,
         rally: currentStreak(byDay),
         doneToday: !!byDay[todayKey],
         dueToday: !!dueKey && dueKey <= todayKey,
       }
-    }).filter(l => l.dueToday || l.doneToday || l.memberTasks.length > 0 || l.allSnoozed)
+    // Plain loops: due/done today. Stacks: ONLY while a cycle is surfaced —
+    // no waiting row, no cleared receipt (v2 behavior).
+    }).filter(l => (l.isStack ? l.cycles.length > 0 : (l.dueToday || l.doneToday)))
   }, [routines, tasks, todayKey])
   const loopsDone = loops.filter(l => l.doneToday).length
   const catches = dailyStats.tasksToday ?? 0
@@ -139,59 +150,34 @@ export default function TodayView({
         <>
           <div className="bm-sec"><span className="bm-sec-tick" /> Loops <span className="bm-sec-n">{loopsDone}/{loops.length}</span></div>
           <div className="bm-rows">
-            {loops.map(({ r, color, byDay, rally, doneToday, isStack, memberTasks, allSnoozed, snoozedUntil }) => {
+            {loops.map(({ r, color, byDay, rally, doneToday, isStack, cycles }) => {
               if (isStack) {
-                // Stack: independent member tasks per cycle. Checks route
-                // through the REAL task path (onCompleteTask) so the 20%
-                // clear-bonus and the lone last-member history stamp hold.
-                if (memberTasks.length === 0) {
-                  return (
-                    <div key={r.id} className="bm-loop" style={{ '--loop': color }}>
-                      <span className="bm-loop-ring"><Repeat2 size={15} strokeWidth={2.2} /></span>
-                      <button className="bm-loop-body" onClick={() => onEditLoop?.(r)}>
-                        <div className="bm-loop-title">{r.title} <em className="bm-stack-count">· {r.members.length} items</em></div>
-                        <div className="bm-loop-sub">
-                          {doneToday ? 'cycle cleared today'
-                            : allSnoozed ? <span className="bm-return-chip">↩ returns {formatSnoozeLabel(snoozedUntil)}</span>
-                            : 'stack'}
-                        </div>
-                      </button>
-                      {doneToday ? (
-                        <span className="bm-loop-chk is-done" style={{ '--loop': color }} aria-hidden="true"><Check size={15} strokeWidth={3.2} /></span>
-                      ) : allSnoozed ? (
-                        <span className="bm-chk is-muted" aria-hidden="true" />
-                      ) : (
-                        <button className="bm-btn bm-btn-tonal bm-stack-start" onClick={() => onSpawnStackToday?.(r.id)}>Start</button>
-                      )}
-                    </div>
-                  )
-                }
-                const done = memberTasks.filter(t => t.status === 'done').length
-                return (
-                  <div key={r.id} className="bm-stack" style={{ '--loop': color }}>
+                // Folder per surfaced cycle: header (name · done/total) over
+                // the OPEN members. Checks ride the real task path so the
+                // clear bonus + single history stamp hold; the folder
+                // disappears with its last member.
+                return cycles.map(c => (
+                  <div key={`${r.id}|${c.due}`} className="bm-stack" style={{ '--loop': color }}>
                     <div className="bm-stack-head">
                       <span className="bm-loop-ring" style={{ width: 26, height: 26 }}><Repeat2 size={13} strokeWidth={2.2} /></span>
                       <button className="bm-stack-title" onClick={() => onEditLoop?.(r)}>{r.title}</button>
-                      <span className="bm-stack-progress">{done}/{memberTasks.length}</span>
+                      <span className="bm-stack-progress">{c.done}/{c.total}</span>
                     </div>
-                    {memberTasks.map(t => {
-                      const mdone = t.status === 'done'
-                      return (
-                        <div key={t.id} className="bm-stack-member">
-                          <button
-                            className={`bm-chk${mdone ? ' is-done' : ''}`}
-                            style={mdone ? { background: color, borderColor: color } : { borderColor: color }}
-                            onClick={() => onCompleteTask?.(t)}
-                            aria-label={mdone ? 'Reopen' : 'Catch it'}
-                          >{mdone && <Check size={13} strokeWidth={3.4} color="var(--bm-on-ember)" />}</button>
-                          <button className="bm-row-body" onClick={() => onOpenTask?.(t)}>
-                            <span className={`bm-row-title${mdone ? ' is-done' : ''}`}>{t.title}</span>
-                          </button>
-                        </div>
-                      )
-                    })}
+                    {c.open.map(t => (
+                      <div key={t.id} className="bm-stack-member">
+                        <button
+                          className="bm-chk"
+                          style={{ borderColor: color }}
+                          onClick={() => onCompleteTask?.(t)}
+                          aria-label="Catch it"
+                        />
+                        <button className="bm-row-body" onClick={() => onOpenTask?.(t)}>
+                          <span className="bm-row-title">{t.title}</span>
+                        </button>
+                      </div>
+                    ))}
                   </div>
-                )
+                ))
               }
               return (
               <div key={r.id} className="bm-loop" style={{ '--loop': color }}>

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,10 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-11
 
+- fix(ui): Kept stacks are folders — v2-parity display (open members only, no history, no chrome rows) [M]
+  - Prod report: the Bedtime folder rendered "36/36" — every done member from every past cycle, struck through. The `due <= today` member filter dragged in all history, and the waiting/cleared stack rows added chrome v2 never had. **Reverted to the v2 StackSection model:** a stack is an organizational folder — grouped by cycle `(routine, due_date)`, rendered ONLY while a cycle has open un-snoozed members, showing ONLY those open members (done ones drop out; the `done/total` header carries progress). Nothing pre-trigger, nothing after clear — no waiting row, no Start button, no cleared receipt (dead `onSpawnStackToday` threading removed from the Kept shells).
+  - Verified against the exact report scenario (2 fully-done past cycles + live cycle + a pre-trigger stack): zero historical ghosts, pre-trigger stack fully hidden, folder vanishes with its last member, exactly one new history stamp.
+
 - fix(ui): Kept Today — trigger-time stacks stay "returns tonight" until their clock time [S]
   - Prod screenshots (the "Bedtime" stack, trigger 8pm-ish) showed snoozed stack members leaking into Today as individual "↩ returns tonight" rows hours early. Pre-trigger, a stack now renders as ONE row — `Bedtime · 3 items · ↩ returns tonight` with a muted check, no Start button — per the trigger-time contract. Members surface grouped only once un-snoozed; `returningSoon` excludes stack members (the stack row represents them). Verified with a 23:45-trigger stack: single returns row, zero member leakage, no premature grouped block.
 


### PR DESCRIPTION
Reverts Kept's stack display to the **v2 model the user confirmed as correct**: a stack is an organizational **folder**, not a habit row.

## What was wrong (prod report: "BEDTIME 36/36")

- The member filter (`due_date <= today`) dragged in **every done member from every past cycle** — 36 struck-through ghosts.
- The waiting ("returns tonight") and cleared-receipt rows were chrome v2 never had — the user wants the stack to appear only when it's supposed to.

## The v2-parity model now

- Members grouped by cycle `(routine, due_date)`; a cycle renders **only while it has open, un-snoozed members**, and shows **only those open members** — done ones drop out, the `done/total` header carries progress.
- **Nothing pre-trigger** (snoozed cycles fully hidden), **nothing after clear** (the folder disappears with its last member). No waiting row, no Start button, no cleared receipt; the dead `onSpawnStackToday` threading is removed from the Kept shells (auto-spawn covers it, and the Routines editor keeps Spawn-now).
- Completion semantics unchanged: checks ride the real task path — clear bonus + single last-member history stamp.

## Verified against the exact report scenario

Seeded 2 fully-done past cycles + a live cycle + a pre-trigger (23:45) stack: **zero historical ghosts**, pre-trigger stack invisible, folder vanished with its last member, history gained exactly one stamp (3 = 2 + 1). Zero page errors; lint 0; tests + build + smoke pass.

https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR)_