### PR TITLE
release: Clean Sweep badge (24)

### DIFF
--- a/src/badges.js
+++ b/src/badges.js
@@ -9,7 +9,7 @@
 // target, hidden? }. `tier` drives display color: bronze | silver | gold.
 // `hidden` badges render as mystery cards until earned.
 
-import { loadSettings, saveSettings, localYMD } from './store'
+import { loadSettings, saveSettings, localYMD, parseLocalDate } from './store'
 
 // Longest run of consecutive calendar days with any completion, from the
 // analytics daily series ([{ day:'YYYY-MM-DD', tasks, points }]).
@@ -97,6 +97,19 @@ export function computeBadges({ lifetimeDone = 0, routines = [], records = {}, s
     longHaulDays = Math.max(longHaulDays, Math.round((Math.max(...hist) - Math.min(...hist)) / 86400000))
   }
 
+  // Clean Sweep: today you caught 3+ tasks that were overdue, and nothing
+  // overdue remains. Computed from live state — the durable earn stamp
+  // makes the moment permanent once it happens.
+  const todayKey = localYMD()
+  const todayStart = new Date(); todayStart.setHours(0, 0, 0, 0)
+  const overdueCaughtToday = done.filter(t =>
+    localYMD(new Date(t.completed_at)) === todayKey
+    && t.due_date && parseLocalDate(String(t.due_date).slice(0, 10)) < todayStart).length
+  const overdueRemaining = (tasks || []).filter(t =>
+    ['not_started', 'doing', 'in_progress', 'waiting'].includes(t.status)
+    && t.due_date && parseLocalDate(String(t.due_date).slice(0, 10)) < todayStart).length
+  const cleanSweep = overdueCaughtToday >= 3 && overdueRemaining === 0 ? 1 : 0
+
   // Phoenix: you lost a 14+ day rally and built a new 7+ day one from the
   // ashes. Only detectable while the new rally is shorter than the old best;
   // the durable earn stamp makes the moment permanent.
@@ -122,6 +135,7 @@ export function computeBadges({ lifetimeDone = 0, routines = [], records = {}, s
     mk('it_comes_back', 'It Comes Back', 'Catch a task 30+ days old', '🪃', 'silver', cameBack, 1, true),
     mk('phoenix', 'Phoenix', 'Lose a 14+ day rally, then build a 7-day one from the ashes', '🔆', 'gold', phoenix, 1, true),
     mk('strategic_retreat', 'Strategic Retreat', 'Set aside 5 tasks — knowing your limits is a skill', '🏳️', 'bronze', setAside, 5),
+    mk('clean_sweep', 'Clean Sweep', 'Catch 3+ overdue tasks and end the day with zero overdue', '🧹', 'gold', cleanSweep, 1),
     // Energy class.
     mk('dragon_slayer', 'Dragon Slayer', 'Catch a ⚡⚡⚡ confrontation task', '🐉', 'silver', dragonsSlain, 1),
     mk('balanced_diet', 'Balanced Diet', 'Catch every energy type in one week', '🥗', 'gold', balancedBest, ENERGY_TYPE_COUNT),

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,10 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-12
 
+- feat(ui): 🧹 Clean Sweep — 24th badge, evens out the wall [XS]
+  - Gold, recovery class: catch 3+ overdue tasks and end the day with zero overdue. Computed from live state (overdue caught today + nothing overdue remaining); the durable earn stamp makes the moment permanent.
+  - Verified live: with overdue caught and the board cleared, the badge earned and stamped (`badges_earned.clean_sweep`); while loop-spawned overdue remained it correctly stayed locked.
+
 - feat(ui): achievements expansion — 11 new badges + durable earn persistence (design wave 4/4) [M]
   - **Earned is forever now**: the first render where a badge qualifies stamps `settings.badges_earned[id] = 'YYYY-MM-DD'` (via `stampEarnedBadges` in the shared BadgesGrid); `computeBadges` merges the map so deleting the rows that earned a badge can never un-earn it — the existing 12 badges were silently vulnerable to exactly the deletion class that caused the streak incident. Server-side key-union guard added for `badges_earned` in `mergeDurableStreakSettings`. Earned cards show their date.
   - **11 new badges** (10/12-earned wall → 23 total): recovery class — 🪃 *It Comes Back* (catch a 30+ day-old task, hidden), 🔆 *Phoenix* (lose a 14+ day rally, build a 7-day one from the ashes, hidden), 🏳️ *Strategic Retreat* (set aside 5 tasks); energy class — 🐉 *Dragon Slayer* (⚡⚡⚡ confrontation catch), 🥗 *Balanced Diet* (every energy type in one week), 🏋️ *Heavy Lifting* (3 L/XL in a day); pattern class — 🌅 *Dawn Patrol* (3 before 8am), 🌙 *Night Shift* (a catch after 10pm, hidden), 🛠️ *Weekend Warrior* (10-catch weekend); loop class — 📦 *Stack Champion* (10 clear-bonuses), 🛤️ *Long Haul* (quarterly+ loop alive a year).


### PR DESCRIPTION
Promotes one badge from dev (PR #508): 🧹 Clean Sweep — catch 3+ overdue and end the day with zero overdue. 24 badges, even wall. Verified live before merge.

https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR)_