### PR TITLE
fix(notion): KB adoption reports REST-access failures [S]

### DIFF
--- a/knowledgeSync.js
+++ b/knowledgeSync.js
@@ -55,7 +55,7 @@ async function verifyRestAccess(databaseId) {
   const token = process.env.NOTION_INTEGRATION_TOKEN
   if (!token) {
     console.warn('[Knowledge] No NOTION_INTEGRATION_TOKEN — REST operations (query, block reads) will use MCP fallback only')
-    return
+    return false
   }
   try {
     const res = await fetch(`${NOTION_BASE}/databases/${databaseId}`, {
@@ -66,6 +66,7 @@ async function verifyRestAccess(databaseId) {
     })
     if (res.ok) {
       console.log('[Knowledge] REST access verified — integration token can reach the KB database')
+      return true
     } else if (res.status === 404 || res.status === 403) {
       console.warn(
         `[Knowledge] WARNING: REST integration token CANNOT access the KB database (${res.status}). ` +
@@ -74,9 +75,11 @@ async function verifyRestAccess(databaseId) {
       )
     } else {
       console.warn(`[Knowledge] REST access check returned ${res.status} — may work, may not`)
+      return false
     }
   } catch (err) {
     console.warn('[Knowledge] REST access check failed:', err.message)
+    return false
   }
 }
 
@@ -169,9 +172,9 @@ export async function adoptKnowledgeDatabase({ databaseId, getData, setData }) {
   }
   setData(KNOWLEDGE_DB_KEY, id)
   setData(KNOWLEDGE_DB_URL_KEY, db.url || null)
-  await verifyRestAccess(id)
-  console.log(`[Knowledge] Adopted existing Notion database ${id}`)
-  return { database_id: id, url: db.url || null, created: false, adopted: true }
+  const restAccess = await verifyRestAccess(id)
+  console.log(`[Knowledge] Adopted existing Notion database ${id} (rest_access=${restAccess})`)
+  return { database_id: id, url: db.url || null, created: false, adopted: true, rest_access: restAccess }
 }
 
 // Query the DB and replace the local cache.

--- a/server.js
+++ b/server.js
@@ -1372,7 +1372,13 @@ app.post('/api/knowledge/setup', async (req, res) => {
       const result = await adoptKnowledgeDatabase({ databaseId: req.body.database_id, getData, setData })
       const refresh = await refreshKnowledgeIndex({ getData, setData })
         .catch(err => ({ ok: false, error: err.message, count: 0 }))
-      return res.json({ ...result, indexed: refresh?.count ?? 0, refresh_error: refresh?.ok === false ? refresh.error : undefined })
+      // No REST access = the MCP fallback can only see the database SCHEMA,
+      // never its rows — the index will sit empty no matter how many
+      // entries exist. Tell the user exactly what to do about it.
+      const hint = result.rest_access === false
+        ? 'Connected, but the Notion REST integration cannot read this database — its rows will not index. In Notion: open the database → ⋯ → Connections → add your Boomerang integration, then Sync now.'
+        : undefined
+      return res.json({ ...result, indexed: refresh?.count ?? 0, hint, refresh_error: refresh?.ok === false ? refresh.error : undefined })
     } catch (err) {
       console.error('[Knowledge] adopt failed:', err?.message)
       return res.status(400).json({ error: err.message || 'Could not connect that database' })

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,10 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-12
 
+- fix(notion): KB adoption reports REST-access failures with the share-the-database fix [S]
+  - Mystery solved (verified by fetching the user's database directly): there are TWO "Boomerang Knowledge" databases — the auto-created `742626dd…` (REST-shared, what the server synced) and `ee8d3826…` (the one the user actually uses, holding the real entries, NOT shared with the REST integration). When REST can't see a database, the MCP fallback returns only the SCHEMA — never rows — so the index sits empty while entries exist: the exact "connected but empty / schema instead of content" symptom.
+  - `verifyRestAccess` now returns a boolean, adoption carries `rest_access`, and the setup response includes a pointed hint when REST is blind: *"open the database → ⋯ → Connections → add your Boomerang integration, then Sync now."*
+
 - fix(ui): Quokka opens at the latest message [XS]
   - Reopening Quokka dropped you at the TOP of your last chat (prod report). The auto-scroll only fired on message changes and only moved the inner pane — on open, the chat hydrates async and Kept's outer page scroller stayed at the top. Both scrollers now land at the bottom on open (frame + post-hydration pass) and stay pinned during streaming. Recorded as diagnosis (d) in the Q-plan; Q2's single-scroller layout retires the dual-scroller problem for good.
   - Verified live: a seeded 29-message chat opens with the newest message in view, both scrollers at bottom.


### PR DESCRIPTION
The KB mystery, fully solved — verified by fetching the user's database directly through Notion:

**There are TWO "Boomerang Knowledge" databases.**
- `742626dd…` — the auto-created original. Shared with the REST integration (which is why the server's background sync worked against it), holding the older 2 items.
- `ee8d3826…` — the one the user actually uses, under "🪃 Boomerang Home", holding the real entries (FirstCall / Water Heater / WD-40). **Not shared with the REST integration.**

When REST can't see a database, `queryDatabase` falls back to MCP `notion-fetch` — which returns only the **schema and views, never rows**. That's the exact "connected but empty / showing schema instead of content" symptom: the index legitimately found zero rows because the only channel it had couldn't see them.

## Fix
- `verifyRestAccess` returns a boolean instead of warn-and-forget.
- Adoption results carry `rest_access`, and the setup response includes a pointed hint when REST is blind: *"Connected, but the Notion REST integration cannot read this database — its rows will not index. In Notion: open the database → ⋯ → Connections → add your Boomerang integration, then Sync now."*

User-side resolution: connect `ee8d3826…` + share that database with the Boomerang integration in Notion; the old `742626dd…` duplicate can be archived after eyeballing its 2 items.

https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR)_