### PR TITLE
release: single-Sparkle AI glyph on Suggestions

### DIFF
--- a/src/kept/LoopsView.jsx
+++ b/src/kept/LoopsView.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
-import { Repeat2, Pencil, Sparkles } from 'lucide-react'
+import { Repeat2, Pencil, Sparkle } from 'lucide-react'
 import FlightTrail from './FlightTrail'
 import MonthDots from './MonthDots'
 import DensityRibbon from './DensityRibbon'
@@ -41,7 +41,7 @@ export default function LoopsView({ routines = [], onEditLoop, onAddLoop, onOpen
       <div className="bm-title-row">
         <h1 className="bm-h1">Loops</h1>
         <button className="bm-btn bm-suggest-btn" onClick={onOpenSuggestions}>
-          <Sparkles size={14} strokeWidth={2.1} /> Suggestions
+          <Sparkle size={14} strokeWidth={2.1} /> Suggestions
           {suggestionCount > 0 && <span className="bm-suggest-dot" aria-label={`${suggestionCount} pending`} />}
         </button>
         <button className="bm-btn bm-btn-tonal" style={{ padding: '9px 14px' }} onClick={onAddLoop}>New loop</button>

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -7,6 +7,7 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 ## 2026-06-11
 
 - fix(ui): New loop goes straight to the form + Suggestions button on Loops [S]
+  - Follow-up: icon swapped to the single four-point `Sparkle` (the universal AI glyph) — `Sparkles` is Quokka's mark.
   - **Flow fix** (prod report: "New loop → Loop List → New routine makes no sense"): the "New loop" button now opens the editor directly in the blank form (`openToForm` prop on RoutinesModal, consumed on open) — no list detour, no second tap. The list's own buttons also respect the Kept noun now ("+ New loop", not "+ New routine").
   - **Loop suggestions live on the Loops page**: gold Sparkles "Suggestions" button in the title row (deliberately not the Quokka ember treatment — it's the pattern scanner, not the adviser), with an ember dot badge when the weekly scan has pending finds (`GET /api/suggestions` count). The "Loop suggestions" row is removed from the mobile More menu; desktop sidebar and Standard theme unchanged.
   - Verified live: Loops header shows the badged button → opens "Loop suggestions"; "New loop" lands on the form; More menu reads Arcs · Analytics · Caught · Packages · Activity log · Settings.


### PR DESCRIPTION
Promotes one icon fix from dev (PR #494): the Loops Suggestions button uses the single four-point `Sparkle` AI glyph — `Sparkles` stays Quokka's mark.

https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR)_