### PR TITLE
fix(ui): Kept — caught tasks leave the list + collapsible sections

### DIFF
--- a/src/kept/Section.jsx
+++ b/src/kept/Section.jsx
@@ -1,0 +1,31 @@
+import { useCallback, useState } from 'react'
+import { ChevronDown } from 'lucide-react'
+import { loadSettings, saveSettings } from '../store'
+import './shell.css'
+
+// Collapsible Kept section header (v2's SectionLabel collapse, Kept-styled).
+// Collapse state persists in settings.kept_collapsed (cross-device, same
+// mechanism as v2's collapsed_sections).
+export function useCollapsedSections() {
+  const [map, setMap] = useState(() => loadSettings().kept_collapsed || {})
+  const toggle = useCallback((id) => {
+    setMap(prev => {
+      const next = { ...prev, [id]: !prev[id] }
+      saveSettings({ ...loadSettings(), kept_collapsed: next })
+      return next
+    })
+  }, [])
+  return [map, toggle]
+}
+
+export default function Section({ id, label, count, collapsed, onToggle, children }) {
+  return (
+    <>
+      <button className="bm-sec bm-sec-toggle" onClick={() => onToggle(id)} aria-expanded={!collapsed}>
+        <span className="bm-sec-tick" /> {label} <span className="bm-sec-n">{count}</span>
+        <ChevronDown size={13} strokeWidth={2.5} className={`bm-sec-chev${collapsed ? ' is-collapsed' : ''}`} />
+      </button>
+      {!collapsed && children}
+    </>
+  )
+}

--- a/src/kept/TasksViewKept.jsx
+++ b/src/kept/TasksViewKept.jsx
@@ -3,6 +3,7 @@ import { Check, Search, Pencil, Trash2, Calendar, X } from 'lucide-react'
 import { localYMD, parseLocalDate, addDays } from '../dates'
 import { isSnoozed } from '../store'
 import RowSwipe from './RowSwipe'
+import Section, { useCollapsedSections } from './Section'
 import './shell.css'
 
 const ACTIVE = ['not_started', 'doing', 'waiting', 'in_progress']
