### PR TITLE
release: cadence-aware loop charts (design wave 1/4)

### DIFF
--- a/src/components/RoutinesModal.jsx
+++ b/src/components/RoutinesModal.jsx
@@ -344,7 +344,7 @@ function FollowUpStepRow({ step, index, isFirst, isLast, onChange, onRemove, onM
   )
 }
 
-function RoutineForm({ initial, onSave, onCancel }) {
+function RoutineForm({ initial, onSave, onCancel, noun = 'routine' }) {
   const isNew = !initial
   const [title, setTitle] = useState(initial?.title || '')
   const [cadence, setCadence] = useState(initial?.cadence || 'weekly')
@@ -579,7 +579,7 @@ function RoutineForm({ initial, onSave, onCancel }) {
 
   return (
     <div className="v2-routine-form">
-      <button type="button" className="v2-routine-back" onClick={onCancel}>← Back to routines</button>
+      <button type="button" className="v2-routine-back" onClick={onCancel}>← Back to {noun}s</button>
 
       <input
         className="v2-form-input v2-form-title"
@@ -1095,6 +1095,7 @@ export default function RoutinesModal({
     >
       {view === 'form' ? (
         <RoutineForm
+          noun={noun}
           initial={editing}
           onSave={handleSubmitForm}
           onCancel={() => { setView('list'); setEditing(null) }}

--- a/src/kept/CycleChips.jsx
+++ b/src/kept/CycleChips.jsx
@@ -1,0 +1,26 @@
+import './shell.css'
+
+// One chip per cadence cycle (design doc §13a) — filled = caught, faded =
+// partial progress toward a habit target, hollow = missed, ringed = the
+// current in-flight window. Reads at a glance for ANY cadence, unlike the
+// day-grid that only made sense for multi-step dailies.
+export default function CycleChips({ windows = [], target = 1, caption }) {
+  return (
+    <div className="bm-cycles">
+      <div className="bm-cycle-row" aria-hidden="true">
+        {windows.map(w => (
+          <span
+            key={w.key}
+            className={[
+              'bm-cycle-chip',
+              w.hits >= target ? 'is-caught' : w.hits > 0 ? 'is-partial' : '',
+              w.current ? 'is-current' : '',
+            ].filter(Boolean).join(' ')}
+            title={w.key}
+          />
+        ))}
+      </div>
+      {caption && <div className="bm-cycle-cap">{caption}</div>}
+    </div>
+  )
+}

--- a/src/kept/LoopsView.jsx
+++ b/src/kept/LoopsView.jsx
@@ -3,6 +3,8 @@ import { Repeat2, Pencil, Sparkle } from 'lucide-react'
 import FlightTrail from './FlightTrail'
 import MonthDots from './MonthDots'
 import DensityRibbon from './DensityRibbon'
+import CycleChips from './CycleChips'
+import { cycleWindows, habitWindows, cycleUnitLabel } from './cycles'
 import { historyByDay, currentStreak } from '../wallaby/heatmapUtils'
 import { routineFeathers } from './feathers'
 import './shell.css'
@@ -68,7 +70,41 @@ export default function LoopsView({ routines = [], onEditLoop, onAddLoop, onOpen
               <Pencil size={13} strokeWidth={2} />
             </button>
           </div>
-          {range === 'trail' && <FlightTrail valueByDay={byDay} color={color} />}
+          {range === 'trail' && (() => {
+            // Cadence-fit visuals (§13a): the day-grid only made sense for
+            // multi-step dailies. Dailies get a compact 4-week mini trail;
+            // habit loops get target-aware cycle chips; everything else gets
+            // one chip per cadence window.
+            if (r.spawn_mode === 'habit' && r.target_count) {
+              const wins = habitWindows(r, 12)
+              const cur = wins[wins.length - 1]
+              const past = wins.filter(w => !w.current)
+              const met = past.filter(w => w.hits >= r.target_count).length
+              const periodWord = r.target_period === 'month' ? 'month' : 'week'
+              return (
+                <CycleChips
+                  windows={wins}
+                  target={r.target_count}
+                  caption={`this ${periodWord} ${cur?.hits ?? 0}/${r.target_count} · target met ${met} of last ${past.length} ${periodWord}s`}
+                />
+              )
+            }
+            if (r.cadence === 'daily') {
+              return <FlightTrail valueByDay={byDay} color={color} weeks={4} mini />
+            }
+            const wins = cycleWindows(r, 12)
+            const past = wins.filter(w => !w.current)
+            const caught = past.filter(w => w.caught).length
+            const cur = wins[wins.length - 1]
+            return (
+              <CycleChips
+                windows={wins}
+                caption={past.length > 0
+                  ? `caught ${caught} of last ${past.length} ${cycleUnitLabel(r)}${cur?.caught ? ' · this one ✓' : ''}`
+                  : 'first cycle in flight'}
+              />
+            )
+          })()}
           {range === 'month' && <MonthDots valueByDay={byDay} color={color} />}
           {range === 'year' && <DensityRibbon valueByDay={byDay} color={color} />}
         </div>

--- a/src/kept/cycles.js
+++ b/src/kept/cycles.js
@@ -1,0 +1,111 @@
+import { localYMD } from '../dates'
+
+// Cadence-window math for the Loops cards (design doc §13a): the
+// visualization unit is the loop's own cycle, not the calendar day. A
+// window is "caught" when any completed_history stamp lands inside it.
+// Windows are anchored at the routine's creation date so they're stable
+// across completions (mirrors the fixed-grid cadence philosophy), and the
+// series always ends with the window containing today.
+
+function windowOf(start, end, today, stamps) {
+  const hits = stamps.filter(d => d >= start && d < end).length
+  return {
+    key: localYMD(start),
+    start,
+    end,
+    hits,
+    caught: hits > 0,
+    current: today >= start && today < end,
+  }
+}
+
+export function cycleWindows(routine, count = 12) {
+  const cadence = routine.cadence || 'weekly'
+  const stamps = (routine.completed_history || [])
+    .map(ts => new Date(ts))
+    .filter(d => Number.isFinite(d.getTime()))
+  const created = routine.created_at ? new Date(routine.created_at) : null
+  const today = new Date(); today.setHours(0, 0, 0, 0)
+
+  const stepDays = cadence === 'daily' ? 1
+    : cadence === 'weekly' ? 7
+    : cadence === 'custom' && routine.custom_unit !== 'months' ? Math.max(1, routine.custom_days || 7)
+    : null
+  const stepMonths = cadence === 'monthly' ? 1
+    : cadence === 'quarterly' ? 3
+    : cadence === 'annually' ? 12
+    : cadence === 'custom' && routine.custom_unit === 'months' ? Math.max(1, routine.custom_days || 1)
+    : null
+
+  const windows = []
+  if (stepDays != null) {
+    const anchor = created
+      ? new Date(created.getFullYear(), created.getMonth(), created.getDate())
+      : today
+    const sinceDays = Math.floor((today - anchor) / 86400000)
+    const idx = Math.max(0, Math.floor(sinceDays / stepDays))
+    for (let i = Math.max(0, idx - count + 1); i <= idx; i++) {
+      const start = new Date(anchor); start.setDate(start.getDate() + i * stepDays)
+      const end = new Date(start); end.setDate(end.getDate() + stepDays)
+      windows.push(windowOf(start, end, today, stamps))
+    }
+  } else if (stepMonths != null) {
+    const anchor = created
+      ? new Date(created.getFullYear(), created.getMonth(), 1)
+      : new Date(today.getFullYear(), today.getMonth(), 1)
+    const monthsSince = (today.getFullYear() - anchor.getFullYear()) * 12 + (today.getMonth() - anchor.getMonth())
+    const idx = Math.max(0, Math.floor(monthsSince / stepMonths))
+    for (let i = Math.max(0, idx - count + 1); i <= idx; i++) {
+      const start = new Date(anchor); start.setMonth(start.getMonth() + i * stepMonths)
+      const end = new Date(start); end.setMonth(end.getMonth() + stepMonths)
+      windows.push(windowOf(start, end, today, stamps))
+    }
+  }
+  return windows
+}
+
+// Habit-mode windows: target_period ('week' | 'month') buckets, hits from
+// completed_history. weekStartsOn matches computeHabitStreak's default.
+export function habitWindows(routine, count = 12, weekStartsOn = 1) {
+  const stamps = (routine.completed_history || [])
+    .map(ts => new Date(ts))
+    .filter(d => Number.isFinite(d.getTime()))
+  const today = new Date(); today.setHours(0, 0, 0, 0)
+  const isWeek = routine.target_period !== 'month'
+
+  const currentStart = new Date(today)
+  if (isWeek) {
+    const diff = (currentStart.getDay() - weekStartsOn + 7) % 7
+    currentStart.setDate(currentStart.getDate() - diff)
+  } else {
+    currentStart.setDate(1)
+  }
+
+  const windows = []
+  for (let i = count - 1; i >= 0; i--) {
+    const start = new Date(currentStart)
+    if (isWeek) start.setDate(start.getDate() - i * 7)
+    else start.setMonth(start.getMonth() - i)
+    const end = new Date(start)
+    if (isWeek) end.setDate(end.getDate() + 7)
+    else end.setMonth(end.getMonth() + 1)
+    windows.push(windowOf(start, end, today, stamps))
+  }
+  return windows
+}
+
+export function cycleUnitLabel(routine) {
+  const c = routine.cadence
+  if (c === 'daily') return 'days'
+  if (c === 'weekly') return 'weeks'
+  if (c === 'monthly') return 'months'
+  if (c === 'quarterly') return 'quarters'
+  if (c === 'annually') return 'years'
+  if (c === 'custom') {
+    const n = Math.max(1, routine.custom_days || (routine.custom_unit === 'months' ? 1 : 7))
+    return routine.custom_unit === 'months'
+      ? (n === 1 ? 'months' : `${n}-month cycles`)
+      : `${n}-day cycles`
+  }
+  return 'cycles'
+}

--- a/src/kept/shell.css
+++ b/src/kept/shell.css
@@ -551,3 +551,17 @@
   width: 7px; height: 7px; border-radius: 50%;
   background: var(--bm-ember);
 }
+
+/* Cycle chips — one per cadence window (CycleChips.jsx, §13a) */
+.bm-cycles { padding: 2px 0 1px; }
+.bm-cycle-row { display: flex; gap: 6px; flex-wrap: wrap; }
+.bm-cycle-chip {
+  width: 18px; height: 18px;
+  border-radius: 6px;
+  border: 1.5px solid var(--bm-hairline-strong);
+  background: transparent;
+}
+.bm-cycle-chip.is-partial { background: color-mix(in srgb, var(--loop, var(--bm-ember)) 35%, transparent); border-color: transparent; }
+.bm-cycle-chip.is-caught { background: var(--loop, var(--bm-ember)); border-color: transparent; }
+.bm-cycle-chip.is-current { box-shadow: 0 0 0 2px color-mix(in srgb, var(--loop, var(--bm-ember)) 45%, transparent); }
+.bm-cycle-cap { margin-top: 7px; font-size: 11.5px; color: var(--bm-text-meta); font-weight: 600; }

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,15 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-11
 
+- feat(ui): cadence-aware loop charts — cycle chips replace the day-grid (design wave 1/4) [M]
+  - The Loops "Trail" tab now fits the visualization to the loop's own cadence (§13a; prod report: the dot grids were "really hard to interpret for as much real estate as they eat"):
+    - **Daily loops** → a compact 4-week mini Flight Trail (single row).
+    - **Habit loops** → 12 target-aware cycle chips (filled = target met, faded = partial, hollow = nothing) + "this week 2/3 · target met N of last M weeks".
+    - **Everything else** (weekly/monthly/quarterly/annually/custom) → one chip per cadence window, anchored at the loop's creation date, with "caught N of last M <units> · this one ✓".
+  - New `src/kept/cycles.js` (window math: day-stepped + month-stepped + habit periods) and `src/kept/CycleChips.jsx`; Month/Year drill-down tabs unchanged. Cards drop to a third of their height.
+  - Also: the loop editor's escape hatch says "← Back to loops" in Kept (noun threaded into RoutineForm — last hardcoded "routines" string).
+  - Verified live across all four shapes (daily mini-trail; habit 3×/week with met/partial/missed weeks; weekly with gaps; monthly) — chip counts and captions match the seeded history exactly.
+
 - fix(ui): New loop goes straight to the form + Suggestions button on Loops [S]
   - Follow-up: icon swapped to the single four-point `Sparkle` (the universal AI glyph) — `Sparkles` is Quokka's mark.
   - **Flow fix** (prod report: "New loop → Loop List → New routine makes no sense"): the "New loop" button now opens the editor directly in the blank form (`openToForm` prop on RoutinesModal, consumed on open) — no list detour, no second tap. The list's own buttons also respect the Kept noun now ("+ New loop", not "+ New routine").


### PR DESCRIPTION
Promotes design-wave batch 1 from dev (PR #496):

- **Cadence-aware loop charts** — cycle chips replace the day-grid on the Loops Trail tab: daily → mini trail, habit → target-aware chips with this-week progress, everything else → one chip per cadence window with caught-N-of-M captions. Cards drop to ⅓ height.
- "← Back to loops" noun fix in the loop editor.

Verified across all four cadence shapes before merge.

https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR)_