### PR TITLE
release: hero tap target + frosted back-button underlay

### DIFF
--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -2482,7 +2482,7 @@ export default function SettingsModal({
                   <div className="v2-settings-row v2-settings-row-stacked">
                     <div className="v2-settings-row-text">
                       <div className="v2-settings-row-label">Theme</div>
-                      <div className="v2-settings-row-hint">Standard is the calm hairline UI. Wallaby is the navy heatmap dashboard. Kept is the new Boomerang language — green-ink + gold, arcs not grids (in progress).</div>
+                      <div className="v2-settings-row-hint">Standard is the calm hairline UI. Wallaby is the navy heatmap dashboard. Kept is the new Boomerang language — warm Smoke/Linen canvases with ember + gold, arcs not grids.</div>
                     </div>
                     <div className="v2-settings-segment" role="radiogroup" aria-label="Theme family">
                       {[

--- a/src/kept/TodayView.jsx
+++ b/src/kept/TodayView.jsx
@@ -131,16 +131,18 @@ export default function TodayView({
           <span className="bm-hero-sub">{new Date().toLocaleDateString('en-US', { month: 'long', day: 'numeric' })}</span>
           {streak > 0 && <span className="bm-rally-chip">↻ {streak}-day rally</span>}
         </div>
-        <DayArc value={dailyStats.pointsToday ?? 0} goal={pointsGoal} />
         <button
-          className="bm-hero-meta"
+          className="bm-hero-tap"
           onClick={() => setShowBreakdown(v => !v)}
           aria-expanded={showBreakdown}
           aria-label="Show daily breakdown"
         >
-          <span><b>{catches}</b> {catches === 1 ? 'catch' : 'catches'}</span>
-          <span><b>{loopsDone}/{loops.length}</b> loops</span>
-          <span><b>{Math.max(0, pointsGoal - (dailyStats.pointsToday ?? 0))}</b> pts left</span>
+          <DayArc value={dailyStats.pointsToday ?? 0} goal={pointsGoal} />
+          <div className="bm-hero-meta">
+            <span><b>{catches}</b> {catches === 1 ? 'catch' : 'catches'}</span>
+            <span><b>{loopsDone}/{loops.length}</b> loops</span>
+            <span><b>{Math.max(0, pointsGoal - (dailyStats.pointsToday ?? 0))}</b> pts left</span>
+          </div>
         </button>
         {showBreakdown && <WeekBreakdown tasks={tasks} />}
         <button className="bm-btn bm-btn-tonal bm-whatnow" onClick={onWhatNow}>

--- a/src/kept/shell.css
+++ b/src/kept/shell.css
@@ -345,12 +345,18 @@
   background: var(--bm-gold-soft);
   border-radius: 10px; padding: 4px 10px;
 }
+/* The whole arc + stats block is one tap target for the daily breakdown —
+   a skinny stats row alone was an unfindable target (prod report). */
+.bm-hero-tap {
+  display: block; width: 100%;
+  background: none; border: none; padding: 0; margin: 0;
+  font-family: inherit; color: inherit; cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+}
 .bm-hero-meta {
   display: flex; justify-content: center; gap: 18px;
   padding-top: 10px;
   font-size: 12px; color: var(--bm-text-meta);
-  background: none; border: none; width: 100%; cursor: pointer;
-  font-family: inherit;
 }
 .bm-hero-meta b { color: var(--bm-text); font-weight: 700; }
 

--- a/src/wallaby/modals.css
+++ b/src/wallaby/modals.css
@@ -46,19 +46,30 @@
    * back arrow (top-LEFT, like the drill-down views), so the title drops below
    * it; the autosave slot still rides top-right. All pick up the notch inset. */
   :is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-modal-header {
-    padding: calc(60px + env(safe-area-inset-top)) 20px 16px;
+    padding: calc(72px + env(safe-area-inset-top)) 20px 16px;
   }
-  /* Pinned-control underlay: scrolled content fades out under the top strip
+  /* Pinned-control underlay: scrolled content frosts out under the top strip
    * instead of colliding with the fixed back button (the "it loop" clipped-
-   * title report). Gradient from the page bg; clicks pass through. */
+   * title report, then the "back button keeps overlapping shit" report).
+   * Backdrop blur + translucent page tint + feathered mask — content visibly
+   * dissolves behind the control, reading as intentional. Clicks pass through. */
   :is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-modal::before {
     content: "";
     position: fixed;
     top: 0; left: 0; right: 0;
-    height: calc(64px + env(safe-area-inset-top));
-    background: linear-gradient(to bottom, var(--v2-bg) 55%, transparent);
+    height: calc(76px + env(safe-area-inset-top));
+    background: color-mix(in srgb, var(--v2-bg) 62%, transparent);
+    -webkit-backdrop-filter: blur(14px) saturate(1.05);
+    backdrop-filter: blur(14px) saturate(1.05);
+    -webkit-mask-image: linear-gradient(to bottom, black 60%, transparent);
+    mask-image: linear-gradient(to bottom, black 60%, transparent);
     z-index: 4;
     pointer-events: none;
+  }
+  /* The Quokka tab surface keeps the app header + nav — no pinned back
+   * control there, so no frosting band over the header. */
+  :is([data-theme^="wallaby"], [data-theme^="kept"]) :is(.wb-shell, .bm-shell) .v2-modal::before {
+    display: none;
   }
   :is([data-theme^="wallaby"], [data-theme^="kept"]) .v2-modal-back {
     /* .v2-modal is the page SCROLLER — absolute positioning rode along with

--- a/wiki/Kept-Design-Language.md
+++ b/wiki/Kept-Design-Language.md
@@ -390,3 +390,63 @@ language and a structurally cleaner codebase.
 
 Each phase is an independently mergeable PR with screenshot verification in
 both palettes (the Local-Verification-Harness runbook applies unchanged).
+
+## 13 · Feedback backlog (2026-06-11 prod tire-kicking round)
+
+Captured from live use; these are the next design lifts, in priority order.
+
+### 13a · Cadence-aware loop trails (replace the dot grids on Loops cards)
+The full FlightTrail dot grid (6×13 dots + streak arcs) eats a card's worth
+of space and reads as noise for anything that isn't a multi-step daily loop —
+a weekly loop shows ~95% empty dots and the arcs almost never connect.
+Direction: **the visualization unit should be the loop's own cadence cycle,
+not the calendar day.**
+- Daily loops → keep a trail but compact: a single 14–21 day row (the `mini`
+  FlightTrail), not a grid.
+- Weekly/monthly/quarterly/annual + custom-interval loops → a row of the
+  last 8–12 **cycle chips**: each chip = one cadence window, filled (caught),
+  hollow (missed), half (skipped via skip-cycle). Plus a "next due" caption.
+- Habit-mode (target frequency) → progress ring or `n/target` bar for the
+  current window, with cycle chips for past windows.
+- The Single/Month/Year range tabs stay for the drill-down detail; the card
+  face gets the compact cadence-fit visual only.
+
+### 13b · Kept-native editors (kill the reskinned v2 forms)
+The Edit-loop / Edit-task full-page forms are the v2 modals with Kept paint —
+dense ALL-CAPS field stacks that read foreign next to the Kept surfaces.
+Direction: **progressive disclosure, Kept type-scale.**
+- Top: name field as a large Fraunces headline input.
+- The 2–3 high-frequency decisions as chip rows (cadence, day, time) —
+  tap-to-pick, not select boxes.
+- Everything else (anchors, auto-roll, end date, follow-up chains, stack
+  members, nag policy) behind hairline disclosure rows that expand in place.
+- Same skeleton for task editor: title, when (date/snooze), energy chips;
+  notes/checklist/links/integrations under disclosures.
+- Per K4 rule: built Kept-first against `--bm-*` tokens, no override CSS.
+
+### 13c · Achievements expansion (future feature; user: "be really creative")
+10/12 earned already — the wall needs depth and wit. Candidate directions
+(ADHD-honest, anti-perfectionist; metaphor-aligned with the brand):
+- **Recovery class** (the signature set): *Phoenix* — start a new rally after
+  losing a 14+ day one; *It Comes Back* — complete a task 30+ days old;
+  *Clean Sweep* — clear every overdue task in a day; *Back From Orbit* —
+  return after 7+ days away and catch 3 the same day.
+- **Honesty class:** *Strategic Retreat* — set-aside 5 tasks (knowing your
+  limits is a skill); *Editor* — delete 10 tasks you were never going to do;
+  *Reframed* — use the reframe flow 5 times.
+- **Time-of-day / pattern class:** *Dawn Patrol* — 3 catches before 8am;
+  *Night Shift* — clear a loop after 10pm; *Weekend Warrior* — 10-catch
+  weekend; *Speedrun* — 5 catches within an hour of waking (first catch).
+- **Energy class:** *Dragon Slayer* — catch a ⚡⚡⚡ confrontation task;
+  *Balanced Diet* — catch every energy type in one week; *Heavy Lifting* —
+  3 L/XL tasks in a day.
+- **Loop class:** *Perfect Week* — every due loop caught for 7 days;
+  *Stack Champion* — 10 stack clear-bonuses; *Long Haul* — keep a
+  quarterly+ loop alive for a year.
+- **Meta class:** *Quokka Whisperer* — 25 applied Quokka plans; *Archivist* —
+  10 knowledge entries; *Weatherproof* — catch an outdoor task on a
+  best-day recommendation.
+- Mechanics notes: tiered (bronze/silver/gold) where counts scale; hidden
+  achievements that reveal on earn (the fun ones); all derived values must
+  follow the Derived-Stat Durability Rules (persist earn-time provenance,
+  never recompute from deletable rows — see CLAUDE.md).

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,12 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-11
 
+- fix(ui): Kept hero tap target + frosted pinned-control underlay [S]
+  - **The whole Day Arc + stats block now toggles the daily breakdown** (prod report: "Still can't click on the hero bar"). The previous tap target was only the skinny catches/loops/pts row — and the harness verification used a JS `.click()`, which bypasses hit-testing and hid how small the real target was. Re-verified with real synthetic touch taps on the arc itself.
+  - **Claude-style frosted underlay behind the pinned back button** (prod report: "it keeps overlapping shit — things need to fade behind it in a way that shows it's intentional"): the full-page modal top strip is now a backdrop-blur band (translucent page tint + feathered mask) instead of a hard gradient, so scrolled content visibly dissolves behind the control. Header padding bumped 60→72px so titles clear the button at rest. Scoped away from the in-shell Quokka surface (no frost band over the app header).
+  - Stale Settings copy fixed: Kept description now says Smoke/Linen + ember, not the abandoned green-ink palette.
+  - Design feedback captured in `wiki/Kept-Design-Language.md` §13: cadence-aware loop trails (dot grids don't fit non-daily loops), Kept-native editors (reskinned v2 forms feel foreign), achievements expansion ideas.
+
 - fix(ui): Kept loop crediting + tap-the-stats breakdown + suggestions scan transparency [M]
   - **Cleared stacks credit as closed loops** (prod report: clearing Bedtime's last member flipped the hero from "2/3 loops" to "2/2" — the finished loop fell out of both counts). A stack whose cycle cleared today now stays counted and renders as a checked receipt row (title · cadence · rally · done-check) until midnight, matching how plain done loops behave. Check is display-only; un-clearing goes through reopening the member task.
   - **Tap the hero stats for a daily breakdown** (prod request): the catches/loops/pts-left row on Today now toggles an inline week strip (Sunday-anchored, activity-intensity bars, prev/next week chevrons) + the selected day's caught tasks with per-task points and the Daily Bonus egg — v2 WeekStrip parity in the Kept skin, defaulting to today. New `src/kept/WeekBreakdown.jsx` + `bm-week-*` styles.


### PR DESCRIPTION
Promotes one fix from dev (PR #484):

- **Hero bar is tappable** — the whole Day Arc + stats block toggles the daily breakdown (the old target was just the skinny stats row; re-verified with real touch taps, not JS clicks).
- **Frosted underlay behind the pinned back button** — scrolled content dissolves into a backdrop-blur band instead of colliding with the control; titles clear the button at rest. Quokka tab surface unaffected.
- Stale Kept palette copy in Settings corrected; morning design feedback captured in the Kept design doc (§13).

https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR)_