### PR TITLE
fix(ui): Loops page speaks one visual language — dailies join the chips [S]

### DIFF
--- a/src/kept/LoopsView.jsx
+++ b/src/kept/LoopsView.jsx
@@ -1,6 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
 import { Repeat2, Pencil, Sparkle } from 'lucide-react'
-import FlightTrail from './FlightTrail'
 import MonthDots from './MonthDots'
 import DensityRibbon from './DensityRibbon'
 import CycleChips from './CycleChips'
@@ -71,10 +70,11 @@ export default function LoopsView({ routines = [], onEditLoop, onAddLoop, onOpen
             </button>
           </div>
           {range === 'trail' && (() => {
-            // Cadence-fit visuals (§13a): the day-grid only made sense for
-            // multi-step dailies. Dailies get a compact 4-week mini trail;
-            // habit loops get target-aware cycle chips; everything else gets
-            // one chip per cadence window.
+            // Cadence-fit visuals (§13a): ONE language for every card —
+            // cycle chips. Dailies get one chip per day, habit loops get
+            // target-aware chips, everything else one chip per cadence
+            // window. (The daily mini-trail exception made the page speak
+            // two visual languages at once — prod report 2026-06-11.)
             if (r.spawn_mode === 'habit' && r.target_count) {
               const wins = habitWindows(r, 12)
               const cur = wins[wins.length - 1]
@@ -85,22 +85,21 @@ export default function LoopsView({ routines = [], onEditLoop, onAddLoop, onOpen
                 <CycleChips
                   windows={wins}
                   target={r.target_count}
-                  caption={`this ${periodWord} ${cur?.hits ?? 0}/${r.target_count} · target met ${met} of last ${past.length} ${periodWord}s`}
+                  caption={`this ${periodWord} ${cur?.hits ?? 0}/${r.target_count} · target met ${met} of last ${past.length} ${periodWord}${past.length === 1 ? '' : 's'}`}
                 />
               )
-            }
-            if (r.cadence === 'daily') {
-              return <FlightTrail valueByDay={byDay} color={color} weeks={4} mini />
             }
             const wins = cycleWindows(r, 12)
             const past = wins.filter(w => !w.current)
             const caught = past.filter(w => w.caught).length
             const cur = wins[wins.length - 1]
+            const unit = cycleUnitLabel(r, past.length === 1)
+            const nowWord = r.cadence === 'daily' ? 'today' : 'this one'
             return (
               <CycleChips
                 windows={wins}
                 caption={past.length > 0
-                  ? `caught ${caught} of last ${past.length} ${cycleUnitLabel(r)}${cur?.caught ? ' · this one ✓' : ''}`
+                  ? `caught ${caught} of last ${past.length} ${unit}${cur?.caught ? ` · ${nowWord} ✓` : ''}`
                   : 'first cycle in flight'}
               />
             )

--- a/src/kept/cycles.js
+++ b/src/kept/cycles.js
@@ -24,7 +24,14 @@ export function cycleWindows(routine, count = 12) {
   const stamps = (routine.completed_history || [])
     .map(ts => new Date(ts))
     .filter(d => Number.isFinite(d.getTime()))
-  const created = routine.created_at ? new Date(routine.created_at) : null
+  // Anchor: creation date, falling back to the oldest history stamp for
+  // legacy rows without created_at — otherwise the series collapses to a
+  // single "first cycle" window despite months of history.
+  let created = routine.created_at ? new Date(routine.created_at) : null
+  if ((!created || !Number.isFinite(created.getTime())) && stamps.length > 0) {
+    created = new Date(Math.min(...stamps.map(d => d.getTime())))
+  }
+  if (created && !Number.isFinite(created.getTime())) created = null
   const today = new Date(); today.setHours(0, 0, 0, 0)
 
   const stepDays = cadence === 'daily' ? 1
@@ -94,18 +101,20 @@ export function habitWindows(routine, count = 12, weekStartsOn = 1) {
   return windows
 }
 
-export function cycleUnitLabel(routine) {
+export function cycleUnitLabel(routine, singular = false) {
   const c = routine.cadence
-  if (c === 'daily') return 'days'
-  if (c === 'weekly') return 'weeks'
-  if (c === 'monthly') return 'months'
-  if (c === 'quarterly') return 'quarters'
-  if (c === 'annually') return 'years'
+  const plural = (w) => (singular ? w : `${w}s`)
+  if (c === 'daily') return plural('day')
+  if (c === 'weekly') return plural('week')
+  if (c === 'monthly') return plural('month')
+  if (c === 'quarterly') return plural('quarter')
+  if (c === 'annually') return plural('year')
   if (c === 'custom') {
     const n = Math.max(1, routine.custom_days || (routine.custom_unit === 'months' ? 1 : 7))
-    return routine.custom_unit === 'months'
-      ? (n === 1 ? 'months' : `${n}-month cycles`)
-      : `${n}-day cycles`
+    if (routine.custom_unit === 'months') {
+      return n === 1 ? plural('month') : `${n}-month ${plural('cycle')}`
+    }
+    return `${n}-day ${plural('cycle')}`
   }
-  return 'cycles'
+  return plural('cycle')
 }

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,10 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-11
 
+- fix(ui): Loops page speaks one visual language — dailies join the cycle chips [S]
+  - Prod report: "Why in the world are there two entirely different design strategies on the loops page?" — the daily mini-trail exception from wave 1 put dot-rows next to chunky chips on the same surface. Dailies now render cycle chips like everything else (one chip per day, "caught 8 of last 11 days · today ✓"); the FlightTrail leaves the Loops cards entirely.
+  - Also: caption pluralization fixed ("caught 1 of last 1 months" → singular units), and the window anchor falls back to the oldest history stamp for legacy loops without created_at.
+
 - feat(ui): loop editor — progressive disclosure (design wave 3/4, part 1) [M]
   - The "reskinned v2 form" complaint (§13b): the loop editor now shows only the decisions you actually make — title, mode, frequency/day, time (or target count for habits) — with everything else behind hairline disclosure rows that expand in place: **More options** (end date, priority, auto-roll, last-done repair), **Stack items**, **Follow-ups**, **Labels & notes**. Collapsed rows summarize their contents ("last done 2026-06-11", "3 items"); rows with content open by default when editing. Submit says "Create loop" in Kept.
   - New `FormDisclosure` primitive in RoutinesModal + `v2-form-disclosure-*` styles on shared tokens — all themes inherit, no override CSS, zero logic changes (every field/handler preserved verbatim).


### PR DESCRIPTION
Prod report: *"These don't make any sense together. Why in the world are there two entirely different design strategies on the loops page?"* — correct call. The daily mini-trail exception from wave 1 left dot-rows (IFR Studying) next to chunky cycle chips (everything else) on the same page.

- **Dailies now render cycle chips like every other cadence** — one chip per day, caption `caught 8 of last 11 days · today ✓`. The FlightTrail leaves the Loops cards entirely (Month/Year drill-downs unchanged).
- Caption grammar fixed (`caught 1 of last 1 months` → singular units via `cycleUnitLabel(routine, singular)`).
- The window anchor falls back to the oldest history stamp for legacy loops without `created_at` (otherwise they collapsed to a single "first cycle" window).

Verified live: seeded daily-with-history renders 12 chips / 9 caught with the right caption alongside the weekly/monthly/habit cards.

https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR)_