### PR TITLE
release: achievements expansion (design wave 4/4 — wave complete)

### DIFF
--- a/server.js
+++ b/server.js
@@ -341,13 +341,14 @@ function mergeDurableStreakSettings(prevSettings, nextSettings) {
       console.log(`[SYNC] ${key} guard: restored ${merged.length - next.length} entries dropped by incoming blob`)
     }
   }
-  const prevEggs = prevSettings?.easter_egg_wins
-  if (prevEggs && Object.keys(prevEggs).length > 0) {
-    const nextEggs = nextSettings.easter_egg_wins || {}
-    const missing = Object.keys(prevEggs).filter(k => !(k in nextEggs))
+  for (const key of ['easter_egg_wins', 'badges_earned']) {
+    const prevMap = prevSettings?.[key]
+    if (!prevMap || Object.keys(prevMap).length === 0) continue
+    const nextMap = nextSettings[key] || {}
+    const missing = Object.keys(prevMap).filter(k => !(k in nextMap))
     if (missing.length > 0) {
-      nextSettings.easter_egg_wins = { ...prevEggs, ...nextEggs }
-      console.log(`[SYNC] easter_egg_wins guard: restored ${missing.length} day(s) dropped by incoming blob`)
+      nextSettings[key] = { ...prevMap, ...nextMap }
+      console.log(`[SYNC] ${key} guard: restored ${missing.length} entr${missing.length === 1 ? 'y' : 'ies'} dropped by incoming blob`)
     }
   }
 }

--- a/src/badges.js
+++ b/src/badges.js
@@ -1,10 +1,15 @@
-// Local, self-derived achievements — NO new data/schema. Everything here is
-// computed from data the app already tracks (done tasks, streaks, daily records,
-// routine completion history, the analytics daily series). Theme-agnostic: this
-// is shared logic surfaced in every skin (Analytics for all, Profile in Wallaby).
+// Local, self-derived achievements surfaced in every skin (Analytics for all,
+// Profile in Wallaby). Progress is computed live from data the app already
+// tracks — but EARNED STATE IS DURABLE: the first time a badge computes as
+// earned, its id + date are stamped into settings.badges_earned (key-union
+// guarded server-side), so deleting the underlying rows can never un-earn an
+// achievement. See Derived-Stat Durability Rules in CLAUDE.md.
 //
-// Each badge: { id, name, desc, emoji, tier, earned, current, target }.
-// `tier` drives display color: bronze | silver | gold.
+// Each badge: { id, name, desc, emoji, tier, earned, earnedOn?, current,
+// target, hidden? }. `tier` drives display color: bronze | silver | gold.
+// `hidden` badges render as mystery cards until earned.
+
+import { loadSettings, saveSettings, localYMD } from './store'
 
 // Longest run of consecutive calendar days with any completion, from the
 // analytics daily series ([{ day:'YYYY-MM-DD', tasks, points }]).
@@ -20,10 +25,23 @@ function longestActiveRun(daily) {
   return best
 }
 
