### PR TITLE
fix(notion): connect an EXISTING knowledge-base database [M]

### DIFF
--- a/adviserToolsKnowledge.js
+++ b/adviserToolsKnowledge.js
@@ -11,6 +11,7 @@ import {
 import {
   createKnowledgeItem, updateKnowledgeItem, archiveKnowledgeItem,
   restoreKnowledgeItem, refreshKnowledgeIndex, fetchKnowledgeBody,
+  adoptKnowledgeDatabase,
 } from './knowledgeSync.js'
 import { isConnected } from './notionMCPProxy.js'
 
@@ -43,6 +44,34 @@ function ensureNotionConnected() {
 
 export function registerKnowledgeTools() {
   // --- READ ---
+  registerTool({
+    name: 'connect_knowledge_database',
+    description: 'Connect an EXISTING Notion database as the knowledge base (when the user already has one, instead of auto-creating). Accepts the database URL or its 32-character ID. Verifies access, stores the connection, and runs the first index sync. Use this when knowledgeDbConfigured is false and the user points at an existing database — do NOT tell them to paste it into Settings.',
+    schema: {
+      type: 'object',
+      properties: {
+        database_url_or_id: { type: 'string', description: 'Notion database URL (notion.so / app.notion.com links fine) or bare ID.' },
+      },
+      required: ['database_url_or_id'],
+    },
+    preview: (args) => `Connect existing Notion database as the knowledge base: ${args.database_url_or_id}`,
+    execute: async (args, deps) => {
+      const result = await adoptKnowledgeDatabase({
+        databaseId: args.database_url_or_id,
+        getData: deps.kbGetData,
+        setData: deps.kbSetData,
+      })
+      await refreshKnowledgeIndex({ getData: deps.kbGetData, setData: deps.kbSetData }).catch(() => {})
+      return {
+        result,
+        compensation: async () => {
+          deps.kbSetData('notion_knowledge_db_id', null)
+          deps.kbSetData('notion_knowledge_db_url', null)
+        },
+      }
+    },
+  })
+
   registerTool({
     name: 'search_knowledge',
     description: 'Search the user\'s personal knowledge base (Notion-backed). Matches against title, tags, and a short summary. Use BEFORE create_knowledge to dedup — the user dislikes duplicates. Returns up to `limit` items, highest-relevance first.',

--- a/knowledgeSync.js
+++ b/knowledgeSync.js
@@ -119,6 +119,45 @@ export async function ensureKnowledgeDatabase({ parentPageId, getData, setData }
   return { database_id: result.id, url: result.url, created: true }
 }
 
+// Pull a database id out of whatever the user pastes — a full Notion URL
+// (notion.so / app.notion.com, /p/ short links included), a dashed UUID, or
+// the bare 32-hex id. Returns the dashed-UUID form or null.
+export function parseDatabaseId(input) {
+  const raw = String(input || '')
+  const toUuid = (h) => `${h.slice(0, 8)}-${h.slice(8, 12)}-${h.slice(12, 16)}-${h.slice(16, 20)}-${h.slice(20)}`
+  const dashed = raw.match(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i)
+  if (dashed) return dashed[0].toLowerCase()
+  // Bare 32-hex run in the raw string (slug dashes break runs naturally, so
+  // a "Knowledge-<id>" slug can't bleed its trailing letters into the id).
+  const hex = raw.match(/[0-9a-f]{32}/i)
+  if (hex) return toUuid(hex[0].toLowerCase())
+  // Last resort: a single hex-and-dash run that collapses to exactly 32 hex
+  // (ids hand-grouped with dashes in a non-UUID pattern).
+  for (const run of raw.match(/[0-9a-f][0-9a-f-]{30,}[0-9a-f]/gi) || []) {
+    const h = run.replace(/-/g, '').toLowerCase()
+    if (h.length === 32) return toUuid(h)
+  }
+  return null
+}
+
+// Adopt an EXISTING Notion database as the knowledge base (prod report
+// 2026-06-12: there was no path for this at all — the id was only ever
+// written by the auto-create flow, so users with a pre-existing KB were
+// stuck, and re-running setup would have minted a duplicate). Verifies the
+// database is reachable and un-archived before storing the id.
+export async function adoptKnowledgeDatabase({ databaseId, getData, setData }) {
+  const id = parseDatabaseId(databaseId)
+  if (!id) throw new Error('Could not find a database ID in that input — paste the database URL or its 32-character ID.')
+  const db = await notion.getDatabase(id)
+  if (!db) throw new Error('That database is not accessible to the Boomerang Notion connection.')
+  if (db.archived) throw new Error('That database is archived in Notion — restore it first.')
+  setData(KNOWLEDGE_DB_KEY, id)
+  setData(KNOWLEDGE_DB_URL_KEY, db.url || null)
+  await verifyRestAccess(id)
+  console.log(`[Knowledge] Adopted existing Notion database ${id}`)
+  return { database_id: id, url: db.url || null, created: false, adopted: true }
+}
+
 // Query the DB and replace the local cache.
 export async function refreshKnowledgeIndex({ getData, setData }) {
   const dbId = getData(KNOWLEDGE_DB_KEY)

--- a/server.js
+++ b/server.js
@@ -41,7 +41,7 @@ import { registerMiscTools } from './adviserToolsMisc.js'
 import { registerKnowledgeTools } from './adviserToolsKnowledge.js'
 import * as notionMCP from './notionMCP.js'
 import * as notionProxy from './notionMCPProxy.js'
-import {
+import { adoptKnowledgeDatabase,
   ensureKnowledgeDatabase, refreshKnowledgeIndex, fetchKnowledgeBody,
   startKnowledgeRefreshLoop, getKnowledgeStatus,
 } from './knowledgeSync.js'
@@ -1365,6 +1365,20 @@ app.get('/api/knowledge/status', (_req, res) => {
 // One-shot setup: creates the Notion database under a parent page (defaults
 // to the user's existing notion_sync_parent_id) and seeds the local index.
 app.post('/api/knowledge/setup', async (req, res) => {
+  // Two modes: adopt an EXISTING database (body.database_id — URL or id), or
+  // auto-create a fresh one under the sync parent (the original flow).
+  if (req.body?.database_id) {
+    try {
+      const result = await adoptKnowledgeDatabase({ databaseId: req.body.database_id, getData, setData })
+      await refreshKnowledgeIndex({ getData, setData }).catch(err => {
+        console.warn('[Knowledge] initial refresh failed:', err.message)
+      })
+      return res.json(result)
+    } catch (err) {
+      console.error('[Knowledge] adopt failed:', err?.message)
+      return res.status(400).json({ error: err.message || 'Could not connect that database' })
+    }
+  }
   const settings = getData('settings') || {}
   const parentPageId = req.body?.parent_page_id || settings.notion_sync_parent_id || null
   if (!parentPageId) {

--- a/src/api.js
+++ b/src/api.js
@@ -627,10 +627,10 @@ export async function knowledgeStatus() {
   }
 }
 
-export async function knowledgeSetup(parentPageId = null) {
+export async function knowledgeSetup(parentPageId = null, databaseId = null) {
   const res = await fetch('/api/knowledge/setup', {
     method: 'POST', headers: { ...getApiHeaders(), 'Content-Type': 'application/json' },
-    body: JSON.stringify(parentPageId ? { parent_page_id: parentPageId } : {}),
+    body: JSON.stringify(databaseId ? { database_id: databaseId } : parentPageId ? { parent_page_id: parentPageId } : {}),
   })
   const data = await res.json().catch(() => ({}))
   if (!res.ok) throw new Error(data.error || 'Knowledge setup failed')

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -650,6 +650,23 @@ function IntegrationsPanel({
     return () => { cancelled = true }
   }, [statuses.notion?.connected])
 
+  const [kbExistingInput, setKbExistingInput] = useState('')
+  const runKnowledgeAdopt = async () => {
+    setKbError(null)
+    setKbSetupBusy(true)
+    try {
+      const api = await import('../api')
+      const result = await api.knowledgeSetup(null, kbExistingInput.trim())
+      const next = await api.knowledgeStatus()
+      setKbStatus(next || result)
+      setKbExistingInput('')
+    } catch (e) {
+      setKbError(e?.message || 'Could not connect that database')
+    } finally {
+      setKbSetupBusy(false)
+    }
+  }
+
   const runKnowledgeSetup = async () => {
     setKbError(null)
     setKbSetupBusy(true)
@@ -966,9 +983,26 @@ function IntegrationsPanel({
                             </div>
                           </>
                         ) : (
-                          <button className="v2-settings-btn" onClick={runKnowledgeSetup} disabled={kbSetupBusy || !settings.notion_sync_parent_id}>
-                            {kbSetupBusy ? 'Setting up…' : 'Set up Knowledge Base'}
-                          </button>
+                          <>
+                            <button className="v2-settings-btn" onClick={runKnowledgeSetup} disabled={kbSetupBusy || !settings.notion_sync_parent_id}>
+                              {kbSetupBusy ? 'Setting up…' : 'Set up Knowledge Base'}
+                            </button>
+                            <div className="v2-integrations-hint" style={{ marginTop: 10 }}>…or connect an existing database:</div>
+                            <div className="v2-integrations-toggle-row" style={{ gap: 8 }}>
+                              <input
+                                className="v2-form-input"
+                                style={{ flex: '1 1 auto', minWidth: 0 }}
+                                placeholder="Notion database URL or ID"
+                                value={kbExistingInput}
+                                onChange={e => setKbExistingInput(e.target.value)}
+                              />
+                              <button
+                                className="v2-settings-btn"
+                                disabled={kbSetupBusy || !kbExistingInput.trim()}
+                                onClick={runKnowledgeAdopt}
+                              >Connect</button>
+                            </div>
+                          </>
                         )}
                         {kbStatus?.last_sync && <div className="v2-integrations-hint">Last synced {new Date(kbStatus.last_sync).toLocaleString()}</div>}
                         {!settings.notion_sync_parent_id && !kbStatus?.configured && (

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,12 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-12
 
+- fix(notion): connect an EXISTING knowledge-base database — the missing path [M]
+  - Prod report: a user with a pre-existing "Boomerang Knowledge" database had no way to register it — the DB id lives in a standalone server key written ONLY by the auto-create flow, the Settings field Quokka described didn't exist, and Quokka's `update_settings` writes settings-blob keys the server never reads. Re-running setup would have minted a duplicate database.
+  - **Three new paths**: (1) `POST /api/knowledge/setup` accepts `database_id` (URL or bare id) and adopts the existing database after verifying it's reachable and un-archived, then runs the first index sync; (2) Settings → Notion → Knowledge Base gains an "…or connect an existing database" input + Connect button; (3) Quokka gains a `connect_knowledge_database` tool (64th) so "use my existing KB" works conversationally — with compensation clearing the stored id on plan rollback.
+  - `parseDatabaseId` handles dashed UUIDs, bare 32-hex, notion.so slug URLs (where a trailing slug letter must not bleed into the id — caught in unit checks), app.notion.com `/p/` short links, and hand-grouped dashed ids.
+  - Verified: parser unit table (6 shapes), endpoint error paths (garbage input → clear parser message; unreachable Notion → clear connection message), Settings UI in the bundle (section renders inside the Notion-connected gate, which the harness can't enter).
+
 - feat(ui)!: K6 — Wallaby teardown [XL]
   - **`src/wallaby/` is gone** (22 files): WallabyShell + the Home/Habits/Tasks/Profile/Goals/Notifications views, nav, header, ContributionHeatmap, the shared.css de-pill overrides, and the wallaby palette blocks. The Wallaby family is removed from the theme picker, `theme.js`, and the index.html pre-paint map.
   - **Survivors relocated into `src/kept/`** (load-bearing for Kept): `heatmapUtils.js`; `WallabyEditTask` → `QuickEditTask.{jsx,css}` (the Kept mobile quick editor); the `modals/forms/settings/analytics` override sheets with gates narrowed from `:is(wallaby, kept)` to `kept` only; and a new `wb-compat.css` carrying the base `--wb-*` token defaults + the Quokka toolbar `.wb-icon-btn` rules so wb-token components resolve everywhere until the quick editor is rebuilt bm-first.


### PR DESCRIPTION
Prod report: a user with an existing "Boomerang Knowledge" database couldn't connect it, and Quokka talked them in circles.

## Root cause
There was **no path to register an existing database at all**:
- The DB id lives in a standalone server key (`getData('notion_knowledge_db_id')`) written **only** by the auto-create flow.
- The Settings field Quokka described ("enter the URL in the Knowledge Base Database section") didn't exist.
- Quokka's `update_settings` writes the *settings-blob* keys (`settings.notion_knowledge_db_id` — vestigial defaults), which the server never reads — so every attempt looked saved and did nothing.
- Re-running "Set up" would have minted a duplicate database instead of adopting the existing one.

## Fix — three paths to the same adoption flow
1. **API**: `POST /api/knowledge/setup` accepts `database_id` (URL or bare id) → verifies the database is reachable + un-archived via the existing proxy, stores the id/url keys, runs the first index sync.
2. **Settings UI**: the Knowledge Base section gains "…or connect an existing database" — input + Connect, with errors surfaced inline.
3. **Quokka**: new `connect_knowledge_database` tool (the 64th) so "use my existing KB" works conversationally; compensation clears the stored id on plan rollback. The tool description explicitly tells the model not to send users to a Settings field.

`parseDatabaseId` handles dashed UUIDs, bare 32-hex, `notion.so` slug URLs (caught a bleed bug where the slug's trailing letter joined the id after global dash-stripping), `app.notion.com/p/` short links, and hand-grouped dashed ids — 6-shape unit table verified.

## Verification
Parser unit table 6/6; endpoint error paths return clear messages (garbage input → parser message; no Notion connection → connection message); the Settings input is in the bundle (the section renders inside the Notion-connected gate, which the credential-less harness can't enter — the adoption call itself uses the same `notion.getDatabase` the existing verify path uses in prod).

https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR)_