### PR TITLE
fix(ui): un-smash loop + task editor forms at iPhone PWA width

### DIFF
--- a/src/components/AddTaskModal.css
+++ b/src/components/AddTaskModal.css
@@ -213,33 +213,36 @@
   border-color: var(--v2-text);
 }
 
-/* Energy type — flex row with all five chips sharing equal width via
- * flex: 1, so the full set (desk / people / errand / creative / physical)
- * fits on one row at iPhone-mini widths. Smaller font + padding than the
- * shared .v2-form-seg shape so "physical" / "creative" don't truncate.
- * Per-type color in the active state still distinguishes via inline border
- * + text colors. */
+/* Energy type — a responsive grid (auto-fit, min 88px) so the full set
+ * (desk / people / errand / confrontation / creative / physical) wraps to as
+ * many rows as it needs and every label stays fully readable. The old
+ * single-row flex (flex: 1; nowrap) truncated long labels — "confrontation"
+ * became "co…" — the moment a 6th type was added. Per-type color in the
+ * active state distinguishes via inline border + text colors. */
 .v2-form-energy-grid {
-  display: flex;
-  flex-wrap: nowrap;
-  gap: 4px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(88px, 1fr));
+  gap: 6px;
 }
 
 .v2-form-energy-pill {
-  flex: 1 1 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   min-width: 0;
-  height: 32px;
-  padding: 0 8px;
+  min-height: 34px;
+  padding: 5px 7px;
   border-radius: var(--v2-radius-pill);
   background: var(--v2-bg);
   color: var(--v2-text);
   border: 1px solid var(--v2-hairline);
-  font: 500 12px/1 var(--v2-font-body);
+  font: 500 12px/1.15 var(--v2-font-body);
   text-align: center;
   text-transform: lowercase;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  /* Wrap (don't ellipsize) so long labels like "confrontation" stay fully
+   * readable in a narrow grid cell instead of clipping to "confrontat…". */
+  white-space: normal;
+  overflow-wrap: anywhere;
   cursor: pointer;
   transition: background var(--v2-dur-quick) var(--v2-ease-standard),
               border-color var(--v2-dur-quick) var(--v2-ease-standard);

--- a/src/components/RoutinesModal.css
+++ b/src/components/RoutinesModal.css
@@ -244,9 +244,19 @@
 }
 
 /* Habit-mode picker: segmented control between Auto and Habit. The segmented
- * class is reused from AddTaskModal.css. */
+ * class is reused from AddTaskModal.css. The labels ("Auto (cadence)" /
+ * "Habit (target frequency)") are too long to share one row at phone widths
+ * without wrapping into floating half-pills, so each gets its own full-width
+ * row. */
 .v2-form-mode-segmented {
   margin-top: 4px;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 6px;
+}
+.v2-form-mode-segmented .v2-form-seg {
+  width: 100%;
+  justify-content: center;
 }
 
 /* Habit-row visual indicators: progress chip + streak. Shown in the summary
@@ -314,6 +324,7 @@
 .v2-followups-step-body {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 8px;
   padding-left: 26px;
 }
@@ -337,7 +348,7 @@
   font: 500 13px/1 var(--v2-font-body);
 }
 .v2-followups-step-mode {
-  width: 96px;
+  width: 116px;
   height: 32px;
   padding: 4px 8px;
   font: 500 13px/1 var(--v2-font-body);

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -15,6 +15,25 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
   - Prod report: "Broke the shit outta Quokka" — new chats open but every send returns "Could not retrieve response". Root cause: every Claude call in the app hardcoded `claude-sonnet-4-20250514` (Claude Sonnet 4, May 2025 snapshot), which Anthropic **deprecated with a retirement date of 2026-06-15** — so it began failing right at the deadline. Quokka surfaced it first because it's the heaviest caller (up to 15 tool-use turns per message → near-certain to hit the failing model), but the same stale ID powered size/energy inference, date extraction, toast lines, research, pattern detection, tag suggestions, Gmail scan, and AI nudges. Confirmed via the `claude-api` skill (authoritative model catalog) — not a regression from recent commits (none touched the adviser path).
   - Fix: swapped every `claude-sonnet-4-20250514` → the current `claude-sonnet-4-6` across all 9 source files (`server.js` `ADVISER_MODEL`, `adviserToolsTasks.js` research_task, `src/api.js`, `src/hooks/useNotifications.js`, `patternDetection.js`, `tagSuggestions.js`, `emailNotifications.js`, `gmailSync.js`, `scripts/generate-seed-data.js`). The adviser/inference call shapes carry no `thinking`/`budget_tokens`/prefill/`output_format`, so the migration is a clean model-ID swap with no breaking-change risk. The Haiku calls (`claude-haiku-4-5-20251001`) are still current and were left untouched. Kept the Sonnet *tier* (Quokka's deliberate cost choice for long tool loops); `claude-sonnet-4-6` is a non-dated alias so it won't silently age out the same way. Effort tuning (Sonnet 4.6 defaults to `high`) deferred — pure correctness swap.
 
+- fix(ui): un-smash the loop + task editor forms at iPhone PWA width [S]
+  - Rendered every edit screen at iPhone PWA size (390px). The forms-based
+    editors (Edit loop / RoutinesModal, full Edit task + Add task / EditTaskModal
+    + AddTaskModal — all sharing `forms.css` + the energy-grid CSS) were cramped;
+    the chip quick-editor, Throw sheet, What-now and Settings rendered fine.
+  - **Energy type pills truncated** ("people"→"pe…", "confrontation"→"co…"): the
+    grid was `flex: 1; flex-wrap: nowrap`, built for 5 chips on one row; the 6th
+    type (confrontation, added earlier today) tipped it into ellipsis. Now a
+    responsive `grid (auto-fit, minmax 88px)` that wraps to a clean 3×2 with
+    text-wrap fallback + tuned font/padding so even "confrontation" reads on one
+    line. Fixes Add + Edit task together (single source in `AddTaskModal.css`).
+  - **Loop "Auto (cadence) / Habit (target frequency)" toggle** wrapped into two
+    floating half-pills → now two full-width stacked segments.
+  - **Follow-up step rows**: the "After prev" timing select truncated to
+    "After pre" (96px → 116px) and the controls row now `flex-wrap`s so the
+    move-up/down arrows drop to their own line instead of overflowing.
+  - CSS-only; `RoutinesModal.css` + `AddTaskModal.css`. Verified via a puppeteer
+    iPhone-viewport harness against the real running app.
+
 - fix(tasks): restore the missing "Confrontation" energy type everywhere [S]
   - Bug report: the energy-type picker (Kept quick-edit, Add/Edit modals, What-now capacity step) offered only 5 types — **Confrontation was absent** — yet badges (Dragon Slayer, the gold "Balanced Diet" = every energy type in one week), the avoidance nagging boost, and the AI inference docs all treat it as a first-class 6th type. So Balanced Diet was literally unearnable and confrontation tasks could never be tagged by hand.
   - Root cause: `confrontation` had been dropped from every UI/inference surface while the Quokka tool enums (`adviserToolsTasks.js`) and badge math still expected 6. Restored across the board:


### PR DESCRIPTION
Rendered every edit screen at iPhone PWA width (390px) in the real running app via a puppeteer harness. The "smashing" was concentrated in the forms-based editors (Edit loop / RoutinesModal, full Edit + Add task / EditTaskModal + AddTaskModal — all sharing `forms.css` + the energy-grid CSS). The chip quick-editor, Throw sheet, What-now and Settings render fine.

## Fixes (CSS-only)
- **Energy type pills truncated** ("people"→"pe…", "confrontation"→"co…"): the grid was `flex: 1; flex-wrap: nowrap`, built for 5 chips on one row; the 6th type (confrontation, added earlier today) tipped it into ellipsis. Now a responsive `grid (auto-fit, minmax 88px)` wrapping to a clean 3×2, with a text-wrap fallback + tuned font/padding so even "confrontation" reads on one line. Fixes Add + Edit task together (single source in `AddTaskModal.css`).
- **Loop "Auto (cadence) / Habit (target frequency)" toggle** wrapped into two floating half-pills → now two full-width stacked segments.
- **Follow-up step rows**: the "After prev" timing select truncated to "After pre" (96px → 116px); the controls row now `flex-wrap`s so the move-up/down arrows drop to their own line instead of overflowing.

Touches `RoutinesModal.css` + `AddTaskModal.css`. Verified before/after at 390px.

https://claude.ai/code/session_01SzMTDswAmeegFirUscLh64

---
_Generated by [Claude Code](https://claude.ai/code/session_01SzMTDswAmeegFirUscLh64)_