### PR TITLE
release: Kept main-page contract restores (audit round 1)

### DIFF
--- a/src/AppV2.jsx
+++ b/src/AppV2.jsx
@@ -1255,6 +1255,8 @@ export default function AppV2() {
           pointsGoal={settingsForRings.daily_points_goal || 15}
           streak={streak}
           onCompleteTask={(task) => task.status === 'done' ? handleUncomplete(task) : handleComplete(task.id)}
+          onLogSession={(p) => handleLogSession(p.id)}
+          gmailPendingCount={tasks.filter(t => t.gmail_pending).length}
           onOpenTask={(task) => setEditTarget(task)}
           onToggleHabit={toggleHabitDay}
           onRescheduleTask={(task, ymd) => updateTask(task.id, { due_date: ymd })}
@@ -1288,6 +1290,8 @@ export default function AppV2() {
           pointsGoal={settingsForRings.daily_points_goal || 15}
           streak={streak}
           onCompleteTask={(task) => task.status === 'done' ? handleUncomplete(task) : handleComplete(task.id)}
+          onLogSession={(p) => handleLogSession(p.id)}
+          gmailPendingCount={tasks.filter(t => t.gmail_pending).length}
           onOpenTask={(task) => setEditTarget(task)}
           onToggleHabit={toggleHabitDay}
           onRescheduleTask={(task, ymd) => updateTask(task.id, { due_date: ymd })}
@@ -1303,6 +1307,7 @@ export default function AppV2() {
           onOpenProjects={() => setShowProjects(true)}
           onOpenDone={() => setShowDone(true)}
           onOpenActivity={() => setShowActivityLog(true)}
+          onOpenSuggestions={() => setShowSuggestions(true)}
           syncStatus={syncStatus}
           queueLength={queueLength}
         />

--- a/src/kept/KeptDesktop.jsx
+++ b/src/kept/KeptDesktop.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import {
   Home, ListTodo, Repeat2, FolderKanban, BarChart3, Package, Settings,
-  Sparkles, Plus, CheckCircle2, ScrollText,
+  Sparkles, Plus, CheckCircle2, ScrollText, Inbox,
 } from 'lucide-react'
 import Logo from '../components/Logo'
 import { useSyncBounce } from '../hooks/useSyncBounce'
@@ -19,9 +19,10 @@ export default function KeptDesktop({
   tasks = [], routines = [], labels = [],
   dailyStats = {}, pointsGoal = 15, streak = 0,
   onCompleteTask, onOpenTask, onToggleHabit, onRescheduleTask, onDeleteTask,
+  onLogSession, gmailPendingCount = 0,
   onThrow, onOpenFullAdd, onEditLoop, onAddLoop,
   onOpenQuokka, onOpenSettings, onOpenPackages, onOpenAnalytics,
-  onOpenProjects, onOpenDone, onOpenActivity,
+  onOpenProjects, onOpenDone, onOpenActivity, onOpenSuggestions,
   syncStatus = 'synced', queueLength = 0,
 }) {
   const [tab, setTab] = useState('today')
@@ -49,6 +50,7 @@ export default function KeptDesktop({
     { label: 'Caught', icon: CheckCircle2, onClick: onOpenDone },
     { label: 'Analytics', icon: BarChart3, onClick: onOpenAnalytics },
     { label: 'Packages', icon: Package, onClick: onOpenPackages },
+    { label: 'Suggestions', icon: Inbox, onClick: onOpenSuggestions },
     { label: 'Activity log', icon: ScrollText, onClick: onOpenActivity },
   ]
 
@@ -70,6 +72,8 @@ export default function KeptDesktop({
         dailyStats={dailyStats} pointsGoal={pointsGoal} streak={streak}
         onCompleteTask={onCompleteTask} onOpenTask={onOpenTask} onToggleHabit={onToggleHabit}
         onDeleteTask={onDeleteTask} onEditLoop={onEditLoop}
+        onLogSession={onLogSession} gmailPendingCount={gmailPendingCount}
+        onOpenSuggestions={onOpenSuggestions}
       />
     )
   }

--- a/src/kept/KeptShell.jsx
+++ b/src/kept/KeptShell.jsx
@@ -16,6 +16,7 @@ export default function KeptShell({
   tasks = [], routines = [], labels = [],
   dailyStats = {}, pointsGoal = 15, streak = 0,
   onCompleteTask, onOpenTask, onToggleHabit, onRescheduleTask, onDeleteTask,
+  onLogSession, gmailPendingCount = 0,
   onThrow, onOpenFullAdd, onEditLoop, onAddLoop,
   onOpenQuokka, onOpenSettings, onOpenPackages, onOpenAnalytics,
   onOpenProjects, onOpenDone, onOpenActivity, onOpenSuggestions,
@@ -51,6 +52,8 @@ export default function KeptShell({
         dailyStats={dailyStats} pointsGoal={pointsGoal} streak={streak}
         onCompleteTask={onCompleteTask} onOpenTask={onOpenTask} onToggleHabit={onToggleHabit}
         onDeleteTask={onDeleteTask} onEditLoop={onEditLoop}
+        onLogSession={onLogSession} gmailPendingCount={gmailPendingCount}
+        onOpenSuggestions={onOpenSuggestions}
       />
     )
   }

--- a/src/kept/TodayView.jsx
+++ b/src/kept/TodayView.jsx
@@ -1,10 +1,10 @@
 import { useMemo } from 'react'
-import { Check, Repeat2 } from 'lucide-react'
+import { Check, Repeat2, Flame, FolderKanban, Inbox, ChevronRight } from 'lucide-react'
 import DayArc from './DayArc'
 import FlightTrail from './FlightTrail'
 import { localYMD } from '../dates'
 import { historyByDay, currentStreak } from '../wallaby/heatmapUtils'
-import { isSnoozed, formatSnoozeLabel, getNextDueDate } from '../store'
+import { isSnoozed, isStale, formatSnoozeLabel, getNextDueDate } from '../store'
 import { routineFeathers } from './feathers'
 import RowSwipe from './RowSwipe'
 import './shell.css'
@@ -18,6 +18,7 @@ export default function TodayView({
   tasks = [], routines = [], labels = [],
   dailyStats = {}, pointsGoal = 15, streak = 0,
   onCompleteTask, onOpenTask, onToggleHabit, onDeleteTask, onEditLoop,
+  onLogSession, onOpenSuggestions, gmailPendingCount = 0,
 }) {
   const todayKey = localYMD()
   const labelsById = useMemo(() => { const m = {}; for (const l of labels) m[l.id] = l; return m }, [labels])
@@ -90,13 +91,26 @@ export default function TodayView({
         r, color: feathers[r.id], byDay, isStack, cycles,
         rally: currentStreak(byDay),
         doneToday: !!byDay[todayKey],
-        dueToday: !!dueKey && dueKey <= todayKey,
+        // Habit-mode (target frequency) loops are loggable ANY day — the
+        // cadence engine doesn't model them, so they're always "due".
+        dueToday: r.spawn_mode === 'habit' || (!!dueKey && dueKey <= todayKey),
       }
     // Plain loops: due/done today. Stacks: ONLY while a cycle is surfaced —
     // no waiting row, no cleared receipt (v2 behavior).
     }).filter(l => (l.isStack ? l.cycles.length > 0 : (l.dueToday || l.doneToday)))
   }, [routines, tasks, todayKey])
   const loopsDone = loops.filter(l => l.doneToday).length
+
+  // Pinned Arcs (projects) — v2's main list led with these; restore them.
+  const pinnedArcs = useMemo(() => tasks.filter(t => t.status === 'project' && t.pinned_to_today), [tasks])
+  const arcChildren = useMemo(() => {
+    const m = {}
+    for (const p2 of pinnedArcs) {
+      m[p2.id] = tasks.filter(t => t.parent_id === p2.id && t.child_visibility === 'active'
+        && ACTIVE.includes(t.status) && !isSnoozed(t))
+    }
+    return m
+  }, [tasks, pinnedArcs])
   const catches = dailyStats.tasksToday ?? 0
 
   return (
@@ -115,6 +129,44 @@ export default function TodayView({
         </div>
       </div>
 
+      {gmailPendingCount > 0 && (
+        <button className="bm-gmail-banner" onClick={onOpenSuggestions}>
+          <Inbox size={15} strokeWidth={2} />
+          <span><b>{gmailPendingCount}</b> imported item{gmailPendingCount === 1 ? '' : 's'} to review</span>
+          <ChevronRight size={15} strokeWidth={2} className="bm-more-chev" />
+        </button>
+      )}
+
+      {pinnedArcs.length > 0 && (
+        <>
+          <div className="bm-sec"><span className="bm-sec-tick" /> Arcs <span className="bm-sec-n">{pinnedArcs.length}</span></div>
+          <div className="bm-rows">
+            {pinnedArcs.map(p2 => (
+              <div key={p2.id} className="bm-arc">
+                <div className="bm-arc-head">
+                  <span className="bm-arc-icon"><FolderKanban size={14} strokeWidth={2} /></span>
+                  <button className="bm-row-body" onClick={() => onOpenTask?.(p2)}>
+                    <span className="bm-row-title">{p2.title}</span>
+                    <span className="bm-row-meta">
+                      <span><Flame size={11} strokeWidth={2.25} style={{ verticalAlign: '-1px' }} /> {p2.session_count || 0} sessions</span>
+                    </span>
+                  </button>
+                  <button className="bm-btn bm-btn-tonal bm-arc-log" onClick={() => onLogSession?.(p2)}>Log session</button>
+                </div>
+                {(arcChildren[p2.id] || []).map(c => (
+                  <div key={c.id} className="bm-stack-member">
+                    <button className="bm-chk" style={{ borderColor: 'var(--bm-gold)' }} onClick={() => onCompleteTask?.(c)} aria-label="Catch it" />
+                    <button className="bm-row-body" onClick={() => onOpenTask?.(c)}>
+                      <span className="bm-row-title">{c.title}</span>
+                    </button>
+                  </div>
+                ))}
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+
       <div className="bm-sec"><span className="bm-sec-tick" /> Today <span className="bm-sec-n">{dayTasks.length}</span></div>
       <div className="bm-rows">
         {dayTasks.length === 0 && <p className="bm-empty">Nothing due — enjoy it.</p>}
@@ -122,19 +174,25 @@ export default function TodayView({
           const done = t.status === 'done'
           const overdue = !done && t.due_date && String(t.due_date).slice(0, 10) < todayKey
           const chips = (t.tags || []).map(id => labelsById[id]).filter(Boolean)
+          const stale = !done && isStale(t)
+          const ageDays = stale ? Math.floor((Date.now() - new Date(t.created_at).getTime()) / 86400000) : 0
+          const statusTag = t.status === 'doing' ? 'doing' : t.status === 'waiting' ? 'waiting' : null
           return (
             <RowSwipe key={t.id} done={done} onCatch={() => onCompleteTask?.(t)} onDelete={() => onDeleteTask?.(t)}>
               <div className="bm-row">
                 <button
-                  className={`bm-chk${done ? ' is-done' : ''}`}
+                  className={`bm-chk${done ? ' is-done' : ''}${t.high_priority ? ' is-hi' : ''}`}
                   onClick={() => onCompleteTask?.(t)}
                   aria-label={done ? 'Reopen' : 'Catch it'}
                 >{done && <Check size={13} strokeWidth={3.4} />}</button>
                 <button className="bm-row-body" onClick={() => onOpenTask?.(t)}>
                   <span className={`bm-row-title${done ? ' is-done' : ''}`}>{t.title}</span>
-                  {!done && (overdue || chips.length > 0) && (
+                  {!done && (overdue || stale || statusTag || t.high_priority || chips.length > 0) && (
                     <span className="bm-row-meta">
+                      {t.high_priority && <span className="bm-tag-hi">high</span>}
+                      {statusTag && <span className="bm-tag-status">{statusTag}</span>}
                       {overdue && <span className="bm-due-over">overdue</span>}
+                      {stale && <span className="bm-tag-stale">{ageDays}d on list</span>}
                       {chips.slice(0, 3).map(l => (
                         <span key={l.id} className="bm-tagdot" style={{ '--tag': l.color }}><i />{l.name}</span>
                       ))}

--- a/src/kept/shell.css
+++ b/src/kept/shell.css
@@ -394,3 +394,30 @@
 .bm-stack-member { display: flex; align-items: center; gap: 12px; padding: 7px 0 7px 14px; }
 .bm-stack-count { font-style: normal; font-weight: 500; color: var(--bm-text-meta); }
 .bm-stack-start { padding: 8px 16px; flex: 0 0 auto; }
+
+/* Main-page contract restores */
+.bm-gmail-banner {
+  display: flex; align-items: center; gap: 9px;
+  width: 100%;
+  background: var(--bm-gold-soft);
+  border: none; border-radius: 12px;
+  padding: 11px 13px; margin-bottom: 14px;
+  font-size: 13px; font-weight: 600;
+  color: var(--bm-text); cursor: pointer; text-align: left;
+}
+.bm-gmail-banner svg:first-child { color: var(--bm-gold); flex: 0 0 auto; }
+.bm-gmail-banner b { color: var(--bm-gold); }
+.bm-arc { padding: 9px 0 6px; border-bottom: 1px solid var(--bm-hairline); }
+.bm-arc:last-child { border-bottom: none; }
+.bm-arc-head { display: flex; align-items: center; gap: 11px; }
+.bm-arc-icon {
+  flex: 0 0 auto;
+  width: 30px; height: 30px; border-radius: 50%;
+  display: grid; place-items: center;
+  background: var(--bm-gold-soft); color: var(--bm-gold);
+}
+.bm-arc-log { padding: 8px 13px; font-size: 12.5px; flex: 0 0 auto; }
+.bm-chk.is-hi { box-shadow: 0 0 0 3px var(--bm-ember-soft); }
+.bm-tag-hi { font-size: 11px; font-weight: 750; color: var(--bm-ember); text-transform: uppercase; letter-spacing: 0.04em; }
+.bm-tag-status { font-size: 11.5px; font-weight: 650; color: var(--bm-gold); }
+.bm-tag-stale { font-size: 11.5px; color: var(--bm-text-meta); }

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,14 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-11
 
+- fix(ui): Kept Today — main-page contract restores (divergence audit, round 1) [M]
+  - From the divergence audit: five places Kept's Today silently dropped v2 main-list behavior.
+  - **Habit-mode loops always visible** — the cadence filter ran target-frequency loops through `getNextDueDate` (which doesn't model them), hiding them after any log; habit-mode is "log any day", so they're now always due.
+  - **Pinned Arcs return to the main page** — pinned projects (title · session count · gold Log-session button) with their active children as catchable rows, above the Today section.
+  - **Gmail-pending visibility** — a gold banner ("N imported items to review") on Today opens Suggestions; Suggestions also added to the desktop sidebar.
+  - **Signal restores** — `Nd on list` staleness meta (isStale), `doing`/`waiting` status tags, and a high-priority marker (ember halo on the check + HIGH tag).
+  - Verified live on seeded data: all five render and behave; zero page errors; lint 0; tests + build + smoke pass.
+
 - fix(ui): lock text-size-adjust — landscape rotation no longer inflates text permanently [XS]
   - Prod report: rotate to landscape and back → row titles and meta stuck at boosted sizes (everything except SVG text). iOS Safari's font boosting inflates text on rotation and, with `text-size-adjust` unlocked, keeps the inflated sizes back in portrait. `html { -webkit-text-size-adjust: 100% }` in index.css renders authored sizes in every orientation. (Not reproducible in headless Chromium — the standard documented remedy, applies to all themes.)
 


### PR DESCRIPTION
Promotes divergence-audit round 1. **Merge with the merge-commit method only.**

One commit: the five main-page contract restores — habit-mode loops always visible (live bug: one log hid them), pinned Arcs back on Today with Log-session + active children, the Gmail-pending review banner (+ desktop Suggestions nav), staleness `Nd on list` meta, doing/waiting tags, and the high-priority marker.

All verified live on seeded data; lint 0; tests + build + smoke pass.

https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR)_