### PR TITLE
release: remove decoy KB settings keys

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -47,13 +47,12 @@ export const DEFAULT_SETTINGS = {
   notion_sync_parent_id: '',   // parent page whose children become tasks
   notion_sync_parent_title: '', // display name for the sync parent
   notion_last_sync: null,
-  // Knowledge base — Notion database holding long-term reference items
-  // (where things are kept, decisions, how-tos, people). Boomerang
-  // creates the DB on demand; this stores the resulting page id so we
-  // can re-find it next session. See knowledgeSync.js.
-  notion_knowledge_db_id: '',
-  notion_knowledge_db_url: '',
-  notion_knowledge_last_sync: null,
+  // Knowledge base: the database id/url live in STANDALONE server keys
+  // (app_data 'notion_knowledge_db_id'), NOT in this settings blob. The
+  // decoy blob keys that used to sit here misled Quokka into declaring a
+  // working KB "unconfigured" (its get_settings reads the blob), and the
+  // repair overwrote the real key — removed 2026-06-12. last_sync is a
+  // server-side standalone key too.
   sort_by: 'age',
   daily_task_goal: 3,
   daily_points_goal: 15,

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,9 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-12
 
+- fix(notion): remove the decoy KB settings keys that misled Quokka [XS]
+  - The vestigial `settings.notion_knowledge_db_id/url/last_sync` blob keys (always empty — the real connection lives in standalone server keys) made Quokka's `get_settings` read a WORKING knowledge base as "unconfigured," which kicked off the whole repair spiral that overwrote the real key with a share-link id. The decoys are gone from DEFAULT_SETTINGS; the knowledge tools' own configured-check (the standalone key) is the single truth.
+
 - fix(notion): KB adoption proves the id is a queryable database + reports indexed count [S]
   - Round 2 of the existing-KB report: adoption "succeeded" with a `/p/` share-link id but every index query came back empty — `getDatabase`'s MCP `notion-fetch` fallback returns content for ANY id (pages, views, share-link targets), so it can't tell a database from anything else. Adoption now runs a real `queryDatabase` against the id BEFORE storing it and rejects non-databases with a pointed message ("open the database as a full page and copy THAT URL").
   - The setup response and Quokka's `connect_knowledge_database` result now include the **indexed count**, so "Connected — 2 items" vs a silently empty index is visible at connect time; refresh errors surface instead of being swallowed.


### PR DESCRIPTION
Promotes the decoy-key removal from dev (PR #528): the always-empty KB blob keys that made Quokka misread a working knowledge base as unconfigured are gone.

https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR)_