### PR TITLE
feat(ui): Activity log refresh — day groups + action icon chips [S]

### DIFF
--- a/src/components/ActivityLog.css
+++ b/src/components/ActivityLog.css
@@ -34,8 +34,24 @@
   padding: 0;
 }
 
+.v2-activity-group { list-style: none; }
+
+.v2-activity-day {
+  position: sticky;
+  top: 0;
+  padding: 10px 4px 6px;
+  font: 700 11px/1 var(--v2-font-body);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--v2-text-meta);
+  background: var(--v2-bg);
+}
+
 .v2-activity-row {
-  padding: 14px 4px;
+  display: flex;
+  align-items: flex-start;
+  gap: 11px;
+  padding: 11px 4px;
   border-bottom: 1px solid var(--v2-hairline);
 }
 
@@ -43,12 +59,28 @@
   border-bottom: none;
 }
 
+.v2-activity-icon {
+  flex: 0 0 auto;
+  width: 26px;
+  height: 26px;
+  margin-top: 1px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  color: var(--tone, var(--v2-text-meta));
+  background: color-mix(in srgb, var(--tone, var(--v2-text-meta)) 14%, transparent);
+}
+
+.v2-activity-body {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
 .v2-activity-meta-row {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 10px;
-  margin-bottom: 4px;
+  gap: 8px;
+  margin-top: 2px;
 }
 
 .v2-activity-action {
@@ -69,7 +101,8 @@
 }
 
 .v2-activity-restore {
-  margin-top: 8px;
+  flex: 0 0 auto;
+  margin-top: 2px;
   height: 28px;
   padding: 0 12px;
   border-radius: var(--v2-radius-pill);

--- a/src/components/ActivityLog.jsx
+++ b/src/components/ActivityLog.jsx
@@ -1,6 +1,9 @@
 import { useState, useEffect, useMemo, useRef } from 'react'
-import { History, Search, Sparkles, X } from 'lucide-react'
-import { loadActivityLog, saveActivityLog, uuid } from '../store'
+import {
+  History, Search, Sparkles, X, Plus, Check, RotateCcw, Trash2,
+  ArrowRightLeft, Pencil, Clock3, FastForward, Flag, AlertTriangle,
+} from 'lucide-react'
+import { loadActivityLog, saveActivityLog, uuid, localYMD } from '../store'
 import { aiSearchActivity } from '../api'
 import ModalShell from './ModalShell'
 import EmptyState from './EmptyState'
@@ -17,6 +20,19 @@ const ACTION_LABELS = {
   skipped: 'Skipped',
   priority_changed: 'Priority changed',
   error: 'Error',
+}
+
+const ACTION_ICONS = {
+  created: Plus,
+  completed: Check,
+  reopened: RotateCcw,
+  deleted: Trash2,
+  status_changed: ArrowRightLeft,
+  edited: Pencil,
+  snoozed: Clock3,
+  skipped: FastForward,
+  priority_changed: Flag,
+  error: AlertTriangle,
 }
 
 const ACTION_TONE = {
@@ -42,6 +58,15 @@ function timeAgo(timestamp) {
   const days = Math.floor(hours / 24)
   if (days < 7) return `${days}d ago`
   return new Date(timestamp).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+}
+
+function dayLabel(ymd) {
+  const today = localYMD(new Date())
+  if (ymd === today) return 'Today'
+  const y = new Date(); y.setDate(y.getDate() - 1)
+  if (ymd === localYMD(y)) return 'Yesterday'
+  const [yy, mm, dd] = ymd.split('-').map(Number)
+  return new Date(yy, mm - 1, dd).toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' })
 }
 
 export default function ActivityLog({ open, onRestore, onClose }) {
@@ -205,28 +230,49 @@ export default function ActivityLog({ open, onRestore, onClose }) {
         />
       ) : (
         <ul className="v2-activity-list">
-          {filteredLog.map(entry => (
-            <li key={entry.id} className="v2-activity-row">
-              <div className="v2-activity-meta-row">
-                <span
-                  className="v2-activity-action"
-                  style={{ color: ACTION_TONE[entry.action] || 'var(--v2-text-meta)' }}
-                >
-                  {ACTION_LABELS[entry.action] || entry.action}
-                </span>
-                <span className="v2-activity-time">{timeAgo(entry.timestamp)}</span>
-              </div>
-              <div className="v2-activity-title">{entry.task_title}</div>
-              {entry.action === 'error' && entry.task_snapshot?.error && (
-                <pre className="v2-activity-error-detail">{entry.task_snapshot.error}</pre>
-              )}
-              {entry.action === 'deleted' && entry.task_snapshot && (
-                <button className="v2-activity-restore" onClick={() => handleRestore(entry)}>
-                  Restore
-                </button>
-              )}
-            </li>
-          ))}
+          {(() => {
+            // Group under day headers — a flat 200-row stream was unscannable.
+            const groups = []
+            for (const entry of filteredLog) {
+              const key = localYMD(new Date(entry.timestamp))
+              const g = groups[groups.length - 1]
+              if (g && g.key === key) g.entries.push(entry)
+              else groups.push({ key, entries: [entry] })
+            }
+            return groups.map(g => (
+              <li key={g.key} className="v2-activity-group">
+                <div className="v2-activity-day">{dayLabel(g.key)}</div>
+                {g.entries.map(entry => {
+                  const Icon = ACTION_ICONS[entry.action] || History
+                  const tone = ACTION_TONE[entry.action] || 'var(--v2-text-meta)'
+                  return (
+                    <div key={entry.id} className="v2-activity-row">
+                      <span className="v2-activity-icon" style={{ '--tone': tone }}>
+                        <Icon size={13} strokeWidth={2.2} />
+                      </span>
+                      <div className="v2-activity-body">
+                        <div className="v2-activity-title">{entry.task_title || '(untitled)'}</div>
+                        <div className="v2-activity-meta-row">
+                          <span className="v2-activity-action" style={{ color: tone }}>
+                            {ACTION_LABELS[entry.action] || entry.action}
+                          </span>
+                          <span className="v2-activity-time">{timeAgo(entry.timestamp)}</span>
+                        </div>
+                        {entry.action === 'error' && entry.task_snapshot?.error && (
+                          <pre className="v2-activity-error-detail">{entry.task_snapshot.error}</pre>
+                        )}
+                      </div>
+                      {entry.action === 'deleted' && entry.task_snapshot && (
+                        <button className="v2-activity-restore" onClick={() => handleRestore(entry)}>
+                          Restore
+                        </button>
+                      )}
+                    </div>
+                  )
+                })}
+              </li>
+            ))
+          })()}
         </ul>
       )}
     </ModalShell>

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,11 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-11
 
+- feat(ui): Activity log refresh — day groups + action icon chips (design wave 2/4) [S]
+  - The flat 200-row stream is now grouped under sticky day headers (Today / Yesterday / Tue, Jun 9) with a tinted icon chip per action type (created/completed/reopened/deleted/status/edited/snoozed/skipped/priority/error), title-first row hierarchy, and the Restore pill right-aligned on the row. Search, All/Deleted/Errors filters, and AI search unchanged.
+  - Styled on `--v2-*` tokens so the Kept palette flows through without override CSS (per the K4 no-reskin-by-override rule); Standard and Wallaby inherit the same cleanup.
+  - Verified live in Kept: three day groups, 10 icon chips, restore pill functional.
+
 - feat(ui): cadence-aware loop charts — cycle chips replace the day-grid (design wave 1/4) [M]
   - The Loops "Trail" tab now fits the visualization to the loop's own cadence (§13a; prod report: the dot grids were "really hard to interpret for as much real estate as they eat"):
     - **Daily loops** → a compact 4-week mini Flight Trail (single row).


### PR DESCRIPTION
Design wave **2/4** — the Activity page Kept refresh.

- **Sticky day headers** (Today / Yesterday / Tue, Jun 9) replace the flat 200-row stream.
- **Tinted icon chip per action type** — created ⊕, completed ✓, deleted 🗑, status ⇄, edited ✎, snoozed 🕓, error ⚠ — each in its tone color on a soft tinted circle.
- **Title-first hierarchy**: task title primary, action + time-ago as the meta line; Restore pill right-aligned on deleted rows.
- Search, All/Deleted/Errors filters, and AI-assisted search unchanged.
- Styled entirely on `--v2-*` tokens, so the Kept palette flows through with **no override CSS** (K4 rule) — Standard and Wallaby inherit the same cleanup.

Verified live in the harness (kept-dark): three day groups render, 10 icon chips, Restore intact. Screenshot in thread.

https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR)_