@@ -19,6 +20,7 @@ export default function TasksViewKept({ tasks = [], labels = [], onToggleComplet
   const [query, setQuery] = useState('')
   const [searchOpen, setSearchOpen] = useState(false)
   const [sheetTask, setSheetTask] = useState(null)
+  const [collapsed, toggleSection] = useCollapsedSections()
   const labelsById = useMemo(() => { const m = {}; for (const l of labels) m[l.id] = l; return m }, [labels])
 
   const visible = useMemo(() => {
@@ -65,7 +67,7 @@ export default function TasksViewKept({ tasks = [], labels = [], onToggleComplet
       {sections.length === 0 && <p className="bm-empty">Nothing here.</p>}
       {sections.map(sec => (
         <div key={sec.key}>
-          <div className="bm-sec"><span className="bm-sec-tick" /> {sec.label} <span className="bm-sec-n">{sec.items.length}</span></div>
+          <Section id={`tasks-${sec.key}`} label={sec.label} count={sec.items.length} collapsed={!!collapsed[`tasks-${sec.key}`]} onToggle={toggleSection}>
           <div className="bm-rows">
             {sec.items.map(t => {
               const done = t.status === 'done'
@@ -95,6 +97,7 @@ export default function TasksViewKept({ tasks = [], labels = [], onToggleComplet
               )
             })}
           </div>
+          </Section>
         </div>
       ))}
 

--- a/src/kept/TodayView.jsx
+++ b/src/kept/TodayView.jsx
@@ -7,6 +7,7 @@ import { historyByDay, currentStreak } from '../wallaby/heatmapUtils'
 import { isSnoozed, isStale, formatSnoozeLabel, getNextDueDate } from '../store'
 import { routineFeathers } from './feathers'
 import RowSwipe from './RowSwipe'
+import Section, { useCollapsedSections } from './Section'
 import './shell.css'
 
 const ACTIVE = ['not_started', 'doing', 'waiting', 'in_progress']
@@ -21,6 +22,7 @@ export default function TodayView({
   onLogSession, onOpenSuggestions, gmailPendingCount = 0,
 }) {
   const todayKey = localYMD()
+  const [collapsed, toggleSection] = useCollapsedSections()
   const labelsById = useMemo(() => { const m = {}; for (const l of labels) m[l.id] = l; return m }, [labels])
 
   const stackRoutineIds = useMemo(() => new Set(
@@ -31,12 +33,12 @@ export default function TodayView({
     if (t.parent_id || t.gmail_pending) return false
     // Stack members render grouped under their stack in the Loops section.
     if (t.routine_id && stackRoutineIds.has(t.routine_id)) return false
-    const doneToday = t.status === 'done' && t.completed_at && localYMD(new Date(t.completed_at)) === todayKey
-    if (doneToday) return true
+    // Caught tasks leave the list immediately (v2 contract — the toast's
+    // Undo covers regret; Caught keeps the record). No done strikethroughs.
     if (!ACTIVE.includes(t.status)) return false
     if (isSnoozed(t)) return false
     return t.due_date ? String(t.due_date).slice(0, 10) <= todayKey : false
-  }).sort((a, b) => (a.status === 'done' ? 1 : 0) - (b.status === 'done' ? 1 : 0)), [tasks, todayKey, stackRoutineIds])
+  }), [tasks, todayKey, stackRoutineIds])
 
   // Undated active tasks — the main page must show them (v2's Up next did).
   // Future-DATED tasks stay off Today until their day; undated means
@@ -138,8 +140,7 @@ export default function TodayView({
       )}
 
       {pinnedArcs.length > 0 && (
-        <>
-          <div className="bm-sec"><span className="bm-sec-tick" /> Arcs <span className="bm-sec-n">{pinnedArcs.length}</span></div>
+        <Section id="arcs" label="Arcs" count={pinnedArcs.length} collapsed={!!collapsed.arcs} onToggle={toggleSection}>
           <div className="bm-rows">
             {pinnedArcs.map(p2 => (
               <div key={p2.id} className="bm-arc">
@@ -164,14 +165,14 @@ export default function TodayView({
               </div>
             ))}
           </div>
-        </>
+        </Section>
       )}
 
-      <div className="bm-sec"><span className="bm-sec-tick" /> Today <span className="bm-sec-n">{dayTasks.length}</span></div>
+      <Section id="today" label="Today" count={dayTasks.length} collapsed={!!collapsed.today} onToggle={toggleSection}>
       <div className="bm-rows">
         {dayTasks.length === 0 && <p className="bm-empty">Nothing due — enjoy it.</p>}
         {dayTasks.map(t => {
-          const done = t.status === 'done'
+          const done = false
           const overdue = !done && t.due_date && String(t.due_date).slice(0, 10) < todayKey
           const chips = (t.tags || []).map(id => labelsById[id]).filter(Boolean)
           const stale = !done && isStale(t)
@@ -213,10 +214,10 @@ export default function TodayView({
           </div>
         ))}
       </div>
+      </Section>
 
       {anytimeTasks.length > 0 && (
-        <>
-          <div className="bm-sec"><span className="bm-sec-tick" /> Anytime <span className="bm-sec-n">{anytimeTasks.length}</span></div>
+        <Section id="anytime" label="Anytime" count={anytimeTasks.length} collapsed={!!collapsed.anytime} onToggle={toggleSection}>
           <div className="bm-rows">
             {anytimeTasks.map(t => {
               const chips = (t.tags || []).map(id => labelsById[id]).filter(Boolean)
@@ -239,12 +240,11 @@ export default function TodayView({
               )
             })}
           </div>
-        </>
+        </Section>
       )}
 
       {loops.length > 0 && (
-        <>
-          <div className="bm-sec"><span className="bm-sec-tick" /> Loops <span className="bm-sec-n">{loopsDone}/{loops.length}</span></div>
+        <Section id="loops" label="Loops" count={`${loopsDone}/${loops.length}`} collapsed={!!collapsed.loops} onToggle={toggleSection}>
           <div className="bm-rows">
             {loops.map(({ r, color, byDay, rally, doneToday, isStack, cycles }) => {
               if (isStack) {
@@ -294,7 +294,7 @@ export default function TodayView({
               )
             })}
           </div>
-        </>
+        </Section>
       )}
     </div>
   )

--- a/src/kept/shell.css
+++ b/src/kept/shell.css
@@ -421,3 +421,17 @@
 .bm-tag-hi { font-size: 11px; font-weight: 750; color: var(--bm-ember); text-transform: uppercase; letter-spacing: 0.04em; }
 .bm-tag-status { font-size: 11.5px; font-weight: 650; color: var(--bm-gold); }
 .bm-tag-stale { font-size: 11.5px; color: var(--bm-text-meta); }
+
+/* Collapsible section headers */
+.bm-sec-toggle {
+  width: 100%;
+  background: none; border: none;
+  cursor: pointer; text-align: left;
+  padding: 0;
+}
+.bm-sec-chev {
+  margin-left: auto;
+  color: var(--bm-text-faint);
+  transition: transform 160ms ease;
+}
+.bm-sec-chev.is-collapsed { transform: rotate(-90deg); }

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,11 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-11
 
+- fix(ui): Kept Today — caught tasks leave the list + collapsible sections [S]
+  - **Caught tasks no longer linger struck-through** on Today (the last day-planner-recap carryover): completion removes the row immediately, v2's contract — the toast's Undo covers regret, Caught keeps the record.
+  - **Sections collapse into their titles**: Arcs / Today / Anytime / Loops on Today and every group on the Tasks tab get a chevron toggle (new shared `Section` component + `useCollapsedSections`), persisted in `settings.kept_collapsed` — the same cross-device mechanism as v2's `collapsed_sections`.
+  - Verified live: catch → row leaves with zero strikethroughs; collapse → rows hidden, aria-expanded + persisted state correct.
+
 - fix(ui): Kept Today — main-page contract restores (divergence audit, round 1) [M]
   - From the divergence audit: five places Kept's Today silently dropped v2 main-list behavior.
   - **Habit-mode loops always visible** — the cadence filter ran target-frequency loops through `getNextDueDate` (which doesn't model them), hiding them after any log; habit-mode is "log any day", so they're now always due.


### PR DESCRIPTION
Two more from prod tire-kicking:

1. **Caught tasks leave the list.** Done tasks were lingering struck-through in TODAY — the last of the Wallaby day-planner-recap carryovers. Completion now removes the row immediately (v2's contract); the toast's Undo covers regret and Caught keeps the record.
2. **Sections collapse into their titles.** Arcs / Today / Anytime / Loops on Today, plus every group on the Tasks tab, get a chevron toggle — new shared `Section` component + `useCollapsedSections`, persisted in `settings.kept_collapsed` (the same cross-device mechanism v2's `collapsed_sections` used).

Verified live: catch removes the row instantly (zero strikethroughs remain); collapse hides rows with correct `aria-expanded` and persisted state. Lint 0; tests + build + smoke pass.

https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR)_