-// Build the full badge list with earned state + progress. All inputs are
-// already computed elsewhere — pass them in (lifetimeDone is a count, history
-// is the analytics daily series [{day,tasks,points}]).
-export function computeBadges({ lifetimeDone = 0, routines = [], records = {}, streak = 0, history = [] } = {}) {
+const ENERGY_TYPE_COUNT = 6 // desk, people, errand, confrontation, creative, physical
+
+// Per-day buckets of completed tasks (local days), reused by several badges.
+function completionsByDay(doneTasks) {
+  const map = {}
+  for (const t of doneTasks) {
+    const key = localYMD(new Date(t.completed_at))
+    if (!map[key]) map[key] = []
+    map[key].push(t)
+  }
+  return map
+}
+
+// Build the full badge list with earned state + progress. `tasks` powers the
+// task-shaped badges; surfaces without the task list (Wallaby Profile) still
+// show durable earned state from settings.badges_earned.
+export function computeBadges({ lifetimeDone = 0, routines = [], records = {}, streak = 0, history = [], tasks = [] } = {}) {
   const bestStreak = Math.max(streak || 0, records?.longestStreak || 0)
   const bestDayTasks = records?.bestTasks || 0
   const bestDayPoints = records?.bestPoints || 0
@@ -31,10 +49,63 @@ export function computeBadges({ lifetimeDone = 0, routines = [], records = {}, s
   const totalPoints = (history || []).reduce((n, d) => n + (d.points || 0), 0)
   const activeRun = longestActiveRun(history)
 
-  const mk = (id, name, desc, emoji, tier, current, target) =>
-    ({ id, name, desc, emoji, tier, current, target, earned: current >= target })
+  const done = (tasks || []).filter(t => t.status === 'done' && t.completed_at)
+  const byDay = completionsByDay(done)
+  const days = Object.values(byDay)
 
-  return [
+  // Recovery + honesty + pattern signals
+  const cameBack = done.filter(t => t.created_at
+    && (new Date(t.completed_at) - new Date(t.created_at)) >= 30 * 86400000).length
+  const dragonsSlain = done.filter(t => t.energy === 'confrontation' && t.energyLevel === 3).length
+  const dawnBest = Math.max(0, ...days.map(d =>
+    d.filter(t => new Date(t.completed_at).getHours() < 8).length))
+  const nightCatches = done.filter(t => new Date(t.completed_at).getHours() >= 22).length
+  const heavyBest = Math.max(0, ...days.map(d =>
+    d.filter(t => t.size === 'L' || t.size === 'XL').length))
+  const stackBonuses = done.filter(t => (t.stack_bonus || 0) > 0).length
+  const setAside = (tasks || []).filter(t => t.snooze_indefinite).length
+
+  // Best Sat+Sun weekend total.
+  let weekendBest = 0
+  for (const [key, list] of Object.entries(byDay)) {
+    const d = new Date(key + 'T12:00:00')
+    if (d.getDay() !== 6) continue // anchor on Saturdays
+    const sun = new Date(d); sun.setDate(sun.getDate() + 1)
+    const sunKey = localYMD(sun)
+    weekendBest = Math.max(weekendBest, list.length + (byDay[sunKey]?.length || 0))
+  }
+
+  // Most distinct energy types caught within a single Mon-Sun week.
+  const weekTypes = {}
+  for (const t of done) {
+    if (!t.energy) continue
+    const d = new Date(t.completed_at); d.setHours(0, 0, 0, 0)
+    const diff = (d.getDay() + 6) % 7 // Monday-anchored
+    d.setDate(d.getDate() - diff)
+    const wk = localYMD(d)
+    if (!weekTypes[wk]) weekTypes[wk] = new Set()
+    weekTypes[wk].add(t.energy)
+  }
+  const balancedBest = Math.max(0, ...Object.values(weekTypes).map(s => s.size))
+
+  // A quarterly+ loop kept alive for a year (history span).
+  let longHaulDays = 0
+  for (const r of routines || []) {
+    if (!['quarterly', 'annually'].includes(r.cadence)) continue
+    const hist = (r.completed_history || []).map(ts => new Date(ts).getTime()).filter(Number.isFinite)
+    if (hist.length < 2) continue
+    longHaulDays = Math.max(longHaulDays, Math.round((Math.max(...hist) - Math.min(...hist)) / 86400000))
+  }
+
+  // Phoenix: you lost a 14+ day rally and built a new 7+ day one from the
+  // ashes. Only detectable while the new rally is shorter than the old best;
+  // the durable earn stamp makes the moment permanent.
+  const phoenix = (records?.longestStreak || 0) >= 14 && streak >= 7 && streak < records.longestStreak ? 1 : 0
+
+  const mk = (id, name, desc, emoji, tier, current, target, hidden = false) =>
+    ({ id, name, desc, emoji, tier, current, target, earned: current >= target, hidden })
+
+  const badges = [
     mk('first_step', 'First Step', 'Complete your first task', '🌱', 'bronze', lifetimeDone, 1),
     mk('getting_going', 'Getting Going', 'Complete 10 tasks', '🚀', 'bronze', lifetimeDone, 10),
     mk('century', 'Century', 'Complete 100 tasks', '💯', 'silver', lifetimeDone, 100),
@@ -47,7 +118,49 @@ export function computeBadges({ lifetimeDone = 0, routines = [], records = {}, s
     mk('point_storm', 'Point Storm', '100 points in one day', '⛈️', 'gold', bestDayPoints, 100),
     mk('habit_former', 'Habit Former', 'A habit logged 30 times', '🌿', 'silver', topHabit, 30),
     mk('point_collector', 'Point Collector', 'Earn 1,000 points', '💎', 'gold', totalPoints, 1000),
+    // Recovery class — the Boomerang signature set.
+    mk('it_comes_back', 'It Comes Back', 'Catch a task 30+ days old', '🪃', 'silver', cameBack, 1, true),
+    mk('phoenix', 'Phoenix', 'Lose a 14+ day rally, then build a 7-day one from the ashes', '🔆', 'gold', phoenix, 1, true),
+    mk('strategic_retreat', 'Strategic Retreat', 'Set aside 5 tasks — knowing your limits is a skill', '🏳️', 'bronze', setAside, 5),
+    // Energy class.
+    mk('dragon_slayer', 'Dragon Slayer', 'Catch a ⚡⚡⚡ confrontation task', '🐉', 'silver', dragonsSlain, 1),
+    mk('balanced_diet', 'Balanced Diet', 'Catch every energy type in one week', '🥗', 'gold', balancedBest, ENERGY_TYPE_COUNT),
+    mk('heavy_lifting', 'Heavy Lifting', '3 L or XL tasks in one day', '🏋️', 'silver', heavyBest, 3),
+    // Time-of-day / pattern class.
+    mk('dawn_patrol', 'Dawn Patrol', '3 catches before 8am in one day', '🌅', 'bronze', dawnBest, 3),
+    mk('night_shift', 'Night Shift', 'A catch after 10pm', '🌙', 'bronze', nightCatches, 1, true),
+    mk('weekend_warrior', 'Weekend Warrior', '10 catches in one weekend', '🛠️', 'silver', weekendBest, 10),
+    // Loop class.
+    mk('stack_champion', 'Stack Champion', 'Earn 10 stack clear-bonuses', '📦', 'silver', stackBonuses, 10),
+    mk('long_haul', 'Long Haul', 'Keep a quarterly+ loop alive for a year', '🛤️', 'gold', longHaulDays, 365),
   ]
+
+  // Durable earned state: once stamped, a badge stays earned no matter what
+  // happens to the rows that earned it.
+  const earnedMap = loadSettings()?.badges_earned || {}
+  for (const b of badges) {
+    if (earnedMap[b.id]) {
+      b.earned = true
+      b.earnedOn = earnedMap[b.id]
+      b.current = Math.max(b.current, b.target)
+    }
+  }
+  return badges
+}
+
+// Stamp newly-earned badges into durable settings. Called by BadgesGrid on
+// render (the single shared surface) — returns the freshly earned list so a
+// caller could celebrate. saveSettings flows to the server via the normal
+// settings sync; the server key-union guard protects it from stale blobs.
+export function stampEarnedBadges(badges) {
+  const fresh = badges.filter(b => b.earned && !b.earnedOn)
+  if (fresh.length === 0) return []
+  const cur = loadSettings()
+  const map = { ...(cur.badges_earned || {}) }
+  const today = localYMD()
+  for (const b of fresh) { if (!map[b.id]) map[b.id] = today }
+  saveSettings({ ...cur, badges_earned: map })
+  return fresh
 }
 
 export function badgeSummary(badges) {

--- a/src/components/AnalyticsModal.jsx
+++ b/src/components/AnalyticsModal.jsx
@@ -109,7 +109,7 @@ export default function AnalyticsModal({ open, onClose, tasks = [], routines = [
   // Local achievements — derived from data we already have (no new schema).
   const badges = useMemo(() => computeBadges({
     lifetimeDone: tasks.filter(t => t.status === 'done').length,
-    routines, records, streak, history: heatMapData || [],
+    routines, records, streak, history: heatMapData || [], tasks,
   }), [tasks, routines, records, streak, heatMapData])
 
   // Radar spokes derived from history.

--- a/src/components/BadgesGrid.css
+++ b/src/components/BadgesGrid.css
@@ -69,3 +69,9 @@
   font-weight: 700;
   color: var(--v2-text-meta);
 }
+
+/* Hidden achievements — mystery cards until earned */
+.v2-badge-mystery {
+  opacity: 0.55;
+  border-style: dashed;
+}

--- a/src/components/BadgesGrid.jsx
+++ b/src/components/BadgesGrid.jsx
@@ -1,16 +1,25 @@
-import { badgeSummary } from '../badges'
+import { useEffect } from 'react'
+import { badgeSummary, stampEarnedBadges } from '../badges'
 import './BadgesGrid.css'
 
 // Shared, theme-agnostic achievements grid. Earned badges render in their tier
-// color; locked ones are dimmed with a progress bar. No new data — `badges`
-// comes from computeBadges(). Used in AnalyticsModal (all skins) + Wallaby
-// Profile. Sorted earned-first, then by closest-to-earning.
+// color; locked ones are dimmed with a progress bar; HIDDEN badges render as
+// mystery cards until earned. Earned state is stamped durably on first render
+// where a badge qualifies (stampEarnedBadges — see Derived-Stat Durability
+// Rules). Used in AnalyticsModal (all skins) + Wallaby Profile. Sorted
+// earned-first, then closest-to-earning, mysteries last.
 export default function BadgesGrid({ badges = [] }) {
+  // Stamp any freshly-earned badges into durable settings.
+  useEffect(() => { stampEarnedBadges(badges) }, [badges])
+
   if (!badges.length) return null
   const { earned, total } = badgeSummary(badges)
   const sorted = [...badges].sort((a, b) => {
     if (a.earned !== b.earned) return a.earned ? -1 : 1
     if (a.earned) return 0
+    const aMystery = a.hidden ? 1 : 0
+    const bMystery = b.hidden ? 1 : 0
+    if (aMystery !== bMystery) return aMystery - bMystery
     return (b.current / b.target) - (a.current / a.target)
   })
   return (
@@ -20,18 +29,27 @@ export default function BadgesGrid({ badges = [] }) {
       </div>
       <div className="v2-badges-grid">
         {sorted.map(b => {
+          if (b.hidden && !b.earned) {
+            return (
+              <div key={b.id} className="v2-badge v2-badge-mystery" title="Hidden achievement">
+                <span className="v2-badge-emoji">❓</span>
+                <span className="v2-badge-name">???</span>
+                <span className="v2-badge-desc">Hidden — keep playing</span>
+              </div>
+            )
+          }
           const pct = Math.min(100, Math.round((b.current / b.target) * 100))
           return (
             <div
               key={b.id}
               className={`v2-badge v2-badge-${b.tier}${b.earned ? ' is-earned' : ''}`}
-              title={b.earned ? `${b.name} — earned` : `${b.name}: ${b.current}/${b.target}`}
+              title={b.earned ? `${b.name} — earned${b.earnedOn ? ` ${b.earnedOn}` : ''}` : `${b.name}: ${b.current}/${b.target}`}
             >
               <span className="v2-badge-emoji">{b.emoji}</span>
               <span className="v2-badge-name">{b.name}</span>
               <span className="v2-badge-desc">{b.desc}</span>
               {b.earned
-                ? <span className="v2-badge-earned-tag">Earned</span>
+                ? <span className="v2-badge-earned-tag">{b.earnedOn ? `Earned ${b.earnedOn.slice(5).replace('-', '/')}` : 'Earned'}</span>
                 : (
                   <span className="v2-badge-progress">
                     <span className="v2-badge-progress-fill" style={{ width: `${pct}%` }} />

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -4,6 +4,14 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ---
 
+## 2026-06-12
+
+- feat(ui): achievements expansion — 11 new badges + durable earn persistence (design wave 4/4) [M]
+  - **Earned is forever now**: the first render where a badge qualifies stamps `settings.badges_earned[id] = 'YYYY-MM-DD'` (via `stampEarnedBadges` in the shared BadgesGrid); `computeBadges` merges the map so deleting the rows that earned a badge can never un-earn it — the existing 12 badges were silently vulnerable to exactly the deletion class that caused the streak incident. Server-side key-union guard added for `badges_earned` in `mergeDurableStreakSettings`. Earned cards show their date.
+  - **11 new badges** (10/12-earned wall → 23 total): recovery class — 🪃 *It Comes Back* (catch a 30+ day-old task, hidden), 🔆 *Phoenix* (lose a 14+ day rally, build a 7-day one from the ashes, hidden), 🏳️ *Strategic Retreat* (set aside 5 tasks); energy class — 🐉 *Dragon Slayer* (⚡⚡⚡ confrontation catch), 🥗 *Balanced Diet* (every energy type in one week), 🏋️ *Heavy Lifting* (3 L/XL in a day); pattern class — 🌅 *Dawn Patrol* (3 before 8am), 🌙 *Night Shift* (a catch after 10pm, hidden), 🛠️ *Weekend Warrior* (10-catch weekend); loop class — 📦 *Stack Champion* (10 clear-bonuses), 🛤️ *Long Haul* (quarterly+ loop alive a year).
+  - **Hidden badges** render as dashed ❓ mystery cards until earned, then reveal with their tier color.
+  - Verified live: seeded a ⚡⚡⚡ confrontation catch, a 45-day-old completion, and a 10pm catch → Dragon Slayer / It Comes Back / Night Shift earned and revealed, earn map stamped with dates, Phoenix still a mystery card.
+
 ## 2026-06-11
 
 - feat(ui): task editor — progressive disclosure (design wave 3/4, part 2) [M]


### PR DESCRIPTION
Promotes design-wave 4/4 from dev (PR #506): achievements expansion — 11 new badges across recovery/energy/pattern/loop classes (3 hidden as mystery cards), plus durable earn persistence (`badges_earned`, server-guarded) so deletions can never un-earn anything. Verified live before merge.

This completes the design wave: cycle chips, Activity log refresh, both editors on progressive disclosure, achievements.

https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR)_