### PR TITLE
fix(ui): Quokka opens at the latest message [XS]

### DIFF
--- a/src/components/AdviserModal.jsx
+++ b/src/components/AdviserModal.jsx
@@ -198,9 +198,28 @@ export default function AdviserModal({ open, adviser, onClose, onAfterCommit, on
     })
   }, [open, draftSeed])
 
+  // Keep the latest message in view. In Kept's full-page mode the OUTER
+  // .v2-modal is the page scroller — scroll both, or reopening lands the
+  // user at the TOP of their last chat (prod report: "uber annoying").
+  const scrollToLatest = () => {
+    const pane = scrollRef.current
+    if (!pane) return
+    pane.scrollTop = pane.scrollHeight
+    const page = pane.closest('.v2-modal')
+    if (page) page.scrollTop = page.scrollHeight
+  }
   useEffect(() => {
-    if (scrollRef.current) scrollRef.current.scrollTop = scrollRef.current.scrollHeight
+    scrollToLatest()
   }, [messages, status])
+
+  // On open: land at the latest message once the active chat hydrates
+  // (messages arrive async after mount, so a second pass after settle).
+  useEffect(() => {
+    if (!open) return
+    requestAnimationFrame(scrollToLatest)
+    const t = setTimeout(scrollToLatest, 250)
+    return () => clearTimeout(t)
+  }, [open])
 
   // Don't auto-focus the input on modal open — on iOS PWA the keyboard
   // pops immediately and covers half the empty-state typing demo +

--- a/wiki/Kept-Design-Language.md
+++ b/wiki/Kept-Design-Language.md
@@ -480,6 +480,14 @@ containing a scrollable box.
 `wb-icon-btn` toolbar buttons, full-page-ified by override CSS designed
 for forms, not chat.
 
+**(d) Reopen lands at the TOP of the last chat** (prod report: "uber
+annoying — I have to either back out or scroll to the bottom"). The
+auto-scroll effect only fired on message changes and only scrolled the
+INNER pane — on open, messages hydrate async and the outer page scroller
+stayed at the top. Hotfixed 2026-06-12 (scroll both scrollers on open +
+after hydration settle); Q2's single-scroller layout removes the dual-
+scroller problem entirely and adds stick-to-bottom with a "↓ latest" pill.
+
 ### The plan — three phases, independently shippable
 
 **Q1 — Chat engine correctness (no visual change).**

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,10 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-12
 
+- fix(ui): Quokka opens at the latest message [XS]
+  - Reopening Quokka dropped you at the TOP of your last chat (prod report). The auto-scroll only fired on message changes and only moved the inner pane — on open, the chat hydrates async and Kept's outer page scroller stayed at the top. Both scrollers now land at the bottom on open (frame + post-hydration pass) and stay pinned during streaming. Recorded as diagnosis (d) in the Q-plan; Q2's single-scroller layout retires the dual-scroller problem for good.
+  - Verified live: a seeded 29-message chat opens with the newest message in view, both scrollers at bottom.
+
 - docs(design): Quokka surface redesign plan (Q1–Q3) + diagnosis [S]
   - Prod report: chat loses message order, has massive overscroll, and "feels like we bolted v2 into Kept again." All three diagnosed to exact causes (design doc §14): the stream handler updates messages BY POSITION (`slice(0,-1)` replace-last) instead of by identity, the SSE resubscribe replays the whole event buffer with no consumed-index filter, and the chat renders two nested scrollers (the Kept full-page `.v2-modal` scroller wrapping a 60dvh inner pane) inside form-oriented override CSS.
   - Plan: **Q1** chat-engine correctness (message ids, update-by-id, one consumed-event cursor across SSE+poll, strict placeholder lifecycle), **Q2** Kept-native QuokkaSurface (fixed three-row column, one scroller with overscroll containment + stick-to-bottom, ember user bubbles / document-voice replies / gold tool chips / plan card as the hero, frosted composer; desktop 720px column), **Q3** polish (history slide-over, suggestion chips, wb-icon-btn retirement).


### PR DESCRIPTION
Hotfix from the Quokka complaint list — small enough to not wait for the Q2 rebuild.

**Reopening Quokka dropped you at the top of your last chat.** The auto-scroll effect only fired on message *changes* and only moved the inner message pane; on open, the chat hydrates asynchronously and Kept's **outer** full-page scroller stayed parked at the top — so you saw the beginning of the conversation and had to scroll or back out.

Both scrollers (the message pane and the `.v2-modal` page scroller) now land at the bottom on open — once on the next frame, once after a 250ms hydration settle — and stay pinned through streaming.

Recorded as diagnosis **(d)** in the Q-plan (design doc §14); Q2's single-scroller layout removes the dual-scroller problem permanently and adds stick-to-bottom with a "↓ latest" pill.

Verified live: a seeded 29-message chat opens with the newest message in view, both scrollers at bottom.

https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR)_