### PR TITLE
release: quick editor — Polish + Research inline, decrowded checklist

### DIFF
--- a/src/kept/QuickEditTask.css
+++ b/src/kept/QuickEditTask.css
@@ -155,3 +155,36 @@
 }
 .wb-edit-more { color: var(--wb-text); }
 .wb-edit-delete { color: var(--wb-action-delete); border-color: color-mix(in srgb, var(--wb-action-delete) 40%, transparent); }
+
+/* Crowding pass (prod report: big lists feel crowded) */
+.wb-edit-title { resize: none; overflow: hidden; line-height: 1.25; }
+.wb-edit-sub { padding: 9px 0; border-bottom: 1px solid var(--wb-hairline); }
+.wb-edit-sub:last-of-type { border-bottom: none; }
+.wb-edit-sub-text { line-height: 1.35; }
+.wb-edit-sub-del { opacity: 0.45; }
+.wb-edit-sub-del:hover, .wb-edit-sub-del:active { opacity: 1; }
+
+/* Inline AI actions */
+.wb-edit-ai-row { display: flex; gap: 8px; margin: 2px 0 12px; }
+.wb-edit-ai-pill {
+  display: inline-flex; align-items: center; gap: 6px;
+  background: var(--wb-card-2, var(--wb-card));
+  border: 1px solid var(--wb-hairline);
+  color: var(--wb-text);
+  border-radius: 10px;
+  padding: 7px 12px;
+  font: 600 12px/1 inherit;
+  font-family: inherit;
+  cursor: pointer;
+}
+.wb-edit-ai-pill:disabled { opacity: 0.55; cursor: default; }
+.wb-edit-ai-pill.is-active { border-color: var(--bm-ember, var(--wb-action)); color: var(--bm-ember, var(--wb-action)); }
+.wb-edit-research { display: flex; gap: 8px; align-items: center; margin: 0 0 12px; }
+.wb-edit-research-input {
+  flex: 1 1 auto;
+  background: var(--wb-card-2, var(--wb-card));
+  border: 1px solid var(--wb-hairline);
+  border-radius: 10px;
+  padding: 8px 11px;
+}
+.wb-edit-ai-error { color: var(--bm-danger, #E0455C); font-size: 12px; margin: -6px 0 10px; }

--- a/src/kept/QuickEditTask.jsx
+++ b/src/kept/QuickEditTask.jsx
@@ -1,13 +1,14 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import {
   Trash2, Plus, Check, ChevronDown, Sliders, Sparkles,
-  Monitor, Users, MapPin, Palette, Dumbbell, Zap,
+  Monitor, Users, MapPin, Palette, Dumbbell, Zap, BookOpenText,
 } from 'lucide-react'
 import ModalShell from '../components/ModalShell'
 import AutosaveIndicator from '../components/AutosaveIndicator'
 import DateField from '../components/DateField'
 import { useTaskForm } from '../hooks/useTaskForm'
 import { loadLabels, uuid } from '../store'
+import { researchTask } from '../api'
 import './QuickEditTask.css'
 
 const STATUSES = [
@@ -46,6 +47,29 @@ export default function WallabyEditTask({ task, onSave, onClose, onDelete, onSta
   const [checklists, setChecklists] = useState(Array.isArray(task.checklists) ? task.checklists : [])
   const [openChip, setOpenChip] = useState(null)
   const [newSub, setNewSub] = useState('')
+  // Inline AI actions (prod report: "polish and research functions are
+  // missing unless I go to more options"). Polish rides useTaskForm's
+  // existing handler; Research mirrors the full editor's runner compactly.
+  const [showResearch, setShowResearch] = useState(false)
+  const [researchPrompt, setResearchPrompt] = useState('')
+  const [researching, setResearching] = useState(false)
+  const [researchError, setResearchError] = useState(null)
+  const runResearch = async () => {
+    const prompt = researchPrompt.trim()
+    if (!prompt) return
+    setResearching(true)
+    setResearchError(null)
+    try {
+      const result = await researchTask(form.title || 'Untitled task', form.notes, prompt, [])
+      if (result?.notes) form.setNotes(result.notes)
+      setResearchPrompt('')
+      setShowResearch(false)
+    } catch (e) {
+      setResearchError(e?.message || 'Research failed')
+    } finally {
+      setResearching(false)
+    }
+  }
   const labels = useMemo(() => loadLabels(), [])
   const labelById = useMemo(() => Object.fromEntries(labels.map(l => [l.id, l])), [labels])
 
@@ -147,11 +171,14 @@ export default function WallabyEditTask({ task, onSave, onClose, onDelete, onSta
       width="narrow"
       headerSlot={<AutosaveIndicator saved={justSaved} />}
     >
-      <input
+      <textarea
         className="wb-edit-title"
         value={form.title}
         onChange={e => form.setTitle(e.target.value)}
+        onInput={e => { e.target.style.height = 'auto'; e.target.style.height = `${e.target.scrollHeight}px` }}
+        ref={el => { if (el) { el.style.height = 'auto'; el.style.height = `${el.scrollHeight}px` } }}
         placeholder="Task title"
+        rows={1}
       />
 
       <textarea
@@ -161,6 +188,36 @@ export default function WallabyEditTask({ task, onSave, onClose, onDelete, onSta
         placeholder="Add details or notes…"
         rows={3}
       />
+
+      {/* AI actions — same capabilities as the full editor, zero detours. */}
+      <div className="wb-edit-ai-row">
+        <button className="wb-edit-ai-pill" onClick={form.handlePolish} disabled={form.polishing}>
+          <Sparkles size={13} strokeWidth={2} /> {form.polishing ? 'Polishing…' : 'Polish'}
+        </button>
+        <button
+          className={`wb-edit-ai-pill${showResearch ? ' is-active' : ''}`}
+          onClick={() => setShowResearch(o => !o)}
+        >
+          <BookOpenText size={13} strokeWidth={2} /> Research
+        </button>
+      </div>
+      {form.polishError && <div className="wb-edit-ai-error">{form.polishError}</div>}
+      {showResearch && (
+        <div className="wb-edit-research">
+          <input
+            className="wb-edit-sub-input wb-edit-research-input"
+            value={researchPrompt}
+            onChange={e => setResearchPrompt(e.target.value)}
+            onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); runResearch() } }}
+            placeholder="What should I look into?"
+            autoFocus
+          />
+          <button className="wb-edit-ai-pill" onClick={runResearch} disabled={researching || !researchPrompt.trim()}>
+            {researching ? 'Researching…' : 'Go'}
+          </button>
+        </div>
+      )}
+      {researchError && <div className="wb-edit-ai-error">{researchError}</div>}
 
       {/* Subtasks */}
       <div className="wb-edit-subs">

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,11 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-12
 
+- feat(ui): quick editor — Polish + Research inline, decrowded checklist [S]
+  - Prod report: "Big lists feel crowded and the polish and research functions are missing unless I go to more options." The Kept quick editor (QuickEditTask) now surfaces both AI actions right under the notes field: a **Polish** pill wired to useTaskForm's existing `handlePolish` (it was always in the form hook, just never rendered here) and a **Research** pill that reveals an inline prompt + Go, running the same `researchTask` call as the full editor and appending results to notes via the autosave path.
+  - Decrowding: checklist rows get breathing room (9px vertical padding, hairline separators, 1.35 line-height) with delete icons dimmed to 0.45 until hover; the title input is now an auto-growing textarea so long titles wrap instead of clipping ("Move Notion connector to new Bo…" → full title visible).
+  - Verified in the harness at 390px kept-dark: 2-line title renders unclipped in a grown textarea, both pills present, Research reveals the prompt input, 6 checklist rows show the new spacing.
+
 - fix(notion): KB adoption reports REST-access failures with the share-the-database fix [S]
   - Mystery solved (verified by fetching the user's database directly): there are TWO "Boomerang Knowledge" databases — the auto-created `742626dd…` (REST-shared, what the server synced) and `ee8d3826…` (the one the user actually uses, holding the real entries, NOT shared with the REST integration). When REST can't see a database, the MCP fallback returns only the SCHEMA — never rows — so the index sits empty while entries exist: the exact "connected but empty / schema instead of content" symptom.
   - `verifyRestAccess` now returns a boolean, adoption carries `rest_access`, and the setup response includes a pointed hint when REST is blind: *"open the database → ⋯ → Connections → add your Boomerang integration, then Sync now."*


### PR DESCRIPTION
Promotes dev → main:

- **feat(ui): quick editor — Polish + Research inline, decrowded checklist [S]** — both AI actions one tap away in the Kept quick editor (Polish pill + inline Research prompt under the notes field), checklist rows with hairline separators and breathing room, auto-growing title textarea so long titles wrap instead of clipping.

Harness-verified at 390px kept-dark before merge to dev.

https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBBZcREPmErHP4LcnpmMNR)_