### PR TITLE
release: restore confrontation energy type

### DIFF
--- a/emailNotifications.js
+++ b/emailNotifications.js
@@ -60,7 +60,7 @@ async function generateAINudge(task) {
 }
 
 // Avoidance-prone energy types (same as client)
-const AVOIDANCE_ENERGY_TYPES = ['errand']
+const AVOIDANCE_ENERGY_TYPES = ['errand', 'confrontation']
 const ACTIVE_STATUSES = ['not_started', 'doing', 'waiting']
 
 let transporter = null

--- a/pushNotifications.js
+++ b/pushNotifications.js
@@ -46,7 +46,7 @@ function ensureVapidKeys() {
   console.log('[Push] Auto-generated VAPID keys and stored in database')
 }
 
-const AVOIDANCE_ENERGY_TYPES = ['errand']
+const AVOIDANCE_ENERGY_TYPES = ['errand', 'confrontation']
 // ACTIVE_STATUSES retained for any legacy refs; new code uses isNotifiable()
 // from db.js which folds in project / snooze_indefinite / gmail_pending rules.
 const ACTIVE_STATUSES = ['not_started', 'doing', 'waiting']

--- a/pushoverNotifications.js
+++ b/pushoverNotifications.js
@@ -26,7 +26,7 @@ import { isInQuietHours, getUserTimeParts } from './userTime.js'
 const PUSHOVER_API = 'https://api.pushover.net/1/messages.json'
 const PUSHOVER_RECEIPT_API = 'https://api.pushover.net/1/receipts'
 
-const AVOIDANCE_ENERGY_TYPES = ['errand']
+const AVOIDANCE_ENERGY_TYPES = ['errand', 'confrontation']
 const ACTIVE_STATUSES = ['not_started', 'doing', 'waiting']
 
 let loopTimer = null

