### PR TITLE
release: toast top banners + fresh message pools

### DIFF
--- a/src/components/Toast.css
+++ b/src/components/Toast.css
@@ -1,12 +1,15 @@
-/* v2 Toast — pill-shaped, off-white background, hairline border, slides up
- * with --v2-ease-emphasis. Reads as a calm confirmation rather than a banner. */
+/* v2 Toast — push-notification-style TOP banner (prod request 2026-06-11:
+ * the bottom pill sat in the way of the list and the bottom nav). Slides
+ * down from the top edge like an iOS banner; tap anywhere to dismiss,
+ * auto-dismisses after a few seconds. Undo + Next-up ride along. */
 
 .v2-toast {
   position: fixed;
-  left: 50%;
-  bottom: 24px;
-  transform: translateX(-50%) translateY(0);
-  z-index: 90;
+  left: 12px;
+  right: 12px;
+  top: calc(10px + env(safe-area-inset-top));
+  margin: 0 auto;
+  z-index: 120; /* above pinned modal controls + shell header */
   background: var(--v2-text);
   color: var(--v2-bg);
   border-radius: 18px;
@@ -14,16 +17,15 @@
   display: flex;
   align-items: center;
   gap: 12px;
-  min-width: 280px;
-  max-width: min(92vw, 420px);
-  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.28);
+  max-width: 480px;
+  box-shadow: 0 10px 32px rgba(0, 0, 0, 0.32);
   cursor: pointer;
   animation: v2-toast-in var(--v2-dur-emphasis) var(--v2-ease-emphasis);
 }
 
 @keyframes v2-toast-in {
-  from { opacity: 0; transform: translateX(-50%) translateY(20px); }
-  to   { opacity: 1; transform: translateX(-50%) translateY(0); }
+  from { opacity: 0; transform: translateY(-24px); }
+  to   { opacity: 1; transform: translateY(0); }
 }
 
 .v2-toast-reopen {

--- a/src/components/Toast.jsx
+++ b/src/components/Toast.jsx
@@ -7,7 +7,20 @@ const MESSAGES_QUICK = [
   'Blink and you missed it.',
   'Any% completion.',
   "Didn't even break a sweat.",
-  'That barely counts as procrastinating.',
+  'Caught it mid-air.',
+  'Same-day service.',
+  'In and out. Surgical.',
+  'The list never saw you coming.',
+  'Thrown and caught in one motion.',
+  'Past-you would be jealous.',
+  'Zero dust collected.',
+  'Done before the doubt showed up.',
+  'That one never touched the ground.',
+  'Efficiency? In this economy?',
+  'No notes. Flawless.',
+  'Today-you carried.',
+  'Fresh off the list, already done.',
+  'Didn’t even get a chance to nag you.',
 ]
 
 const MESSAGES_NORMAL = [
@@ -17,15 +30,38 @@ const MESSAGES_NORMAL = [
   'That task never stood a chance.',
   'One less thing haunting you.',
   'Off the list, out of your brain.',
+  'Right on schedule. Who even are you?',
+  'The boomerang came back. You caught it.',
+  'Filed under: handled.',
+  'Your future self says thanks.',
+  'Momentum looks good on you.',
+  'Quietly competent. Love that.',
+  'Another loop closed.',
+  'Brain RAM: freed.',
+  'It’s done. It’s actually done.',
+  'Cross it off with feeling.',
+  'One throw, one catch.',
+  'The list shrinks. The legend grows.',
 ]
 
 const MESSAGES_LONG = [
   'The prodigal task returns... completed.',
-  'It only took you forever.',
   'Archaeologists found this task.',
   'That one aged like fine wine.',
   'Better late than literally never.',
   'The prophecy is fulfilled.',
+  'Long flight. Stuck the landing.',
+  'It waited. You delivered.',
+  'Carbon dating says: finally.',
+  'The siege is over.',
+  'Released from the haunted backlog.',
+  'Some boomerangs take the scenic route.',
+  'You outlasted it.',
+  'Closure. Actual closure.',
+  'The long game pays out.',
+  'Vintage task, fresh finish.',
+  'It thought you forgot. You didn’t.',
+  'Persistence: 1, entropy: 0.',
 ]
 
 const MESSAGES_REOPEN = [
@@ -33,11 +69,32 @@ const MESSAGES_REOPEN = [
   'Plot twist.',
   'The sequel nobody asked for.',
   'Back from the dead.',
-  'You thought you were done? Cute.',
   'Round two. Fight!',
+  'It boomeranged.',
+  'Encore performance.',
+  'False summit.',
+  'The director’s cut.',
+  'It had other plans.',
+  'Re-throw incoming.',
+  'Back in the air.',
 ]
 
-function pickRandom(arr) { return arr[Math.floor(Math.random() * arr.length)] }
+// Shuffle-bag picker: remembers the last ~14 shown per variant in
+// localStorage and only repeats once the pool is exhausted (prod report:
+// "I get the same like 6 every time").
+const RECENT_KEY = 'boom_toast_recent_v1'
+function pickFresh(variant, arr) {
+  let recent = {}
+  try { recent = JSON.parse(localStorage.getItem(RECENT_KEY)) || {} } catch { /* fresh bag */ }
+  const seen = Array.isArray(recent[variant]) ? recent[variant] : []
+  const unseen = arr.filter(m => !seen.includes(m))
+  const pool = unseen.length > 0 ? unseen : arr
+  const pick = pool[Math.floor(Math.random() * pool.length)]
+  const cap = Math.min(arr.length - 1, 14)
+  recent[variant] = [...seen.filter(m => m !== pick), pick].slice(-cap)
+  try { localStorage.setItem(RECENT_KEY, JSON.stringify(recent)) } catch { /* best effort */ }
+  return pick
+}
 
 function getVariantKey(daysOnList, isReopen) {
   if (isReopen) return 'reopen'
@@ -47,10 +104,10 @@ function getVariantKey(daysOnList, isReopen) {
 }
 
 function getStaticMessage(daysOnList, isReopen) {
-  if (isReopen) return pickRandom(MESSAGES_REOPEN)
-  if (daysOnList === 0) return pickRandom(MESSAGES_QUICK)
-  if (daysOnList <= 3) return pickRandom(MESSAGES_NORMAL)
-  return pickRandom(MESSAGES_LONG)
+  if (isReopen) return pickFresh('reopen', MESSAGES_REOPEN)
+  if (daysOnList === 0) return pickFresh('quick', MESSAGES_QUICK)
+  if (daysOnList <= 3) return pickFresh('normal', MESSAGES_NORMAL)
+  return pickFresh('long', MESSAGES_LONG)
 }
 
 function getStaticSubtitle(daysOnList, todayCount, isReopen, taskTitle) {

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,11 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-11
 
+- feat(ui): completion toasts — push-style top banner + fresh no-repeat message pools [S]
+  - **Top banner** (prod request: the bottom pill "sits in the way"): the toast now slides down from the top edge like an iOS push banner — tap anywhere to dismiss, auto-dismisses after 4s (8s with a Next-up suggestion), Undo and Next-up unchanged. z-index above the shell header and pinned modal controls.
+  - **Fresh messages** (prod report: "I get the same like 6 every time… really tired of 'That's barely procrastination'"): root cause — routine/stack tasks completed same-day fall back to the 5-message static quick pool (AI prefetch only backfills on app load, so spawn-and-complete-today always went static). Pools expanded to 12–18 messages per variant (brand-voiced: "Caught it mid-air.", "The boomerang came back. You caught it.", "Released from the haunted backlog."), the offending line culled, and a **shuffle-bag picker** (last ~14 shown per variant persisted in `boom_toast_recent_v1`) guarantees no repeats until a pool is exhausted.
+  - Verified live: catch → banner at top with a new message + Undo; tap dismisses; recent-bag persists.
+
 - fix(ui): Kept hero tap target + frosted pinned-control underlay [S]
   - **The whole Day Arc + stats block now toggles the daily breakdown** (prod report: "Still can't click on the hero bar"). The previous tap target was only the skinny catches/loops/pts row — and the harness verification used a JS `.click()`, which bypasses hit-testing and hid how small the real target was. Re-verified with real synthetic touch taps on the arc itself.
   - **Claude-style frosted underlay behind the pinned back button** (prod report: "it keeps overlapping shit — things need to fade behind it in a way that shows it's intentional"): the full-page modal top strip is now a backdrop-blur band (translucent page tint + feathered mask) instead of a hard gradient, so scrolled content visibly dissolves behind the control. Header padding bumped 60→72px so titles clear the button at rest. Scoped away from the in-shell Quokka surface (no frost band over the app header).


### PR DESCRIPTION
Promotes one feature from dev (PR #486):

- **Completion toasts → push-style top banners with fresh, no-repeat copy.** Banner slides from the top (tap to dismiss, Undo + Next-up intact), message pools tripled with brand-voiced lines, and a shuffle-bag picker guarantees no repeats until a pool cycles. "That's barely procrastination" is retired.

Verified live in the harness before merge.

https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR)_