### PR TITLE
release: Tasks sorting + frosted toast

### DIFF
--- a/src/components/Toast.css
+++ b/src/components/Toast.css
@@ -10,15 +10,21 @@
   top: calc(10px + env(safe-area-inset-top));
   margin: 0 auto;
   z-index: 120; /* above pinned modal controls + shell header */
-  background: var(--v2-text);
-  color: var(--v2-bg);
+  /* Frosted banner (the Kept chrome language — same treatment as the nav
+     bar and the pinned-control underlay) with an ember accent edge. */
+  background: color-mix(in srgb, var(--v2-surface) 86%, transparent);
+  -webkit-backdrop-filter: blur(16px) saturate(1.1);
+  backdrop-filter: blur(16px) saturate(1.1);
+  border: 1px solid var(--v2-hairline);
+  border-left: 3px solid var(--v2-accent);
+  color: var(--v2-text);
   border-radius: 18px;
   padding: 14px 18px;
   display: flex;
   align-items: center;
   gap: 12px;
   max-width: 480px;
-  box-shadow: 0 10px 32px rgba(0, 0, 0, 0.32);
+  box-shadow: 0 10px 32px rgba(0, 0, 0, 0.28);
   cursor: pointer;
   animation: v2-toast-in var(--v2-dur-emphasis) var(--v2-ease-emphasis);
 }