--- a/src/api.js
+++ b/src/api.js
@@ -60,7 +60,7 @@ export async function inferDate(title, notes = '') {
 
 // --- T-shirt sizing + energy inference ---
 // Returns { size, energy, energyLevel } in a single API call.
-// energy = type of capacity (desk|people|errand|creative|physical)
+// energy = type of capacity (desk|people|errand|confrontation|creative|physical)
 // energyLevel = drain intensity (1=low, 2=medium, 3=high)
 export async function inferSize(title, notes = '', labels = []) {
   const taggable = Array.isArray(labels) ? labels.filter(l => l && l.id && l.name) : []
@@ -80,6 +80,7 @@ For ENERGY TYPE, determine what kind of capacity this task draws from:
 - "desk" — focused computer/paperwork (writing, coding, paying bills, data entry)
 - "people" — social interaction (meetings, lunch with someone, asking favors)
 - "errand" — going somewhere physically (pickup, returns, shopping, appointments)
+- "confrontation" — emotionally difficult interaction (disputing a bill, giving hard feedback, dreaded phone calls, conflict)
 - "creative" — open-ended thinking/making (design, writing, planning, brainstorming)
 - "physical" — bodily effort (cleaning, moving, exercise, yard work, assembly)
 
@@ -213,11 +214,11 @@ When should this be due? JSON only.`
 }
 
 // --- What Now ---
-// capacity = optional energy type filter (desk|people|errand|creative|physical|null)
+// capacity = optional energy type filter (desk|people|errand|confrontation|creative|physical|null)
 // weather = optional summary string like "Today: sunny, 72° · Tomorrow: rain, 55° · Sat: snow"
 export async function getWhatNow(tasks, time, energy, capacity = null, weather = null) {
   const ACTIVE = ['not_started', 'doing', 'waiting', 'open']
-  const ENERGY_LABELS = { desk: 'Desk', people: 'People', errand: 'Errand', creative: 'Creative', physical: 'Physical' }
+  const ENERGY_LABELS = { desk: 'Desk', people: 'People', errand: 'Errand', confrontation: 'Confrontation', creative: 'Creative', physical: 'Physical' }
   const openTasks = tasks
     .filter(t => ACTIVE.includes(t.status))
     .map(t => {
@@ -238,7 +239,7 @@ export async function getWhatNow(tasks, time, energy, capacity = null, weather =
   const system = `You are a helpful assistant for someone with ADHD. You help them pick the right task to work on right now. Be warm, direct, and practical. No fluff. Never be preachy or condescending.
 
 Tasks have t-shirt sizes: XS (~5 min), S (~15 min), M (~30-60 min), L (~half day), XL (~full day+).
-Tasks also have energy types (desk, people, errand, creative, physical) and drain levels (low, med, high).
+Tasks also have energy types (desk, people, errand, confrontation, creative, physical) and drain levels (low, med, high).
 HARD RULE: Never suggest a task bigger than the available time allows. If they have 15 minutes, only suggest XS or S tasks. If they say "fumes" or "low" energy, only suggest XS or S AND prefer low-drain tasks. A medium task requires at least 30 minutes AND moderate energy. Ignore stale/old tasks if they are too big for the window.${capacityRule}${weatherRule}
 
 Respond with JSON only — an object with two fields:
@@ -572,7 +573,7 @@ export async function analyzeNotionPage(title, plainTextContent) {
 For each task, determine:
 - title: clear, actionable task title (imperative mood)
 - size: T-shirt size (XS/S/M/L/XL)
-- energy: type of capacity needed (desk/people/errand/creative/physical)
+- energy: type of capacity needed (desk/people/errand/confrontation/creative/physical)
 - energyLevel: drain intensity (1=low, 2=medium, 3=high)
 - due_date: ISO date (YYYY-MM-DD) if mentioned or inferable, null otherwise
 - notes: brief context from the page content

--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -1,5 +1,5 @@
 import { memo, useCallback, useRef, useState } from 'react'
-import { Check, Pencil, Moon, Monitor, Users, MapPin, Palette, Dumbbell, Zap, SkipForward } from 'lucide-react'
+import { Check, Pencil, Moon, Monitor, Users, MapPin, Palette, Dumbbell, Flame, Zap, SkipForward } from 'lucide-react'
 import {
   isStale, isSnoozed, isOverdue,
   formatSnoozeLabel, formatDueDate, daysOld, ENERGY_TYPES,
@@ -7,7 +7,7 @@ import {
 import WeatherBadge from './WeatherBadge'
 import './TaskCard.css'
 
-const ENERGY_ICONS = { Monitor, Users, MapPin, Palette, Dumbbell }
+const ENERGY_ICONS = { Monitor, Users, MapPin, Flame, Palette, Dumbbell }
 
 // Swipe tuning. v2 only supports swipe-left for action reveal — destructive
 // actions stay in EditTaskModal with explicit confirm so the calm aesthetic

--- a/src/components/WhatNowModal.jsx
+++ b/src/components/WhatNowModal.jsx
@@ -1,11 +1,11 @@
 import { useState } from 'react'
-import { Target, Monitor, Users, MapPin, Palette, Dumbbell } from 'lucide-react'
+import { Target, Monitor, Users, MapPin, Flame, Palette, Dumbbell } from 'lucide-react'
 import { getWhatNow, getWeather } from '../api'
 import { ENERGY_TYPES } from '../store'
 import ModalShell from './ModalShell'
 import './WhatNowModal.css'
 
-const ENERGY_ICONS = { Monitor, Users, MapPin, Palette, Dumbbell }
+const ENERGY_ICONS = { Monitor, Users, MapPin, Flame, Palette, Dumbbell }
 
 const TIME_OPTIONS = [
   { label: '5–10 minutes', sub: 'Quick win' },

--- a/src/kept/QuickEditTask.jsx
+++ b/src/kept/QuickEditTask.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import {
   Trash2, Plus, Check, ChevronDown, Sliders, Sparkles,
-  Monitor, Users, MapPin, Palette, Dumbbell, Zap, BookOpenText,
+  Monitor, Users, MapPin, Flame, Palette, Dumbbell, Zap, BookOpenText,
 } from 'lucide-react'
 import ModalShell from '../components/ModalShell'
 import AutosaveIndicator from '../components/AutosaveIndicator'
@@ -24,6 +24,7 @@ const ENERGY = [
   { id: 'desk', label: 'Desk', Icon: Monitor, color: 'var(--energy-desk)' },
   { id: 'people', label: 'People', Icon: Users, color: 'var(--energy-people)' },
   { id: 'errand', label: 'Errand', Icon: MapPin, color: 'var(--energy-errand)' },
+  { id: 'confrontation', label: 'Confrontation', Icon: Flame, color: 'var(--energy-confrontation)' },
   { id: 'creative', label: 'Creative', Icon: Palette, color: 'var(--energy-creative)' },
   { id: 'physical', label: 'Physical', Icon: Dumbbell, color: 'var(--energy-physical)' },
 ]

--- a/src/kept/palette.css
+++ b/src/kept/palette.css
@@ -34,6 +34,7 @@
   --bm-f-billabong: #6FA6C9;
   --bm-f-ironbark: #9D87D6;
   --bm-f-heath: #C77C9E;
+  --bm-f-flame: #E5734F;    /* confrontation — hotter than clay, never collides */
   --bm-trail-empty: rgba(243, 238, 229, 0.10);
   --bm-scrim: rgba(8, 6, 3, 0.6);
   --bm-shadow: 0 1px 2px rgba(0, 0, 0, 0.45), 0 10px 28px rgba(0, 0, 0, 0.30);
@@ -57,6 +58,7 @@
   --energy-desk: var(--bm-f-billabong);
   --energy-people: var(--bm-f-ironbark);
   --energy-errand: var(--bm-f-eucalypt);
+  --energy-confrontation: var(--bm-f-flame);
   --energy-creative: var(--bm-f-heath);
   --energy-physical: var(--bm-f-clay);
   /* ── Wallaby-token bridge ─────────────────────────────────────────────
@@ -127,6 +129,7 @@
   --bm-f-billabong: #41799C;
   --bm-f-ironbark: #7E61C7;
   --bm-f-heath: #B25579;
+  --bm-f-flame: #C0392B;    /* confrontation — deeper than clay, never collides */
   --bm-trail-empty: rgba(38, 32, 26, 0.11);
   --bm-scrim: rgba(38, 32, 26, 0.35);
   --bm-shadow: 0 1px 2px rgba(38, 32, 26, 0.06), 0 10px 28px rgba(38, 32, 26, 0.10);
@@ -136,6 +139,7 @@
   --energy-desk: var(--bm-f-billabong);
   --energy-people: var(--bm-f-ironbark);
   --energy-errand: var(--bm-f-eucalypt);
+  --energy-confrontation: var(--bm-f-flame);
   --energy-creative: var(--bm-f-heath);
   --energy-physical: var(--bm-f-clay);
   /* ── Wallaby-token bridge ─────────────────────────────────────────────

--- a/src/store.js
+++ b/src/store.js
@@ -179,12 +179,13 @@ const ENERGY_TYPES = [
   { id: 'desk', label: 'Desk', icon: 'Monitor', color: 'var(--energy-desk)' },
   { id: 'people', label: 'People', icon: 'Users', color: 'var(--energy-people)' },
   { id: 'errand', label: 'Errand', icon: 'MapPin', color: 'var(--energy-errand)' },
+  { id: 'confrontation', label: 'Confrontation', icon: 'Flame', color: 'var(--energy-confrontation)' },
   { id: 'creative', label: 'Creative', icon: 'Palette', color: 'var(--energy-creative)' },
   { id: 'physical', label: 'Physical', icon: 'Dumbbell', color: 'var(--energy-physical)' },
 ]
 
 // Energy types that get more aggressive nagging (ADHD avoidance-prone)
-const AVOIDANCE_ENERGY_TYPES = ['errand']
+const AVOIDANCE_ENERGY_TYPES = ['errand', 'confrontation']
 
 const LABEL_COLORS = [
   '#4A9EFF', '#52C97F', '#FFB347', '#FF6240', '#A78BFA',

--- a/src/tokens.css
+++ b/src/tokens.css
@@ -9,6 +9,7 @@
   --energy-desk: #60A5FA;
   --energy-people: #A78BFA;
   --energy-errand: #34D399;
+  --energy-confrontation: #E8806A;
   --energy-creative: #F472B6;
   --energy-physical: #FBBF24;
   /* Typography — Syne for display (existing font), DM Sans for body */

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -4,6 +4,17 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ---
 
+## 2026-06-14
+
+- fix(tasks): restore the missing "Confrontation" energy type everywhere [S]
+  - Bug report: the energy-type picker (Kept quick-edit, Add/Edit modals, What-now capacity step) offered only 5 types — **Confrontation was absent** — yet badges (Dragon Slayer, the gold "Balanced Diet" = every energy type in one week), the avoidance nagging boost, and the AI inference docs all treat it as a first-class 6th type. So Balanced Diet was literally unearnable and confrontation tasks could never be tagged by hand.
+  - Root cause: `confrontation` had been dropped from every UI/inference surface while the Quokka tool enums (`adviserToolsTasks.js`) and badge math still expected 6. Restored across the board:
+    - `store.ENERGY_TYPES` (the single source for Add/Edit modals, EditTaskModal, WhatNowModal, TaskCard) + tap-to-cycle now includes Confrontation (`Flame` icon).
+    - `src/kept/QuickEditTask.jsx` hardcoded `ENERGY` list (the modal in the report) + `TaskCard`/`WhatNowModal` icon maps gained `Flame`.
+    - **Color token** `--energy-confrontation` was missing from the single-source block — added to `tokens.css` (#E8806A) and both Kept palettes via a new `--bm-f-flame` flight token (light #C0392B / dark #E5734F), distinct from clay (physical) and eucalypt (errand). Verified all six render distinctly in kept-dark.
+    - **AI inference prompt** (`inferSize` in `src/api.js`) never listed confrontation, so the model could never emit it either — added it plus the What-now / capture prompts and label maps.
+    - **Avoidance nagging boost** (`AVOIDANCE_ENERGY_TYPES`) was `['errand']` only across `store.js` + the three server engines (`email`/`push`/`pushover`), contradicting the documented "confrontation/errand get nagged ~30-56% more" — now `['errand', 'confrontation']` everywhere.
+
 ## 2026-06-13
 
 - fix(api): research mode no longer crashes on backslashes / newlines [S]


### PR DESCRIPTION
Promotes `dev` to production — single change since the last release:

- **fix(tasks): restore the missing "Confrontation" energy type everywhere** — the energy-type picker (Kept quick-edit, Add/Edit modals, What-now capacity step) offered only 5 types; Confrontation was absent, the AI inference prompt never listed it either, and the `--energy-confrontation` color token was missing from the single-source block. That made the gold **"Balanced Diet"** badge (every energy type in one week) literally unearnable and confrontation tasks impossible to tag by hand. Restored across `store.ENERGY_TYPES`, `QuickEditTask`, the modal/TaskCard/WhatNow icon maps, both Kept palettes + `tokens.css` (new `--bm-f-flame` flight token), the AI prompts, and `AVOIDANCE_ENERGY_TYPES` (nag boost) across the three server engines. Verified all six pills render distinctly in kept-dark.

`npm audit`: 3 high-severity advisories, all in build-time-only devDeps (`vite`/`@vitejs/plugin-react`) — not shipped to the container, pre-existing.

Merge with the **merge-commit** method.

https://claude.ai/code/session_01SzMTDswAmeegFirUscLh64

---
_Generated by [Claude Code](https://claude.ai/code/session_01SzMTDswAmeegFirUscLh64)_