### PR TITLE
fix(routines): make the loop trail tappable into the missed-days breakdown

### DIFF
--- a/src/kept/LoopsView.jsx
+++ b/src/kept/LoopsView.jsx
@@ -115,6 +115,17 @@ export default function LoopsView({ routines = [], tasks = [], onEditLoop, onAdd
               <Pencil size={13} strokeWidth={2} />
             </button>
           </div>
+          {/* The trail/calendar is the thing that shows the misses — make it a
+              tap target straight into the loop detail (where the per-day
+              "Needs attention" breakdown lives). */}
+          <div
+            className="bm-loop-card-viz"
+            role="button"
+            tabIndex={0}
+            onClick={() => setDetailId(r.id)}
+            onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setDetailId(r.id) } }}
+            aria-label={`Open ${r.title} — see caught and missed cycles`}
+          >
           {range === 'trail' && (() => {
             // Cadence-fit visuals (§13a): ONE language for every card —
             // cycle chips. Dailies get one chip per day, habit loops get
@@ -152,6 +163,7 @@ export default function LoopsView({ routines = [], tasks = [], onEditLoop, onAdd
           })()}
           {range === 'month' && <MonthDots valueByDay={byDay} color={color} />}
           {range === 'year' && <DensityRibbon valueByDay={byDay} color={color} />}
+          </div>
         </div>
         )
         // Cadence loops get swipe-to-Spawn/Skip (plan item 1). Habit loops are

--- a/src/kept/shell.css
+++ b/src/kept/shell.css
@@ -656,6 +656,8 @@
 }
 .bm-loop-fix-done { background: var(--bm-gold); color: var(--bm-on-ember); }
 .bm-loop-fix-skip { background: var(--bm-card-2); color: var(--bm-text-meta); }
+.bm-loop-card-viz { cursor: pointer; border-radius: 10px; }
+.bm-loop-card-viz:focus-visible { outline: 2px solid var(--bm-gold); outline-offset: 3px; }
 
 /* Sort toggle active hint (Tasks tab) */
 .bm-back.is-active-sort { color: var(--bm-ember); border-color: var(--bm-ember); }

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,9 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-13
 
+- fix(routines): make the loop trail tappable into the missed-days breakdown [XS]
+  - User report (with screenshot): "I should be able to click on this and see what was missed on a given loop." The cycle-chip trail / month / year visualization — the thing that visually shows the misses — wasn't a tap target; only the loop title opened the detail. Wrapped the visualization in a keyboard-accessible button (`bm-loop-card-viz`) that opens `LoopDetail`, where the per-day "Needs attention" breakdown (unrecorded + missed, each with Mark done / Skip) already lives.
+
 - feat(routines): loop reconcile review surface — see + fix the days per loop [M]
   - Follow-up to the reconcile work (user: "I'd like to click on the missing loops to see what days I need to look at and fix"). Instead of silently auto-closing stuck loops on load, Boomerang now surfaces them for review. `loopGaps(routine, tasks)` (`src/kept/cycles.js`) walks the cadence windows and splits past, non-current, uncaught cycles into **unrecorded** (a finished task exists in the window — the loop just never recorded it) and **missed** (due but no completion at all).
   - `LoopsView` shows an "N to fix" chip on each affected loop card; tapping it (or the card) opens `LoopDetail`, which renders a **Needs attention** card listing each day, labeled by group, with two actions per day: **Mark done** (`markRoutineDayDone` → stamps `completed_history`, crediting the cycle) or **Skip** (`skipRoutineDay` → records the day so it stops surfacing, without crediting — the trail stays honestly uncaught).


### PR DESCRIPTION
Screenshot follow-up: *"I should be able to click on this and see what was missed on a given loop."*

The cycle-chip trail / month / year visualization — the thing that visually shows the misses on a Loops card — wasn't a tap target; only the loop title opened the detail. Now the whole visualization is a keyboard-accessible button (`bm-loop-card-viz`) that opens `LoopDetail`, where the per-day **Needs attention** breakdown (unrecorded + missed, each with Mark done / Skip) lives.

Small, self-contained. `npm test`/lint/build green via pre-push hook. Docs: Version-History.

https://claude.ai/code/session_01SzMTDswAmeegFirUscLh64

---
_Generated by [Claude Code](https://claude.ai/code/session_01SzMTDswAmeegFirUscLh64)_