### PR TITLE
fix(ui): Settings card aesthetic + edit-modal title affordance

### DIFF
--- a/src/kept/forms.css
+++ b/src/kept/forms.css
@@ -140,15 +140,18 @@
   background: var(--bm-card-2);
 }
 
-/* The title field reads as the form's heading, not a boxed input (mirrors the
- * big LoopDetail title). Wins over the .v2-form-input rule above by order. */
+/* The title field reads as the form's heading (mirrors the big LoopDetail
+ * title) — but keeps a hairline underline so it's clearly an editable field
+ * when empty, instead of looking like a section header you can't type into. */
 [data-theme^="kept"] .v2-form-title {
   background: transparent;
   border: none;
-  padding: 4px 2px;
+  border-bottom: 1.5px solid var(--bm-hairline-strong);
+  border-radius: 0;
+  padding: 4px 2px 8px;
   font: 700 21px/1.3 var(--v2-font-display);
 }
-[data-theme^="kept"] .v2-form-title:focus { outline: none; box-shadow: none; }
+[data-theme^="kept"] .v2-form-title:focus { outline: none; box-shadow: none; border-bottom-color: var(--bm-ember); }
 
 /* FormDisclosure (loop-editor collapsibles) → its own card, not a bare
  * hairline divider. */

--- a/src/kept/settings.css
+++ b/src/kept/settings.css
@@ -95,3 +95,48 @@
   background: var(--wb-card-3);
   border-color: var(--wb-hairline);
 }
+
+/* ════════════════════════════════════════════════════════════════════════
+ * Bring Settings the rest of the way into the loop-editor card aesthetic
+ * (2026-06-13): inset inputs (match the edit modals), ember active states,
+ * and a proper card surface for the Logs tab (it had no Kept treatment — its
+ * active filter was an inverted near-black pill that clashed with the warm
+ * palette). Gated to kept.
+ * ════════════════════════════════════════════════════════════════════════ */
+
+/* Inputs → INSET on the page bg, identical to the edit modals (was --wb-card-2,
+ * which made settings fields read differently from the loop/task editors). */
+[data-theme^="kept"] .v2-form-input,
+[data-theme^="kept"] .v2-settings-compact-input,
+[data-theme^="kept"] .v2-settings-quiet-field input {
+  background: var(--bm-bg);
+  border-color: var(--bm-hairline);
+}
+
+/* Settings buttons → raised card-2 chips (consistent with the editor chips). */
+[data-theme^="kept"] .v2-settings-btn {
+  background: var(--bm-card-2);
+  border-color: var(--bm-hairline);
+  color: var(--bm-text);
+}
+[data-theme^="kept"] .v2-settings-btn:hover { background: color-mix(in srgb, var(--bm-text) 6%, var(--bm-card-2)); }
+
+/* Logs tab — make it feel intentional, not a raw debug dump. */
+[data-theme^="kept"] .v2-settings-filter {
+  background: var(--bm-card-2);
+  border-color: var(--bm-hairline);
+  color: var(--bm-text-meta);
+}
+/* Active filter was background:var(--v2-text) (a near-black/white inverted
+ * pill) — swap to the ember the rest of the theme uses. */
+[data-theme^="kept"] .v2-settings-filter-active,
+[data-theme^="kept"] .v2-settings-filter.v2-settings-filter-active {
+  background: var(--bm-ember);
+  border-color: var(--bm-ember);
+  color: var(--bm-on-ember);
+}
+[data-theme^="kept"] .v2-settings-logs-stream {
+  background: var(--bm-card);
+  border-color: var(--bm-hairline);
+  border-radius: 14px;
+}

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,10 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-13
 
+- fix(ui): Settings joins the card aesthetic + edit-modal title affordance [S]
+  - Settings was lagging the loop/edit-modal polish: inputs sat on a different surface, and the **Logs tab had no Kept treatment** — its active filter was an inverted near-black pill clashing with the warm palette. Now (Kept) settings inputs are inset on the page bg to match the editors, buttons are raised card-2 chips, the Logs filter chips use ember when active, and the log stream is a proper warm card.
+  - Edit-modal title fix: the heading-styled title input read as a section header with no visible field when empty (you couldn't tell where to type a new loop/task name). Added a hairline underline (ember on focus) so it's clearly editable while keeping the big-title look.
+
 - feat(ui): Kept edit modals adopt the LoopDetail card aesthetic [M]
   - Polish pass toward the native build. The Add/Edit task + loop-editor forms still wore the flat wallaby-era form styling; now (Kept only) each `.v2-form-section` / `.v2-form-row` / `FormDisclosure` renders as a warm rounded card (matching LoopDetail's "Recent cycles"/"Needs attention" cards) — an iOS-grouped-form feel. Inputs are inset on the page bg so they don't blend card-on-card; chips/pills are raised to `--bm-card-2`; the title reads as a heading (display font, no box); the primary submit is gold to match the LoopDetail primary. All in `src/kept/forms.css`, gated to `[data-theme^="kept"]`, so Standard themes are untouched.
 


### PR DESCRIPTION
Follow-up on the polish pass (still iterating on dev before prod):

- **Settings joins the aesthetic.** Inputs are now inset on the page bg to match the loop/task editors; buttons are raised card-2 chips; and the **Logs tab** — which had no Kept treatment — gets the warm card surface plus **ember active filter chips** (the active filter was an inverted near-black pill that clashed). The settings blocks were already carded.
- **Edit-modal title affordance.** The heading-styled title input read as a section header with no visible field when empty (you couldn't tell where to type a new loop's name). Added a hairline underline (ember on focus) so it's clearly editable, keeping the big-title look.

Build green. Still on dev for review — say the word to promote the whole polish batch to prod.

https://claude.ai/code/session_01SzMTDswAmeegFirUscLh64

---
_Generated by [Claude Code](https://claude.ai/code/session_01SzMTDswAmeegFirUscLh64)_