### PR TITLE
release: desktop Today rail + sidebar parity (K5 pt 1)

### DIFF
--- a/src/kept/KeptDesktop.jsx
+++ b/src/kept/KeptDesktop.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import {
   Home, ListTodo, Repeat2, FolderKanban, BarChart3, Package, Settings,
-  Sparkles, Plus, CheckCircle2, ScrollText, Inbox, Compass,
+  Sparkles, Plus, CheckCircle2, ScrollText, Inbox, Compass, Bell, TrendingUp,
 } from 'lucide-react'
 import Logo from '../components/Logo'
 import { useSyncBounce } from '../hooks/useSyncBounce'
@@ -9,6 +9,7 @@ import TodayView from './TodayView'
 import TasksViewKept from './TasksViewKept'
 import LoopsView from './LoopsView'
 import ThrowSheet from './ThrowSheet'
+import TodayRail from './TodayRail'
 import './shell.css'
 import './desktop.css'
 
@@ -23,6 +24,7 @@ export default function KeptDesktop({
   onThrow, onOpenFullAdd, onEditLoop, onAddLoop,
   onOpenQuokka, onOpenSettings, onOpenPackages, onOpenAnalytics,
   onOpenProjects, onOpenDone, onOpenActivity, onOpenSuggestions,
+  onOpenNotifications, onOpenFlightLog,
   syncStatus = 'synced', queueLength = 0,
 }) {
   const [tab, setTab] = useState('today')
@@ -46,6 +48,8 @@ export default function KeptDesktop({
     { id: 'loops', label: 'Loops', icon: Repeat2 },
   ]
   const navReview = [
+    { label: 'Flight log', icon: TrendingUp, onClick: onOpenFlightLog },
+    { label: 'Notifications', icon: Bell, onClick: onOpenNotifications },
     { label: 'Arcs', icon: FolderKanban, onClick: onOpenProjects },
     { label: 'Caught', icon: CheckCircle2, onClick: onOpenDone },
     { label: 'Analytics', icon: BarChart3, onClick: onOpenAnalytics },
@@ -123,6 +127,13 @@ export default function KeptDesktop({
         </button>
       </aside>
       <main className="bm-main">{surface}</main>
+      {tab !== 'today' && (
+        <TodayRail
+          tasks={tasks} routines={routines}
+          dailyStats={dailyStats} pointsGoal={pointsGoal} streak={streak}
+          onCompleteTask={onCompleteTask} onOpenTask={onOpenTask} onWhatNow={onWhatNow}
+        />
+      )}
       <ThrowSheet
         open={throwOpen}
         onClose={() => setThrowOpen(false)}

--- a/src/kept/TodayRail.jsx
+++ b/src/kept/TodayRail.jsx
@@ -1,0 +1,69 @@
+import { useMemo } from 'react'
+import { Check, Compass } from 'lucide-react'
+import DayArc from './DayArc'
+import { localYMD } from '../dates'
+import { isSnoozed } from '../store'
+import './shell.css'
+import './desktop.css'
+
+const ACTIVE = ['not_started', 'doing', 'waiting', 'in_progress']
+
+// Today rail (K5) — the ambient "what matters right now" column on the
+// desktop command center, visible while you work in Tasks or Loops. Day Arc
+// + stats + today's catchable list; catches ride the canonical handlers.
+export default function TodayRail({
+  tasks = [], routines = [], dailyStats = {}, pointsGoal = 15, streak = 0,
+  onCompleteTask, onOpenTask, onWhatNow,
+}) {
+  const todayKey = localYMD()
+  const stackIds = useMemo(() => new Set(
+    routines.filter(r => Array.isArray(r.members) && r.members.length > 0).map(r => r.id),
+  ), [routines])
+
+  const dueToday = useMemo(() => tasks.filter(t => {
+    if (t.parent_id || t.gmail_pending) return false
+    if (t.routine_id && stackIds.has(t.routine_id)) return false
+    if (!ACTIVE.includes(t.status)) return false
+    if (isSnoozed(t)) return false
+    return t.due_date ? String(t.due_date).slice(0, 10) <= todayKey : false
+  }).slice(0, 12), [tasks, todayKey, stackIds])
+
+  const catches = dailyStats.tasksToday ?? 0
+
+  return (
+    <aside className="bm-rail">
+      <div className="bm-rail-date">
+        {new Date().toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric' })}
+        {streak > 0 && <span className="bm-rally-chip">↻ {streak}</span>}
+      </div>
+      <DayArc value={dailyStats.pointsToday ?? 0} goal={pointsGoal} />
+      <div className="bm-hero-meta" style={{ paddingTop: 4 }}>
+        <span><b>{catches}</b> {catches === 1 ? 'catch' : 'catches'}</span>
+        <span><b>{Math.max(0, pointsGoal - (dailyStats.pointsToday ?? 0))}</b> pts left</span>
+      </div>
+      <button className="bm-btn bm-btn-tonal bm-whatnow" style={{ margin: '10px 0 14px' }} onClick={onWhatNow}>
+        <Compass size={14} strokeWidth={2.1} /> What now?
+      </button>
+
+      <div className="bm-rail-sec">Due today</div>
+      {dueToday.length === 0 ? (
+        <p className="bm-rail-empty">Nothing due — enjoy it.</p>
+      ) : (
+        <div className="bm-rows">
+          {dueToday.map(t => (
+            <div key={t.id} className="bm-row bm-rail-row">
+              <button
+                className={`bm-chk${t.high_priority ? ' is-hi' : ''}`}
+                onClick={() => onCompleteTask?.(t)}
+                aria-label="Catch it"
+              ><Check size={12} strokeWidth={3.2} style={{ opacity: 0 }} /></button>
+              <button className="bm-row-body" onClick={() => onOpenTask?.(t)}>
+                <span className="bm-row-title" style={{ fontSize: 13.5 }}>{t.title}</span>
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </aside>
+  )
+}

--- a/src/kept/desktop.css
+++ b/src/kept/desktop.css
@@ -80,3 +80,28 @@
 /* Centered dialog treatment for sheets on desktop */
 .bm-desktop-sheets .bm-sheet-backdrop { align-items: center; justify-content: center; }
 .bm-desktop-sheets .bm-sheet { max-width: 480px; border-radius: 22px; border: 1px solid var(--bm-hairline); }
+
+/* Today rail (TodayRail.jsx, K5) — ambient today column while working in
+ * Tasks/Loops. */
+.bm-rail {
+  flex: 0 0 290px;
+  border-left: 1px solid var(--bm-hairline);
+  padding: 20px 18px;
+  overflow-y: auto;
+}
+.bm-rail-date {
+  display: flex; align-items: center; gap: 8px;
+  font: 700 14px/1.2 var(--v2-font-display);
+  color: var(--bm-text);
+  margin-bottom: 10px;
+}
+.bm-rail-date .bm-rally-chip { margin-left: auto; }
+.bm-rail-sec {
+  font-size: 10.5px; font-weight: 700;
+  letter-spacing: 0.1em; text-transform: uppercase;
+  color: var(--bm-text-meta);
+  margin: 4px 2px 4px;
+}
+.bm-rail-row { padding: 9px 0; }
+.bm-rail-row .bm-chk { width: 19px; height: 19px; }
+.bm-rail-empty { color: var(--bm-text-meta); font-size: 12.5px; padding: 8px 2px; }

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,12 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-12
 
+- feat(ui): desktop Today rail + sidebar K4 parity (K5 continuation, part 1) [M]
+  - **Today rail**: the Kept desktop command center gains its third column — while working in Tasks or Loops, a 290px right rail keeps today ambient: date + rally chip, the Day Arc, catches/pts-left, a What now button, and the Due-today list with catchable checks (canonical handlers). Hidden on the Today tab, where the full surface IS today.
+  - **Sidebar K4 parity**: Flight log and Notifications rows join the Review section — the K4 destinations were mobile-only until now.
+  - New `src/kept/TodayRail.jsx` + `bm-rail-*` styles in desktop.css.
+  - Verified live at 1440px: rail renders on Tasks (arc + stats + due rows), disappears on Today, sidebar rows open the Flight log and Notifications center.
+
 - feat(ui): Tasks sort modes + Kept-native frosted toast [S]
   - **Tasks tab sorting** (the queued ask): an ArrowUpDown toggle next to search reveals sort chips — **By due date** (the grouped day-planner default) / **Newest** / **Oldest** / **A–Z**; non-default modes flatten to one sorted section within the active tab + label filter, and the toggle glows ember while a custom sort is active. Done/Snoozed keep their natural orders.
   - **Toast restyle, the visual half of the earlier overhaul**: the inverted black pill becomes a **frosted banner** — translucent surface + backdrop blur (the same chrome language as the Kept nav and the pinned-control underlay), hairline border, a 3px ember accent edge, ember UNDO pill. Reopen variant tints toward the accent. All on `--v2` tokens, so Standard inherits gracefully.


### PR DESCRIPTION
Promotes K5 part 1 from dev (PR #518): the desktop Today rail (Day Arc + stats + What now + Due-today list alongside Tasks/Loops) and Flight log + Notifications rows in the sidebar. Verified live at desktop width before merge.

https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR)_