### PR TITLE
release: research crash fix + edit-modal & Settings polish

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -291,10 +291,10 @@ Return JSON with these fields:
 
 // --- Research ---
 export async function researchTask(title, existingNotes, prompt, attachments = []) {
-  const system = `You are a research assistant for someone with ADHD. Given a task and a research question, provide practical, actionable research notes. Be specific and concrete — links, steps, options, pros/cons. Format as bullet points starting with "- ". Keep it concise but thorough. Don't repeat what's already in the existing notes. If images or documents are attached, incorporate relevant details from them into your research. Return JSON only: {"notes": "the research notes as a string with line breaks between bullets"}`
+  const system = `You are a research assistant for someone with ADHD. Given a task and a research question, provide practical, actionable research notes. Be specific and concrete — links, steps, options, pros/cons. Format as a plain markdown bullet list, each line starting with "- ". Keep it concise but thorough. Don't repeat what's already in the existing notes. If images or documents are attached, incorporate relevant details from them into your research. Return ONLY the bullet list — no preamble, no JSON, no code fences.`
 
   const context = existingNotes ? `\nExisting notes:\n${existingNotes}` : ''
-  const textContent = `Task: "${title}"${context}\n\nResearch question: "${prompt}"\n\nProvide research notes. JSON only.`
+  const textContent = `Task: "${title}"${context}\n\nResearch question: "${prompt}"\n\nProvide the research notes as a bullet list.`
 
   // Build content blocks — text + any image/document attachments
   const content = []
@@ -332,10 +332,24 @@ export async function researchTask(title, existingNotes, prompt, attachments = [
   }
 
   const data = await res.json()
-  const text = data.content[0].text
-  const match = text.match(/\{[\s\S]*\}/)
-  if (!match) throw new Error('Could not parse research results')
-  return JSON.parse(match[0])
+  let text = (data.content?.[0]?.text || '').trim()
+  // Research notes are freeform markdown (bullets with line breaks, and often
+  // backslashes — measurements like 3\4", paths, escapes). Do NOT JSON.parse
+  // them: the old `{"notes":"..."}` contract threw "Unrecognized token '\'" the
+  // moment the notes held a character that isn't a valid JSON escape. Use the
+  // text directly; if an older model response still wraps it in JSON, unwrap by
+  // hand (no JSON.parse) and strip any code fences.
+  if (/^\s*\{/.test(text) && /"notes"\s*:/.test(text)) {
+    const inner = text.match(/"notes"\s*:\s*"([\s\S]*?)"\s*\}\s*$/)
+    if (inner) {
+      text = inner[1]
+        .replace(/\\n/g, '\n').replace(/\\t/g, '\t')
+        .replace(/\\"/g, '"').replace(/\\\\/g, '\\')
+    }
+  }
+  text = text.replace(/^```[a-z]*\s*\n?/i, '').replace(/\n?```\s*$/, '').trim()
+  if (!text) throw new Error('Research returned no content')
+  return { notes: text }
 }
 
 // --- Attachment text extraction (OCR / verbatim transcript) ---

--- a/src/kept/forms.css
+++ b/src/kept/forms.css
@@ -92,3 +92,78 @@
 [data-theme^="kept"] .v2-edit-checklist-progress-fill {
   background: var(--wb-action-complete);
 }
+
+/* ════════════════════════════════════════════════════════════════════════
+ * Kept edit-modal aesthetic (2026-06-13): bring the Add/Edit task + loop
+ * editor forms into the LoopDetail card language — grouped warm cards, inset
+ * fields, raised chips, gold primary. An iOS-grouped-form feel for the polish
+ * push toward the native build. Gated to kept; mobile + desktop.
+ * ════════════════════════════════════════════════════════════════════════ */
+
+/* Each form section becomes a warm rounded card (matches the LoopDetail
+ * "Recent cycles" / "Needs attention" cards). Empty add-pill rows stay flat. */
+[data-theme^="kept"] .v2-form-section:not(.v2-form-section-compact),
+[data-theme^="kept"] .v2-form-row {
+  background: var(--bm-card);
+  border: 1px solid var(--bm-hairline);
+  border-radius: 16px;
+  box-shadow: var(--bm-shadow);
+  padding: 13px 14px;
+  margin-top: 12px;
+}
+[data-theme^="kept"] .v2-form-section-compact { margin-top: 10px; }
+
+/* Section label → quiet card eyebrow. */
+[data-theme^="kept"] .v2-form-label { color: var(--bm-text-meta); font-weight: 700; }
+
+/* Inputs/textareas/selects → INSET on the page bg so they contrast with the
+ * card they sit in (the earlier rule put them on --wb-card = the card color,
+ * so they vanished card-on-card). */
+[data-theme^="kept"] .v2-form-input,
+[data-theme^="kept"] .v2-form-textarea,
+[data-theme^="kept"] .v2-edit-duration-input,
+[data-theme^="kept"] .v2-edit-checklist-add-input,
+[data-theme^="kept"] .v2-edit-comment-input-row input {
+  background: var(--bm-bg);
+  border-color: var(--bm-hairline);
+}
+
+/* Chips / pills inside the cards → raised one step (card-2) so they read as
+ * tappable chips against the card surface. */
+[data-theme^="kept"] .v2-form-seg,
+[data-theme^="kept"] .v2-form-energy-pill,
+[data-theme^="kept"] .v2-form-label-pill,
+[data-theme^="kept"] .v2-edit-add-pill,
+[data-theme^="kept"] .v2-edit-connection-pill,
+[data-theme^="kept"] .v2-edit-knowledge-chip,
+[data-theme^="kept"] .v2-edit-blocker-chip {
+  background: var(--bm-card-2);
+}
+
+/* The title field reads as the form's heading, not a boxed input (mirrors the
+ * big LoopDetail title). Wins over the .v2-form-input rule above by order. */
+[data-theme^="kept"] .v2-form-title {
+  background: transparent;
+  border: none;
+  padding: 4px 2px;
+  font: 700 21px/1.3 var(--v2-font-display);
+}
+[data-theme^="kept"] .v2-form-title:focus { outline: none; box-shadow: none; }
+
+/* FormDisclosure (loop-editor collapsibles) → its own card, not a bare
+ * hairline divider. */
+[data-theme^="kept"] .v2-form-disclosure {
+  background: var(--bm-card);
+  border: 1px solid var(--bm-hairline);
+  border-radius: 16px;
+  box-shadow: var(--bm-shadow);
+  margin-top: 12px;
+  padding: 0 14px;
+}
+[data-theme^="kept"] .v2-form-disclosure:last-of-type { border-bottom: 1px solid var(--bm-hairline); }
+
+/* Primary submit → gold, matching the LoopDetail primary action. */
+[data-theme^="kept"] .v2-form-submit {
+  background: var(--bm-gold);
+  color: var(--bm-on-ember);
+}

--- a/src/kept/forms.css
+++ b/src/kept/forms.css
@@ -140,15 +140,18 @@
   background: var(--bm-card-2);
 }
 
-/* The title field reads as the form's heading, not a boxed input (mirrors the
- * big LoopDetail title). Wins over the .v2-form-input rule above by order. */
+/* The title field reads as the form's heading (mirrors the big LoopDetail
+ * title) — but keeps a hairline underline so it's clearly an editable field
+ * when empty, instead of looking like a section header you can't type into. */
 [data-theme^="kept"] .v2-form-title {
   background: transparent;
   border: none;
-  padding: 4px 2px;
+  border-bottom: 1.5px solid var(--bm-hairline-strong);
+  border-radius: 0;
+  padding: 4px 2px 8px;
   font: 700 21px/1.3 var(--v2-font-display);
 }
-[data-theme^="kept"] .v2-form-title:focus { outline: none; box-shadow: none; }
+[data-theme^="kept"] .v2-form-title:focus { outline: none; box-shadow: none; border-bottom-color: var(--bm-ember); }
 
 /* FormDisclosure (loop-editor collapsibles) → its own card, not a bare
  * hairline divider. */

--- a/src/kept/settings.css
+++ b/src/kept/settings.css
@@ -95,3 +95,48 @@
   background: var(--wb-card-3);
   border-color: var(--wb-hairline);
 }
