### PR TITLE
release: loop detail + cycle-true rally (K4 pt 2)

### DIFF
--- a/src/kept/LoopDetail.jsx
+++ b/src/kept/LoopDetail.jsx
@@ -1,0 +1,100 @@
+import { useState } from 'react'
+import { ArrowLeft, Pencil, ChevronLeft, ChevronRight, Repeat2 } from 'lucide-react'
+import MonthDots from './MonthDots'
+import CycleChips from './CycleChips'
+import { cycleWindows, habitWindows, cycleUnitLabel, cycleRally } from './cycles'
+import { historyByDay } from '../wallaby/heatmapUtils'
+import { formatCadence, formatScheduleAnchor } from '../store'
+import './shell.css'
+
+// Loop detail (K4): tapping a loop card lands HERE — rally / best / total
+// stat cards, the cycle-chip trail, and a steppable month calendar — instead
+// of dumping straight into the editor. Edit is a deliberate button.
+export default function LoopDetail({ routine, color, onBack, onEdit }) {
+  const [monthRef, setMonthRef] = useState(() => new Date())
+  if (!routine) return null
+
+  const byDay = historyByDay(routine.completed_history)
+  const total = routine.completed_history?.length || 0
+  const isHabit = routine.spawn_mode === 'habit' && routine.target_count
+
+  // Rally/best are measured in the loop's own CYCLES, not calendar days —
+  // a weekly loop's rally is consecutive weeks caught. Deep window set so
+  // best isn't artificially capped by the visible chip count.
+  const deepWins = isHabit ? habitWindows(routine, 60) : cycleWindows(routine, 60)
+  const { rally, best } = cycleRally(deepWins, isHabit ? routine.target_count : 1)
+  const wins = deepWins.slice(-16)
+  const past = wins.filter(w => !w.current)
+  const target = isHabit ? routine.target_count : 1
+  const met = past.filter(w => w.hits >= target).length
+  const unit = isHabit
+    ? (routine.target_period === 'month' ? 'months' : 'weeks')
+    : cycleUnitLabel(routine, past.length === 1)
+
+  const anchor = formatScheduleAnchor(routine)
+  const meta = isHabit
+    ? `habit · ${routine.target_count}× / ${routine.target_period}`
+    : `${formatCadence(routine)}${anchor ? ` · ${anchor}` : ''}${routine.trigger_time ? ` · ${routine.trigger_time}` : ''}`
+
+  const stepMonth = (dir) => {
+    setMonthRef(m => new Date(m.getFullYear(), m.getMonth() + dir, 1))
+  }
+  const monthLabel = monthRef.toLocaleDateString('en-US', { month: 'long', year: 'numeric' })
+
+  return (
+    <div className="bm-surface bm-loop-detail" style={{ '--loop': color }}>
+      <div className="bm-title-row">
+        <button className="bm-back" onClick={onBack} aria-label="Back to loops">
+          <ArrowLeft size={17} strokeWidth={2.2} />
+        </button>
+        <h1 className="bm-h1 bm-detail-title">{routine.title}</h1>
+        <button className="bm-btn bm-btn-tonal" style={{ marginLeft: 'auto', padding: '9px 14px' }} onClick={() => onEdit?.(routine)}>
+          <Pencil size={13} strokeWidth={2.2} /> Edit
+        </button>
+      </div>
+      <div className="bm-detail-meta">
+        <span className="bm-loop-ring" style={{ width: 24, height: 24 }}><Repeat2 size={12} strokeWidth={2.2} /></span>
+        {meta}{routine.paused ? ' · paused' : ''}
+      </div>
+
+      <div className="bm-stat-row">
+        <div className="bm-stat-card">
+          <div className="bm-stat-num">↻ {rally}</div>
+          <div className="bm-stat-cap">rally</div>
+        </div>
+        <div className="bm-stat-card">
+          <div className="bm-stat-num">{best}</div>
+          <div className="bm-stat-cap">best</div>
+        </div>
+        <div className="bm-stat-card">
+          <div className="bm-stat-num">{total}×</div>
+          <div className="bm-stat-cap">lifetime</div>
+        </div>
+      </div>
+
+      <div className="bm-card">
+        <div className="bm-card-title">Recent cycles</div>
+        <CycleChips
+          windows={wins}
+          target={target}
+          caption={past.length > 0
+            ? `${isHabit ? 'target met' : 'caught'} ${met} of last ${past.length} ${unit}`
+            : 'first cycle in flight'}
+        />
+      </div>
+
+      <div className="bm-card">
+        <div className="bm-card-title bm-month-head">
+          <button className="bm-back" style={{ width: 26, height: 26 }} onClick={() => stepMonth(-1)} aria-label="Previous month">
+            <ChevronLeft size={14} strokeWidth={2.2} />
+          </button>
+          <span style={{ flex: '1 1 auto', textAlign: 'center' }}>{monthLabel}</span>
+          <button className="bm-back" style={{ width: 26, height: 26 }} onClick={() => stepMonth(1)} aria-label="Next month">
+            <ChevronRight size={14} strokeWidth={2.2} />
+          </button>
+        </div>
+        <MonthDots monthRef={monthRef} valueByDay={byDay} color={color} />
+      </div>
+    </div>
+  )
+}

