### PR TITLE
release: Today Anytime section + iOS rotation text-size fix

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -4,6 +4,15 @@
   padding: 0;
 }
 
+/* iOS Safari font boosting: on rotation to landscape Safari auto-inflates
+ * text, and without text-size-adjust locked it KEEPS the inflated sizes
+ * after rotating back to portrait (prod report: row titles stuck huge).
+ * 100% = render exactly the authored sizes in every orientation. */
+html {
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
+}
+
 :root {
   --bg: #0B0B0F;
   --surface: #141418;

--- a/src/kept/TodayView.jsx
+++ b/src/kept/TodayView.jsx
@@ -37,6 +37,16 @@ export default function TodayView({
     return t.due_date ? String(t.due_date).slice(0, 10) <= todayKey : false
   }).sort((a, b) => (a.status === 'done' ? 1 : 0) - (b.status === 'done' ? 1 : 0)), [tasks, todayKey, stackRoutineIds])
 
+  // Undated active tasks — the main page must show them (v2's Up next did).
+  // Future-DATED tasks stay off Today until their day; undated means
+  // "anytime", and anytime includes today.
+  const anytimeTasks = useMemo(() => tasks.filter(t => {
+    if (t.parent_id || t.gmail_pending || t.due_date) return false
+    if (t.routine_id && stackRoutineIds.has(t.routine_id)) return false
+    if (!ACTIVE.includes(t.status)) return false
+    return !isSnoozed(t)
+  }), [tasks, stackRoutineIds])
+
   const returningSoon = useMemo(() => tasks.filter(t =>
     ACTIVE.includes(t.status) && !t.parent_id && !t.gmail_pending && isSnoozed(t) && !t.snooze_indefinite
     && !(t.routine_id && stackRoutineIds.has(t.routine_id)),
@@ -145,6 +155,34 @@ export default function TodayView({
           </div>
         ))}
       </div>
+
+      {anytimeTasks.length > 0 && (
+        <>
+          <div className="bm-sec"><span className="bm-sec-tick" /> Anytime <span className="bm-sec-n">{anytimeTasks.length}</span></div>
+          <div className="bm-rows">
+            {anytimeTasks.map(t => {
+              const chips = (t.tags || []).map(id => labelsById[id]).filter(Boolean)
+              return (
+                <RowSwipe key={t.id} onCatch={() => onCompleteTask?.(t)} onDelete={() => onDeleteTask?.(t)}>
+                  <div className="bm-row">
+                    <button className="bm-chk" onClick={() => onCompleteTask?.(t)} aria-label="Catch it" />
+                    <button className="bm-row-body" onClick={() => onOpenTask?.(t)}>
+                      <span className="bm-row-title">{t.title}</span>
+                      {chips.length > 0 && (
+                        <span className="bm-row-meta">
+                          {chips.slice(0, 3).map(l => (
+                            <span key={l.id} className="bm-tagdot" style={{ '--tag': l.color }}><i />{l.name}</span>
+                          ))}
+                        </span>
+                      )}
+                    </button>
+                  </div>
+                </RowSwipe>
+              )
+            })}
+          </div>
+        </>
+      )}
 
       {loops.length > 0 && (
         <>

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,9 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-11
 
+- fix(ui): Kept Today — undated tasks get an Anytime section (new throws were invisible) [S]
+  - Prod report ("new tasks not hitting the main page" — with three duplicate throws as evidence): the Throw sheet defaults to *No date*, and Kept's Today only showed tasks with `due_date <= today` — Wallaby Home's day-planner filter carried into what is actually the main page, so undated tasks never appeared there (v2's Up next always showed them). Today now renders an **Anytime** section (overdue/today rows first, then undated active tasks, same row anatomy + swipe). Future-DATED tasks still stay off Today until their day, per the scheduled-work rule. Verified: a thrown no-date task appears under Anytime immediately.
+
 - fix(ui): Kept stacks are folders — v2-parity display (open members only, no history, no chrome rows) [M]
   - Prod report: the Bedtime folder rendered "36/36" — every done member from every past cycle, struck through. The `due <= today` member filter dragged in all history, and the waiting/cleared stack rows added chrome v2 never had. **Reverted to the v2 StackSection model:** a stack is an organizational folder — grouped by cycle `(routine, due_date)`, rendered ONLY while a cycle has open un-snoozed members, showing ONLY those open members (done ones drop out; the `done/total` header carries progress). Nothing pre-trigger, nothing after clear — no waiting row, no Start button, no cleared receipt (dead `onSpawnStackToday` threading removed from the Kept shells).
   - Verified against the exact report scenario (2 fully-done past cycles + live cycle + a pre-trigger stack): zero historical ghosts, pre-trigger stack fully hidden, folder vanishes with its last member, exactly one new history stamp.

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,9 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-11
 
+- fix(ui): lock text-size-adjust — landscape rotation no longer inflates text permanently [XS]
+  - Prod report: rotate to landscape and back → row titles and meta stuck at boosted sizes (everything except SVG text). iOS Safari's font boosting inflates text on rotation and, with `text-size-adjust` unlocked, keeps the inflated sizes back in portrait. `html { -webkit-text-size-adjust: 100% }` in index.css renders authored sizes in every orientation. (Not reproducible in headless Chromium — the standard documented remedy, applies to all themes.)
+
 - fix(ui): Kept Today — undated tasks get an Anytime section (new throws were invisible) [S]
   - Prod report ("new tasks not hitting the main page" — with three duplicate throws as evidence): the Throw sheet defaults to *No date*, and Kept's Today only showed tasks with `due_date <= today` — Wallaby Home's day-planner filter carried into what is actually the main page, so undated tasks never appeared there (v2's Up next always showed them). Today now renders an **Anytime** section (overdue/today rows first, then undated active tasks, same row anatomy + swipe). Future-DATED tasks still stay off Today until their day, per the scheduled-work rule. Verified: a thrown no-date task appears under Anytime immediately.
 


### PR DESCRIPTION
Promotes tonight's two prod-reported fixes. **Merge with the merge-commit method only.**

1. **Undated tasks hit the main page again** — the Throw sheet defaults to *No date* and Kept's Today only showed dated tasks, so new throws were invisible (hence the triple "Empty Reencle"). Today now has an **Anytime** section: overdue/due-today first, then undated active tasks; future-dated work still waits for its day. Verified live.
2. **Landscape rotation no longer inflates text permanently** — `text-size-adjust: 100%` locks iOS Safari's font boosting, all themes.

https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR)_