### PR TITLE
release: Balanced Diet breakdown coherence

### DIFF
--- a/src/badges.js
+++ b/src/badges.js
@@ -86,13 +86,15 @@ export function computeBadges({ lifetimeDone = 0, routines = [], records = {}, s
     if (!weekTypes[wk]) weekTypes[wk] = new Set()
     weekTypes[wk].add(t.energy)
   }
-  const balancedBest = Math.max(0, ...Object.values(weekTypes).map(s => s.size))
-
-  // This-week energy types caught — powers the Balanced Diet detail breakdown
-  // ("what's done vs outstanding" right now, the actionable view).
-  const cwStart = new Date(); cwStart.setHours(0, 0, 0, 0)
-  cwStart.setDate(cwStart.getDate() - ((cwStart.getDay() + 6) % 7)) // Monday
-  const thisWeekTypes = weekTypes[localYMD(cwStart)] || new Set()
+  // Track the BEST week's type SET (not just its size) so the detail breakdown
+  // describes the same week the progress number does — "Catch every energy type
+  // in one week" is a single-week measure, and 4/6 means your best week caught
+  // 4 of the 6. Showing this-week's types instead would contradict that number.
+  let balancedBestSet = new Set()
+  for (const s of Object.values(weekTypes)) {
+    if (s.size > balancedBestSet.size) balancedBestSet = s
+  }
+  const balancedBest = balancedBestSet.size
 
   // A quarterly+ loop kept alive for a year (history span).
   let longHaulDays = 0
@@ -164,9 +166,12 @@ export function computeBadges({ lifetimeDone = 0, routines = [], records = {}, s
   }
   const balanced = badges.find(b => b.id === 'balanced_diet')
   if (balanced) {
-    balanced.checklistTitle = 'Caught this week'
+    // Same week as the 4/6 progress — these are the types your best single
+    // week caught; the unchecked ones are what that week was missing (catch
+    // all six within one week to earn it).
+    balanced.checklistTitle = 'Your best week'
     balanced.checklist = Object.keys(ENERGY_LABELS).map(t => ({
-      label: ENERGY_LABELS[t], done: thisWeekTypes.has(t),
+      label: ENERGY_LABELS[t], done: balancedBestSet.has(t),
     }))
   }
 

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,9 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-13
 
+- fix(achievements): Balanced Diet breakdown matches the progress number [XS]
+  - The detail checklist showed THIS week's energy types while the card's "4/6" is the BEST week ever — two different weeks, so the breakdown contradicted the number (the achievement is "every energy type in one week"). The overlay now reflects the **best week's** type set (`balancedBestSet` in `badges.js`), titled "Your best week", so the 4 checked match the 4/6 and the two unchecked are what that single week was missing.
+
 - feat(achievements): tier legend, aligned card footers, tap-through detail overlay [S]
   - Three asks from a prod screenshot. (1) **What the colors mean** is now explicit — a Bronze/Silver/Gold legend sits in the grid header (the card tints are achievement tiers). (2) **Footer alignment** — earned dates and progress bars sat at different heights because cards were different sizes; cards are now equal-height (`grid-auto-rows: 1fr`) with the footer pinned to the bottom (`margin-top:auto`), so dates/bars line up across the whole grid. (3) **Detail overlay** — tapping any badge opens a popup with the emoji, tier, description, and either the earned date or a progress bar + "N to go". Set-shaped badges show a **done/outstanding checklist**: Balanced Diet lists all six energy types with this-week checks (`checklist`/`checklistTitle` added in `badges.js`). Mystery badges open a "keep playing" card. Cards are now buttons; `BadgesGrid` is shared by Analytics + the Flight log so all surfaces get it.
 


### PR DESCRIPTION
Promotes `dev` to production: Balanced Diet's detail breakdown now reflects your best week (matching the 4/6 progress number) instead of the current week, so the display matches the execution.

Merge with the **merge-commit** method.

https://claude.ai/code/session_01SzMTDswAmeegFirUscLh64

---
_Generated by [Claude Code](https://claude.ai/code/session_01SzMTDswAmeegFirUscLh64)_