### PR TITLE
fix(api): research mode crashes on backslashes/newlines (JSON parse)

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -291,10 +291,10 @@ Return JSON with these fields:
 
 // --- Research ---
 export async function researchTask(title, existingNotes, prompt, attachments = []) {
-  const system = `You are a research assistant for someone with ADHD. Given a task and a research question, provide practical, actionable research notes. Be specific and concrete — links, steps, options, pros/cons. Format as bullet points starting with "- ". Keep it concise but thorough. Don't repeat what's already in the existing notes. If images or documents are attached, incorporate relevant details from them into your research. Return JSON only: {"notes": "the research notes as a string with line breaks between bullets"}`
+  const system = `You are a research assistant for someone with ADHD. Given a task and a research question, provide practical, actionable research notes. Be specific and concrete — links, steps, options, pros/cons. Format as a plain markdown bullet list, each line starting with "- ". Keep it concise but thorough. Don't repeat what's already in the existing notes. If images or documents are attached, incorporate relevant details from them into your research. Return ONLY the bullet list — no preamble, no JSON, no code fences.`
 
   const context = existingNotes ? `\nExisting notes:\n${existingNotes}` : ''
-  const textContent = `Task: "${title}"${context}\n\nResearch question: "${prompt}"\n\nProvide research notes. JSON only.`
+  const textContent = `Task: "${title}"${context}\n\nResearch question: "${prompt}"\n\nProvide the research notes as a bullet list.`
 
   // Build content blocks — text + any image/document attachments
   const content = []
@@ -332,10 +332,24 @@ export async function researchTask(title, existingNotes, prompt, attachments = [
   }
 
   const data = await res.json()
-  const text = data.content[0].text
-  const match = text.match(/\{[\s\S]*\}/)
-  if (!match) throw new Error('Could not parse research results')
-  return JSON.parse(match[0])
+  let text = (data.content?.[0]?.text || '').trim()
+  // Research notes are freeform markdown (bullets with line breaks, and often
+  // backslashes — measurements like 3\4", paths, escapes). Do NOT JSON.parse
+  // them: the old `{"notes":"..."}` contract threw "Unrecognized token '\'" the
+  // moment the notes held a character that isn't a valid JSON escape. Use the
+  // text directly; if an older model response still wraps it in JSON, unwrap by
+  // hand (no JSON.parse) and strip any code fences.
+  if (/^\s*\{/.test(text) && /"notes"\s*:/.test(text)) {
+    const inner = text.match(/"notes"\s*:\s*"([\s\S]*?)"\s*\}\s*$/)
+    if (inner) {
+      text = inner[1]
+        .replace(/\\n/g, '\n').replace(/\\t/g, '\t')
+        .replace(/\\"/g, '"').replace(/\\\\/g, '\\')
+    }
+  }
+  text = text.replace(/^```[a-z]*\s*\n?/i, '').replace(/\n?```\s*$/, '').trim()
+  if (!text) throw new Error('Research returned no content')
+  return { notes: text }
 }
 
 // --- Attachment text extraction (OCR / verbatim transcript) ---

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,9 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-13
 
+- fix(api): research mode no longer crashes on backslashes / newlines [S]
+  - Prod: running Research threw "JSON Parse error: Unrecognized token '\'". `researchTask` asked the model for `{"notes":"…multi-line bullets…"}` then `JSON.parse`d it — but freeform notes routinely contain raw newlines and backslashes (measurements like `3\4"`, paths, escapes) that aren't valid JSON, so the parse blew up and the result was lost. Long-standing fragility, not a regression from the recent tags/loops work (git log on `researchTask` confirms it was untouched). Fix: prompt for a plain markdown bullet list and use the response text directly; if an older reply still wraps it in JSON, unwrap by hand (no `JSON.parse`) and strip code fences. Verified the failing backslash case + fenced + legacy-JSON inputs.
+
 - fix(ui): Settings joins the card aesthetic + edit-modal title affordance [S]
   - Settings was lagging the loop/edit-modal polish: inputs sat on a different surface, and the **Logs tab had no Kept treatment** — its active filter was an inverted near-black pill clashing with the warm palette. Now (Kept) settings inputs are inset on the page bg to match the editors, buttons are raised card-2 chips, the Logs filter chips use ember when active, and the log stream is a proper warm card.
   - Edit-modal title fix: the heading-styled title input read as a section header with no visible field when empty (you couldn't tell where to type a new loop/task name). Added a hairline underline (ember on focus) so it's clearly editable while keeping the big-title look.


### PR DESCRIPTION
Prod bug: running **Research** threw `JSON Parse error: Unrecognized token '\'`.

`researchTask` asked the model for `{"notes":"…multi-line bullets…"}` then `JSON.parse`d it — but freeform research notes routinely contain raw newlines and backslashes (measurements like `3\4"`, paths, escape sequences) that aren't valid JSON, so the parse threw and the notes were lost. This is a **long-standing fragility, not a regression from the recent tags/loops work** — `git log` on `researchTask` shows it was untouched since it was added.

**Fix:** prompt for a plain markdown bullet list (no JSON) and use the response text directly. If an older model reply still wraps it in `{"notes":"…"}`, unwrap by hand (no `JSON.parse`) and strip any code fences.

Verified: the failing backslash case (`3\4"`) now passes through cleanly, plus code-fenced and legacy-JSON-wrapped inputs.

https://claude.ai/code/session_01SzMTDswAmeegFirUscLh64

---
_Generated by [Claude Code](https://claude.ai/code/session_01SzMTDswAmeegFirUscLh64)_