### PR TITLE
feat(ui): Board view mode — Kanban demoted to a mode (K5 complete) [M]

### DIFF
--- a/src/AppV2.jsx
+++ b/src/AppV2.jsx
@@ -1401,6 +1401,7 @@ export default function AppV2() {
           onOpenActivity={() => setShowActivityLog(true)}
           onOpenNotifications={() => setShowNotifications(true)}
           onOpenFlightLog={() => setShowFlightLog(true)}
+          onStatusChange={handleStatusChange}
           onOpenSuggestions={() => setShowSuggestions(true)}
           syncStatus={syncStatus}
           queueLength={queueLength}

--- a/src/kept/BoardView.jsx
+++ b/src/kept/BoardView.jsx
@@ -1,0 +1,88 @@
+import { useMemo, useState } from 'react'
+import { Check } from 'lucide-react'
+import './shell.css'
+import './desktop.css'
+
+const COLUMNS = [
+  { id: 'not_started', label: 'Up next' },
+  { id: 'doing', label: 'Doing' },
+  { id: 'waiting', label: 'Waiting' },
+  { id: 'done', label: 'Done' },
+]
+const ACTIVE = ['not_started', 'doing', 'waiting', 'in_progress']
+
+// Board view mode (K5) — desktop-only status columns with native drag-and-
+// drop. Dragging a card to a column changes its status; dropping on Done
+// catches it through the canonical completion handler (toast, points,
+// undo — everything rides along). Kanban, demoted to a view mode.
+export default function BoardView({ tasks = [], onStatusChange, onToggleComplete, onOpenTask }) {
+  const [dragId, setDragId] = useState(null)
+  const [overCol, setOverCol] = useState(null)
+
+  const cols = useMemo(() => {
+    const m = { not_started: [], doing: [], waiting: [], done: [] }
+    for (const t of tasks) {
+      if (t.status === 'done') { m.done.push(t); continue }
+      if (t.status === 'in_progress' || t.status === 'doing') m.doing.push(t)
+      else if (t.status === 'waiting') m.waiting.push(t)
+      else if (t.status === 'not_started') m.not_started.push(t)
+    }
+    m.done = m.done
+      .sort((a, b) => (b.completed_at || '').localeCompare(a.completed_at || ''))
+      .slice(0, 15)
+    return m
+  }, [tasks])
+
+  const handleDrop = (colId) => {
+    setOverCol(null)
+    if (!dragId) return
+    const task = tasks.find(t => t.id === dragId)
+    setDragId(null)
+    if (!task || task.status === colId) return
+    if (colId === 'done') {
+      if (task.status !== 'done') onToggleComplete?.(task)
+    } else if (task.status === 'done') {
+      onToggleComplete?.(task) // reopen, then place
+      if (colId !== 'not_started') onStatusChange?.(task.id, colId)
+    } else {
+      onStatusChange?.(task.id, colId)
+    }
+  }
+
+  return (
+    <div className="bm-board">
+      {COLUMNS.map(col => (
+        <div
+          key={col.id}
+          className={`bm-board-col${overCol === col.id ? ' is-over' : ''}`}
+          onDragOver={(e) => { e.preventDefault(); setOverCol(col.id) }}
+          onDragLeave={() => setOverCol(o => (o === col.id ? null : o))}
+          onDrop={() => handleDrop(col.id)}
+        >
+          <div className="bm-board-head">
+            {col.label} <span className="bm-sec-n">{cols[col.id].length}</span>
+          </div>
+          <div className="bm-board-cards">
+            {cols[col.id].map(t => (
+              <div
+                key={t.id}
+                className={`bm-board-card${t.status === 'done' ? ' is-done' : ''}${dragId === t.id ? ' is-dragging' : ''}`}
+                draggable
+                onDragStart={() => setDragId(t.id)}
+                onDragEnd={() => { setDragId(null); setOverCol(null) }}
+                onClick={() => onOpenTask?.(t)}
+              >
+                {t.status === 'done' && <Check size={12} strokeWidth={3} className="bm-board-card-chk" />}
+                <span className="bm-board-card-title">{t.title}</span>
+                {t.high_priority && t.status !== 'done' && <span className="bm-board-hi">!</span>}
+              </div>
+            ))}
+            {cols[col.id].length === 0 && <div className="bm-board-empty">Drop here</div>}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export { ACTIVE as BOARD_ACTIVE }

--- a/src/kept/KeptDesktop.jsx
+++ b/src/kept/KeptDesktop.jsx
@@ -24,7 +24,7 @@ export default function KeptDesktop({
   onThrow, onOpenFullAdd, onEditLoop, onAddLoop,
   onOpenQuokka, onOpenSettings, onOpenPackages, onOpenAnalytics,
   onOpenProjects, onOpenDone, onOpenActivity, onOpenSuggestions,
-  onOpenNotifications, onOpenFlightLog,
+  onOpenNotifications, onOpenFlightLog, onStatusChange,
   syncStatus = 'synced', queueLength = 0,
 }) {
   const [tab, setTab] = useState('today')
@@ -66,6 +66,7 @@ export default function KeptDesktop({
         routines={routines}
         onToggleComplete={onCompleteTask} onToggleItem={onToggleItem} onOpenTask={onOpenTask}
         onDelete={onDeleteTask} onReschedule={onRescheduleTask} onUnsnooze={onUnsnooze}
+        boardable onStatusChange={onStatusChange}
       />
     )
   } else if (tab === 'loops') {

--- a/src/kept/TasksViewKept.jsx
+++ b/src/kept/TasksViewKept.jsx
@@ -4,6 +4,7 @@ import { localYMD, parseLocalDate, addDays } from '../dates'
 import { isSnoozed, formatSnoozeLabel } from '../store'
 import RowSwipe from './RowSwipe'
 import Section, { useCollapsedSections } from './Section'
+import BoardView from './BoardView'
 import './shell.css'
 
 const ACTIVE = ['not_started', 'doing', 'waiting', 'in_progress']
@@ -16,8 +17,11 @@ const TABS = [
 
 // Kept "Tasks" — grouped hairline rows, gold circle checks, dot-tags, and the
 // action sheet with reschedule chips ("throw it back") (spec §6).
-export default function TasksViewKept({ tasks = [], labels = [], routines = [], onToggleComplete, onToggleItem, onOpenTask, onDelete, onReschedule, onUnsnooze }) {
+export default function TasksViewKept({ tasks = [], labels = [], routines = [], onToggleComplete, onToggleItem, onOpenTask, onDelete, onReschedule, onUnsnooze, boardable = false, onStatusChange }) {
   const [tab, setTab] = useState('upcoming')
+  // 'list' | 'board' — Board is the desktop view mode (K5): status columns
+  // with drag-and-drop; Kanban demoted to a mode, per the spec.
+  const [view, setView] = useState('list')
   const [query, setQuery] = useState('')
   const [searchOpen, setSearchOpen] = useState(false)
   const [sheetTask, setSheetTask] = useState(null)
@@ -63,8 +67,14 @@ export default function TasksViewKept({ tasks = [], labels = [], routines = [], 
     <div className="bm-surface">
       <div className="bm-title-row">
         <h1 className="bm-h1">Tasks</h1>
+        {boardable && (
+          <div className="bm-view-toggle" role="tablist" aria-label="View mode" style={{ marginLeft: 'auto' }}>
+            <button role="tab" aria-selected={view === 'list'} className={`bm-fl-toggle-btn${view === 'list' ? ' is-active' : ''}`} onClick={() => setView('list')}>List</button>
+            <button role="tab" aria-selected={view === 'board'} className={`bm-fl-toggle-btn${view === 'board' ? ' is-active' : ''}`} onClick={() => setView('board')}>Board</button>
+          </div>
+        )}
         <button
-          className={`bm-back${sortBy !== 'due' ? ' is-active-sort' : ''}`} style={{ marginLeft: 'auto' }}
+          className={`bm-back${sortBy !== 'due' ? ' is-active-sort' : ''}`} style={boardable ? undefined : { marginLeft: 'auto' }}
           onClick={() => setSortOpen(o => !o)}
           aria-label="Sort tasks"
           aria-expanded={sortOpen}
@@ -75,6 +85,7 @@ export default function TasksViewKept({ tasks = [], labels = [], routines = [], 
           aria-label="Search tasks"
         ><Search size={16} strokeWidth={2} /></button>
       </div>
+      {(!boardable || view === 'list') && (
       <div className="bm-seg" role="tablist" aria-label="Task list">
         {TABS.map(t => (
           <button key={t.id} role="tab" aria-selected={tab === t.id}
@@ -82,6 +93,7 @@ export default function TasksViewKept({ tasks = [], labels = [], routines = [], 
             onClick={() => setTab(t.id)}>{t.label}</button>
         ))}
       </div>
+      )}
       {sortOpen && tab !== 'done' && tab !== 'snoozed' && (
         <div className="bm-filter-row" aria-label="Sort order">
           {[['due', 'By due date'], ['newest', 'Newest'], ['oldest', 'Oldest'], ['az', 'A–Z']].map(([id, label]) => (
@@ -110,8 +122,19 @@ export default function TasksViewKept({ tasks = [], labels = [], routines = [], 
         />
       )}
 
-      {sections.length === 0 && <p className="bm-empty">Nothing here.</p>}
-      {sections.map(sec => (
+      {boardable && view === 'board' && (
+        <BoardView
+          tasks={tasks.filter(t => !t.gmail_pending && !t.parent_id
+            && !(t.routine_id && stackIds.has(t.routine_id))
+            && (t.status === 'done' || (ACTIVE.includes(t.status) && !isSnoozed(t)))
+            && (labelFilter === 'all' || (t.tags || []).includes(labelFilter)))}
+          onStatusChange={onStatusChange}
+          onToggleComplete={onToggleComplete}
+          onOpenTask={onOpenTask}
+        />
+      )}
+      {(!boardable || view === 'list') && sections.length === 0 && <p className="bm-empty">Nothing here.</p>}
+      {(!boardable || view === 'list') && sections.map(sec => (
         <div key={sec.key}>
           <Section id={`tasks-${sec.key}`} label={sec.label} count={sec.items.length} collapsed={!!collapsed[`tasks-${sec.key}`]} onToggle={toggleSection}>
           <div className="bm-rows">

--- a/src/kept/desktop.css
+++ b/src/kept/desktop.css
@@ -105,3 +105,50 @@
 .bm-rail-row { padding: 9px 0; }
 .bm-rail-row .bm-chk { width: 19px; height: 19px; }
 .bm-rail-empty { color: var(--bm-text-meta); font-size: 12.5px; padding: 8px 2px; }
+
+/* Board view mode (BoardView.jsx, K5) — status columns with native DnD */
+.bm-view-toggle { display: flex; gap: 4px; }
+.bm-board { display: flex; gap: 14px; align-items: flex-start; }
+.bm-board-col {
+  flex: 1 1 0; min-width: 0;
+  background: var(--bm-card);
+  border: 1px solid var(--bm-hairline);
+  border-radius: 14px;
+  padding: 10px;
+  transition: border-color 120ms ease, background 120ms ease;
+}
+.bm-board-col.is-over {
+  border-color: var(--bm-ember);
+  background: color-mix(in srgb, var(--bm-ember) 6%, var(--bm-card));
+}
+.bm-board-head {
+  font: 700 11px/1 var(--v2-font-body);
+  letter-spacing: 0.1em; text-transform: uppercase;
+  color: var(--bm-text-meta);
+  padding: 4px 4px 10px;
+  display: flex; gap: 6px; align-items: center;
+}
+.bm-board-cards { display: flex; flex-direction: column; gap: 8px; min-height: 60px; }
+.bm-board-card {
+  display: flex; align-items: flex-start; gap: 7px;
+  background: var(--bm-bg);
+  border: 1px solid var(--bm-hairline);
+  border-radius: 10px;
+  padding: 10px 11px;
+  font-size: 13px; font-weight: 550; color: var(--bm-text);
+  cursor: grab;
+}
+.bm-board-card:active { cursor: grabbing; }
+.bm-board-card.is-dragging { opacity: 0.45; }
+.bm-board-card.is-done { opacity: 0.6; }
+.bm-board-card.is-done .bm-board-card-title { text-decoration: line-through; color: var(--bm-text-meta); }
+.bm-board-card-chk { color: var(--bm-ember); flex: 0 0 auto; margin-top: 2px; }
+.bm-board-card-title { flex: 1 1 auto; min-width: 0; }
+.bm-board-hi { color: var(--bm-ember); font-weight: 800; }
+.bm-board-empty {
+  border: 1px dashed var(--bm-hairline-strong);
+  border-radius: 10px;
+  padding: 14px;
+  text-align: center;
+  font-size: 11.5px; color: var(--bm-text-faint);
+}

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,12 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-12
 
+- feat(ui): Board view mode — Kanban demoted to a mode (K5 complete) [M]
+  - The desktop Tasks surface gains a **List | Board** toggle: Board renders Up next / Doing / Waiting / Done as Kept-native columns with native drag-and-drop. Dragging a card between columns changes its status; **dropping on Done catches it** through the canonical completion handler (points, toast, undo all ride along); dragging out of Done reopens. Done column shows the last 15. Label filters compose; the board excludes gmail-pending, children, and stack members like the list does.
+  - New `src/kept/BoardView.jsx` + `bm-board-*` styles; `boardable` + `onStatusChange` threaded through KeptDesktop only (mobile keeps the list).
+  - With the Today rail (part 1) and Board, **K5 is functionally complete** — the remaining spec items (Timeline mode, detail panel, j/k nav) move to the post-teardown polish list.
+  - Verified live at 1440px: 4 columns render with correct counts; dragging "Change furnace filter" onto Done moved it and completed the task server-side.
+
 - feat(ui): desktop Today rail + sidebar K4 parity (K5 continuation, part 1) [M]
   - **Today rail**: the Kept desktop command center gains its third column — while working in Tasks or Loops, a 290px right rail keeps today ambient: date + rally chip, the Day Arc, catches/pts-left, a What now button, and the Due-today list with catchable checks (canonical handlers). Hidden on the Today tab, where the full surface IS today.
   - **Sidebar K4 parity**: Flight log and Notifications rows join the Review section — the K4 destinations were mobile-only until now.


### PR DESCRIPTION
**K5 complete** — Kanban demoted to a view mode, per the spec.

The desktop Tasks surface gets a **List | Board** toggle. Board renders **Up next / Doing / Waiting / Done** as Kept-native columns with native HTML5 drag-and-drop:

- Drag between columns → status change through `handleStatusChange`.
- **Drop on Done → the task is caught** through the canonical completion handler — points, toast copy, undo, streak stamps all ride along.
- Drag out of Done → reopens (and re-statuses if dropped on Doing/Waiting).
- Done column caps at the last 15; label filters compose; gmail-pending/children/stack-members excluded same as the list.

`boardable` + `onStatusChange` are threaded through KeptDesktop only — mobile keeps the list.

With part 1's Today rail, K5 is functionally complete; Timeline mode, the detail panel, and j/k nav move to the post-teardown polish list.

Verified live at 1440×900: four columns with correct counts; dragging "Change furnace filter" onto Done moved the card and completed the task server-side. Screenshot in thread.

https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR)_