+
+/* ════════════════════════════════════════════════════════════════════════
+ * Bring Settings the rest of the way into the loop-editor card aesthetic
+ * (2026-06-13): inset inputs (match the edit modals), ember active states,
+ * and a proper card surface for the Logs tab (it had no Kept treatment — its
+ * active filter was an inverted near-black pill that clashed with the warm
+ * palette). Gated to kept.
+ * ════════════════════════════════════════════════════════════════════════ */
+
+/* Inputs → INSET on the page bg, identical to the edit modals (was --wb-card-2,
+ * which made settings fields read differently from the loop/task editors). */
+[data-theme^="kept"] .v2-form-input,
+[data-theme^="kept"] .v2-settings-compact-input,
+[data-theme^="kept"] .v2-settings-quiet-field input {
+  background: var(--bm-bg);
+  border-color: var(--bm-hairline);
+}
+
+/* Settings buttons → raised card-2 chips (consistent with the editor chips). */
+[data-theme^="kept"] .v2-settings-btn {
+  background: var(--bm-card-2);
+  border-color: var(--bm-hairline);
+  color: var(--bm-text);
+}
+[data-theme^="kept"] .v2-settings-btn:hover { background: color-mix(in srgb, var(--bm-text) 6%, var(--bm-card-2)); }
+
+/* Logs tab — make it feel intentional, not a raw debug dump. */
+[data-theme^="kept"] .v2-settings-filter {
+  background: var(--bm-card-2);
+  border-color: var(--bm-hairline);
+  color: var(--bm-text-meta);
+}
+/* Active filter was background:var(--v2-text) (a near-black/white inverted
+ * pill) — swap to the ember the rest of the theme uses. */
+[data-theme^="kept"] .v2-settings-filter-active,
+[data-theme^="kept"] .v2-settings-filter.v2-settings-filter-active {
+  background: var(--bm-ember);
+  border-color: var(--bm-ember);
+  color: var(--bm-on-ember);
+}
+[data-theme^="kept"] .v2-settings-logs-stream {
+  background: var(--bm-card);
+  border-color: var(--bm-hairline);
+  border-radius: 14px;
+}