@@ -29,8 +35,8 @@
 }
 
 .v2-toast-reopen {
-  background: var(--v2-accent);
-  color: #fff;
+  border-left-color: var(--v2-alert-high-pri, var(--v2-accent));
+  background: color-mix(in srgb, var(--v2-accent) 14%, var(--v2-surface));
 }
 
 .v2-toast-content {
@@ -55,7 +61,7 @@
   flex-wrap: wrap;
   margin-top: 10px;
   padding-top: 10px;
-  border-top: 1px solid rgba(255, 255, 255, 0.12);
+  border-top: 1px solid var(--v2-hairline);
   background: transparent;
   border-left: none;
   border-right: none;
@@ -84,8 +90,8 @@
 .v2-toast-undo {
   flex: 0 0 auto;
   background: transparent;
-  color: inherit;
-  border: 1px solid rgba(255, 255, 255, 0.25);
+  color: var(--v2-accent);
+  border: 1px solid var(--v2-hairline-strong, var(--v2-hairline));
   border-radius: var(--v2-radius-pill);
   padding: 6px 14px;
   font: 600 12px/1 var(--v2-font-body);
@@ -96,5 +102,5 @@
 }
 
 .v2-toast-undo:hover {
-  background: rgba(255, 255, 255, 0.10);
+  background: color-mix(in srgb, var(--v2-accent) 12%, transparent);
 }

--- a/src/kept/TasksViewKept.jsx
+++ b/src/kept/TasksViewKept.jsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react'
-import { Check, Search, Pencil, Trash2, X, Undo2 } from 'lucide-react'
+import { Check, Search, Pencil, Trash2, X, Undo2, ArrowUpDown } from 'lucide-react'
 import { localYMD, parseLocalDate, addDays } from '../dates'
 import { isSnoozed, formatSnoozeLabel } from '../store'
 import RowSwipe from './RowSwipe'
@@ -24,6 +24,10 @@ export default function TasksViewKept({ tasks = [], labels = [], routines = [], 
   const [collapsed, toggleSection] = useCollapsedSections()
   const labelsById = useMemo(() => { const m = {}; for (const l of labels) m[l.id] = l; return m }, [labels])
   const [labelFilter, setLabelFilter] = useState('all')
+  // Sort modes (prod-requested): 'due' keeps the grouped day-planner view;
+  // the others flatten to a single sorted list within the active tab+filters.
+  const [sortBy, setSortBy] = useState('due')
+  const [sortOpen, setSortOpen] = useState(false)
   // Stack members live in their Today folder (v2 dropped them from the main
   // sections too); they stay visible in Done as records.
   const stackIds = useMemo(() => new Set(
@@ -45,14 +49,28 @@ export default function TasksViewKept({ tasks = [], labels = [], routines = [], 
     })
   }, [tasks, tab, query, labelFilter, stackIds])
 
-  const sections = useMemo(() => groupTasks(visible, tab), [visible, tab])
+  const sections = useMemo(() => {
+    if (sortBy === 'due' || tab === 'done' || tab === 'snoozed') return groupTasks(visible, tab)
+    const sorted = [...visible]
+    if (sortBy === 'newest') sorted.sort((a, b) => (b.created_at || '').localeCompare(a.created_at || ''))
+    else if (sortBy === 'oldest') sorted.sort((a, b) => (a.created_at || '').localeCompare(b.created_at || ''))
+    else if (sortBy === 'az') sorted.sort((a, b) => (a.title || '').localeCompare(b.title || ''))
+    const label = sortBy === 'newest' ? 'Newest first' : sortBy === 'oldest' ? 'Oldest first' : 'A to Z'
+    return sorted.length ? [{ key: `sort-${sortBy}`, label, items: sorted }] : []
+  }, [visible, tab, sortBy])
 
   return (
     <div className="bm-surface">
       <div className="bm-title-row">
         <h1 className="bm-h1">Tasks</h1>
         <button
-          className="bm-back" style={{ marginLeft: 'auto' }}
+          className={`bm-back${sortBy !== 'due' ? ' is-active-sort' : ''}`} style={{ marginLeft: 'auto' }}
+          onClick={() => setSortOpen(o => !o)}
+          aria-label="Sort tasks"
+          aria-expanded={sortOpen}
+        ><ArrowUpDown size={15} strokeWidth={2} /></button>
+        <button
+          className="bm-back"
           onClick={() => { setSearchOpen(o => !o); if (searchOpen) setQuery('') }}
           aria-label="Search tasks"
         ><Search size={16} strokeWidth={2} /></button>
@@ -64,6 +82,13 @@ export default function TasksViewKept({ tasks = [], labels = [], routines = [], 
             onClick={() => setTab(t.id)}>{t.label}</button>
         ))}
       </div>
+      {sortOpen && tab !== 'done' && tab !== 'snoozed' && (
+        <div className="bm-filter-row" aria-label="Sort order">
+          {[['due', 'By due date'], ['newest', 'Newest'], ['oldest', 'Oldest'], ['az', 'A–Z']].map(([id, label]) => (
+            <button key={id} className={`bm-pick bm-pick-sm${sortBy === id ? ' is-on' : ''}`} onClick={() => setSortBy(id)}>{label}</button>
+          ))}
+        </div>
+      )}
       {labels.length > 0 && tab !== 'done' && (
         <div className="bm-filter-row">
           <button className={`bm-pick bm-pick-sm${labelFilter === 'all' ? ' is-on' : ''}`} onClick={() => setLabelFilter('all')}>All</button>

--- a/src/kept/shell.css
+++ b/src/kept/shell.css
@@ -585,3 +585,6 @@
 .bm-stat-num { font: 700 19px/1.1 var(--v2-font-display); color: var(--loop, var(--bm-ember)); }
 .bm-stat-cap { margin-top: 3px; font-size: 10.5px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; color: var(--bm-text-meta); }
 .bm-month-head { display: flex; align-items: center; gap: 8px; }
+
+/* Sort toggle active hint (Tasks tab) */
+.bm-back.is-active-sort { color: var(--bm-ember); border-color: var(--bm-ember); }

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,11 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-12
 
+- feat(ui): Tasks sort modes + Kept-native frosted toast [S]
+  - **Tasks tab sorting** (the queued ask): an ArrowUpDown toggle next to search reveals sort chips — **By due date** (the grouped day-planner default) / **Newest** / **Oldest** / **A–Z**; non-default modes flatten to one sorted section within the active tab + label filter, and the toggle glows ember while a custom sort is active. Done/Snoozed keep their natural orders.
+  - **Toast restyle, the visual half of the earlier overhaul**: the inverted black pill becomes a **frosted banner** — translucent surface + backdrop blur (the same chrome language as the Kept nav and the pinned-control underlay), hairline border, a 3px ember accent edge, ember UNDO pill. Reopen variant tints toward the accent. All on `--v2` tokens, so Standard inherits gracefully.
+  - Verified live: sort chips render, A–Z flattens correctly (first/last alphabetical), toast renders frosted with the ember edge + Next-up row.
+
 - feat(ui): Flight log — the avatar's real destination (K4 complete) [M]
   - The Kept header avatar opened Analytics — the last borrowed screen. It now opens the **Flight log**: a six-card records strip (↻ rally / best rally / lifetime / year points / best day / today, gold-iconed), **Your year** as a Density Ribbon with a Catches/Points toggle (arcs not grids, per the spec), and the full achievements wall with earned dates. Reads the analytics daily series; no new data. Analytics keeps its More-menu home.
   - New `src/kept/FlightLog.{jsx → flightlog.css}`; avatar wiring threaded through KeptShell with the Analytics fallback.


### PR DESCRIPTION
Promotes the small pair from dev (PR #516): Tasks-tab sort modes (due/newest/oldest/A–Z) + the frosted Kept toast with ember accent edge. Verified live before merge.

https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR)_