### PR TITLE
feat(ui): Kept pull-to-refresh + toast swipe-up dismiss [S]

### DIFF
--- a/src/AppV2.jsx
+++ b/src/AppV2.jsx
@@ -247,7 +247,7 @@ export default function AppV2() {
     }
   }, [hydrateTasks, hydrateRoutines])
 
-  const { flush: flushSync, checkVersion, syncStatus, queueLength } = useServerSync(tasks, routines, hydrateFromServer, (newVersion) => {
+  const { flush: flushSync, checkVersion, syncStatus, queueLength, refetch: refetchFromServer } = useServerSync(tasks, routines, hydrateFromServer, (newVersion) => {
     setUpdateVersion(newVersion)
     if ('serviceWorker' in navigator) {
       navigator.serviceWorker.getRegistrations().then(regs => {
@@ -1302,6 +1302,7 @@ export default function AppV2() {
           dailyStats={dailyStats}
           pointsGoal={settingsForRings.daily_points_goal || 15}
           streak={streak}
+          onRefresh={refetchFromServer}
           onCompleteTask={(task) => task.status === 'done' ? handleUncomplete(task) : handleComplete(task.id)}
           onGmailKeep={async (t) => {
             updateTask(t.id, { gmail_pending: false })

--- a/src/components/Toast.jsx
+++ b/src/components/Toast.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { computeTaskPoints } from '../store'
 import './Toast.css'
 
@@ -149,10 +149,33 @@ export default function Toast({ task, todayCount, variant = 'complete', onDone, 
     return () => clearTimeout(timer)
   }, [nextTask])
 
+  // Swipe-up to dismiss — the banner follows the finger and flicks away
+  // past the threshold, like a real push notification.
+  const [dragY, setDragY] = useState(0)
+  const dragStart = useRef(null)
+  const onTouchStart = (e) => { dragStart.current = e.touches[0].clientY }
+  const onTouchMove = (e) => {
+    if (dragStart.current == null) return
+    const dy = e.touches[0].clientY - dragStart.current
+    if (dy < 0) setDragY(dy)
+  }
+  const onTouchEnd = () => {
+    dragStart.current = null
+    if (dragY < -36) onDoneRef.current?.()
+    else setDragY(0)
+  }
+
   const { message, subtitle } = frozen.current
 
   return (
-    <div className={`v2-toast${isReopen ? ' v2-toast-reopen' : ''}`} onClick={onDone}>
+    <div
+      className={`v2-toast${isReopen ? ' v2-toast-reopen' : ''}`}
+      onClick={onDone}
+      onTouchStart={onTouchStart}
+      onTouchMove={onTouchMove}
+      onTouchEnd={onTouchEnd}
+      style={dragY ? { transform: `translateY(${dragY}px)`, opacity: Math.max(0.3, 1 + dragY / 120), transition: 'none' } : undefined}
+    >
       <div className="v2-toast-content">
         <div className="v2-toast-message">{message}</div>
         <div className="v2-toast-subtitle">{subtitle}</div>

--- a/src/hooks/useServerSync.js
+++ b/src/hooks/useServerSync.js
@@ -495,7 +495,7 @@ export function useServerSync(tasks, routines, onHydrate, onVersionMismatch) {
 
   const queueLength = loadQueue().length
 
-  return { flush, checkVersion, syncStatus, queueLength }
+  return { flush, checkVersion, syncStatus, queueLength, refetch: () => fetchAndHydrate('pull-refresh') }
 }
 
 // Bulk PUT carries settings + labels only. Tasks and routines have their own

--- a/src/kept/KeptShell.jsx
+++ b/src/kept/KeptShell.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import KeptHeader from './KeptHeader'
 import KeptNav from './KeptNav'
+import PullToRefresh from './PullToRefresh'
 import TodayView from './TodayView'
 import LoopsView from './LoopsView'
 import TasksViewKept from './TasksViewKept'
@@ -20,6 +21,7 @@ export default function KeptShell({
   onThrow, onOpenFullAdd, onEditLoop, onAddLoop,
   onOpenQuokka, onOpenSettings, onOpenPackages, onOpenAnalytics,
   onOpenProjects, onOpenDone, onOpenActivity, onOpenSuggestions,
+  onRefresh,
   syncStatus = 'synced', queueLength = 0,
 }) {
   const [tab, setTab] = useState('today')
@@ -68,7 +70,7 @@ export default function KeptShell({
         syncStatus={syncStatus}
         queueLength={queueLength}
       />
-      <div className="bm-shell-surface">{surface}</div>
+      <PullToRefresh onRefresh={onRefresh}>{surface}</PullToRefresh>
       <KeptNav active={tab} onChange={setTab} onThrow={() => setThrowOpen(true)} />
       <ThrowSheet
         open={throwOpen}

--- a/src/kept/PullToRefresh.jsx
+++ b/src/kept/PullToRefresh.jsx
@@ -1,0 +1,73 @@
+import { useRef, useState, useCallback } from 'react'
+import './shell.css'
+
+// Pull-down-to-refresh for the Kept mobile shell. Wraps the scrolling
+// surface: dragging down while the scroller is at its top reveals a
+// boomerang spinner; releasing past the threshold runs `onRefresh`
+// (the server refetch) and holds the spinner until it resolves.
+const THRESHOLD = 64
+const MAX_PULL = 96
+
+export default function PullToRefresh({ onRefresh, children }) {
+  const ref = useRef(null)
+  const startY = useRef(null)
+  const [pull, setPull] = useState(0)
+  const [refreshing, setRefreshing] = useState(false)
+
+  const onTouchStart = useCallback((e) => {
+    if (refreshing) return
+    if ((ref.current?.scrollTop ?? 1) <= 0) {
+      startY.current = e.touches[0].clientY
+    } else {
+      startY.current = null
+    }
+  }, [refreshing])
+
+  const onTouchMove = useCallback((e) => {
+    if (startY.current == null || refreshing) return
+    const dy = e.touches[0].clientY - startY.current
+    if (dy <= 0 || (ref.current?.scrollTop ?? 0) > 0) {
+      setPull(0)
+      return
+    }
+    // dampened drag, capped
+    setPull(Math.min(MAX_PULL, dy * 0.45))
+  }, [refreshing])
+
+  const onTouchEnd = useCallback(async () => {
+    if (startY.current == null) return
+    startY.current = null
+    if (pull >= THRESHOLD && !refreshing) {
+      setRefreshing(true)
+      setPull(THRESHOLD * 0.75)
+      try { await onRefresh?.() } catch { /* indicator still resets */ }
+      setRefreshing(false)
+    }
+    setPull(0)
+  }, [pull, refreshing, onRefresh])
+
+  const active = pull > 0 || refreshing
+  const shown = refreshing ? THRESHOLD * 0.75 : pull
+
+  return (
+    <div
+      ref={ref}
+      className="bm-shell-surface"
+      onTouchStart={onTouchStart}
+      onTouchMove={onTouchMove}
+      onTouchEnd={onTouchEnd}
+    >
+      <div className={`bm-ptr${refreshing ? ' is-refreshing' : ''}`} style={{ height: active ? shown : 0 }} aria-hidden={!active}>
+        <svg
+          className="bm-ptr-mark"
+          style={{ opacity: Math.min(1, shown / THRESHOLD), transform: refreshing ? undefined : `rotate(${shown * 3}deg)` }}
+          width="22" height="22" viewBox="0 0 100 100" fill="none"
+        >
+          <path d="M 22 52 C 30 18, 70 18, 78 52" stroke="currentColor" strokeWidth="11" strokeLinecap="round" />
+          <circle cx="78" cy="52" r="8" fill="currentColor" />
+        </svg>
+      </div>
+      {children}
+    </div>
+  )
+}

--- a/src/kept/shell.css
+++ b/src/kept/shell.css
@@ -16,6 +16,7 @@
   top: calc(var(--bm-header-h) + env(safe-area-inset-top));
   left: 0; right: 0; bottom: 0;
   overflow-y: auto;
+  overscroll-behavior-y: contain; /* our pull-to-refresh, not the browser's rubber-band */
   -webkit-overflow-scrolling: touch;
 }
 .bm-surface { min-height: 100%; padding: 14px 16px 130px; }
@@ -524,3 +525,13 @@
 .bm-subtask-text { font-size: 13px; color: var(--bm-text-meta); }
 .bm-subtask-text.is-done { text-decoration: line-through; opacity: 0.6; }
 .bm-bringback { padding: 8px 11px; font-size: 12px; flex: 0 0 auto; gap: 4px; }
+
+/* Pull-to-refresh indicator (PullToRefresh.jsx) */
+.bm-ptr {
+  display: grid; place-items: center;
+  height: 0; overflow: hidden;
+  color: var(--bm-ember);
+  transition: height 160ms ease-out;
+}
+.bm-ptr.is-refreshing .bm-ptr-mark { animation: bm-ptr-spin 0.9s linear infinite; }
+@keyframes bm-ptr-spin { to { transform: rotate(360deg); } }

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,11 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-11
 
+- feat(ui): Kept pull-to-refresh + toast swipe-up dismiss [S]
+  - **Pull-down-to-refresh on the Kept mobile shell** (the dropped ask, recovered by auditing the transcript — it predated a context compaction and fell out of the working notes): dragging down from the top of any tab surface (Today/Tasks/Loops/More) reveals a boomerang-arc spinner; releasing past the threshold runs a full server refetch (`useServerSync.refetch` → the same hydration path SSE uses) and holds the spinner until it resolves. `overscroll-behavior-y: contain` keeps the browser's own rubber-band out of the way. New `src/kept/PullToRefresh.jsx`.
+  - **Toast swipe-up dismiss**: the top banner now follows the finger upward and flicks away past 36px — a real push-notification gesture to go with tap-dismiss. (Honest accounting from the user's audit: the earlier toast round changed position, animation, dismissal, and copy — the visual shell itself is still the adaptive dark pill; a Kept-native banner restyle rides with the editor redesign wave.)
+  - Verified live: drag → spinner at 96px + `/api/data` refetch fired on release; catch → toast at top → swipe up → dismissed.
+
 - fix(ui): hero follows breakdown date selection + Loop suggestions rename + nav swap [S]
   - **The hero now follows the breakdown's selected day** (prod report: "slider and counts should change with the date selection"): selection state lifted from `WeekBreakdown` into `TodayView`; picking a non-today day swaps the headline date, the Day Arc (value + "points that day" caption), and the meta row to that day's numbers — catches/points computed identically to the breakdown's item list so the arc total always matches the itemization; loops shown as a plain done-count (historical due-ness isn't reconstructable). Reverts to live today-stats when today is selected or the breakdown closes.
   - **"Routine suggestions" → "Loop suggestions"** everywhere Kept-facing (More row, desktop sidebar row, modal title via a `title` prop — Standard theme keeps "Routine suggestions").


### PR DESCRIPTION
The recovered ask + the toast gesture gap:

## 1. Pull-down-to-refresh (Kept mobile shell)
Dragging down from the top of any tab surface (Today / Tasks / Loops / More) reveals a boomerang-arc spinner; releasing past the threshold runs a full server refetch (`useServerSync.refetch` → the same `fetchAndHydrate` path SSE uses) and holds the spinner until it resolves. `overscroll-behavior-y: contain` keeps the browser rubber-band out of the gesture. New `src/kept/PullToRefresh.jsx`.

*(This ask predated a context compaction and fell out of my working notes — recovered by auditing the transcript at the user's prompt.)*

## 2. Toast swipe-up dismiss
The top banner now follows the finger upward and flicks away past 36px — the real push-notification gesture, alongside tap-dismiss.

Verified live in the harness: drag → spinner at 96px + `/api/data` refetch count incremented on release; catch → toast at top → swipe up → gone.

https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR)_