### PR TITLE
fix(streak): backward-only streak anchor — deletes can't shorten the rally [S]

### DIFF
--- a/src/AppV2.jsx
+++ b/src/AppV2.jsx
@@ -297,6 +297,44 @@ export default function AppV2() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
+  // Streak-anchor maintenance: persist the earliest-known activity date so
+  // the streak floor can never move FORWARD when old records are deleted
+  // (dismissing old Gmail imports shortened a 36-day rally to 27). Seeds
+  // from the oldest task AND the server's analytics history — the latter
+  // survives task deletion/cleanup. Only ever writes a smaller date.
+  const anchorCheckedRef = useRef(false)
+  useEffect(() => {
+    if (anchorCheckedRef.current || tasks.length === 0) return
+    anchorCheckedRef.current = true
+    ;(async () => {
+      let earliest = null
+      for (const t of tasks) {
+        if (!t.created_at) continue
+        const d = new Date(t.created_at)
+        if (Number.isFinite(d.getTime()) && (!earliest || d < earliest)) earliest = d
+      }
+      try {
+        const res = await fetch('/api/analytics/history?days=365')
+        if (res.ok) {
+          const hist = await res.json()
+          const first = (hist?.daily || []).find(x => (x.tasks || 0) > 0 || (x.points || 0) > 0)
+          if (first?.day) {
+            const d = new Date(`${first.day}T12:00:00`)
+            if (!earliest || d < earliest) earliest = d
+          }
+        }
+      } catch { /* tasks-only seed is fine */ }
+      if (!earliest) return
+      const ymd = localYMD(earliest)
+      const cur = loadSettings()
+      if (!cur.streak_anchor || ymd < cur.streak_anchor) {
+        saveSettings({ ...cur, streak_anchor: ymd })
+        flushSync()
+      }
+    })()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tasks])
+
   // Spawn due routine tasks on load + when routines change. Auto-roll routines
   // bump an existing active instance forward instead of spawning a duplicate
   // — see useRoutines.spawnDueTasks + wiki/Activity-Prompts.md.

--- a/src/store.js
+++ b/src/store.js
@@ -886,8 +886,16 @@ export function computeStreak(tasks, settings) {
   // nothing meaningful before then. Without this floor, no-fault empty
   // days (which all pre-history days qualify as) would walk back
   // indefinitely until JS Date underflowed and `.toISOString()` threw.
-  const floor = earliest
-    ? new Date(earliest.getFullYear(), earliest.getMonth(), earliest.getDate())
+  //
+  // The floor honors `settings.streak_anchor` (a 'YYYY-MM-DD' that only
+  // ever moves BACKWARD, maintained in AppV2 from tasks + the server's
+  // analytics history): deriving the floor purely from live tasks meant
+  // deleting your oldest record — e.g. dismissing an old Gmail import —
+  // retroactively shortened the streak (prod incident: 36 → 27).
+  const anchorDate = settings.streak_anchor ? parseLocalDate(settings.streak_anchor) : null
+  const floorBasis = anchorDate && (!earliest || anchorDate < earliest) ? anchorDate : earliest
+  const floor = floorBasis
+    ? new Date(floorBasis.getFullYear(), floorBasis.getMonth(), floorBasis.getDate())
     : null
 
   const isNoFaultDay = (d) => {

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,11 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-11
 
+- fix(streak): persistent backward-only streak anchor — deleting old records can't shorten the rally [S]
+  - Prod incident: a 36-day rally dropped to 27 after dismissing old Gmail imports. Root cause: `computeStreak`'s history floor = the creation date of the OLDEST SURVIVING task, recomputed live — deleting your earliest record moved the floor forward and retroactively cut the streak. The bonus/egg math was untouched and innocent.
+  - Fix: `settings.streak_anchor` ('YYYY-MM-DD', only ever moves backward) now bounds the floor. AppV2 maintains it once per load from the oldest task AND the earliest active day in `/api/analytics/history` (which survives deletion/cleanup) — so affected users' floors restore to their true history start on next load, and no future delete/dismiss can shrink a rally.
+  - Verified against the exact incident shape: seeded a 36-day-old import as the oldest record, anchor persisted (from analytics, even earlier), dismissed the import → rally unchanged.
+
 - fix(ui): Kept audit round 2 — real Gmail review, What Now, subtasks, Snoozed tab, label filters [L]
   - **Gmail review actually works now** (prod report: "imported items isn't doing shit"): the banner routed to SuggestionsModal — the *routine-pattern* surface — and deeper, the Keep/Dismiss buttons died with v1's TaskCard and were never ported to v2 at all. Today now has a **Review** section: pending rows with **Keep** (approves via `/api/gmail/approve`, task joins the list optimistically) and **Dismiss** (deletes). The More/sidebar row is relabeled "Routine suggestions" to match what it actually opens.
   - **What Now is reachable again**: a Compass button under the Day Arc (mobile) + a sidebar row (desktop) open the existing WhatNowModal.


### PR DESCRIPTION
## Root cause

`computeStreak` in `src/store.js` derives its walk-back floor from the **oldest surviving task's `created_at`**, recomputed live on every render. Dismissing the old Gmail imports deleted the oldest records, the floor jumped forward ~9 days, and the rally read 27 instead of 36. The bonus/points math was never touched.

## Fix

- **`src/store.js`** — the floor now honors a persisted `settings.streak_anchor` ('YYYY-MM-DD'). The anchor is **backward-only**: it can extend the floor earlier but the live earliest-task date still wins when it's older. Deleting records can never shorten the rally again.
- **`src/AppV2.jsx`** — one-time post-hydration effect seeds/maintains the anchor from `min(oldest task created_at, earliest active day in /api/analytics/history?days=365)`. Analytics history survives task deletions, so the anchor recovers floors that were already lost — the user's rally self-restores on next load.

## Verification

Reproduced the exact incident shape against a seeded server: created a gmail-pending task dated 36 days back as the oldest record, confirmed the anchor persisted as `2026-02-13` (analytics found an even older active day), dismissed the import via the Review section → **rally unchanged**.

https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR)_