--- a/src/kept/LoopsView.jsx
+++ b/src/kept/LoopsView.jsx
@@ -3,8 +3,9 @@ import { Repeat2, Pencil, Sparkle } from 'lucide-react'
 import MonthDots from './MonthDots'
 import DensityRibbon from './DensityRibbon'
 import CycleChips from './CycleChips'
-import { cycleWindows, habitWindows, cycleUnitLabel } from './cycles'
-import { historyByDay, currentStreak } from '../wallaby/heatmapUtils'
+import LoopDetail from './LoopDetail'
+import { cycleWindows, habitWindows, cycleUnitLabel, cycleRally } from './cycles'
+import { historyByDay } from '../wallaby/heatmapUtils'
 import { routineFeathers } from './feathers'
 import './shell.css'
 
@@ -18,6 +19,9 @@ const RANGES = [
 // Density Ribbon (spec §6). Edit routes to the existing routine editor.
 export default function LoopsView({ routines = [], onEditLoop, onAddLoop, onOpenSuggestions }) {
   const [range, setRange] = useState('trail')
+  // Tapping a card opens the loop DETAIL (K4) — stats + month calendar —
+  // not the editor. Edit is a deliberate button on the detail page.
+  const [detailId, setDetailId] = useState(null)
   // Pending pattern-scan suggestions — drives the dot badge on the
   // Suggestions button so a passive Sunday-scan find still waves at you.
   const [suggestionCount, setSuggestionCount] = useState(0)
@@ -33,9 +37,28 @@ export default function LoopsView({ routines = [], onEditLoop, onAddLoop, onOpen
     const feathers = routineFeathers(routines)
     return routines.filter(r => !r.paused).map(r => {
       const byDay = historyByDay(r.completed_history)
-      return { r, color: feathers[r.id], byDay, rally: currentStreak(byDay), total: r.completed_history?.length || 0 }
+      const isHabit = r.spawn_mode === 'habit' && r.target_count
+      const wins = isHabit ? habitWindows(r, 60) : cycleWindows(r, 60)
+      // Rally in the loop's own cycles (consecutive weeks/months/etc caught),
+      // not calendar days — day-streaks read as 1 forever on non-dailies.
+      const { rally } = cycleRally(wins, isHabit ? r.target_count : 1)
+      return { r, color: feathers[r.id], byDay, rally, total: r.completed_history?.length || 0 }
     })
   }, [routines])
+
+  if (detailId) {
+    const sel = loops.find(l => l.r.id === detailId)
+    if (sel) {
+      return (
+        <LoopDetail
+          routine={sel.r}
+          color={sel.color}
+          onBack={() => setDetailId(null)}
+          onEdit={(r) => { setDetailId(null); onEditLoop?.(r) }}
+        />
+      )
+    }
+  }
 
   return (
     <div className="bm-surface">
@@ -61,7 +84,7 @@ export default function LoopsView({ routines = [], onEditLoop, onAddLoop, onOpen
             <span className="bm-loop-ring" style={{ width: 28, height: 28 }}><Repeat2 size={13} strokeWidth={2.2} /></span>
             <button
               style={{ flex: '1 1 auto', minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', background: 'none', border: 'none', padding: 0, font: 'inherit', color: 'inherit', textAlign: 'left', cursor: 'pointer' }}
-              onClick={() => onEditLoop?.(r)}
+              onClick={() => setDetailId(r.id)}
             >{r.title}</button>
             {rally > 0 && <span className="bm-loop-rally" style={{ fontSize: 11.5 }}>↻ {rally}</span>}
             <span style={{ fontSize: 11.5, fontWeight: 700, color: 'var(--bm-text-meta)' }}>{total}×</span>

--- a/src/kept/cycles.js
+++ b/src/kept/cycles.js
@@ -118,3 +118,22 @@ export function cycleUnitLabel(routine, singular = false) {
   }
   return plural('cycle')
 }
+
+// Consecutive-cycle rally + best, from a window series (oldest -> newest).
+// The CURRENT window only extends the rally when already caught — an
+// in-flight cycle you haven't hit yet doesn't break anything.
+export function cycleRally(windows, target = 1) {
+  const closed = windows.filter(w => !w.current)
+  const cur = windows[windows.length - 1]
+  let rally = cur && cur.current && cur.hits >= target ? 1 : 0
+  for (let i = closed.length - 1; i >= 0; i--) {
+    if (closed[i].hits >= target) rally++
+    else break
+  }
+  let best = 0, run = 0
+  for (const w of closed) {
+    if (w.hits >= target) { run++; best = Math.max(best, run) } else run = 0
+  }
+  if (cur && cur.current && cur.hits >= target) best = Math.max(best, rally)
+  return { rally, best }
+}

--- a/src/kept/shell.css
+++ b/src/kept/shell.css
@@ -565,3 +565,23 @@
 .bm-cycle-chip.is-caught { background: var(--loop, var(--bm-ember)); border-color: transparent; }
 .bm-cycle-chip.is-current { box-shadow: 0 0 0 2px color-mix(in srgb, var(--loop, var(--bm-ember)) 45%, transparent); }
 .bm-cycle-cap { margin-top: 7px; font-size: 11.5px; color: var(--bm-text-meta); font-weight: 600; }
+
+/* Loop detail (LoopDetail.jsx, K4) */
+.bm-detail-title { flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 22px; }
+.bm-detail-meta {
+  display: flex; align-items: center; gap: 8px;
+  margin: -6px 2px 14px;
+  font-size: 12.5px; color: var(--bm-text-meta); font-weight: 600;
+}
+.bm-stat-row { display: flex; gap: 10px; margin-bottom: 14px; }
+.bm-stat-card {
+  flex: 1 1 0;
+  background: var(--bm-card);
+  border: 1px solid var(--bm-hairline);
+  border-radius: 14px;
+  padding: 12px 8px;
+  text-align: center;
+}
+.bm-stat-num { font: 700 19px/1.1 var(--v2-font-display); color: var(--loop, var(--bm-ember)); }
+.bm-stat-cap { margin-top: 3px; font-size: 10.5px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; color: var(--bm-text-meta); }
+.bm-month-head { display: flex; align-items: center; gap: 8px; }

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,11 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-12
 
+- feat(ui): loop detail page + cycle-true rally (K4, part 2) [M]
+  - **Tapping a loop card opens a real detail page** instead of dumping into the editor: back arrow + title + a deliberate Edit button, cadence/anchor/time meta, three stat cards (↻ rally / best / lifetime in the loop's feather color), a 16-chip "Recent cycles" trail, and a steppable month calendar (MonthDots with prev/next). The card's pencil still edits directly.
+  - **Rally and best are now measured in the loop's own cycles** — consecutive weeks/months/intervals caught (`cycleRally` in cycles.js, computed over a 60-window depth) — replacing the calendar-day streak that read "↻ 1" forever on anything non-daily. Card chips and detail agree; the current in-flight cycle extends the rally only once caught and never breaks it.
+  - Verified live: weekly loop with catches 0/7/14 days back reads ↻ 3 on card + detail (best 3, 9× lifetime); month stepper steps; Edit opens the editor; back returns to the list.
+
 - feat(ui): notifications center — the bell's real destination (K4, part 1) [M]
   - The Kept header bell opened the Activity log — a borrowed screen. It now opens a real **Notifications** center reading the existing server `notification_log` (no new data): All/Unread tabs with a live unread count, day-grouped rows in the Activity log's icon-chip language (overdue/stale/pile-up/package/weather/Quokka tones), unread dots, two-line body previews, channel + time-ago meta.
   - **Tap a row** → marks it read (stamps `tapped_at` via the engagement API when task-linked) and deep-links into the task editor. **Mark all read** clears the dots optimistically. Activity log remains in More, unchanged.


### PR DESCRIPTION
Promotes K4 part 2 from dev (PR #512): loop detail page (stat cards, recent-cycles trail, steppable month calendar, deliberate Edit) + cycle-true rally (consecutive cycles caught, not calendar days). Verified live before merge.

https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR)_