### PR TITLE
fix(notion): KB adoption proves the id is a queryable database [S]

### DIFF
--- a/adviserToolsKnowledge.js
+++ b/adviserToolsKnowledge.js
@@ -61,9 +61,10 @@ export function registerKnowledgeTools() {
         getData: deps.kbGetData,
         setData: deps.kbSetData,
       })
-      await refreshKnowledgeIndex({ getData: deps.kbGetData, setData: deps.kbSetData }).catch(() => {})
+      const refresh = await refreshKnowledgeIndex({ getData: deps.kbGetData, setData: deps.kbSetData })
+        .catch(err => ({ ok: false, error: err.message, count: 0 }))
       return {
-        result,
+        result: { ...result, indexed: refresh?.count ?? 0 },
         compensation: async () => {
           deps.kbSetData('notion_knowledge_db_id', null)
           deps.kbSetData('notion_knowledge_db_url', null)

--- a/knowledgeSync.js
+++ b/knowledgeSync.js
@@ -151,6 +151,22 @@ export async function adoptKnowledgeDatabase({ databaseId, getData, setData }) {
   const db = await notion.getDatabase(id)
   if (!db) throw new Error('That database is not accessible to the Boomerang Notion connection.')
   if (db.archived) throw new Error('That database is archived in Notion — restore it first.')
+  // Prove the id is a QUERYABLE DATABASE before storing it. The MCP
+  // notion-fetch fallback in getDatabase returns content for ANY id —
+  // pages, views, /p/ share-link targets — so getDatabase alone can't
+  // tell (prod incident: a /p/ short-link id "adopted" fine, then every
+  // index query came back empty).
+  let queryOk = false
+  try {
+    const { raw } = await notion.queryDatabase(id)
+    let json = null
+    try { json = typeof raw === 'string' ? JSON.parse(raw) : raw } catch { json = null }
+    if (json && Array.isArray(json.results)) queryOk = true
+    else if (typeof raw === 'string' && /"results"|data[ _-]?source/i.test(raw.slice(0, 600))) queryOk = true
+  } catch { queryOk = false }
+  if (!queryOk) {
+    throw new Error("That ID doesn't behave like a database — it may be a page or a share link. Open the database as a full page in Notion and copy THAT URL; it contains the real database ID.")
+  }
   setData(KNOWLEDGE_DB_KEY, id)
   setData(KNOWLEDGE_DB_URL_KEY, db.url || null)
   await verifyRestAccess(id)

--- a/server.js
+++ b/server.js
@@ -1370,10 +1370,9 @@ app.post('/api/knowledge/setup', async (req, res) => {
   if (req.body?.database_id) {
     try {
       const result = await adoptKnowledgeDatabase({ databaseId: req.body.database_id, getData, setData })
-      await refreshKnowledgeIndex({ getData, setData }).catch(err => {
-        console.warn('[Knowledge] initial refresh failed:', err.message)
-      })
-      return res.json(result)
+      const refresh = await refreshKnowledgeIndex({ getData, setData })
+        .catch(err => ({ ok: false, error: err.message, count: 0 }))
+      return res.json({ ...result, indexed: refresh?.count ?? 0, refresh_error: refresh?.ok === false ? refresh.error : undefined })
     } catch (err) {
       console.error('[Knowledge] adopt failed:', err?.message)
       return res.status(400).json({ error: err.message || 'Could not connect that database' })

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,10 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-12
 
+- fix(notion): KB adoption proves the id is a queryable database + reports indexed count [S]
+  - Round 2 of the existing-KB report: adoption "succeeded" with a `/p/` share-link id but every index query came back empty — `getDatabase`'s MCP `notion-fetch` fallback returns content for ANY id (pages, views, share-link targets), so it can't tell a database from anything else. Adoption now runs a real `queryDatabase` against the id BEFORE storing it and rejects non-databases with a pointed message ("open the database as a full page and copy THAT URL").
+  - The setup response and Quokka's `connect_knowledge_database` result now include the **indexed count**, so "Connected — 2 items" vs a silently empty index is visible at connect time; refresh errors surface instead of being swallowed.
+
 - fix(notion): connect an EXISTING knowledge-base database — the missing path [M]
   - Prod report: a user with a pre-existing "Boomerang Knowledge" database had no way to register it — the DB id lives in a standalone server key written ONLY by the auto-create flow, the Settings field Quokka described didn't exist, and Quokka's `update_settings` writes settings-blob keys the server never reads. Re-running setup would have minted a duplicate database.
   - **Three new paths**: (1) `POST /api/knowledge/setup` accepts `database_id` (URL or bare id) and adopts the existing database after verifying it's reachable and un-archived, then runs the first index sync; (2) Settings → Notion → Knowledge Base gains an "…or connect an existing database" input + Connect button; (3) Quokka gains a `connect_knowledge_database` tool (64th) so "use my existing KB" works conversationally — with compensation clearing the stored id on plan rollback.


### PR DESCRIPTION
Round 2 of the existing-KB report: the connect "worked" but Quokka still saw an empty knowledge base — while the user's real database holds 2 entries.

## Root cause
The adopted id came from an `app.notion.com/p/…` **share link, which doesn't carry the database id**. `getDatabase`'s MCP `notion-fetch` fallback happily returns content for *any* id (pages, views, share-link targets) — and the REST 404 that would have caught it was warn-and-fall-through — so adoption stored a non-database id and every index query against it found nothing. (The user's actual database id is visible in their own server logs: the background refresh has been syncing `742626dd-…` with 2 items.)

## Fix
- **Adoption proves the id is a queryable database before storing it**: a real `queryDatabase` must return a recognizable results shape; otherwise it rejects with *"That ID doesn't behave like a database — it may be a page or a share link. Open the database as a full page in Notion and copy THAT URL."*
- **The indexed count is part of the result**: the setup response and Quokka's `connect_knowledge_database` now report `indexed: N`, so "Connected — 2 items" vs a silent empty index is visible at connect time, and refresh errors surface instead of being swallowed.

Verified the error paths in the harness (no-Notion → clean message); the query-shape validation mirrors the exact parsing the production refresh loop already runs.

https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR)_