### PR TITLE
docs: update wiki model references to claude-sonnet-4-6

### DIFF
--- a/wiki/Development.md
+++ b/wiki/Development.md
@@ -90,6 +90,6 @@ boomerang/
 
 - **Frontend**: React 19, Vite, PWA (vite-plugin-pwa)
 - **Backend**: Express 5, sql.js (SQLite in-process)
-- **AI**: Anthropic Claude API (claude-sonnet-4-20250514)
+- **AI**: Anthropic Claude API (claude-sonnet-4-6)
 - **Integrations**: Notion API, Trello REST API
 - **Deployment**: Docker (node:22-alpine), GitHub Actions, GHCR

--- a/wiki/Features.md
+++ b/wiki/Features.md
@@ -61,7 +61,7 @@ The header shows a task count with configurable display modes:
 
 ## AI Features (requires Anthropic API key)
 
-All AI features use Claude (claude-sonnet-4-20250514) via a server-side proxy. They are fully disabled if no API key is configured — the rest of the app works normally without them.
+All AI features use Claude (claude-sonnet-4-6) via a server-side proxy. They are fully disabled if no API key is configured — the rest of the app works normally without them.
 
 - **What Now** — a guided flow that asks how much time you have (5-10 min, 30 min, a couple hours) and your energy level (running on fumes, moderate, I've got it), then recommends 1-3 tasks with reasons. Enforces hard rules matching task size to available time and energy. When fewer than 3 picks are available, shows a "Feeling ambitious?" stretch suggestion one size up. You can mark tasks done directly from the suggestions.
 - **Polish** — takes messy brain-dump notes and turns them into clear, actionable bullet points. Also cleans up the task title if it's vague. Automatically triggers date inference and size inference on the polished content.

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -4,6 +4,11 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ---
 
+## 2026-06-15
+
+- docs: update wiki model references to claude-sonnet-4-6 [XS]
+  - `Development.md` + `Features.md` still named the retired `claude-sonnet-4-20250514`; aligned them with the app-wide model swap. (Version-History references to the old id are intentional — they describe the migration.)
+
 ## 2026-06-14
 
 - fix(ai)!: migrate off the retiring `claude-sonnet-4-20250514` model app-wide [S]


### PR DESCRIPTION
Doc-only follow-up to the Quokka model-retirement hotfix (#565/#566). `wiki/Development.md` and `wiki/Features.md` still named the retired `claude-sonnet-4-20250514`; aligned them with the live `claude-sonnet-4-6`. (Version-History references to the old ID are intentional — they describe the migration.)

No code change.

https://claude.ai/code/session_01SzMTDswAmeegFirUscLh64

---
_Generated by [Claude Code](https://claude.ai/code/session_01SzMTDswAmeegFirUscLh64)_