### PR TITLE
fix(routines): Mark done on a stack cycle inflated the count + never cleared

### DIFF
--- a/src/hooks/useRoutines.js
+++ b/src/hooks/useRoutines.js
@@ -310,16 +310,29 @@ export function useRoutines() {
   // Loop-reconcile review actions (per-day Mark done / Skip). Both key off a
   // local 'YYYY-MM-DD' day so they're stable regardless of clock time.
 
-  // Credit a specific day as a completion (stamp completed_history at noon, the
-  // same convention the Today loop-check uses). No-op if the day is already
-  // recorded. Used by "Mark done" on the loop's needs-attention list.
+  // Credit a specific local DAY (`ymd`) as a completion. No-op if that day is
+  // already recorded. Used by "Mark done" on the loop's needs-attention list.
+  //
+  // The stamp MUST bucket to `ymd` in local time, or the idempotency check
+  // below — and loopGaps' gap-resolution, which keys on the cycle day — won't
+  // see it: you'd re-stamp on every click, inflating the lifetime count while
+  // the gap never clears. (Bug: stacks pass the cycle's due_date as `ymd` but
+  // a member's `completed_at` as `iso`; a late-night completion buckets to the
+  // next local day, so the real-time stamp landed on the wrong day forever.)
+  // Use the real completion time only when it lands on the same local day;
+  // otherwise noon-of-ymd. Also self-heal any exact-duplicate stamps a prior
+  // re-stamp piled up (identical timestamps are never legitimate).
   const markRoutineDayDone = useCallback((routineId, ymd, iso) => {
     if (!ymd) return
     setRoutines(prev => prev.map(r => {
       if (r.id !== routineId) return r
-      const hist = Array.isArray(r.completed_history) ? r.completed_history : []
-      if (hist.some(ts => localYMD(new Date(ts)) === ymd)) return r
-      const stamp = iso || `${ymd}T12:00:00.000Z`
+      const raw = Array.isArray(r.completed_history) ? r.completed_history : []
+      const hist = Array.from(new Set(raw)) // drop exact-duplicate timestamps
+      const already = hist.some(ts => localYMD(new Date(ts)) === ymd)
+      if (already) {
+        return hist.length === raw.length ? r : { ...r, completed_history: hist.sort() }
+      }
+      const stamp = (iso && localYMD(new Date(iso)) === ymd) ? iso : `${ymd}T12:00:00.000Z`
       return { ...r, completed_history: [...hist, stamp].sort() }
     }))
   }, [])
@@ -338,9 +351,16 @@ export function useRoutines() {
   }, [])
 
   const hydrateRoutines = useCallback((data) => {
-    if (Array.isArray(data)) {
-      setRoutines(data)
-    }
+    if (!Array.isArray(data)) return
+    // Self-heal exact-duplicate completed_history stamps (artifacts of the
+    // re-stamp bug that inflated lifetime counts). Identical timestamps are
+    // never legitimate — even habit double-logs differ by milliseconds — so
+    // collapsing them is safe and corrects an inflated count on next load.
+    setRoutines(data.map(r => {
+      const h = Array.isArray(r.completed_history) ? r.completed_history : []
+      const deduped = Array.from(new Set(h))
+      return deduped.length === h.length ? r : { ...r, completed_history: deduped }
+    }))
   }, [])
 
   return {

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,10 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-13
 
+- fix(routines)!: "Mark done" on a stack cycle inflated the count + never cleared [S]
+  - Prod report: tapping **Mark done** on a Bedtime (stack) needs-attention day kept ticking the lifetime count up (12 → 43) while the day stayed "finished, not recorded". Cause: `markRoutineDayDone` keyed its idempotency + the gap check on the cycle's **due day** (`ymd`) but STAMPED the member's `completed_at` ISO — for a stack, members are often completed on a *different* local day than the due date, so the stamp bucketed elsewhere, the June-8 check never saw it, and every click appended another stamp.
+  - Fix: the stamp now always buckets to `ymd` (use the real completion time only when it lands on the same local day, else noon-of-`ymd`), so a single click resolves the gap and further clicks are true no-ops. `markRoutineDayDone` also self-heals exact-duplicate timestamps, and `hydrateRoutines` collapses exact-duplicate `completed_history` stamps on load — correcting counts already inflated by the bug (identical timestamps are never legitimate). Verified: 4 junk dupes → 1, gap clears on click 1, clicks 2-3 unchanged.
+
 - fix(achievements): Balanced Diet breakdown matches the progress number [XS]
   - The detail checklist showed THIS week's energy types while the card's "4/6" is the BEST week ever — two different weeks, so the breakdown contradicted the number (the achievement is "every energy type in one week"). The overlay now reflects the **best week's** type set (`balancedBestSet` in `badges.js`), titled "Your best week", so the 4 checked match the 4/6 and the two unchecked are what that single week was missing.
 


### PR DESCRIPTION
Prod bug (screenshots): tapping **Mark done** on a Bedtime (stack) needs-attention day kept ticking the lifetime count up (12 → 43) while the day stayed "finished, not recorded".

**Cause:** `markRoutineDayDone` keyed its idempotency check + loopGaps' gap-resolution on the cycle's **due day** (`ymd`), but stamped the member's `completed_at` ISO. For a stack, members are often completed on a *different* local day than the due date, so the stamp bucketed to the wrong day — the due-day check never saw it, the gap never cleared, and every click appended another stamp.

**Fix:**
- The stamp now always buckets to `ymd` (use the real completion time only when it lands on the same local day, else noon-of-`ymd`) → one click resolves the gap, further clicks are true no-ops.
- `markRoutineDayDone` self-heals exact-duplicate timestamps; `hydrateRoutines` collapses exact-duplicate `completed_history` on load — so counts already inflated by the bug correct themselves (identical timestamps are never legitimate).

Verified (TZ-pinned): 4 junk dupes → 1, gap clears on click 1, clicks 2-3 unchanged. Lint/build green.

https://claude.ai/code/session_01SzMTDswAmeegFirUscLh64

---
_Generated by [Claude Code](https://claude.ai/code/session_01SzMTDswAmeegFirUscLh64)_