### PR TITLE
fix(ui): lock text-size-adjust against iOS rotation font boosting

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -4,6 +4,15 @@
   padding: 0;
 }
 
+/* iOS Safari font boosting: on rotation to landscape Safari auto-inflates
+ * text, and without text-size-adjust locked it KEEPS the inflated sizes
+ * after rotating back to portrait (prod report: row titles stuck huge).
+ * 100% = render exactly the authored sizes in every orientation. */
+html {
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
+}
+
 :root {
   --bg: #0B0B0F;
   --surface: #141418;

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,9 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-11
 
+- fix(ui): lock text-size-adjust — landscape rotation no longer inflates text permanently [XS]
+  - Prod report: rotate to landscape and back → row titles and meta stuck at boosted sizes (everything except SVG text). iOS Safari's font boosting inflates text on rotation and, with `text-size-adjust` unlocked, keeps the inflated sizes back in portrait. `html { -webkit-text-size-adjust: 100% }` in index.css renders authored sizes in every orientation. (Not reproducible in headless Chromium — the standard documented remedy, applies to all themes.)
+
 - fix(ui): Kept Today — undated tasks get an Anytime section (new throws were invisible) [S]
   - Prod report ("new tasks not hitting the main page" — with three duplicate throws as evidence): the Throw sheet defaults to *No date*, and Kept's Today only showed tasks with `due_date <= today` — Wallaby Home's day-planner filter carried into what is actually the main page, so undated tasks never appeared there (v2's Up next always showed them). Today now renders an **Anytime** section (overdue/today rows first, then undated active tasks, same row anatomy + swipe). Future-DATED tasks still stay off Today until their day, per the scheduled-work rule. Verified: a thrown no-date task appears under Anytime immediately.
 


### PR DESCRIPTION
Prod report: rotate the phone to landscape and back → row titles and meta text stay stuck at inflated sizes (everything except the SVG gauge text — the tell for iOS Safari **font boosting**).

With `text-size-adjust` unlocked, Safari inflates small text on rotation and keeps the boosted sizes after returning to portrait. The standard remedy: `html { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; }` in the global reset — authored sizes render in every orientation, all themes.

(Not reproducible in headless Chromium — this is iOS-Safari-specific behavior with the documented one-line fix.)

https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR)_