### PR TITLE
release: notifications center (K4 pt 1)

### DIFF
--- a/src/AppV2.jsx
+++ b/src/AppV2.jsx
@@ -17,6 +17,7 @@ import SettingsModal from './components/SettingsModal'
 import ProjectsView from './components/ProjectsView'
 import DoneList from './components/DoneList'
 import ActivityLog from './components/ActivityLog'
+import NotificationsModal from './components/NotificationsModal'
 import RoutinesModal from './components/RoutinesModal'
 import WallabyShell from './wallaby/WallabyShell'
 import KeptShell from './kept/KeptShell'
@@ -89,6 +90,7 @@ export default function AppV2() {
   const [showProjects, setShowProjects] = useState(false)
   const [showDone, setShowDone] = useState(false)
   const [showActivityLog, setShowActivityLog] = useState(false)
+  const [showNotifications, setShowNotifications] = useState(false)
   const [showMarkdownImport, setShowMarkdownImport] = useState(false)
   const [updateVersion, setUpdateVersion] = useState(null)
   // SpacesHub is the destination for the Spaces tab. Opens a picker
@@ -512,6 +514,7 @@ export default function AppV2() {
   if (showProjects) activeModals.push('projects')
   if (showDone) activeModals.push('done')
   if (showActivityLog) activeModals.push('activitylog')
+  if (showNotifications) activeModals.push('notifications')
   if (showRoutines) activeModals.push('routines')
   if (showPackages) activeModals.push('packages')
   if (showAdviser) activeModals.push('adviser')
@@ -531,6 +534,7 @@ export default function AppV2() {
     if (showProjects) { setShowProjects(false); return }
     if (showDone) { setShowDone(false); return }
     if (showActivityLog) { setShowActivityLog(false); return }
+    if (showNotifications) { setShowNotifications(false); return }
     if (showRoutines) { setShowRoutines(false); return }
     if (showPackages) { setShowPackages(false); return }
     if (showAdviser) { setShowAdviser(false); return }
@@ -1339,6 +1343,7 @@ export default function AppV2() {
           onOpenProjects={() => setShowProjects(true)}
           onOpenDone={() => setShowDone(true)}
           onOpenActivity={() => setShowActivityLog(true)}
+          onOpenNotifications={() => setShowNotifications(true)}
           onOpenSuggestions={() => setShowSuggestions(true)}
           syncStatus={syncStatus}
           queueLength={queueLength}
@@ -1389,6 +1394,7 @@ export default function AppV2() {
           onOpenProjects={() => setShowProjects(true)}
           onOpenDone={() => setShowDone(true)}
           onOpenActivity={() => setShowActivityLog(true)}
+          onOpenNotifications={() => setShowNotifications(true)}
           onOpenSuggestions={() => setShowSuggestions(true)}
           syncStatus={syncStatus}
           queueLength={queueLength}
@@ -1557,6 +1563,14 @@ export default function AppV2() {
         open={showActivityLog}
         onClose={() => setShowActivityLog(false)}
         onRestore={handleRestore}
+      />
+      <NotificationsModal
+        open={showNotifications}
+        onClose={() => setShowNotifications(false)}
+        onOpenTask={(taskId) => {
+          const t = tasks.find(x => x.id === taskId)
+          if (t) setEditTarget(t)
+        }}
       />
       <RoutinesModal
         open={showRoutines}

--- a/src/components/NotificationsModal.css
+++ b/src/components/NotificationsModal.css
@@ -1,0 +1,55 @@
+/* Notifications center — rides the Activity log's row language; only the
+ * notification-specific bits live here. */
+
+.v2-notif-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 6px;
+}
+
+.v2-notif-markall {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: none;
+  border: none;
+  color: var(--v2-accent);
+  font: 600 12.5px/1 var(--v2-font-body);
+  cursor: pointer;
+  padding: 6px 4px;
+}
+
+.v2-notif-row {
+  width: 100%;
+  background: none;
+  border-left: none;
+  border-right: none;
+  border-top: none;
+  text-align: left;
+  cursor: pointer;
+  font: inherit;
+  color: inherit;
+}
+
+.v2-notif-row.is-unread .v2-activity-title { font-weight: 650; }
+
+.v2-notif-body {
+  font: 400 12.5px/1.4 var(--v2-font-body);
+  color: var(--v2-text-meta);
+  margin-top: 1px;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.v2-notif-dot {
+  flex: 0 0 auto;
+  width: 8px;
+  height: 8px;
+  margin-top: 8px;
+  border-radius: 50%;
+  background: var(--v2-accent);
+}

--- a/src/components/NotificationsModal.jsx
+++ b/src/components/NotificationsModal.jsx
@@ -1,0 +1,153 @@
+import { useEffect, useMemo, useState } from 'react'
+import {
+  Bell, AlertCircle, Clock3, Layers, Package, CloudSun, Sparkles, CheckCheck,
+} from 'lucide-react'
+import { localYMD } from '../store'
+import { getNotifLog, markNotificationTap } from '../api'
+import ModalShell from './ModalShell'
+import EmptyState from './EmptyState'
+import './ActivityLog.css'
+import './NotificationsModal.css'
+
+// Notifications center — the bell's real destination (K4: it used to borrow
+// the Activity log). Reads the existing server notification_log; no new data.
+// Rows reuse the Activity log's day-group + icon-chip language so the two
+// header destinations read as siblings. Tapping a row marks it read and
+// deep-links to its task when one exists.
+
+function typeMeta(type = '') {
+  if (type.includes('overdue') || type.includes('highpri')) return { Icon: AlertCircle, tone: 'var(--v2-alert-overdue)' }
+  if (type.includes('stale')) return { Icon: Clock3, tone: 'var(--v2-alert-high-pri)' }
+  if (type.includes('pileup')) return { Icon: Layers, tone: '#A78BFA' }
+  if (type.includes('package')) return { Icon: Package, tone: '#6B8AFD' }
+  if (type.includes('weather')) return { Icon: CloudSun, tone: '#6B8AFD' }
+  if (type.includes('quokka') || type.includes('adviser')) return { Icon: Sparkles, tone: '#A78BFA' }
+  return { Icon: Bell, tone: '#5DBC9B' }
+}
+
+function ago(iso) {
+  const t = new Date(iso).getTime()
+  if (Number.isNaN(t)) return ''
+  const s = Math.max(0, (Date.now() - t) / 1000)
+  if (s < 60) return 'just now'
+  if (s < 3600) return `${Math.floor(s / 60)}m ago`
+  if (s < 86400) return `${Math.floor(s / 3600)}h ago`
+  return `${Math.floor(s / 86400)}d ago`
+}
+
+function dayLabel(ymd) {
+  const today = localYMD(new Date())
+  if (ymd === today) return 'Today'
+  const y = new Date(); y.setDate(y.getDate() - 1)
+  if (ymd === localYMD(y)) return 'Yesterday'
+  const [yy, mm, dd] = ymd.split('-').map(Number)
+  return new Date(yy, mm - 1, dd).toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' })
+}
+
+export default function NotificationsModal({ open, onClose, onOpenTask }) {
+  const [entries, setEntries] = useState([])
+  const [tab, setTab] = useState('all')
+
+  useEffect(() => {
+    if (!open) return
+    setTab('all')
+    getNotifLog(200).then(d => setEntries(d.entries || [])).catch(() => setEntries([]))
+  }, [open])
+
+  const unread = useMemo(() => entries.filter(e => !e.tapped_at).length, [entries])
+  const shown = tab === 'unread' ? entries.filter(e => !e.tapped_at) : entries
+
+  const groups = useMemo(() => {
+    const out = []
+    for (const e of shown) {
+      const key = localYMD(new Date(e.sent_at))
+      const g = out[out.length - 1]
+      if (g && g.key === key) g.items.push(e)
+      else out.push({ key, items: [e] })
+    }
+    return out
+  }, [shown])
+
+  const markAllRead = () => {
+    const now = new Date().toISOString()
+    setEntries(prev => prev.map(e => (e.tapped_at ? e : { ...e, tapped_at: now })))
+  }
+
+  const handleTap = (entry) => {
+    if (!entry.tapped_at) {
+      setEntries(prev => prev.map(e => (e.id === entry.id ? { ...e, tapped_at: new Date().toISOString() } : e)))
+      if (entry.task_id) markNotificationTap(entry.task_id).catch(() => {})
+    }
+    if (entry.task_id && onOpenTask) {
+      onClose()
+      onOpenTask(entry.task_id)
+    }
+  }
+
+  return (
+    <ModalShell
+      open={open}
+      onClose={onClose}
+      title="Notifications"
+      subtitle={unread > 0 ? `${unread} unread` : undefined}
+      width="wide"
+    >
+      <div className="v2-notif-toolbar">
+        <div className="v2-activity-filters">
+          <button className={`v2-form-seg${tab === 'all' ? ' v2-form-seg-active' : ''}`} onClick={() => setTab('all')}>All</button>
+          <button className={`v2-form-seg${tab === 'unread' ? ' v2-form-seg-active' : ''}`} onClick={() => setTab('unread')}>
+            Unread{unread > 0 ? ` · ${unread}` : ''}
+          </button>
+        </div>
+        {unread > 0 && (
+          <button className="v2-notif-markall" onClick={markAllRead}>
+            <CheckCheck size={14} strokeWidth={2} /> Mark all read
+          </button>
+        )}
+      </div>
+
+      {shown.length === 0 ? (
+        <EmptyState
+          icon={Bell}
+          title={tab === 'unread' ? 'All caught up' : 'No notifications yet'}
+          body={tab === 'unread'
+            ? 'Nothing unread — nicely done.'
+            : 'Nags, package updates, weather alerts, and Quokka plan pings land here as they go out.'}
+        />
+      ) : (
+        <ul className="v2-activity-list">
+          {groups.map(g => (
+            <li key={g.key} className="v2-activity-group">
+              <div className="v2-activity-day">{dayLabel(g.key)}</div>
+              {g.items.map(e => {
+                const { Icon, tone } = typeMeta(e.type)
+                return (
+                  <button
+                    key={e.id}
+                    className={`v2-activity-row v2-notif-row${e.tapped_at ? '' : ' is-unread'}`}
+                    onClick={() => handleTap(e)}
+                  >
+                    <span className="v2-activity-icon" style={{ '--tone': tone }}>
+                      <Icon size={13} strokeWidth={2.2} />
+                    </span>
+                    <div className="v2-activity-body">
+                      <div className="v2-activity-title">{e.title}</div>
+                      {e.body && <div className="v2-notif-body">{e.body}</div>}
+                      <div className="v2-activity-meta-row">
+                        <span className="v2-activity-action" style={{ color: tone }}>
+                          {String(e.type || '').replace(/_/g, ' ')}
+                        </span>
+                        <span className="v2-activity-time">{ago(e.sent_at)} · {e.channel}</span>
+                      </div>
+                    </div>
+                    {!e.tapped_at && <span className="v2-notif-dot" aria-label="Unread" />}
+                  </button>
+                )
+              })}
+            </li>
+          ))}
+        </ul>
+      )}
+    </ModalShell>
+  )
+}

--- a/src/kept/KeptShell.jsx
+++ b/src/kept/KeptShell.jsx
@@ -20,7 +20,7 @@ export default function KeptShell({
   onLogSession, onGmailKeep, onGmailDismiss, onWhatNow, onToggleItem, onUnsnooze,
   onThrow, onOpenFullAdd, onEditLoop, onAddLoop,
   onOpenQuokka, onOpenSettings, onOpenPackages, onOpenAnalytics,
-  onOpenProjects, onOpenDone, onOpenActivity, onOpenSuggestions,
+  onOpenProjects, onOpenDone, onOpenActivity, onOpenSuggestions, onOpenNotifications,
   onRefresh,
   syncStatus = 'synced', queueLength = 0,
 }) {
@@ -65,7 +65,7 @@ export default function KeptShell({
     <div className="bm-shell">
       <KeptHeader
         onQuokka={onOpenQuokka}
-        onBell={onOpenActivity}
+        onBell={onOpenNotifications || onOpenActivity}
         onAvatar={onOpenAnalytics}
         syncStatus={syncStatus}
         queueLength={queueLength}

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,12 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-12
 
+- feat(ui): notifications center — the bell's real destination (K4, part 1) [M]
+  - The Kept header bell opened the Activity log — a borrowed screen. It now opens a real **Notifications** center reading the existing server `notification_log` (no new data): All/Unread tabs with a live unread count, day-grouped rows in the Activity log's icon-chip language (overdue/stale/pile-up/package/weather/Quokka tones), unread dots, two-line body previews, channel + time-ago meta.
+  - **Tap a row** → marks it read (stamps `tapped_at` via the engagement API when task-linked) and deep-links into the task editor. **Mark all read** clears the dots optimistically. Activity log remains in More, unchanged.
+  - New `src/components/NotificationsModal.{jsx,css}`; bell wiring threaded through KeptShell (`onOpenNotifications`).
+  - Verified live with mocked log fixtures: day groups + unread dots render, Unread tab filters (2 of 5), mark-all-read empties it, tapping a task-linked row opens the editor.
+
 - feat(ui): 🧹 Clean Sweep — 24th badge, evens out the wall [XS]
   - Gold, recovery class: catch 3+ overdue tasks and end the day with zero overdue. Computed from live state (overdue caught today + nothing overdue remaining); the durable earn stamp makes the moment permanent.
   - Verified live: with overdue caught and the board cleared, the badge earned and stamped (`badges_earned.clean_sweep`); while loop-spawned overdue remained it correctly stayed locked.


### PR DESCRIPTION
Promotes K4 part 1 from dev (PR #510): the bell opens a real notifications center — All/Unread tabs, day-grouped type-toned rows, tap-to-read with task deep-links, mark-all-read. Activity log stays in More. Verified live before merge.

https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR)_