### PR TITLE
fix(ui): Kept audit round 2 — Gmail review, What Now, subtasks, Snoozed, filters

### DIFF
--- a/src/AppV2.jsx
+++ b/src/AppV2.jsx
@@ -52,7 +52,7 @@ import { useTrelloSync } from './hooks/useTrelloSync'
 import { useNotionSync } from './hooks/useNotionSync'
 import { useGCalSync } from './hooks/useGCalSync'
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts'
-import { inferSize, trelloUpdateCard, serverSkipAdvanceTask } from './api'
+import { inferSize, trelloUpdateCard, serverSkipAdvanceTask, gmailApprove, gmailDismiss } from './api'
 import { loadLabels, loadSettings, saveSettings, saveLabels, sortTasks, computeDailyStats, computeStreak, logActivity, localYMD } from './store'
 import { computeRecords, calculateTaskPoints } from './scoring'
 import { applyTheme } from './theme'
@@ -1255,8 +1255,23 @@ export default function AppV2() {
           pointsGoal={settingsForRings.daily_points_goal || 15}
           streak={streak}
           onCompleteTask={(task) => task.status === 'done' ? handleUncomplete(task) : handleComplete(task.id)}
+          onGmailKeep={async (t) => {
+            updateTask(t.id, { gmail_pending: false })
+            try { await gmailApprove(t.id) } catch { /* refetch reverts */ }
+          }}
+          onGmailDismiss={async (t) => {
+            deleteTask(t.id)
+            try { await gmailDismiss(t.id) } catch { /* refetch reverts */ }
+          }}
+          onWhatNow={() => setShowWhatNow(true)}
+          onToggleItem={(task, clId, itemId) => {
+            const checklists = (task.checklists || []).map(cl =>
+              cl.id !== clId ? cl : { ...cl, items: (cl.items || []).map(it => it.id === itemId ? { ...it, completed: !it.completed } : it) },
+            )
+            updateTask(task.id, { checklists })
+          }}
+          onUnsnooze={(t) => unsnoozeTask(t.id)}
           onLogSession={(p) => handleLogSession(p.id)}
-          gmailPendingCount={tasks.filter(t => t.gmail_pending).length}
           onOpenTask={(task) => setEditTarget(task)}
           onToggleHabit={toggleHabitDay}
           onRescheduleTask={(task, ymd) => updateTask(task.id, { due_date: ymd })}
@@ -1290,8 +1305,23 @@ export default function AppV2() {
           pointsGoal={settingsForRings.daily_points_goal || 15}
           streak={streak}
           onCompleteTask={(task) => task.status === 'done' ? handleUncomplete(task) : handleComplete(task.id)}
+          onGmailKeep={async (t) => {
+            updateTask(t.id, { gmail_pending: false })
+            try { await gmailApprove(t.id) } catch { /* refetch reverts */ }
+          }}
+          onGmailDismiss={async (t) => {
+            deleteTask(t.id)
+            try { await gmailDismiss(t.id) } catch { /* refetch reverts */ }
+          }}
+          onWhatNow={() => setShowWhatNow(true)}
+          onToggleItem={(task, clId, itemId) => {
+            const checklists = (task.checklists || []).map(cl =>
+              cl.id !== clId ? cl : { ...cl, items: (cl.items || []).map(it => it.id === itemId ? { ...it, completed: !it.completed } : it) },
+            )
+            updateTask(task.id, { checklists })
+          }}
+          onUnsnooze={(t) => unsnoozeTask(t.id)}
           onLogSession={(p) => handleLogSession(p.id)}
-          gmailPendingCount={tasks.filter(t => t.gmail_pending).length}
           onOpenTask={(task) => setEditTarget(task)}
           onToggleHabit={toggleHabitDay}
           onRescheduleTask={(task, ymd) => updateTask(task.id, { due_date: ymd })}

--- a/src/kept/KeptDesktop.jsx
+++ b/src/kept/KeptDesktop.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import {
   Home, ListTodo, Repeat2, FolderKanban, BarChart3, Package, Settings,
-  Sparkles, Plus, CheckCircle2, ScrollText, Inbox,
+  Sparkles, Plus, CheckCircle2, ScrollText, Inbox, Compass,
 } from 'lucide-react'
 import Logo from '../components/Logo'
 import { useSyncBounce } from '../hooks/useSyncBounce'
@@ -19,7 +19,7 @@ export default function KeptDesktop({
   tasks = [], routines = [], labels = [],
   dailyStats = {}, pointsGoal = 15, streak = 0,
   onCompleteTask, onOpenTask, onToggleHabit, onRescheduleTask, onDeleteTask,
-  onLogSession, gmailPendingCount = 0,
+  onLogSession, onGmailKeep, onGmailDismiss, onWhatNow, onToggleItem, onUnsnooze,
   onThrow, onOpenFullAdd, onEditLoop, onAddLoop,
   onOpenQuokka, onOpenSettings, onOpenPackages, onOpenAnalytics,
   onOpenProjects, onOpenDone, onOpenActivity, onOpenSuggestions,
@@ -50,7 +50,7 @@ export default function KeptDesktop({
     { label: 'Caught', icon: CheckCircle2, onClick: onOpenDone },
     { label: 'Analytics', icon: BarChart3, onClick: onOpenAnalytics },
     { label: 'Packages', icon: Package, onClick: onOpenPackages },
-    { label: 'Suggestions', icon: Inbox, onClick: onOpenSuggestions },
+    { label: 'Routine suggestions', icon: Inbox, onClick: onOpenSuggestions },
     { label: 'Activity log', icon: ScrollText, onClick: onOpenActivity },
   ]
 
@@ -59,8 +59,9 @@ export default function KeptDesktop({
     surface = (
       <TasksViewKept
         tasks={tasks} labels={labels}
-        onToggleComplete={onCompleteTask} onOpenTask={onOpenTask}
-        onDelete={onDeleteTask} onReschedule={onRescheduleTask}
+        routines={routines}
+        onToggleComplete={onCompleteTask} onToggleItem={onToggleItem} onOpenTask={onOpenTask}
+        onDelete={onDeleteTask} onReschedule={onRescheduleTask} onUnsnooze={onUnsnooze}
       />
     )
   } else if (tab === 'loops') {
@@ -72,8 +73,8 @@ export default function KeptDesktop({
         dailyStats={dailyStats} pointsGoal={pointsGoal} streak={streak}
         onCompleteTask={onCompleteTask} onOpenTask={onOpenTask} onToggleHabit={onToggleHabit}
         onDeleteTask={onDeleteTask} onEditLoop={onEditLoop}
-        onLogSession={onLogSession} gmailPendingCount={gmailPendingCount}
-        onOpenSuggestions={onOpenSuggestions}
+        onLogSession={onLogSession} onGmailKeep={onGmailKeep} onGmailDismiss={onGmailDismiss}
+        onWhatNow={onWhatNow}
       />
     )
   }
@@ -91,6 +92,9 @@ export default function KeptDesktop({
         </div>
         <button className="bm-side-throw" onClick={() => setThrowOpen(true)}>
           <Plus size={15} strokeWidth={2.4} /> Throw a task <kbd>⌘K</kbd>
+        </button>
+        <button className="bm-side-item" onClick={onWhatNow}>
+          <Compass size={17} strokeWidth={2} /> What now?
         </button>
         {navMain.map(t => {
           const Icon = t.icon

--- a/src/kept/KeptShell.jsx
+++ b/src/kept/KeptShell.jsx
@@ -16,7 +16,7 @@ export default function KeptShell({
   tasks = [], routines = [], labels = [],
   dailyStats = {}, pointsGoal = 15, streak = 0,
   onCompleteTask, onOpenTask, onToggleHabit, onRescheduleTask, onDeleteTask,
-  onLogSession, gmailPendingCount = 0,
+  onLogSession, onGmailKeep, onGmailDismiss, onWhatNow, onToggleItem, onUnsnooze,
   onThrow, onOpenFullAdd, onEditLoop, onAddLoop,
   onOpenQuokka, onOpenSettings, onOpenPackages, onOpenAnalytics,
   onOpenProjects, onOpenDone, onOpenActivity, onOpenSuggestions,
@@ -32,8 +32,9 @@ export default function KeptShell({
     surface = (
       <TasksViewKept
         tasks={tasks} labels={labels}
-        onToggleComplete={onCompleteTask} onOpenTask={onOpenTask}
-        onDelete={onDeleteTask} onReschedule={onRescheduleTask}
+        routines={routines}
+        onToggleComplete={onCompleteTask} onToggleItem={onToggleItem} onOpenTask={onOpenTask}
+        onDelete={onDeleteTask} onReschedule={onRescheduleTask} onUnsnooze={onUnsnooze}
       />
     )
   } else if (tab === 'more') {
@@ -52,8 +53,8 @@ export default function KeptShell({
         dailyStats={dailyStats} pointsGoal={pointsGoal} streak={streak}
         onCompleteTask={onCompleteTask} onOpenTask={onOpenTask} onToggleHabit={onToggleHabit}
         onDeleteTask={onDeleteTask} onEditLoop={onEditLoop}
-        onLogSession={onLogSession} gmailPendingCount={gmailPendingCount}
-        onOpenSuggestions={onOpenSuggestions}
+        onLogSession={onLogSession} onGmailKeep={onGmailKeep} onGmailDismiss={onGmailDismiss}
+        onWhatNow={onWhatNow}
       />
     )
   }

--- a/src/kept/MoreView.jsx
+++ b/src/kept/MoreView.jsx
@@ -9,7 +9,7 @@ export default function MoreView({ onOpenProjects, onOpenAnalytics, onOpenPackag
     { icon: BarChart3, label: 'Analytics', sub: 'Productivity insights', onClick: onOpenAnalytics },
     { icon: CheckCircle2, label: 'Caught', sub: 'Everything you finished', onClick: onOpenDone },
     { icon: Package, label: 'Packages', sub: 'Track deliveries', onClick: onOpenPackages },
-    { icon: Inbox, label: 'Suggestions', sub: 'Gmail-imported items to review', onClick: onOpenSuggestions },
+    { icon: Inbox, label: 'Routine suggestions', sub: 'Recurring patterns spotted in your tasks', onClick: onOpenSuggestions },
     { icon: ScrollText, label: 'Activity log', sub: 'Every change, restorable', onClick: onOpenActivity },
     { icon: Settings, label: 'Settings', sub: 'App configuration', onClick: onOpenSettings },
   ]

--- a/src/kept/TasksViewKept.jsx
+++ b/src/kept/TasksViewKept.jsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react'
-import { Check, Search, Pencil, Trash2, Calendar, X } from 'lucide-react'
+import { Check, Search, Pencil, Trash2, X, Undo2 } from 'lucide-react'
 import { localYMD, parseLocalDate, addDays } from '../dates'
-import { isSnoozed } from '../store'
+import { isSnoozed, formatSnoozeLabel } from '../store'
 import RowSwipe from './RowSwipe'
 import Section, { useCollapsedSections } from './Section'
 import './shell.css'
@@ -9,31 +9,41 @@ import './shell.css'
 const ACTIVE = ['not_started', 'doing', 'waiting', 'in_progress']
 const TABS = [
   { id: 'upcoming', label: 'Upcoming' },
+  { id: 'snoozed', label: 'Snoozed' },
   { id: 'backlog', label: 'Backlog' },
   { id: 'done', label: 'Done' },
 ]
 
 // Kept "Tasks" — grouped hairline rows, gold circle checks, dot-tags, and the
 // action sheet with reschedule chips ("throw it back") (spec §6).
-export default function TasksViewKept({ tasks = [], labels = [], onToggleComplete, onOpenTask, onDelete, onReschedule }) {
+export default function TasksViewKept({ tasks = [], labels = [], routines = [], onToggleComplete, onToggleItem, onOpenTask, onDelete, onReschedule, onUnsnooze }) {
   const [tab, setTab] = useState('upcoming')
   const [query, setQuery] = useState('')
   const [searchOpen, setSearchOpen] = useState(false)
   const [sheetTask, setSheetTask] = useState(null)
   const [collapsed, toggleSection] = useCollapsedSections()
   const labelsById = useMemo(() => { const m = {}; for (const l of labels) m[l.id] = l; return m }, [labels])
+  const [labelFilter, setLabelFilter] = useState('all')
+  // Stack members live in their Today folder (v2 dropped them from the main
+  // sections too); they stay visible in Done as records.
+  const stackIds = useMemo(() => new Set(
+    routines.filter(r => Array.isArray(r.members) && r.members.length > 0).map(r => r.id),
+  ), [routines])
 
   const visible = useMemo(() => {
     const q = query.trim().toLowerCase()
     return tasks.filter(t => {
       if (t.gmail_pending || t.parent_id) return false
+      if (tab !== 'done' && t.routine_id && stackIds.has(t.routine_id)) return false
       if (tab === 'done') { if (t.status !== 'done') return false }
       else if (tab === 'backlog') { if (t.status !== 'backlog') return false }
+      else if (tab === 'snoozed') { if (!ACTIVE.includes(t.status) || !isSnoozed(t)) return false }
       else if (!ACTIVE.includes(t.status) || isSnoozed(t)) return false
+      if (labelFilter !== 'all' && !(t.tags || []).includes(labelFilter)) return false
       if (q && !t.title.toLowerCase().includes(q)) return false
       return true
     })
-  }, [tasks, tab, query])
+  }, [tasks, tab, query, labelFilter, stackIds])
 
   const sections = useMemo(() => groupTasks(visible, tab), [visible, tab])
 
@@ -54,6 +64,17 @@ export default function TasksViewKept({ tasks = [], labels = [], onToggleComplet
             onClick={() => setTab(t.id)}>{t.label}</button>
         ))}
       </div>
+      {labels.length > 0 && tab !== 'done' && (
+        <div className="bm-filter-row">
+          <button className={`bm-pick bm-pick-sm${labelFilter === 'all' ? ' is-on' : ''}`} onClick={() => setLabelFilter('all')}>All</button>
+          {labels.map(l => (
+            <button key={l.id} className={`bm-pick bm-pick-sm${labelFilter === l.id ? ' is-on' : ''}`} style={{ '--tag': l.color }} onClick={() => setLabelFilter(labelFilter === l.id ? 'all' : l.id)}>
+              <i className="bm-filter-dot" /> {l.name}
+            </button>
+          ))}
+        </div>
+      )}
+
       {searchOpen && (
         <input
           className="bm-throw-input"
@@ -73,25 +94,49 @@ export default function TasksViewKept({ tasks = [], labels = [], onToggleComplet
               const done = t.status === 'done'
               const due = dueMeta(t.due_date)
               const chips = (t.tags || []).map(id => labelsById[id]).filter(Boolean)
+              const subItems = tab === 'snoozed' || done ? [] : (Array.isArray(t.checklists) ? t.checklists : [])
+                .flatMap(cl => (cl.items || []).map(it => ({ ...it, clId: cl.id })))
               return (
                 <RowSwipe key={t.id} done={done} onCatch={() => onToggleComplete?.(t)} onDelete={() => onDelete?.(t)}>
                   <div className="bm-row">
                     <button
-                      className={`bm-chk${done ? ' is-done' : ''}`}
+                      className={`bm-chk${done ? ' is-done' : ''}${t.high_priority ? ' is-hi' : ''}`}
                       onClick={() => onToggleComplete?.(t)}
                       aria-label={done ? 'Reopen' : 'Catch it'}
                     >{done && <Check size={13} strokeWidth={3.4} />}</button>
-                    <button className="bm-row-body" onClick={() => setSheetTask(t)}>
-                      <span className={`bm-row-title${done ? ' is-done' : ''}`}>{t.title}</span>
-                      {!done && (due || chips.length > 0) && (
-                        <span className="bm-row-meta">
-                          {due && <span className={due.tone === 'over' ? 'bm-due-over' : due.tone === 'hot' ? 'bm-due-hot' : undefined}>{due.label}</span>}
-                          {chips.slice(0, 3).map(l => (
-                            <span key={l.id} className="bm-tagdot" style={{ '--tag': l.color }}><i />{l.name}</span>
+                    <div className="bm-row-stack">
+                      <button className="bm-row-body" onClick={() => setSheetTask(t)}>
+                        <span className={`bm-row-title${done ? ' is-done' : ''}`}>{t.title}</span>
+                        {!done && (due || chips.length > 0 || tab === 'snoozed') && (
+                          <span className="bm-row-meta">
+                            {tab === 'snoozed' && <span className="bm-return-chip">↩ returns {formatSnoozeLabel(t.snoozed_until)}</span>}
+                            {due && <span className={due.tone === 'over' ? 'bm-due-over' : due.tone === 'hot' ? 'bm-due-hot' : undefined}>{due.label}</span>}
+                            {chips.slice(0, 3).map(l => (
+                              <span key={l.id} className="bm-tagdot" style={{ '--tag': l.color }}><i />{l.name}</span>
+                            ))}
+                          </span>
+                        )}
+                      </button>
+                      {subItems.length > 0 && (
+                        <ul className="bm-subtasks">
+                          {subItems.map(it => (
+                            <li key={it.id} className="bm-subtask">
+                              <button
+                                className={`bm-subcheck${it.completed ? ' is-done' : ''}`}
+                                onClick={() => onToggleItem?.(t, it.clId, it.id)}
+                                aria-label={it.completed ? 'Uncheck' : 'Check'}
+                              >{it.completed && <Check size={10} strokeWidth={3} />}</button>
+                              <span className={`bm-subtask-text${it.completed ? ' is-done' : ''}`}>{it.text}</span>
+                            </li>
                           ))}
-                        </span>
+                        </ul>
                       )}
-                    </button>
+                    </div>
+                    {tab === 'snoozed' && (
+                      <button className="bm-btn bm-btn-tonal bm-bringback" onClick={() => onUnsnooze?.(t)}>
+                        <Undo2 size={13} strokeWidth={2.2} /> Now
+                      </button>
+                    )}
                   </div>
                 </RowSwipe>
               )
@@ -154,6 +199,10 @@ function groupTasks(list, tab) {
   }
   if (tab === 'backlog') {
     return list.length ? [{ key: 'backlog', label: 'Backlog', items: list }] : []
+  }
+  if (tab === 'snoozed') {
+    const sorted = [...list].sort((a, b) => (a.snoozed_until || '').localeCompare(b.snoozed_until || ''))
+    return sorted.length ? [{ key: 'snoozed', label: 'Returning', items: sorted }] : []
   }
   const today = localYMD()
   const tmr = localYMD(addDays(new Date(), 1))

--- a/src/kept/TodayView.jsx
+++ b/src/kept/TodayView.jsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { Check, Repeat2, Flame, FolderKanban, Inbox, ChevronRight } from 'lucide-react'
+import { Check, Repeat2, Flame, FolderKanban, Inbox, X, Compass } from 'lucide-react'
 import DayArc from './DayArc'
 import FlightTrail from './FlightTrail'
 import { localYMD } from '../dates'
@@ -19,7 +19,7 @@ export default function TodayView({
   tasks = [], routines = [], labels = [],
   dailyStats = {}, pointsGoal = 15, streak = 0,
   onCompleteTask, onOpenTask, onToggleHabit, onDeleteTask, onEditLoop,
-  onLogSession, onOpenSuggestions, gmailPendingCount = 0,
+  onLogSession, onGmailKeep, onGmailDismiss, onWhatNow,
 }) {
   const todayKey = localYMD()
   const [collapsed, toggleSection] = useCollapsedSections()
@@ -103,6 +103,10 @@ export default function TodayView({
   }, [routines, tasks, todayKey])
   const loopsDone = loops.filter(l => l.doneToday).length
 
+  // Gmail-imported items awaiting review (Keep / Dismiss) — restores the
+  // v1-era inline review that died in the purge (v2 never ported it).
+  const gmailPending = useMemo(() => tasks.filter(t => t.gmail_pending), [tasks])
+
   // Pinned Arcs (projects) — v2's main list led with these; restore them.
   const pinnedArcs = useMemo(() => tasks.filter(t => t.status === 'project' && t.pinned_to_today), [tasks])
   const arcChildren = useMemo(() => {
@@ -129,14 +133,31 @@ export default function TodayView({
           <span><b>{loopsDone}/{loops.length}</b> loops</span>
           <span><b>{Math.max(0, pointsGoal - (dailyStats.pointsToday ?? 0))}</b> pts left</span>
         </div>
+        <button className="bm-btn bm-btn-tonal bm-whatnow" onClick={onWhatNow}>
+          <Compass size={15} strokeWidth={2.1} /> What now?
+        </button>
       </div>
 
-      {gmailPendingCount > 0 && (
-        <button className="bm-gmail-banner" onClick={onOpenSuggestions}>
-          <Inbox size={15} strokeWidth={2} />
-          <span><b>{gmailPendingCount}</b> imported item{gmailPendingCount === 1 ? '' : 's'} to review</span>
-          <ChevronRight size={15} strokeWidth={2} className="bm-more-chev" />
-        </button>
+      {gmailPending.length > 0 && (
+        <Section id="review" label="Review" count={gmailPending.length} collapsed={!!collapsed.review} onToggle={toggleSection}>
+          <div className="bm-rows">
+            {gmailPending.map(t => (
+              <div key={t.id} className="bm-row bm-review-row">
+                <span className="bm-review-icon"><Inbox size={14} strokeWidth={2} /></span>
+                <button className="bm-row-body" onClick={() => onOpenTask?.(t)}>
+                  <span className="bm-row-title">{t.title}</span>
+                  <span className="bm-row-meta"><span>from Gmail</span></span>
+                </button>
+                <button className="bm-btn bm-btn-tonal bm-review-keep" onClick={() => onGmailKeep?.(t)}>
+                  <Check size={13} strokeWidth={2.6} /> Keep
+                </button>
+                <button className="bm-review-dismiss" onClick={() => onGmailDismiss?.(t)} aria-label="Dismiss">
+                  <X size={15} strokeWidth={2.2} />
+                </button>
+              </div>
+            ))}
+          </div>
+        </Section>
       )}
 
       {pinnedArcs.length > 0 && (

--- a/src/kept/shell.css
+++ b/src/kept/shell.css
@@ -435,3 +435,44 @@
   transition: transform 160ms ease;
 }
 .bm-sec-chev.is-collapsed { transform: rotate(-90deg); }
+
+/* Audit round 2 */
+.bm-review-row { align-items: center; }
+.bm-review-icon {
+  flex: 0 0 auto;
+  width: 28px; height: 28px; border-radius: 50%;
+  display: grid; place-items: center;
+  background: var(--bm-gold-soft); color: var(--bm-gold);
+}
+.bm-review-keep { padding: 8px 12px; font-size: 12.5px; flex: 0 0 auto; gap: 5px; }
+.bm-review-dismiss {
+  flex: 0 0 auto;
+  width: 32px; height: 32px; border-radius: 50%;
+  border: 1px solid var(--bm-hairline-strong);
+  background: transparent; color: var(--bm-text-meta);
+  display: grid; place-items: center; cursor: pointer;
+}
+.bm-whatnow { width: 100%; margin-top: 10px; }
+.bm-filter-row {
+  display: flex; gap: 7px;
+  overflow-x: auto;
+  padding: 0 2px 12px;
+  scrollbar-width: none;
+}
+.bm-filter-row::-webkit-scrollbar { display: none; }
+.bm-pick-sm { padding: 6px 11px; font-size: 12px; flex: 0 0 auto; display: inline-flex; align-items: center; gap: 6px; }
+.bm-filter-dot { width: 7px; height: 7px; border-radius: 50%; background: var(--tag, var(--bm-text-faint)); display: inline-block; }
+.bm-row-stack { flex: 1 1 auto; min-width: 0; display: flex; flex-direction: column; }
+.bm-subtasks { list-style: none; margin: 7px 0 0; padding: 0; display: flex; flex-direction: column; gap: 6px; }
+.bm-subtask { display: flex; align-items: center; gap: 9px; }
+.bm-subcheck {
+  flex: 0 0 auto;
+  display: grid; place-items: center;
+  width: 17px; height: 17px; border-radius: 50%;
+  border: 1.5px solid var(--bm-hairline-strong);
+  background: transparent; color: var(--bm-on-ember); cursor: pointer;
+}
+.bm-subcheck.is-done { background: var(--bm-gold); border-color: var(--bm-gold); }
+.bm-subtask-text { font-size: 13px; color: var(--bm-text-meta); }
+.bm-subtask-text.is-done { text-decoration: line-through; opacity: 0.6; }
+.bm-bringback { padding: 8px 11px; font-size: 12px; flex: 0 0 auto; gap: 4px; }

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,14 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-11
 
+- fix(ui): Kept audit round 2 — real Gmail review, What Now, subtasks, Snoozed tab, label filters [L]
+  - **Gmail review actually works now** (prod report: "imported items isn't doing shit"): the banner routed to SuggestionsModal — the *routine-pattern* surface — and deeper, the Keep/Dismiss buttons died with v1's TaskCard and were never ported to v2 at all. Today now has a **Review** section: pending rows with **Keep** (approves via `/api/gmail/approve`, task joins the list optimistically) and **Dismiss** (deletes). The More/sidebar row is relabeled "Routine suggestions" to match what it actually opens.
+  - **What Now is reachable again**: a Compass button under the Day Arc (mobile) + a sidebar row (desktop) open the existing WhatNowModal.
+  - **Checklist subtasks render inline** on Tasks rows (gold circle sub-checks, toggle via the canonical checklist update) — Wallaby parity restored.
+  - **Snoozed tab** on Tasks: returns chips + a **Now** bring-back button (unsnoozeTask).
+  - **Label filter chips** on the Tasks tab (All + labels, dot-styled, horizontal scroll); **stack members excluded** from Upcoming/Backlog/Snoozed (they live in their Today folder; still in Done as records).
+  - All verified live end-to-end on seeded data; lint 0; tests + build + smoke pass.
+
 - fix(ui): Kept Today — caught tasks leave the list + collapsible sections [S]
   - **Caught tasks no longer linger struck-through** on Today (the last day-planner-recap carryover): completion removes the row immediately, v2's contract — the toast's Undo covers regret, Caught keeps the record.
   - **Sections collapse into their titles**: Arcs / Today / Anytime / Loops on Today and every group on the Tasks tab get a chevron toggle (new shared `Section` component + `useCollapsedSections`), persisted in `settings.kept_collapsed` — the same cross-device mechanism as v2's `collapsed_sections`.


### PR DESCRIPTION
Audit round 2 + the "imported items isn't doing shit" report.

## Gmail review actually works now

Two layers of broken: my banner routed to `SuggestionsModal` — which is the **routine-pattern** suggestions surface, hence "blank" — and underneath, the Keep/Dismiss review buttons **died with v1's TaskCard in the purge and were never ported to v2** (CLAUDE.md's claim described v1 reality; nothing in the v2 tree ever called `gmailApprove`/`gmailDismiss`).

Today now has a **Review** section: each pending row shows **Keep** (calls `/api/gmail/approve/:id`, the task joins the list optimistically) and **Dismiss** (deletes). The More/sidebar row is relabeled **"Routine suggestions"** to match what it actually opens.

## Audit items knocked down

- **What Now is reachable again** — Compass button under the Day Arc (mobile) + desktop sidebar row → the existing WhatNowModal.
- **Checklist subtasks render inline** on Tasks rows (gold circle sub-checks, toggling through the canonical checklist update) — Wallaby parity.
- **Snoozed tab** on Tasks — returns chips + a **Now** bring-back button.
- **Label filter chips** on Tasks (All + labels, horizontal scroll).
- **Stack members excluded** from Upcoming/Backlog/Snoozed (they live in their Today folder; Done keeps the records) — closes the last flagged stack divergence.

## Verified live

Keep moves the pending task into the list; What Now opens; subtask toggle works; Snoozed → Bring back works; label filter narrows; zero page errors. Lint 0; tests + build + smoke pass.

Remaining from the audit: Tasks-tab sort options, desktop keyboard nav in Kept, and the K4 surfaces (Flight log, notifications center, loop stats detail).

https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR)_