### PR TITLE
release: hero date-follow, Loop suggestions rename, nav swap

### DIFF
--- a/src/AppV2.jsx
+++ b/src/AppV2.jsx
@@ -1591,6 +1591,7 @@ export default function AppV2() {
 
       <SuggestionsModal
         open={showSuggestions}
+        title={isKept ? 'Loop suggestions' : 'Routine suggestions'}
         onClose={() => setShowSuggestions(false)}
         onAccepted={() => {
           // Routine was just created server-side — refresh the local routines

--- a/src/components/SuggestionsModal.jsx
+++ b/src/components/SuggestionsModal.jsx
@@ -88,7 +88,7 @@ function SuggestionCard({ suggestion, onAccept, onSnooze, onDismiss, busy }) {
   )
 }
 
-export default function SuggestionsModal({ open, onClose, onAccepted }) {
+export default function SuggestionsModal({ open, onClose, onAccepted, title = 'Routine suggestions' }) {
   const [suggestions, setSuggestions] = useState([])
   const [loading, setLoading] = useState(false)
   const [busyId, setBusyId] = useState(null)
@@ -183,7 +183,7 @@ export default function SuggestionsModal({ open, onClose, onAccepted }) {
     <ModalShell
       open={open}
       onClose={onClose}
-      title="Routine suggestions"
+      title={title}
       subtitle={suggestions.length === 0
         ? (loading ? 'Loading…' : undefined)
         : `${suggestions.length} waiting`}

--- a/src/kept/KeptDesktop.jsx
+++ b/src/kept/KeptDesktop.jsx
@@ -50,7 +50,7 @@ export default function KeptDesktop({
     { label: 'Caught', icon: CheckCircle2, onClick: onOpenDone },
     { label: 'Analytics', icon: BarChart3, onClick: onOpenAnalytics },
     { label: 'Packages', icon: Package, onClick: onOpenPackages },
-    { label: 'Routine suggestions', icon: Inbox, onClick: onOpenSuggestions },
+    { label: 'Loop suggestions', icon: Inbox, onClick: onOpenSuggestions },
     { label: 'Activity log', icon: ScrollText, onClick: onOpenActivity },
   ]
 

--- a/src/kept/KeptNav.jsx
+++ b/src/kept/KeptNav.jsx
@@ -1,14 +1,16 @@
 import { Home, Repeat2, ListTodo, MoreHorizontal } from 'lucide-react'
 import './shell.css'
 
-// Kept bottom nav: Today · Loops · [Throw] · Tasks · More (spec §6).
+// Kept bottom nav: Today · Tasks · [Throw] · Loops · More (spec §6; Tasks
+// and Loops swapped 2026-06-11 per user preference — Tasks is the higher-
+// frequency destination, it sits next to Today).
 // One accent — active tabs go gold with a dot, never per-tab colors.
 const LEFT = [
   { id: 'today', label: 'Today', icon: Home },
-  { id: 'loops', label: 'Loops', icon: Repeat2 },
+  { id: 'tasks', label: 'Tasks', icon: ListTodo },
 ]
 const RIGHT = [
-  { id: 'tasks', label: 'Tasks', icon: ListTodo },
+  { id: 'loops', label: 'Loops', icon: Repeat2 },
   { id: 'more', label: 'More', icon: MoreHorizontal },
 ]
 

--- a/src/kept/MoreView.jsx
+++ b/src/kept/MoreView.jsx
@@ -9,7 +9,7 @@ export default function MoreView({ onOpenProjects, onOpenAnalytics, onOpenPackag
     { icon: BarChart3, label: 'Analytics', sub: 'Productivity insights', onClick: onOpenAnalytics },
     { icon: CheckCircle2, label: 'Caught', sub: 'Everything you finished', onClick: onOpenDone },
     { icon: Package, label: 'Packages', sub: 'Track deliveries', onClick: onOpenPackages },
-    { icon: Inbox, label: 'Routine suggestions', sub: 'Recurring patterns spotted in your tasks', onClick: onOpenSuggestions },
+    { icon: Inbox, label: 'Loop suggestions', sub: 'Recurring patterns spotted in your tasks', onClick: onOpenSuggestions },
     { icon: ScrollText, label: 'Activity log', sub: 'Every change, restorable', onClick: onOpenActivity },
     { icon: Settings, label: 'Settings', sub: 'App configuration', onClick: onOpenSettings },
   ]

--- a/src/kept/TodayView.jsx
+++ b/src/kept/TodayView.jsx
@@ -2,9 +2,10 @@ import { useMemo, useState } from 'react'
 import { Check, Repeat2, Flame, FolderKanban, Inbox, X, Compass } from 'lucide-react'
 import DayArc from './DayArc'
 import FlightTrail from './FlightTrail'
-import { localYMD } from '../dates'
+import { localYMD, parseLocalDate } from '../dates'
 import { historyByDay, currentStreak } from '../wallaby/heatmapUtils'
-import { isSnoozed, isStale, formatSnoozeLabel, getNextDueDate } from '../store'
+import { isSnoozed, isStale, formatSnoozeLabel, getNextDueDate, loadSettings } from '../store'
+import { calculateTaskPoints } from '../scoring'
 import { routineFeathers } from './feathers'
 import RowSwipe from './RowSwipe'
 import Section, { useCollapsedSections } from './Section'
@@ -25,6 +26,9 @@ export default function TodayView({
   const todayKey = localYMD()
   const [collapsed, toggleSection] = useCollapsedSections()
   const [showBreakdown, setShowBreakdown] = useState(false)
+  // Breakdown day selection lives here so the hero arc + counts follow it
+  // (prod report: "slider and counts should change with the date selection").
+  const [breakdownDay, setBreakdownDay] = useState(null)
   const labelsById = useMemo(() => { const m = {}; for (const l of labels) m[l.id] = l; return m }, [labels])
 
   const stackRoutineIds = useMemo(() => new Set(
@@ -123,28 +127,72 @@ export default function TodayView({
   }, [tasks, pinnedArcs])
   const catches = dailyStats.tasksToday ?? 0
 
+  // Stats for a non-today breakdown selection — the hero swaps to that
+  // day's numbers. Catches/points computed the same way the breakdown's
+  // item list is, so the arc total always matches the itemization. Loops
+  // shown as a plain done-count (historical due-ness isn't reconstructable).
+  const selStats = useMemo(() => {
+    if (!showBreakdown || !breakdownDay || breakdownDay === todayKey) return null
+    let pts = 0, n = 0
+    for (const t of tasks) {
+      const ts = t.status === 'done' && t.completed_at ? t.completed_at
+        : t.status === 'waiting' && t.waiting_at ? t.waiting_at
+        : null
+      if (!ts || localYMD(new Date(ts)) !== breakdownDay) continue
+      n++; pts += calculateTaskPoints(t)
+    }
+    if ((loadSettings().easter_egg_wins || {})[breakdownDay]) { n++; pts += 1 }
+    let loopsDone = 0
+    for (const r2 of routines) {
+      if (historyByDay(r2.completed_history)[breakdownDay]) loopsDone++
+    }
+    const d = parseLocalDate(breakdownDay)
+    return { pts, n, loopsDone, date: d }
+  }, [showBreakdown, breakdownDay, todayKey, tasks, routines])
+
   return (
     <div className="bm-surface">
       <div className="bm-card bm-card-hero">
         <div className="bm-hero-date">
-          <span className="bm-hero-day">{new Date().toLocaleDateString('en-US', { weekday: 'long' })}</span>
-          <span className="bm-hero-sub">{new Date().toLocaleDateString('en-US', { month: 'long', day: 'numeric' })}</span>
+          <span className="bm-hero-day">{(selStats ? selStats.date : new Date()).toLocaleDateString('en-US', { weekday: 'long' })}</span>
+          <span className="bm-hero-sub">{(selStats ? selStats.date : new Date()).toLocaleDateString('en-US', { month: 'long', day: 'numeric' })}</span>
           {streak > 0 && <span className="bm-rally-chip">↻ {streak}-day rally</span>}
         </div>
         <button
           className="bm-hero-tap"
-          onClick={() => setShowBreakdown(v => !v)}
+          onClick={() => {
+            setShowBreakdown(v => {
+              setBreakdownDay(v ? null : todayKey)
+              return !v
+            })
+          }}
           aria-expanded={showBreakdown}
           aria-label="Show daily breakdown"
         >
-          <DayArc value={dailyStats.pointsToday ?? 0} goal={pointsGoal} />
+          <DayArc
+            value={selStats ? selStats.pts : (dailyStats.pointsToday ?? 0)}
+            goal={pointsGoal}
+            caption={selStats ? 'points that day' : 'points today'}
+          />
           <div className="bm-hero-meta">
-            <span><b>{catches}</b> {catches === 1 ? 'catch' : 'catches'}</span>
-            <span><b>{loopsDone}/{loops.length}</b> loops</span>
-            <span><b>{Math.max(0, pointsGoal - (dailyStats.pointsToday ?? 0))}</b> pts left</span>
+            {selStats ? (
+              <>
+                <span><b>{selStats.n}</b> {selStats.n === 1 ? 'catch' : 'catches'}</span>
+                <span><b>{selStats.loopsDone}</b> {selStats.loopsDone === 1 ? 'loop' : 'loops'}</span>
+                <span><b>{selStats.pts}</b> pts</span>
+              </>
+            ) : (
+              <>
+                <span><b>{catches}</b> {catches === 1 ? 'catch' : 'catches'}</span>
+                <span><b>{loopsDone}/{loops.length}</b> loops</span>
+                <span><b>{Math.max(0, pointsGoal - (dailyStats.pointsToday ?? 0))}</b> pts left</span>
+              </>
+            )}
           </div>
         </button>
-        {showBreakdown && <WeekBreakdown tasks={tasks} />}
+        {showBreakdown && (
+          <WeekBreakdown tasks={tasks} selected={breakdownDay} onSelect={setBreakdownDay} />
+        )}
         <button className="bm-btn bm-btn-tonal bm-whatnow" onClick={onWhatNow}>
           <Compass size={15} strokeWidth={2.1} /> What now?
         </button>

--- a/src/kept/WeekBreakdown.jsx
+++ b/src/kept/WeekBreakdown.jsx
@@ -15,12 +15,11 @@ function weekStartSunday(date) {
 
 // Tap-the-hero-stats breakdown (parity with v2's WeekStrip detail): a
 // Sunday-anchored week of day chips with activity intensity, and the
-// selected day's caught tasks with per-task points. Defaults to today —
-// one tap on the stats answers "what did I actually do today?".
-export default function WeekBreakdown({ tasks = [] }) {
+// selected day's caught tasks with per-task points. Selection is OWNED BY
+// THE PARENT (TodayView) so the hero arc + counts can follow it.
+export default function WeekBreakdown({ tasks = [], selected, onSelect }) {
   const todayKey = localYMD()
   const [offset, setOffset] = useState(0)
-  const [selected, setSelected] = useState(todayKey)
   const settings = loadSettings()
   const eggs = settings.easter_egg_wins || {}
   const goal = settings.daily_task_goal > 0 ? settings.daily_task_goal : 3
@@ -101,7 +100,7 @@ export default function WeekBreakdown({ tasks = [] }) {
               selected === d.key ? 'is-selected' : '',
               `i${d.intensity}`,
             ].filter(Boolean).join(' ')}
-            onClick={() => setSelected(prev => (prev === d.key ? null : d.key))}
+            onClick={() => onSelect?.(selected === d.key ? null : d.key)}
             aria-expanded={selected === d.key}
             aria-label={`${d.label} ${d.dayNumber}: ${d.count} ${d.count === 1 ? 'catch' : 'catches'}`}
           >

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,12 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-11
 
+- fix(ui): hero follows breakdown date selection + Loop suggestions rename + nav swap [S]
+  - **The hero now follows the breakdown's selected day** (prod report: "slider and counts should change with the date selection"): selection state lifted from `WeekBreakdown` into `TodayView`; picking a non-today day swaps the headline date, the Day Arc (value + "points that day" caption), and the meta row to that day's numbers — catches/points computed identically to the breakdown's item list so the arc total always matches the itemization; loops shown as a plain done-count (historical due-ness isn't reconstructable). Reverts to live today-stats when today is selected or the breakdown closes.
+  - **"Routine suggestions" → "Loop suggestions"** everywhere Kept-facing (More row, desktop sidebar row, modal title via a `title` prop — Standard theme keeps "Routine suggestions").
+  - **Bottom nav swap**: Today · Tasks · [Throw] · Loops · More (Tasks promoted next to Today per user preference).
+  - Achievements expansion + cadence-aware charts confirmed into the next design wave alongside the Kept-native editors (design doc §13).
+
 - feat(ui): completion toasts — push-style top banner + fresh no-repeat message pools [S]
   - **Top banner** (prod request: the bottom pill "sits in the way"): the toast now slides down from the top edge like an iOS push banner — tap anywhere to dismiss, auto-dismisses after 4s (8s with a Next-up suggestion), Undo and Next-up unchanged. z-index above the shell header and pinned modal controls.
   - **Fresh messages** (prod report: "I get the same like 6 every time… really tired of 'That's barely procrastination'"): root cause — routine/stack tasks completed same-day fall back to the 5-message static quick pool (AI prefetch only backfills on app load, so spawn-and-complete-today always went static). Pools expanded to 12–18 messages per variant (brand-voiced: "Caught it mid-air.", "The boomerang came back. You caught it.", "Released from the haunted backlog."), the offending line culled, and a **shuffle-bag picker** (last ~14 shown per variant persisted in `boom_toast_recent_v1`) guarantees no repeats until a pool is exhausted.


### PR DESCRIPTION
Promotes one fix-batch from dev (PR #488):

- **Hero follows the breakdown's date selection** — headline, Day Arc, and counts swap to the selected day's numbers, always matching the itemized list.
- **"Loop suggestions"** rename across every Kept-facing label.
- **Bottom nav**: Today · Tasks · [Throw] · Loops · More.

Verified live before merge.

https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR)_