### PR TITLE
fix(ui): card the General/AI settings tab (rendered flat)

### DIFF
--- a/src/kept/settings.css
+++ b/src/kept/settings.css
@@ -140,3 +140,16 @@
   border-color: var(--bm-hairline);
   border-radius: 14px;
 }
+
+/* The General/appearance tab puts settings rows DIRECTLY in .v2-settings-form
+ * (no .v2-settings-block wrapper like the other tabs), so it rendered flat —
+ * not carded like the rest. Card those forms specifically (the :has guard
+ * skips forms that wrap their own blocks, so we never double-card). */
+[data-theme^="kept"] .v2-settings-form:has(> .v2-settings-row) {
+  background: var(--bm-card);
+  border: 1px solid var(--bm-hairline);
+  border-radius: 16px;
+  box-shadow: var(--bm-shadow);
+  padding: 2px 16px;
+  margin-top: 6px;
+}


### PR DESCRIPTION
Verified locally with the Local-Verification-Harness (puppeteer, Kept-dark, seeded): the **General/AI settings tab rendered flat** — it puts rows directly in `.v2-settings-form` with no `.v2-settings-block` wrapper, so it missed the card treatment every other tab had. Added a `:has(> .v2-settings-row)` rule so those forms get the warm card too (the `:has` guard skips forms that wrap their own blocks → no double-carding).

Confirmed by screenshot: General now sits in a warm card with inset fields, matching Notifications/Data/etc. and the loop editors.

https://claude.ai/code/session_01SzMTDswAmeegFirUscLh64

---
_Generated by [Claude Code](https://claude.ai/code/session_01SzMTDswAmeegFirUscLh64)_