### PR TITLE
feat(ui): Flight log — the avatar's real destination (K4 complete) [M]

### DIFF
--- a/src/AppV2.jsx
+++ b/src/AppV2.jsx
@@ -18,6 +18,7 @@ import ProjectsView from './components/ProjectsView'
 import DoneList from './components/DoneList'
 import ActivityLog from './components/ActivityLog'
 import NotificationsModal from './components/NotificationsModal'
+import FlightLog from './kept/FlightLog'
 import RoutinesModal from './components/RoutinesModal'
 import WallabyShell from './wallaby/WallabyShell'
 import KeptShell from './kept/KeptShell'
@@ -91,6 +92,7 @@ export default function AppV2() {
   const [showDone, setShowDone] = useState(false)
   const [showActivityLog, setShowActivityLog] = useState(false)
   const [showNotifications, setShowNotifications] = useState(false)
+  const [showFlightLog, setShowFlightLog] = useState(false)
   const [showMarkdownImport, setShowMarkdownImport] = useState(false)
   const [updateVersion, setUpdateVersion] = useState(null)
   // SpacesHub is the destination for the Spaces tab. Opens a picker
@@ -515,6 +517,7 @@ export default function AppV2() {
   if (showDone) activeModals.push('done')
   if (showActivityLog) activeModals.push('activitylog')
   if (showNotifications) activeModals.push('notifications')
+  if (showFlightLog) activeModals.push('flightlog')
   if (showRoutines) activeModals.push('routines')
   if (showPackages) activeModals.push('packages')
   if (showAdviser) activeModals.push('adviser')
@@ -535,6 +538,7 @@ export default function AppV2() {
     if (showDone) { setShowDone(false); return }
     if (showActivityLog) { setShowActivityLog(false); return }
     if (showNotifications) { setShowNotifications(false); return }
+    if (showFlightLog) { setShowFlightLog(false); return }
     if (showRoutines) { setShowRoutines(false); return }
     if (showPackages) { setShowPackages(false); return }
     if (showAdviser) { setShowAdviser(false); return }
@@ -1344,6 +1348,7 @@ export default function AppV2() {
           onOpenDone={() => setShowDone(true)}
           onOpenActivity={() => setShowActivityLog(true)}
           onOpenNotifications={() => setShowNotifications(true)}
+          onOpenFlightLog={() => setShowFlightLog(true)}
           onOpenSuggestions={() => setShowSuggestions(true)}
           syncStatus={syncStatus}
           queueLength={queueLength}
@@ -1395,6 +1400,7 @@ export default function AppV2() {
           onOpenDone={() => setShowDone(true)}
           onOpenActivity={() => setShowActivityLog(true)}
           onOpenNotifications={() => setShowNotifications(true)}
+          onOpenFlightLog={() => setShowFlightLog(true)}
           onOpenSuggestions={() => setShowSuggestions(true)}
           syncStatus={syncStatus}
           queueLength={queueLength}
@@ -1563,6 +1569,15 @@ export default function AppV2() {
         open={showActivityLog}
         onClose={() => setShowActivityLog(false)}
         onRestore={handleRestore}
+      />
+      <FlightLog
+        open={showFlightLog}
+        onClose={() => setShowFlightLog(false)}
+        tasks={tasks}
+        routines={routines}
+        records={records}
+        streak={streak}
+        dailyStats={dailyStats}
       />
       <NotificationsModal
         open={showNotifications}

--- a/src/kept/FlightLog.jsx
+++ b/src/kept/FlightLog.jsx
@@ -1,0 +1,84 @@
+import { useEffect, useMemo, useState } from 'react'
+import { Flame, Trophy, Star, Zap, Target, CalendarCheck } from 'lucide-react'
+import ModalShell from '../components/ModalShell'
+import BadgesGrid from '../components/BadgesGrid'
+import DensityRibbon from './DensityRibbon'
+import { computeBadges } from '../badges'
+import './shell.css'
+import './flightlog.css'
+
+// Flight log (K4) — the avatar's real destination: your whole arc in one
+// place. Records strip, the year as a Density Ribbon (tasks or points),
+// and the full achievements wall. Reads the analytics daily series; no
+// new data.
+export default function FlightLog({
+  open, onClose,
+  tasks = [], routines = [], records = {}, streak = 0, dailyStats = {},
+}) {
+  const [history, setHistory] = useState([])
+  const [metric, setMetric] = useState('tasks')
+
+  useEffect(() => {
+    if (!open) return
+    fetch('/api/analytics/history?days=365')
+      .then(r => (r.ok ? r.json() : null))
+      .then(d => setHistory(d?.daily || []))
+      .catch(() => setHistory([]))
+  }, [open])
+
+  const lifetimeDone = useMemo(() => tasks.filter(t => t.status === 'done').length, [tasks])
+  const totalPoints = useMemo(() => history.reduce((n, d) => n + (d.points || 0), 0), [history])
+  const valueByDay = useMemo(() => {
+    const m = {}
+    for (const d of history) m[d.day] = metric === 'points' ? (d.points || 0) : (d.tasks || 0)
+    return m
+  }, [history, metric])
+
+  const badges = useMemo(() => computeBadges({
+    lifetimeDone, routines, records, streak, history, tasks,
+  }), [lifetimeDone, routines, records, streak, history, tasks])
+
+  const bestStreak = Math.max(streak || 0, records?.longestStreak || 0)
+  const stats = [
+    { Icon: Flame, label: 'rally', value: `↻ ${streak || 0}` },
+    { Icon: Trophy, label: 'best rally', value: bestStreak },
+    { Icon: Star, label: 'lifetime', value: `${lifetimeDone}×` },
+    { Icon: Zap, label: 'points (yr)', value: totalPoints },
+    { Icon: Target, label: 'best day', value: `${records?.bestTasks || 0}×` },
+    { Icon: CalendarCheck, label: 'today', value: `${dailyStats?.tasksToday ?? 0}×` },
+  ]
+
+  return (
+    <ModalShell open={open} onClose={onClose} title="Flight log" subtitle="Your year, in arcs" width="wide">
+      <div className="bm-fl-stats">
+        {stats.map(s => (
+          <div key={s.label} className="bm-fl-stat">
+            <s.Icon size={14} strokeWidth={2.1} className="bm-fl-stat-icon" />
+            <div className="bm-fl-stat-num">{s.value}</div>
+            <div className="bm-fl-stat-cap">{s.label}</div>
+          </div>
+        ))}
+      </div>
+
+      <div className="bm-fl-year">
+        <div className="bm-fl-year-head">
+          <span className="bm-fl-year-title">Your year</span>
+          <div className="bm-fl-toggle" role="tablist" aria-label="Year metric">
+            <button role="tab" aria-selected={metric === 'tasks'}
+              className={`bm-fl-toggle-btn${metric === 'tasks' ? ' is-active' : ''}`}
+              onClick={() => setMetric('tasks')}>Catches</button>
+            <button role="tab" aria-selected={metric === 'points'}
+              className={`bm-fl-toggle-btn${metric === 'points' ? ' is-active' : ''}`}
+              onClick={() => setMetric('points')}>Points</button>
+          </div>
+        </div>
+        <DensityRibbon valueByDay={valueByDay} />
+      </div>
+
+      <div className="bm-fl-badges">
+        <div className="bm-fl-year-title" style={{ marginBottom: 8 }}>Achievements</div>
+        <BadgesGrid badges={badges} />
+      </div>
+    </ModalShell>
+  )
+}

--- a/src/kept/KeptShell.jsx
+++ b/src/kept/KeptShell.jsx
@@ -20,7 +20,7 @@ export default function KeptShell({
   onLogSession, onGmailKeep, onGmailDismiss, onWhatNow, onToggleItem, onUnsnooze,
   onThrow, onOpenFullAdd, onEditLoop, onAddLoop,
   onOpenQuokka, onOpenSettings, onOpenPackages, onOpenAnalytics,
-  onOpenProjects, onOpenDone, onOpenActivity, onOpenSuggestions, onOpenNotifications,
+  onOpenProjects, onOpenDone, onOpenActivity, onOpenSuggestions, onOpenNotifications, onOpenFlightLog,
   onRefresh,
   syncStatus = 'synced', queueLength = 0,
 }) {
@@ -66,7 +66,7 @@ export default function KeptShell({
       <KeptHeader
         onQuokka={onOpenQuokka}
         onBell={onOpenNotifications || onOpenActivity}
-        onAvatar={onOpenAnalytics}
+        onAvatar={onOpenFlightLog || onOpenAnalytics}
         syncStatus={syncStatus}
         queueLength={queueLength}
       />

--- a/src/kept/flightlog.css
+++ b/src/kept/flightlog.css
@@ -1,0 +1,61 @@
+/* Flight log (FlightLog.jsx, K4) — records strip + year ribbon + badge wall.
+ * Lives in a ModalShell page; bm tokens resolve in every v2 theme via the
+ * palette.css base block. */
+
+.bm-fl-stats {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 10px;
+  margin-bottom: 18px;
+}
+.bm-fl-stat {
+  background: var(--bm-card);
+  border: 1px solid var(--bm-hairline);
+  border-radius: 14px;
+  padding: 11px 8px 9px;
+  text-align: center;
+}
+.bm-fl-stat-icon { color: var(--bm-gold); }
+.bm-fl-stat-num {
+  margin-top: 3px;
+  font: 700 18px/1.1 var(--v2-font-display);
+  color: var(--bm-text);
+}
+.bm-fl-stat-cap {
+  margin-top: 3px;
+  font-size: 10px; font-weight: 700;
+  letter-spacing: 0.08em; text-transform: uppercase;
+  color: var(--bm-text-meta);
+}
+
+.bm-fl-year {
+  background: var(--bm-card);
+  border: 1px solid var(--bm-hairline);
+  border-radius: 16px;
+  padding: 14px 15px;
+  margin-bottom: 18px;
+}
+.bm-fl-year-head {
+  display: flex; align-items: center; justify-content: space-between;
+  margin-bottom: 8px;
+}
+.bm-fl-year-title {
+  font-family: var(--v2-font-display);
+  font-weight: 700; font-size: 14.5px;
+  color: var(--bm-text);
+}
+.bm-fl-toggle { display: flex; gap: 4px; }
+.bm-fl-toggle-btn {
+  border: 1px solid var(--bm-hairline);
+  background: transparent;
+  color: var(--bm-text-meta);
+  border-radius: 999px;
+  padding: 5px 12px;
+  font: 600 11.5px/1 var(--v2-font-body);
+  cursor: pointer;
+}
+.bm-fl-toggle-btn.is-active {
+  background: var(--bm-ember);
+  border-color: var(--bm-ember);
+  color: var(--bm-on-ember);
+}

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,12 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-12
 
+- feat(ui): Flight log — the avatar's real destination (K4 complete) [M]
+  - The Kept header avatar opened Analytics — the last borrowed screen. It now opens the **Flight log**: a six-card records strip (↻ rally / best rally / lifetime / year points / best day / today, gold-iconed), **Your year** as a Density Ribbon with a Catches/Points toggle (arcs not grids, per the spec), and the full achievements wall with earned dates. Reads the analytics daily series; no new data. Analytics keeps its More-menu home.
+  - New `src/kept/FlightLog.{jsx → flightlog.css}`; avatar wiring threaded through KeptShell with the Analytics fallback.
+  - **K4 is complete**: bell → notifications center, loop card → detail page, avatar → Flight log. Every header affordance now leads to its own purpose-built surface.
+  - Verified live: avatar → Flight log with correct stats (records strip matches seeded data), ribbon renders, metric toggle flips, 6/24 badge wall embedded.
+
 - feat(ui): loop detail page + cycle-true rally (K4, part 2) [M]
   - **Tapping a loop card opens a real detail page** instead of dumping into the editor: back arrow + title + a deliberate Edit button, cadence/anchor/time meta, three stat cards (↻ rally / best / lifetime in the loop's feather color), a 16-chip "Recent cycles" trail, and a steppable month calendar (MonthDots with prev/next). The card's pencil still edits directly.
   - **Rally and best are now measured in the loop's own cycles** — consecutive weeks/months/intervals caught (`cycleRally` in cycles.js, computed over a 60-window depth) — replacing the calendar-day streak that read "↻ 1" forever on anything non-daily. Card chips and detail agree; the current in-flight cycle extends the rally only once caught and never breaks it.


### PR DESCRIPTION
**K4 part 3 — Flight log. K4 complete.**

The header avatar opened Analytics — the last borrowed screen in the Kept IA. It now opens the **Flight log**, your whole arc in one place:

- **Records strip** — six gold-iconed cards: ↻ rally · best rally · lifetime catches · year points · best day · today.
- **Your year** — the Density Ribbon (arcs not grids, per the design spec §5.3) with a **Catches / Points** metric toggle.
- **Achievements** — the full 24-badge wall with earned dates, embedded.

Reads the analytics daily series; no new data. Analytics keeps its More-menu home for the deep-dive charts. New `src/kept/FlightLog.jsx` + `flightlog.css`; avatar threaded through KeptShell with an Analytics fallback.

With this, **every Kept header affordance leads to its own purpose-built surface**: Quokka → adviser, bell → notifications center, avatar → Flight log, and loop cards → loop detail. No more borrowed screens.

Verified live: avatar → Flight log with stats matching the seeded data exactly, ribbon renders, metric toggle flips, 6/24 wall embedded. Screenshot in thread.

https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR)_