### PR TITLE
feat(ui): Kept edit modals adopt the LoopDetail card aesthetic

### DIFF
--- a/src/kept/forms.css
+++ b/src/kept/forms.css
@@ -92,3 +92,78 @@
 [data-theme^="kept"] .v2-edit-checklist-progress-fill {
   background: var(--wb-action-complete);
 }
+
+/* ════════════════════════════════════════════════════════════════════════
+ * Kept edit-modal aesthetic (2026-06-13): bring the Add/Edit task + loop
+ * editor forms into the LoopDetail card language — grouped warm cards, inset
+ * fields, raised chips, gold primary. An iOS-grouped-form feel for the polish
+ * push toward the native build. Gated to kept; mobile + desktop.
+ * ════════════════════════════════════════════════════════════════════════ */
+
+/* Each form section becomes a warm rounded card (matches the LoopDetail
+ * "Recent cycles" / "Needs attention" cards). Empty add-pill rows stay flat. */
+[data-theme^="kept"] .v2-form-section:not(.v2-form-section-compact),
+[data-theme^="kept"] .v2-form-row {
+  background: var(--bm-card);
+  border: 1px solid var(--bm-hairline);
+  border-radius: 16px;
+  box-shadow: var(--bm-shadow);
+  padding: 13px 14px;
+  margin-top: 12px;
+}
+[data-theme^="kept"] .v2-form-section-compact { margin-top: 10px; }
+
+/* Section label → quiet card eyebrow. */
+[data-theme^="kept"] .v2-form-label { color: var(--bm-text-meta); font-weight: 700; }
+
+/* Inputs/textareas/selects → INSET on the page bg so they contrast with the
+ * card they sit in (the earlier rule put them on --wb-card = the card color,
+ * so they vanished card-on-card). */
+[data-theme^="kept"] .v2-form-input,
+[data-theme^="kept"] .v2-form-textarea,
+[data-theme^="kept"] .v2-edit-duration-input,
+[data-theme^="kept"] .v2-edit-checklist-add-input,
+[data-theme^="kept"] .v2-edit-comment-input-row input {
+  background: var(--bm-bg);
+  border-color: var(--bm-hairline);
+}
+
+/* Chips / pills inside the cards → raised one step (card-2) so they read as
+ * tappable chips against the card surface. */
+[data-theme^="kept"] .v2-form-seg,
+[data-theme^="kept"] .v2-form-energy-pill,
+[data-theme^="kept"] .v2-form-label-pill,
+[data-theme^="kept"] .v2-edit-add-pill,
+[data-theme^="kept"] .v2-edit-connection-pill,
+[data-theme^="kept"] .v2-edit-knowledge-chip,
+[data-theme^="kept"] .v2-edit-blocker-chip {
+  background: var(--bm-card-2);
+}
+
+/* The title field reads as the form's heading, not a boxed input (mirrors the
+ * big LoopDetail title). Wins over the .v2-form-input rule above by order. */
+[data-theme^="kept"] .v2-form-title {
+  background: transparent;
+  border: none;
+  padding: 4px 2px;
+  font: 700 21px/1.3 var(--v2-font-display);
+}
+[data-theme^="kept"] .v2-form-title:focus { outline: none; box-shadow: none; }
+
+/* FormDisclosure (loop-editor collapsibles) → its own card, not a bare
+ * hairline divider. */
+[data-theme^="kept"] .v2-form-disclosure {
+  background: var(--bm-card);
+  border: 1px solid var(--bm-hairline);
+  border-radius: 16px;
+  box-shadow: var(--bm-shadow);
+  margin-top: 12px;
+  padding: 0 14px;
+}
+[data-theme^="kept"] .v2-form-disclosure:last-of-type { border-bottom: 1px solid var(--bm-hairline); }
+
+/* Primary submit → gold, matching the LoopDetail primary action. */
+[data-theme^="kept"] .v2-form-submit {
+  background: var(--bm-gold);
+  color: var(--bm-on-ember);
+}

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,9 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-13
 
+- feat(ui): Kept edit modals adopt the LoopDetail card aesthetic [M]
+  - Polish pass toward the native build. The Add/Edit task + loop-editor forms still wore the flat wallaby-era form styling; now (Kept only) each `.v2-form-section` / `.v2-form-row` / `FormDisclosure` renders as a warm rounded card (matching LoopDetail's "Recent cycles"/"Needs attention" cards) — an iOS-grouped-form feel. Inputs are inset on the page bg so they don't blend card-on-card; chips/pills are raised to `--bm-card-2`; the title reads as a heading (display font, no box); the primary submit is gold to match the LoopDetail primary. All in `src/kept/forms.css`, gated to `[data-theme^="kept"]`, so Standard themes are untouched.
+
 - fix(routines)!: "Mark done" on a stack cycle inflated the count + never cleared [S]
   - Prod report: tapping **Mark done** on a Bedtime (stack) needs-attention day kept ticking the lifetime count up (12 → 43) while the day stayed "finished, not recorded". Cause: `markRoutineDayDone` keyed its idempotency + the gap check on the cycle's **due day** (`ymd`) but STAMPED the member's `completed_at` ISO — for a stack, members are often completed on a *different* local day than the due date, so the stamp bucketed elsewhere, the June-8 check never saw it, and every click appended another stamp.
   - Fix: the stamp now always buckets to `ymd` (use the real completion time only when it lands on the same local day, else noon-of-`ymd`), so a single click resolves the gap and further clicks are true no-ops. `markRoutineDayDone` also self-heals exact-duplicate timestamps, and `hydrateRoutines` collapses exact-duplicate `completed_history` stamps on load — correcting counts already inflated by the bug (identical timestamps are never legitimate). Verified: 4 junk dupes → 1, gap clears on click 1, clicks 2-3 unchanged.


### PR DESCRIPTION
The edit-modal polish pass. The Add/Edit task + loop-editor forms now wear the **LoopDetail card aesthetic** (Kept only):

- Each form section / two-column row / collapsible (`FormDisclosure`) renders as a **warm rounded card** — an iOS-grouped-form feel, matching the "Recent cycles"/"Needs attention" cards.
- **Inputs are inset** on the page bg so they don't blend card-on-card; **chips/pills raised** to `--bm-card-2`.
- The **title reads as a heading** (display font, no box); the **primary submit is gold** to match the LoopDetail primary.
- All in `src/kept/forms.css`, gated to `[data-theme^="kept"]` — Standard themes untouched.

Build green. This is a broad visual change, so I'd suggest a look on `boomerang-dev:3002` before promoting to prod.

https://claude.ai/code/session_01SzMTDswAmeegFirUscLh64

---
_Generated by [Claude Code](https://claude.ai/code/session_01SzMTDswAmeegFirUscLh64)_