--- a/src/kept/settings.css
+++ b/src/kept/settings.css
@@ -140,3 +140,16 @@
   border-color: var(--bm-hairline);
   border-radius: 14px;
 }
+
+/* The General/appearance tab puts settings rows DIRECTLY in .v2-settings-form
+ * (no .v2-settings-block wrapper like the other tabs), so it rendered flat —
+ * not carded like the rest. Card those forms specifically (the :has guard
+ * skips forms that wrap their own blocks, so we never double-card). */
+[data-theme^="kept"] .v2-settings-form:has(> .v2-settings-row) {
+  background: var(--bm-card);
+  border: 1px solid var(--bm-hairline);
+  border-radius: 16px;
+  box-shadow: var(--bm-shadow);
+  padding: 2px 16px;
+  margin-top: 6px;
+}

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,9 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-13
 
+- fix(api): research mode no longer crashes on backslashes / newlines [S]
+  - Prod: running Research threw "JSON Parse error: Unrecognized token '\'". `researchTask` asked the model for `{"notes":"…multi-line bullets…"}` then `JSON.parse`d it — but freeform notes routinely contain raw newlines and backslashes (measurements like `3\4"`, paths, escapes) that aren't valid JSON, so the parse blew up and the result was lost. Long-standing fragility, not a regression from the recent tags/loops work (git log on `researchTask` confirms it was untouched). Fix: prompt for a plain markdown bullet list and use the response text directly; if an older reply still wraps it in JSON, unwrap by hand (no `JSON.parse`) and strip code fences. Verified the failing backslash case + fenced + legacy-JSON inputs.
+
 - fix(ui): Settings joins the card aesthetic + edit-modal title affordance [S]
   - Settings was lagging the loop/edit-modal polish: inputs sat on a different surface, and the **Logs tab had no Kept treatment** — its active filter was an inverted near-black pill clashing with the warm palette. Now (Kept) settings inputs are inset on the page bg to match the editors, buttons are raised card-2 chips, the Logs filter chips use ember when active, and the log stream is a proper warm card.
   - Edit-modal title fix: the heading-styled title input read as a section header with no visible field when empty (you couldn't tell where to type a new loop/task name). Added a hairline underline (ember on focus) so it's clearly editable while keeping the big-title look.

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,10 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-13
 
+- fix(ui): Settings joins the card aesthetic + edit-modal title affordance [S]
+  - Settings was lagging the loop/edit-modal polish: inputs sat on a different surface, and the **Logs tab had no Kept treatment** — its active filter was an inverted near-black pill clashing with the warm palette. Now (Kept) settings inputs are inset on the page bg to match the editors, buttons are raised card-2 chips, the Logs filter chips use ember when active, and the log stream is a proper warm card.
+  - Edit-modal title fix: the heading-styled title input read as a section header with no visible field when empty (you couldn't tell where to type a new loop/task name). Added a hairline underline (ember on focus) so it's clearly editable while keeping the big-title look.
+
 - feat(ui): Kept edit modals adopt the LoopDetail card aesthetic [M]
   - Polish pass toward the native build. The Add/Edit task + loop-editor forms still wore the flat wallaby-era form styling; now (Kept only) each `.v2-form-section` / `.v2-form-row` / `FormDisclosure` renders as a warm rounded card (matching LoopDetail's "Recent cycles"/"Needs attention" cards) — an iOS-grouped-form feel. Inputs are inset on the page bg so they don't blend card-on-card; chips/pills are raised to `--bm-card-2`; the title reads as a heading (display font, no box); the primary submit is gold to match the LoopDetail primary. All in `src/kept/forms.css`, gated to `[data-theme^="kept"]`, so Standard themes are untouched.
 

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,9 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-06-13
 
+- feat(ui): Kept edit modals adopt the LoopDetail card aesthetic [M]
+  - Polish pass toward the native build. The Add/Edit task + loop-editor forms still wore the flat wallaby-era form styling; now (Kept only) each `.v2-form-section` / `.v2-form-row` / `FormDisclosure` renders as a warm rounded card (matching LoopDetail's "Recent cycles"/"Needs attention" cards) — an iOS-grouped-form feel. Inputs are inset on the page bg so they don't blend card-on-card; chips/pills are raised to `--bm-card-2`; the title reads as a heading (display font, no box); the primary submit is gold to match the LoopDetail primary. All in `src/kept/forms.css`, gated to `[data-theme^="kept"]`, so Standard themes are untouched.
+
 - fix(routines)!: "Mark done" on a stack cycle inflated the count + never cleared [S]
   - Prod report: tapping **Mark done** on a Bedtime (stack) needs-attention day kept ticking the lifetime count up (12 → 43) while the day stayed "finished, not recorded". Cause: `markRoutineDayDone` keyed its idempotency + the gap check on the cycle's **due day** (`ymd`) but STAMPED the member's `completed_at` ISO — for a stack, members are often completed on a *different* local day than the due date, so the stamp bucketed elsewhere, the June-8 check never saw it, and every click appended another stamp.
   - Fix: the stamp now always buckets to `ymd` (use the real completion time only when it lands on the same local day, else noon-of-`ymd`), so a single click resolves the gap and further clicks are true no-ops. `markRoutineDayDone` also self-heals exact-duplicate timestamps, and `hydrateRoutines` collapses exact-duplicate `completed_history` stamps on load — correcting counts already inflated by the bug (identical timestamps are never legitimate). Verified: 4 junk dupes → 1, gap clears on click 1, clicks 2-3 unchanged.


### PR DESCRIPTION
Promotes `dev` to production — one release covering:

- **fix(api): research mode crash** — `JSON Parse error: Unrecognized token '\'` when running Research; now uses plain text instead of `JSON.parse`-ing freeform notes.
- **feat(ui): Kept edit modals adopt the LoopDetail card aesthetic** — Add/Edit task + loop editor forms render as warm grouped cards (iOS-grouped feel), inset fields, gold primary, title-as-heading with an editable underline.
- **fix(ui): Settings joins the card aesthetic** — inset inputs, ember active filter on the Logs tab, warm log-stream card, and the General/AI tab now carded (it was rendering flat).

All verified locally in Kept-dark via the verification harness (screenshots). Merge with the **merge-commit** method.

https://claude.ai/code/session_01SzMTDswAmeegFirUscLh64

---
_Generated by [Claude Code](https://claude.ai/code/session_01SzMTDswAmeegFirUscLh64)_