### PR TITLE
release: New-loop flow fix + Loops Suggestions button

### DIFF
--- a/src/AppV2.jsx
+++ b/src/AppV2.jsx
@@ -97,6 +97,9 @@ export default function AppV2() {
   // picker rows with rich preview cards but keeps the contract.
   const [spacesHubOpen, setSpacesHubOpen] = useState(false)
   const [showRoutines, setShowRoutines] = useState(false)
+  // "New loop" entry points open RoutinesModal directly in the blank form
+  // (list-first made the flow New loop -> list -> New routine).
+  const [routinesOpenToForm, setRoutinesOpenToForm] = useState(false)
   const [editRoutineId, setEditRoutineId] = useState(null)
   const [showPackages, setShowPackages] = useState(false)
   const [showAdviser, setShowAdviser] = useState(false)
@@ -1328,7 +1331,7 @@ export default function AppV2() {
           onThrow={({ title, dueDate }) => handleAddTask({ title, dueDate })}
           onOpenFullAdd={() => setShowAdd(true)}
           onEditLoop={(r) => { setEditRoutineId(r.id); setShowRoutines(true) }}
-          onAddLoop={() => setShowRoutines(true)}
+          onAddLoop={() => { setRoutinesOpenToForm(true); setShowRoutines(true) }}
           onOpenQuokka={() => setShowAdviser(true)}
           onOpenSettings={() => setShowSettings(true)}
           onOpenPackages={() => setShowPackages(true)}
@@ -1378,7 +1381,7 @@ export default function AppV2() {
           onThrow={({ title, dueDate }) => handleAddTask({ title, dueDate })}
           onOpenFullAdd={() => setShowAdd(true)}
           onEditLoop={(r) => { setEditRoutineId(r.id); setShowRoutines(true) }}
-          onAddLoop={() => setShowRoutines(true)}
+          onAddLoop={() => { setRoutinesOpenToForm(true); setShowRoutines(true) }}
           onOpenQuokka={() => setShowAdviser(true)}
           onOpenSettings={() => setShowSettings(true)}
           onOpenPackages={() => setShowPackages(true)}
@@ -1557,6 +1560,8 @@ export default function AppV2() {
       />
       <RoutinesModal
         open={showRoutines}
+        openToForm={routinesOpenToForm}
+        onConsumeOpenToForm={() => setRoutinesOpenToForm(false)}
         title={isKept ? 'Loops' : 'Routines'}
         noun={isKept ? 'loop' : 'routine'}
         routines={routines}

--- a/src/components/RoutinesModal.jsx
+++ b/src/components/RoutinesModal.jsx
@@ -997,6 +997,7 @@ export default function RoutinesModal({
   open, routines, tasks = [], onAdd, onDelete, onTogglePause, onUpdate, onSpawnNow, onLogHabit, onSkipCycle, onClose,
   editRoutineId, onClearEditRoutineId, activeRoutineIds,
   title = 'Routines', noun = 'routine',
+  openToForm = false, onConsumeOpenToForm,
 }) {
   const [view, setView] = useState('list')  // 'list' | 'form'
   const [editing, setEditing] = useState(null)  // routine being edited; null = new
@@ -1010,6 +1011,17 @@ export default function RoutinesModal({
       setExpandedId(null)
     }
   }, [open])
+
+  // "New loop" entry points jump straight to the blank form — landing on
+  // the list and asking for a second "+ New" tap made no sense (prod
+  // report 2026-06-11: New loop -> Loop List -> New routine).
+  useEffect(() => {
+    if (open && openToForm) {
+      setEditing(null)
+      setView('form')
+      onConsumeOpenToForm?.()
+    }
+  }, [open, openToForm, onConsumeOpenToForm])
 
   // Open directly into edit form when AppV2 supplies an editRoutineId — same
   // pattern v1 uses (e.g. EditTaskModal → "Open routine" jumps the user here).
@@ -1092,9 +1104,9 @@ export default function RoutinesModal({
           {routines.length === 0 ? (
             <EmptyState
               icon={RotateCw}
-              title="No routines yet"
+              title={`No ${noun}s yet`}
               body="Recurring tasks like dentist visits, plant watering, oil changes. Create one to start tracking the rhythm."
-              cta="New routine"
+              cta={`New ${noun}`}
               ctaOnClick={() => { setEditing(null); setView('form') }}
             />
           ) : (
@@ -1149,7 +1161,7 @@ export default function RoutinesModal({
                 className="v2-routine-new-btn"
                 onClick={() => { setEditing(null); setView('form') }}
               >
-                <Plus size={16} strokeWidth={2} /> New routine
+                <Plus size={16} strokeWidth={2} /> New {noun}
               </button>
             </>
           )}

--- a/src/kept/KeptShell.jsx
+++ b/src/kept/KeptShell.jsx
@@ -29,7 +29,7 @@ export default function KeptShell({
 
   let surface
   if (tab === 'loops') {
-    surface = <LoopsView routines={routines} onEditLoop={onEditLoop} onAddLoop={onAddLoop} />
+    surface = <LoopsView routines={routines} onEditLoop={onEditLoop} onAddLoop={onAddLoop} onOpenSuggestions={onOpenSuggestions} />
   } else if (tab === 'tasks') {
     surface = (
       <TasksViewKept
@@ -44,7 +44,7 @@ export default function KeptShell({
       <MoreView
         onOpenProjects={onOpenProjects} onOpenAnalytics={onOpenAnalytics}
         onOpenPackages={onOpenPackages} onOpenDone={onOpenDone}
-        onOpenActivity={onOpenActivity} onOpenSuggestions={onOpenSuggestions}
+        onOpenActivity={onOpenActivity}
         onOpenSettings={onOpenSettings}
       />
     )

--- a/src/kept/LoopsView.jsx
+++ b/src/kept/LoopsView.jsx
@@ -1,5 +1,5 @@
-import { useMemo, useState } from 'react'
-import { Repeat2, Pencil } from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
+import { Repeat2, Pencil, Sparkles } from 'lucide-react'
 import FlightTrail from './FlightTrail'
 import MonthDots from './MonthDots'
 import DensityRibbon from './DensityRibbon'
@@ -15,8 +15,19 @@ const RANGES = [
 
 // Kept "Loops" — one card per loop carrying its Flight Trail / Month Dots /
 // Density Ribbon (spec §6). Edit routes to the existing routine editor.
-export default function LoopsView({ routines = [], onEditLoop, onAddLoop }) {
+export default function LoopsView({ routines = [], onEditLoop, onAddLoop, onOpenSuggestions }) {
   const [range, setRange] = useState('trail')
+  // Pending pattern-scan suggestions — drives the dot badge on the
+  // Suggestions button so a passive Sunday-scan find still waves at you.
+  const [suggestionCount, setSuggestionCount] = useState(0)
+  useEffect(() => {
+    let alive = true
+    fetch('/api/suggestions')
+      .then(r => (r.ok ? r.json() : null))
+      .then(d => { if (alive && d) setSuggestionCount(d.count || 0) })
+      .catch(() => {})
+    return () => { alive = false }
+  }, [])
   const loops = useMemo(() => {
     const feathers = routineFeathers(routines)
     return routines.filter(r => !r.paused).map(r => {
@@ -29,7 +40,11 @@ export default function LoopsView({ routines = [], onEditLoop, onAddLoop }) {
     <div className="bm-surface">
       <div className="bm-title-row">
         <h1 className="bm-h1">Loops</h1>
-        <button className="bm-btn bm-btn-tonal" style={{ marginLeft: 'auto', padding: '9px 14px' }} onClick={onAddLoop}>New loop</button>
+        <button className="bm-btn bm-suggest-btn" onClick={onOpenSuggestions}>
+          <Sparkles size={14} strokeWidth={2.1} /> Suggestions
+          {suggestionCount > 0 && <span className="bm-suggest-dot" aria-label={`${suggestionCount} pending`} />}
+        </button>
+        <button className="bm-btn bm-btn-tonal" style={{ padding: '9px 14px' }} onClick={onAddLoop}>New loop</button>
       </div>
       <div className="bm-seg" role="tablist" aria-label="History range">
         {RANGES.map(m => (

--- a/src/kept/MoreView.jsx
+++ b/src/kept/MoreView.jsx
@@ -1,15 +1,16 @@
-import { ChevronRight, BarChart3, Package, Settings, FolderKanban, CheckCircle2, ScrollText, Inbox } from 'lucide-react'
+import { ChevronRight, BarChart3, Package, Settings, FolderKanban, CheckCircle2, ScrollText } from 'lucide-react'
 import './shell.css'
 
 // Kept "More" — the low-frequency surfaces. Arcs (projects) routes to the
 // existing ProjectsView; Flight log (profile) arrives with K5's dashboard.
-export default function MoreView({ onOpenProjects, onOpenAnalytics, onOpenPackages, onOpenDone, onOpenActivity, onOpenSuggestions, onOpenSettings }) {
+// Loop suggestions moved to a Sparkles button on the Loops surface
+// (2026-06-11) — suggestions are about loops, they live with loops.
+export default function MoreView({ onOpenProjects, onOpenAnalytics, onOpenPackages, onOpenDone, onOpenActivity, onOpenSettings }) {
   const rows = [
     { icon: FolderKanban, label: 'Arcs', sub: 'Long-term projects · sessions + steps', onClick: onOpenProjects },
     { icon: BarChart3, label: 'Analytics', sub: 'Productivity insights', onClick: onOpenAnalytics },
     { icon: CheckCircle2, label: 'Caught', sub: 'Everything you finished', onClick: onOpenDone },
     { icon: Package, label: 'Packages', sub: 'Track deliveries', onClick: onOpenPackages },
-    { icon: Inbox, label: 'Loop suggestions', sub: 'Recurring patterns spotted in your tasks', onClick: onOpenSuggestions },
     { icon: ScrollText, label: 'Activity log', sub: 'Every change, restorable', onClick: onOpenActivity },
     { icon: Settings, label: 'Settings', sub: 'App configuration', onClick: onOpenSettings },
   ]

--- a/src/kept/shell.css
+++ b/src/kept/shell.css
@@ -535,3 +535,19 @@
 }
 .bm-ptr.is-refreshing .bm-ptr-mark { animation: bm-ptr-spin 0.9s linear infinite; }
 @keyframes bm-ptr-spin { to { transform: rotate(360deg); } }
+
+/* Loops "Suggestions" button — gold AI accent, deliberately NOT the Quokka
+   ember treatment (it's the pattern scanner, not the adviser). */
+.bm-suggest-btn {
+  position: relative;
+  margin-left: auto;
+  padding: 9px 12px;
+  background: var(--bm-gold-soft);
+  color: var(--bm-gold);
+  font-size: 12.5px;
+}
+.bm-suggest-dot {
+  position: absolute; top: 4px; right: 5px;
+  width: 7px; height: 7px; border-radius: 50%;
+  background: var(--bm-ember);
+}

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,11 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-11
 
+- fix(ui): New loop goes straight to the form + Suggestions button on Loops [S]
+  - **Flow fix** (prod report: "New loop → Loop List → New routine makes no sense"): the "New loop" button now opens the editor directly in the blank form (`openToForm` prop on RoutinesModal, consumed on open) — no list detour, no second tap. The list's own buttons also respect the Kept noun now ("+ New loop", not "+ New routine").
+  - **Loop suggestions live on the Loops page**: gold Sparkles "Suggestions" button in the title row (deliberately not the Quokka ember treatment — it's the pattern scanner, not the adviser), with an ember dot badge when the weekly scan has pending finds (`GET /api/suggestions` count). The "Loop suggestions" row is removed from the mobile More menu; desktop sidebar and Standard theme unchanged.
+  - Verified live: Loops header shows the badged button → opens "Loop suggestions"; "New loop" lands on the form; More menu reads Arcs · Analytics · Caught · Packages · Activity log · Settings.
+
 - feat(ui): Kept pull-to-refresh + toast swipe-up dismiss [S]
   - **Pull-down-to-refresh on the Kept mobile shell** (the dropped ask, recovered by auditing the transcript — it predated a context compaction and fell out of the working notes): dragging down from the top of any tab surface (Today/Tasks/Loops/More) reveals a boomerang-arc spinner; releasing past the threshold runs a full server refetch (`useServerSync.refetch` → the same hydration path SSE uses) and holds the spinner until it resolves. `overscroll-behavior-y: contain` keeps the browser's own rubber-band out of the way. New `src/kept/PullToRefresh.jsx`.
   - **Toast swipe-up dismiss**: the top banner now follows the finger upward and flicks away past 36px — a real push-notification gesture to go with tap-dismiss. (Honest accounting from the user's audit: the earlier toast round changed position, animation, dismissal, and copy — the visual shell itself is still the adaptive dark pill; a Kept-native banner restyle rides with the editor redesign wave.)


### PR DESCRIPTION
Promotes one fix-pair from dev (PR #492):

- **"New loop" goes straight to the blank form** — no list detour, correct noun on list buttons.
- **Suggestions button on the Loops page** — gold Sparkles + label, ember badge for pending finds; removed from the mobile More menu.

Verified live before merge.

https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR)_