### PR TITLE
feat(server): opt-in auth gate + iOS Shortcut intake endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,3 +38,23 @@ PORT=3001
 # Register at https://developers.usps.com and create an app with Tracking API access
 # USPS_CLIENT_ID=your_consumer_key
 # USPS_CLIENT_SECRET=your_consumer_secret
+
+# --- Authentication (opt-in; for public / externally-hosted deployments) ---
+# Boomerang ships with NO auth (single-user, trusted-machine threat model).
+# Setting either AUTH_PASSWORD or AUTH_PASSWORD_HASH turns ON a login gate over
+# every /api route. Generate both values below with:
+#   node scripts/auth-setup.js [your-password]
+#
+# Browser login: password -> httpOnly session cookie. Prefer the hashed form so
+# the plaintext password is never stored in the environment.
+# AUTH_PASSWORD_HASH='scrypt$<saltHex>$<hashHex>'
+# AUTH_PASSWORD=your_plaintext_password   # simpler alternative to the hash
+#
+# Machine/API access (iOS Shortcut, future native app): a static token sent as
+# `Authorization: Bearer <token>` or `x-api-token: <token>`.
+# API_TOKEN=long_random_hex_token
+#
+# Force the Secure flag on the session cookie. Auto-detected from
+# X-Forwarded-Proto behind a TLS proxy (trust proxy is on); set to 1 to force,
+# 0 to disable (e.g. plain-HTTP localhost testing).
+# COOKIE_SECURE=1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1061,6 +1061,19 @@ user confirms Kept as the daily driver.
 ## Additional Notes
 - Single developer (ryakel) — no PR review process needed.
 
+## Authentication (2026-06-19, opt-in)
+**Off by default; turn on before public hosting.** `auth.js` (root module, in the Dockerfile runtime COPY list) adds an `authGate` middleware over every `/api` route — INERT unless `AUTH_PASSWORD` or `AUTH_PASSWORD_HASH` is set in env, so existing self-hosted instances are unchanged until configured. Two credential types share the gate:
+- **Humans** → `POST /api/auth/login {password}` → httpOnly+SameSite=Lax+Secure session cookie `boom_session` (30-day rolling, persisted in `app_data.auth_sessions` so restarts don't log you out). Cookies ride every same-origin fetch + the SSE stream automatically, so the client is gated by ONE boot check: `src/App.jsx` calls `GET /api/auth/status` and renders `src/components/LoginScreen.jsx` when `authEnabled && !authenticated`. Fails OPEN on a flaky status probe (the server is the real enforcement; client gate is just UX).
+- **Machines** (iOS Shortcut, future native app) → static `API_TOKEN` env as `Authorization: Bearer <token>` or `x-api-token: <token>`.
+
+Passwords verified with `scrypt` + timing-safe compare (hash format `scrypt$<saltHex>$<hashHex>`); API token timing-safe compared. `scripts/auth-setup.js [password]` prints `AUTH_PASSWORD_HASH` + a fresh `API_TOKEN`. Cookie `Secure` auto-detects via `req.secure` (`trust proxy` is on) or force with `COOKIE_SECURE=1`/`0`.
+
+**Open paths even when gated:** `GET /api/health`, `GET /api/auth/status`, `POST /api/auth/login`, `POST /api/auth/logout` (login/status must be reachable pre-auth).
+
+**Quick intake endpoint:** `POST /api/intake {title|text, notes?, due_date?, high_priority?, tags?}` — authed by the gate (API token or cookie), builds a full task with server-side defaults + `size_inferred=false` so the background auto-sizer refines it. This is the iOS Shortcut's target. Recipe: `wiki/iOS-Shortcut.md`.
+
+**Not serverless-friendly** (persistent notification loops + SSE + in-memory Quokka runner + local SQLite + session store all assume one always-on instance) — host on a small always-on box, NOT Lambda.
+
 ## Security Posture (2026-05-02)
 **Threat model:** single-user self-hosted, user controls the machine. See `wiki/Security-Notes.md` for the full breakdown.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ ENV APP_VERSION=${APP_VERSION}
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY package.json ./
-COPY server.js db.js seed.js emailNotifications.js pushNotifications.js pushoverNotifications.js digestBuilder.js notifAi.js userTime.js gmailSync.js weatherSync.js notionMCP.js notionMCPProxy.js patternDetection.js tagSuggestions.js knowledgeSync.js ./
+COPY server.js auth.js db.js seed.js emailNotifications.js pushNotifications.js pushoverNotifications.js digestBuilder.js notifAi.js userTime.js gmailSync.js weatherSync.js notionMCP.js notionMCPProxy.js patternDetection.js tagSuggestions.js knowledgeSync.js ./
 COPY adviserTools.js adviserToolsTasks.js adviserToolsIntegrations.js adviserToolsMisc.js adviserToolsKnowledge.js ./
 COPY migrations ./migrations
 COPY scripts ./scripts

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Open `http://localhost:3001` and add your API keys in Settings.
 - **Routines + Habits + Suggestions** — recurring tasks with cadence (daily/weekly/monthly/quarterly/annually), an optional trigger time (surface-at clock time so a chore stays hidden/silent until e.g. 8pm) including absolute clock times on follow-up steps, an `auto_roll` flag for meds that can't double up, habit mode for target-frequency tracking (`2× / week`, behind-pace nudges), plus a weekly server scan that detects patterns in completed-task history and surfaces them as routine suggestions
 - **Projects with sessions** — long-term work lives as projects. Pin a project to the main list to chip away; "Log session" awards points + bumps the streak (capped at 10 sessions before requiring a child completion). Add child tasks for the concrete steps; completing them awards their own points. Silent by default; opt in to nags via `Allow nags without a due date` or just set a deadline
 - **"Later — set aside" snooze** — park a task indefinitely with no auto-resurface; bring it back from the Snooze modal when you're ready
+- **Optional authentication** — opt-in login gate for public/external hosting: password → session cookie for the browser, plus a static API token for automations. Off by default (single-user, trusted-machine). See Configuration below
+- **iOS Shortcut intake** — create tasks from the share sheet / Siri / Action button via `POST /api/intake` and a static API token (`wiki/iOS-Shortcut.md`)
 - **Custom labels**, due dates, high-priority escalation
 
 ### Notifications
@@ -70,6 +72,29 @@ docker run -d -p 3001:3001 \
 ```
 
 `PUSHOVER_DEFAULT_APP_TOKEN` is optional — it provides a default app token so you don't have to paste it in the UI for every install. Per-user keys are always entered in the Settings UI.
+
+### Authentication (for public hosting)
+
+Boomerang ships with **no auth** (single-user, trusted-machine threat model). If
+you expose it to the internet, turn the login gate on by setting credentials:
+
+```bash
+node scripts/auth-setup.js            # prints AUTH_PASSWORD_HASH + a fresh API_TOKEN
+```
+
+```bash
+docker run -d -p 3001:3001 -v boomerang-data:/data \
+  -e AUTH_PASSWORD_HASH='scrypt$...$...' \   # browser login
+  -e API_TOKEN=long_random_hex \             # iOS Shortcut / automations
+  -e COOKIE_SECURE=1 \                        # behind a TLS proxy
+  ghcr.io/ryakel/boomerang:latest
+```
+
+Humans log in with the password (→ httpOnly session cookie); the iOS Shortcut
+and any automations authenticate with `Authorization: Bearer <API_TOKEN>`. Run
+behind HTTPS. **Not serverless-friendly** — needs one always-on instance (it runs
+persistent notification loops, holds SSE connections, and uses local SQLite), so
+host on a small VPS / Fly.io machine / Render service rather than Lambda.
 
 ## Tech Stack
 

--- a/auth.js
+++ b/auth.js
@@ -1,0 +1,185 @@
+// auth.js — single-user authentication for Boomerang.
+//
+// OPT-IN: the gate is completely inert unless AUTH_PASSWORD (or
+// AUTH_PASSWORD_HASH) is set in the environment. This preserves the legacy
+// "single-user, trusted machine" deployment — nothing changes until you
+// provide credentials, which is exactly what you do when you move the app onto
+// a public host.
+//
+// Two credential types share one gate:
+//   1. Humans   -> POST /api/auth/login with the password -> httpOnly session
+//      cookie (boom_session). Cookies ride every same-origin /api fetch AND the
+//      SSE EventSource automatically, so the React app needs no per-call change.
+//   2. Machines (the iOS Shortcut, a future native app) -> a static API_TOKEN
+//      sent as `Authorization: Bearer <token>` or `x-api-token: <token>`.
+//
+// Sessions persist in app_data.auth_sessions so a server restart / redeploy
+// doesn't log you out. This (like SQLite + the in-memory Quokka runner) assumes
+// a single always-on instance — NOT a serverless / multi-instance host.
+
+import crypto from 'crypto'
+
+const SESSION_COOKIE = 'boom_session'
+const SESSION_TTL_MS = 30 * 24 * 60 * 60 * 1000 // 30 days, rolling on login
+const SESSIONS_KEY = 'auth_sessions'
+
+let deps = { getData: () => null, setData: () => {} }
+export function initAuth(d) { deps = { ...deps, ...d } }
+
+export function isAuthEnabled() {
+  return Boolean(process.env.AUTH_PASSWORD || process.env.AUTH_PASSWORD_HASH)
+}
+
+function apiToken() {
+  return process.env.API_TOKEN || ''
+}
+
+// Timing-safe compare that won't throw on length mismatch.
+function safeEqual(a, b) {
+  const ab = Buffer.from(String(a))
+  const bb = Buffer.from(String(b))
+  if (ab.length !== bb.length) {
+    crypto.timingSafeEqual(ab, ab) // burn a compare to keep timing flatter
+    return false
+  }
+  return crypto.timingSafeEqual(ab, bb)
+}
+
+// AUTH_PASSWORD_HASH format: `scrypt$<saltHex>$<hashHex>` (see scripts/auth-setup.js).
+// Falls back to a plaintext AUTH_PASSWORD compare if only that is set.
+function checkPassword(password) {
+  const hash = process.env.AUTH_PASSWORD_HASH
+  if (hash) {
+    const parts = String(hash).split('$')
+    if (parts.length === 3 && parts[0] === 'scrypt') {
+      const [, saltHex, hashHex] = parts
+      try {
+        const derived = crypto.scryptSync(String(password), Buffer.from(saltHex, 'hex'), 32)
+        return safeEqual(derived.toString('hex'), hashHex)
+      } catch {
+        return false
+      }
+    }
+    return false
+  }
+  return safeEqual(password, process.env.AUTH_PASSWORD || '')
+}
+
+function loadSessions() {
+  const s = deps.getData(SESSIONS_KEY)
+  return (s && typeof s === 'object') ? s : {}
+}
+function saveSessions(s) { deps.setData(SESSIONS_KEY, s) }
+
+function sweep(sessions) {
+  const now = Date.now()
+  let changed = false
+  for (const [tok, exp] of Object.entries(sessions)) {
+    if (!exp || exp < now) { delete sessions[tok]; changed = true }
+  }
+  return changed
+}
+
+export function createSession() {
+  const token = crypto.randomBytes(32).toString('hex')
+  const sessions = loadSessions()
+  sweep(sessions)
+  sessions[token] = Date.now() + SESSION_TTL_MS
+  saveSessions(sessions)
+  return token
+}
+
+export function verifySession(token) {
+  if (!token) return false
+  const sessions = loadSessions()
+  const exp = sessions[token]
+  if (!exp || exp < Date.now()) {
+    if (sweep(sessions)) saveSessions(sessions)
+    return false
+  }
+  return true
+}
+
+export function destroySession(token) {
+  if (!token) return
+  const sessions = loadSessions()
+  if (sessions[token]) { delete sessions[token]; saveSessions(sessions) }
+}
+
+export function login(password) {
+  if (!checkPassword(password)) return null
+  return createSession()
+}
+
+function parseCookies(header) {
+  const out = {}
+  if (!header) return out
+  for (const part of header.split(';')) {
+    const i = part.indexOf('=')
+    if (i < 0) continue
+    out[part.slice(0, i).trim()] = decodeURIComponent(part.slice(i + 1).trim())
+  }
+  return out
+}
+
+export function sessionTokenFromReq(req) {
+  return parseCookies(req.headers.cookie)[SESSION_COOKIE] || null
+}
+
+function bearerFromReq(req) {
+  const h = req.headers['authorization'] || ''
+  if (h.toLowerCase().startsWith('bearer ')) return h.slice(7).trim()
+  return req.headers['x-api-token'] || null
+}
+
+export function verifyApiToken(token) {
+  const t = apiToken()
+  return Boolean(t) && Boolean(token) && safeEqual(token, t)
+}
+
+// Authenticated by EITHER a valid session cookie OR the static API token.
+export function isAuthenticated(req) {
+  if (verifySession(sessionTokenFromReq(req))) return true
+  if (verifyApiToken(bearerFromReq(req))) return true
+  return false
+}
+
+function cookieSecure(req) {
+  if (process.env.COOKIE_SECURE === '1') return true
+  if (process.env.COOKIE_SECURE === '0') return false
+  return Boolean(req.secure) // honored when `trust proxy` is set + X-Forwarded-Proto=https
+}
+
+export function setSessionCookie(req, res, token) {
+  res.cookie(SESSION_COOKIE, token, {
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: cookieSecure(req),
+    maxAge: SESSION_TTL_MS,
+    path: '/',
+  })
+}
+
+export function clearSessionCookie(req, res) {
+  res.clearCookie(SESSION_COOKIE, {
+    path: '/', httpOnly: true, sameSite: 'lax', secure: cookieSecure(req),
+  })
+}
+
+// Paths reachable WITHOUT auth even when the gate is on. Everything else under
+// /api/ requires a session cookie or the API token. Static assets + the SPA are
+// not under /api, so the login page itself always loads.
+const OPEN_PATHS = new Set([
+  '/api/health',
+  '/api/auth/status',
+  '/api/auth/login',
+  '/api/auth/logout',
+])
+
+export function authGate(req, res, next) {
+  if (!isAuthEnabled()) return next()                 // inert until configured
+  if (!req.path.startsWith('/api/')) return next()    // static / SPA served freely
+  if (OPEN_PATHS.has(req.path)) return next()
+  if (isAuthenticated(req)) return next()
+  return res.status(401).json({ error: 'Authentication required' })
+}

--- a/scripts/auth-setup.js
+++ b/scripts/auth-setup.js
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+// scripts/auth-setup.js — generate the env vars for Boomerang auth.
+//
+// Usage:
+//   node scripts/auth-setup.js [password]
+//
+// Prints:
+//   AUTH_PASSWORD_HASH  — scrypt hash of your password (server-only, never plaintext)
+//   API_TOKEN           — a fresh random token for the iOS Shortcut / native app
+//
+// Set both in your host's environment. If no password is given, one is
+// generated for you and printed once.
+
+import crypto from 'crypto'
+
+function hashPassword(password) {
+  const salt = crypto.randomBytes(16)
+  const hash = crypto.scryptSync(password, salt, 32)
+  return `scrypt$${salt.toString('hex')}$${hash.toString('hex')}`
+}
+
+const arg = process.argv[2]
+const generatedPw = !arg
+const password = arg || crypto.randomBytes(9).toString('base64url')
+const apiToken = crypto.randomBytes(32).toString('hex')
+
+console.log('# --- Boomerang auth env vars ---')
+console.log('# Add these to your host environment (PaaS dashboard, .env, etc.)')
+console.log('')
+if (generatedPw) {
+  console.log(`# Generated password (save it — this is the only time it is shown):`)
+  console.log(`#   ${password}`)
+  console.log('')
+}
+console.log(`AUTH_PASSWORD_HASH='${hashPassword(password)}'`)
+console.log(`API_TOKEN='${apiToken}'`)
+console.log('')
+console.log('# Optional: COOKIE_SECURE=1 to force Secure cookies behind a TLS proxy')
+console.log('# (auto-detected from X-Forwarded-Proto when `trust proxy` is on).')

--- a/server.js
+++ b/server.js
@@ -49,6 +49,8 @@ import { adoptKnowledgeDatabase,
 } from './knowledgeSync.js'
 import { getAllKnowledgeItems, searchKnowledgeItems, getKnowledgeItem } from './db.js'
 import crypto from 'crypto'
+import { initAuth, authGate, login, destroySession, sessionTokenFromReq,
+  setSessionCookie, clearSessionCookie, isAuthEnabled, isAuthenticated } from './auth.js'
 
 // Register adviser tools once at module load
 registerTaskTools()
@@ -185,9 +187,60 @@ app.set('trust proxy', 1)
 app.use(cors())
 app.use(express.json({ limit: '2mb' }))
 
+// --- Auth gate (opt-in; inert unless AUTH_PASSWORD/AUTH_PASSWORD_HASH is set) ---
+initAuth({ getData, setData })
+app.use(authGate)
+
 // --- Health check ---
 app.get('/api/health', (req, res) => {
   res.json({ status: 'ok', appVersion, isDev: isDevEnv })
+})
+
+// --- Auth endpoints (all reachable without a session; see auth.js OPEN_PATHS) ---
+app.get('/api/auth/status', (req, res) => {
+  res.json({ authEnabled: isAuthEnabled(), authenticated: isAuthEnabled() ? isAuthenticated(req) : true })
+})
+
+app.post('/api/auth/login', (req, res) => {
+  if (!isAuthEnabled()) return res.json({ ok: true, authEnabled: false })
+  const token = login(req.body?.password || '')
+  if (!token) return res.status(401).json({ error: 'Invalid password' })
+  setSessionCookie(req, res, token)
+  res.json({ ok: true })
+})
+
+app.post('/api/auth/logout', (req, res) => {
+  destroySession(sessionTokenFromReq(req))
+  clearSessionCookie(req, res)
+  res.json({ ok: true })
+})
+
+// --- Quick intake (iOS Shortcut / share-sheet target). Authed by the gate via
+// the API token or a session cookie. Takes free text and builds a full task
+// with server-side defaults so the Shortcut body stays trivial. size_inferred
+// is false so the background auto-sizer refines size/energy after creation.
+app.post('/api/intake', (req, res) => {
+  const body = req.body || {}
+  const title = (body.title || body.text || '').toString().trim()
+  if (!title) return res.status(400).json({ error: 'title (or text) is required' })
+  const now = new Date().toISOString()
+  const task = {
+    id: crypto.randomUUID(),
+    title: title.slice(0, 500),
+    status: 'not_started',
+    notes: (body.notes || '').toString(),
+    due_date: body.due_date || null,
+    high_priority: Boolean(body.high_priority),
+    tags: Array.isArray(body.tags) ? body.tags : [],
+    size: 'M',
+    size_inferred: false,
+    last_touched: now,
+    created_at: now,
+  }
+  upsertTask(task)
+  const newVersion = bumpVersion()
+  broadcast(newVersion, null)
+  res.json({ ok: true, task: getTask(task.id), version: newVersion })
 })
 
 // --- Server logs endpoint ---

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,7 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import AppV2 from './AppV2.jsx'
 import ErrorBoundary from './components/ErrorBoundary.jsx'
+import LoginScreen from './components/LoginScreen.jsx'
 import { logSystemError } from './store'
 
 // The legacy v1 UI was removed (2026-06-10) — v2 is the only interface.
@@ -26,6 +27,10 @@ function setupGlobalErrorLogging() {
 let errorLoggingWired = false
 
 export default function App() {
+  // 'checking' until /api/auth/status resolves; 'ok' when auth is off OR we hold
+  // a valid session; 'needed' when the server requires a login we don't have.
+  const [authState, setAuthState] = useState('checking')
+
   useEffect(() => {
     document.documentElement.setAttribute('data-ui-version', 'v2')
     if (!errorLoggingWired) {
@@ -33,6 +38,21 @@ export default function App() {
       errorLoggingWired = true
     }
   }, [])
+
+  useEffect(() => {
+    let cancelled = false
+    fetch('/api/auth/status')
+      .then((r) => r.json())
+      .then((d) => {
+        if (cancelled) return
+        setAuthState(!d.authEnabled || d.authenticated ? 'ok' : 'needed')
+      })
+      .catch(() => { if (!cancelled) setAuthState('ok') }) // fail open — don't lock out on a flaky status probe
+    return () => { cancelled = true }
+  }, [])
+
+  if (authState === 'checking') return null
+  if (authState === 'needed') return <LoginScreen onAuthenticated={() => setAuthState('ok')} />
 
   return (
     <ErrorBoundary>

--- a/src/components/LoginScreen.css
+++ b/src/components/LoginScreen.css
@@ -1,0 +1,73 @@
+.login-screen {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: var(--bm-bg, #f7f4ef);
+}
+
+.login-card {
+  width: 100%;
+  max-width: 340px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 32px 28px;
+  border-radius: 18px;
+  background: var(--bm-surface, #fff);
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.12);
+}
+
+.login-mark {
+  font-family: 'Fraunces', Georgia, serif;
+  font-size: 28px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--bm-ink, #1c1a17);
+}
+
+.login-sub {
+  margin: -6px 0 4px;
+  font-size: 14px;
+  color: var(--bm-ink-soft, #6b655c);
+}
+
+.login-input {
+  width: 100%;
+  padding: 12px 14px;
+  font-size: 16px; /* >=16px avoids iOS zoom-on-focus */
+  border: 1px solid var(--bm-line, #e2dcd2);
+  border-radius: 12px;
+  background: var(--bm-bg, #faf8f4);
+  color: var(--bm-ink, #1c1a17);
+  box-sizing: border-box;
+}
+
+.login-input:focus {
+  outline: none;
+  border-color: var(--bm-ember, #d9622b);
+}
+
+.login-error {
+  font-size: 13px;
+  color: #c0392b;
+}
+
+.login-btn {
+  width: 100%;
+  padding: 12px 14px;
+  font-size: 15px;
+  font-weight: 600;
+  color: #fff;
+  background: var(--bm-ember, #d9622b);
+  border: none;
+  border-radius: 12px;
+  cursor: pointer;
+}
+
+.login-btn:disabled {
+  opacity: 0.55;
+  cursor: default;
+}

--- a/src/components/LoginScreen.jsx
+++ b/src/components/LoginScreen.jsx
@@ -1,0 +1,58 @@
+import { useState } from 'react'
+import './LoginScreen.css'
+
+// Shown only when server-side auth is enabled (AUTH_PASSWORD set) and the
+// browser has no valid session cookie. On success the httpOnly cookie is set by
+// the server and every same-origin /api fetch + the SSE stream authenticate
+// automatically — so we just reload into the app.
+export default function LoginScreen({ onAuthenticated }) {
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
+  const [busy, setBusy] = useState(false)
+
+  async function submit(e) {
+    e.preventDefault()
+    if (busy) return
+    setBusy(true)
+    setError('')
+    try {
+      const res = await fetch('/api/auth/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ password }),
+      })
+      if (res.ok) {
+        onAuthenticated?.()
+        return
+      }
+      const data = await res.json().catch(() => ({}))
+      setError(data.error || 'Login failed')
+    } catch {
+      setError('Network error — is the server reachable?')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="login-screen">
+      <form className="login-card" onSubmit={submit}>
+        <div className="login-mark">boomerang.</div>
+        <p className="login-sub">Sign in to continue</p>
+        <input
+          type="password"
+          className="login-input"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          autoFocus
+          autoComplete="current-password"
+        />
+        {error && <div className="login-error">{error}</div>}
+        <button type="submit" className="login-btn" disabled={busy || !password}>
+          {busy ? 'Signing in…' : 'Sign in'}
+        </button>
+      </form>
+    </div>
+  )
+}

--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -255,11 +255,27 @@ Stage 3 will migrate `useNotionSync` + `useExternalSync` + the REST proxy to MCP
 
 `GET /api/health` returns `{ status: "ok" }`. Used by the Docker healthcheck (wget-based, every 30 seconds) to monitor container health.
 
+## Authentication (opt-in)
+
+`auth.js` adds an `authGate` middleware over every `/api` route. It is **inert
+unless `AUTH_PASSWORD` or `AUTH_PASSWORD_HASH` is set** in env, preserving the
+default no-auth single-user deployment. When enabled, a request passes if it
+carries a valid `boom_session` cookie (human login) OR a valid `API_TOKEN` in
+`Authorization: Bearer …` / `x-api-token` (machine access). Sessions persist in
+`app_data.auth_sessions`. Open-without-auth: `/api/health`, `/api/auth/status`,
+`/api/auth/login`, `/api/auth/logout`. Client gate: `src/App.jsx` probes
+`/api/auth/status` on boot and renders `LoginScreen` when required. Setup helper:
+`scripts/auth-setup.js`. Full writeup: `wiki/Security-Notes.md` → Authentication.
+
 ## Server Routes
 
 | Method | Path | Description |
 |--------|------|-------------|
 | `GET` | `/api/health` | Health check |
+| `GET` | `/api/auth/status` | `{ authEnabled, authenticated }` — drives the client login gate |
+| `POST` | `/api/auth/login` | `{ password }` → sets `boom_session` httpOnly cookie (401 on bad password) |
+| `POST` | `/api/auth/logout` | Destroys the session + clears the cookie |
+| `POST` | `/api/intake` | Quick task create for the iOS Shortcut: `{ title\|text, notes?, due_date?, high_priority?, tags? }` (authed by gate) |
 | `GET` | `/api/keys/status` | Reports env var key availability |
 | `GET` | `/api/events` | SSE endpoint for real-time cross-client sync |
 | `GET` | `/api/data` | Get all data from SQLite (includes `_version`) |

--- a/wiki/Features.md
+++ b/wiki/Features.md
@@ -593,3 +593,21 @@ Attach files to any task (5 MB limit per file). Attachments can be added in the 
 ## Version Display
 
 The current app version (from git tags or the `APP_VERSION` build arg) is shown in the Settings header.
+
+## Authentication (optional)
+
+Off by default — Boomerang is built for single-user, trusted-machine use. When
+you host it externally, enable a login gate by setting `AUTH_PASSWORD_HASH` (or
+`AUTH_PASSWORD`) and `API_TOKEN` in the environment (`node scripts/auth-setup.js`
+generates both). Once enabled, the app shows a password login screen; signing in
+stores a 30-day session cookie. Automations (the iOS Shortcut, a future native
+app) authenticate with the API token instead. See the README → Authentication
+and `wiki/Security-Notes.md` for setup and the threat-model details.
+
+## Create tasks from anywhere on iOS (Shortcut)
+
+With auth enabled, an iOS Shortcut can drop a task into Boomerang from the share
+sheet (share a Message, email, webpage, or selected text → *Add to Boomerang*),
+Siri, the Action button, or Back Tap — no native app needed. It POSTs to
+`/api/intake` with the API token; the task lands with AI sizing/energy inferred
+in the background. Step-by-step build instructions: `wiki/iOS-Shortcut.md`.

--- a/wiki/Security-Notes.md
+++ b/wiki/Security-Notes.md
@@ -2,6 +2,45 @@
 
 Boomerang is built for **single-user self-hosted deployment**. The threat model is "your own machine, your own data, your own network." This document is honest about what that means for credential handling — read it before deciding whether the app fits your situation.
 
+## Authentication (opt-in — required before public hosting)
+
+By default Boomerang has **no auth at all** — every `/api` route is open. That's
+acceptable only when the app is unreachable from untrusted networks (LAN, VPN,
+localhost). **The moment you put it on a public host, turn auth on.**
+
+Setting `AUTH_PASSWORD` (or, preferred, `AUTH_PASSWORD_HASH`) in the environment
+activates a gate (`auth.js`, `authGate` middleware) over every `/api` route.
+Two credential types pass it:
+
+- **Humans** → `POST /api/auth/login` with the password → an **httpOnly,
+  SameSite=Lax, Secure** session cookie (`boom_session`, 30-day rolling).
+  Cookies ride every same-origin fetch + the SSE stream automatically, so the
+  whole React app is gated by one boot check (`/api/auth/status`) that shows a
+  login screen when needed.
+- **Machines** (the iOS Shortcut, a future native app) → a static `API_TOKEN`
+  sent as `Authorization: Bearer <token>` or `x-api-token: <token>`.
+
+Generate both with `node scripts/auth-setup.js [password]`. Passwords are
+verified with `scrypt` + timing-safe compare; the API token with a timing-safe
+compare. Sessions persist in `app_data.auth_sessions` (survives restarts).
+
+**What this does and doesn't cover:**
+- ✅ Stops anonymous internet access to your tasks, settings, and integrations.
+- ✅ Keeps the Shortcut/API surface authenticated with a revocable token
+  (rotate by re-running `auth-setup.js`).
+- ❌ Still single-user — one password, one token. Not multi-tenant.
+- ❌ Does **not** encrypt secrets at rest (see below) — a host compromise still
+  exposes the DB. Use the env-var path for integration keys to keep them out of
+  the settings blob, and pair with HTTPS + a TLS-terminating proxy.
+- ⚠️ Open even when the gate is on: `GET /api/health`, `GET /api/auth/status`,
+  `POST /api/auth/login`, `POST /api/auth/logout` (login/status need to be
+  reachable pre-auth; health leaks only the version string).
+
+> **Not serverless-friendly.** The session store, the persistent notification
+> loops, SSE, the in-memory Quokka runner, and local SQLite all assume a single
+> always-on instance. Host on a small always-on box (Fly.io machine, Render web
+> service, a VPS) — not Lambda/Cloud Functions.
+
 ## Credential Storage: How It Actually Works
 
 ### Where secrets live

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -4,6 +4,17 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ---
 
+## 2026-06-19
+
+- feat(server): opt-in authentication gate + iOS Shortcut intake endpoint [L]
+  - New `auth.js` root module (added to the Dockerfile runtime COPY list) with an `authGate` middleware mounted over every `/api` route. **INERT unless `AUTH_PASSWORD` or `AUTH_PASSWORD_HASH` is set** — existing self-hosted instances are unchanged until configured, so this ships safely. Built for the "I want to host this on a public web host" move, which breaks the old "attacker who can read the DB already has shell" threat model.
+  - **Two credential types share the gate.** Humans: `POST /api/auth/login {password}` → httpOnly + SameSite=Lax + Secure session cookie `boom_session` (30-day rolling, persisted in `app_data.auth_sessions` so restarts/redeploys don't log you out). Because cookies ride every same-origin fetch + the SSE EventSource automatically, the client needed ZERO per-fetch changes — just one boot gate in `src/App.jsx` that probes `GET /api/auth/status` and renders the new `src/components/LoginScreen.{jsx,css}` when `authEnabled && !authenticated` (fails OPEN on a flaky probe; the server is the real enforcement). Machines (iOS Shortcut / future native app): static `API_TOKEN` as `Authorization: Bearer <token>` or `x-api-token: <token>`.
+  - Passwords verified with `scrypt` + `crypto.timingSafeEqual` (hash format `scrypt$<saltHex>$<hashHex>`); API token timing-safe compared. `scripts/auth-setup.js [password]` prints `AUTH_PASSWORD_HASH` + a fresh `API_TOKEN`. Cookie `Secure` auto-detects via `req.secure` (`trust proxy` already on) or force with `COOKIE_SECURE=1`/`0`. Open-without-auth even when gated: `/api/health`, `/api/auth/status`, `/api/auth/login`, `/api/auth/logout`.
+  - **New `POST /api/intake`** `{ title|text, notes?, due_date?, high_priority?, tags? }` — the iOS Shortcut's target. Authed by the gate (API token or cookie), builds a full task with server-side defaults + `size_inferred=false` so the background auto-sizer refines size/energy. Recipe doc `wiki/iOS-Shortcut.md` covers share-sheet / Siri / Action button wiring.
+  - Verified by live boot tests: gate inert with no env (200 on `/api/data`); with creds set, `/api/data` 401 without auth, `/api/intake` 401 on wrong token + creates a task on valid Bearer token, login rejects wrong password (401) and sets an httpOnly cookie on the right one, cookie then authorizes `/api/data` (200). `npm run build`, `eslint`, and `npm test` (smoke + date units) all pass.
+  - Docs: README (Features bullet + Configuration → Authentication), `wiki/Security-Notes.md` (new Authentication section + serverless caveat), `wiki/Architecture.md` (Authentication section + new routes), `wiki/Features.md` (Authentication + iOS Shortcut sections), CLAUDE.md (Authentication section), `.env.example` (auth vars). **Note:** the app is NOT serverless-friendly (persistent notification loops + SSE + in-memory Quokka runner + local SQLite + session store assume one always-on instance) — documented so a Lambda/Cloud-Functions host isn't attempted.
+  - Pre-existing `npm audit` high (`nodemailer` <=9.0.0, used by the email engine — untouched here; fix is a breaking major bump) flagged, not bundled into this PR.
+
 ## 2026-06-18
 
 - feat(api): one-command live health check across every integration ("check my integrations") [M]

--- a/wiki/iOS-Shortcut.md
+++ b/wiki/iOS-Shortcut.md
@@ -1,0 +1,80 @@
+# iOS Shortcut — "Add to Boomerang"
+
+Create a task in Boomerang from anywhere on iOS: the **share sheet** (select a
+Message, an email, a webpage, highlighted text → Share → *Add to Boomerang*),
+**Siri** ("Hey Siri, Add to Boomerang"), the **Action button**, or the Home
+Screen. No native app required — the Shortcut talks to the `POST /api/intake`
+endpoint over HTTPS.
+
+## Prerequisites
+
+1. Boomerang reachable over **HTTPS** at a stable URL (e.g. `https://boomerang.example.com`).
+2. **Auth enabled** with an API token. On the server:
+   ```sh
+   node scripts/auth-setup.js
+   ```
+   Copy the printed `API_TOKEN` and set it (plus `AUTH_PASSWORD_HASH`) in your
+   host's environment, then redeploy. See `.env.example` → *Authentication*.
+
+> The Shortcut authenticates with the **API token**, not your password. Treat the
+> token like a password — anyone holding it can create tasks. Rotate it by
+> re-running `auth-setup.js` and updating the env var + the Shortcut.
+
+## The endpoint
+
+```
+POST https://YOUR_HOST/api/intake
+Authorization: Bearer YOUR_API_TOKEN
+Content-Type: application/json
+
+{ "title": "text of the task", "notes": "optional", "high_priority": false }
+```
+
+`title` (or `text`) is required; everything else is optional. The server fills
+in id / status / timestamps and flags the task for background AI sizing/energy
+inference. Optional fields: `notes`, `due_date` (`"YYYY-MM-DD"`),
+`high_priority` (bool), `tags` (array of label ids).
+
+## Build it in the Shortcuts app
+
+1. Open **Shortcuts** → **+** (new shortcut) → name it **Add to Boomerang**.
+2. Tap the **(i)** info button → enable **Show in Share Sheet**. Under *Share
+   Sheet Types* leave **Text** and **URLs** on (turn the rest off if you like).
+   This is what makes it appear when you share a Message/email/webpage.
+3. Add action **Get Contents of URL**:
+   - **URL:** `https://YOUR_HOST/api/intake`
+   - **Method:** `POST`
+   - **Headers** (add two):
+     - `Authorization` → `Bearer YOUR_API_TOKEN`
+     - `Content-Type` → `application/json`
+   - **Request Body:** `JSON`
+     - `title` (Text) → set to the **Shortcut Input** variable (the shared text).
+       Tip: wrap it as `Shortcut Input` so a shared Message body becomes the title.
+     - (optional) `high_priority` (Boolean) → `false`
+4. (Optional) Add a **Show Notification** action after it with text "Caught it ✓"
+   for confirmation.
+5. Done. Test by running it once (it'll use clipboard/empty input), then from a
+   Message: long-press a bubble → **Share** → **Add to Boomerang**.
+
+### Wiring it to Siri / Action button
+
+- **Siri:** the shortcut name *is* the phrase — "Hey Siri, Add to Boomerang".
+- **Action button** (iPhone 15 Pro+): Settings → Action Button → Shortcut →
+  *Add to Boomerang*.
+- **Back Tap:** Settings → Accessibility → Touch → Back Tap → Double Tap →
+  *Add to Boomerang*.
+
+## "Type a quick task" variant
+
+For a shortcut that prompts you for text instead of taking shared input, insert
+an **Ask for Input** (Text) action first and feed *Provided Input* into the
+`title` field instead of *Shortcut Input*.
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+|---|---|
+| `401 Authentication required` | Missing/wrong `Authorization` header. Must be `Bearer <API_TOKEN>` exactly, and `API_TOKEN` must be set on the server. |
+| `400 title (or text) is required` | The JSON `title` field is empty — check the variable feeding it. |
+| Nothing happens from share sheet | "Show in Share Sheet" not enabled, or the shared type (e.g. an image) isn't Text/URL. |
+| Works on Wi-Fi, not cellular | Host isn't publicly reachable / not on HTTPS. The endpoint must be internet-facing (or use a VPN/Tailscale that's always on). |


### PR DESCRIPTION
## What & why

You're hosting Boomerang enough to put it on a public web host — which breaks the old "single-user, trusted-machine; an attacker who can read the DB already has shell" threat model. This adds a proper, **opt-in** authentication gate plus the server side of the iOS Shortcut you asked for.

**Crucially, it's inert until you configure it.** With no `AUTH_PASSWORD`/`AUTH_PASSWORD_HASH` set, nothing changes — your current self-hosted instance keeps working exactly as before. Auth turns on the moment you set the env vars (i.e. when you deploy externally).

## How it works

Two credential types share one gate (`auth.js` → `authGate` middleware over every `/api` route):

- **Humans** → `POST /api/auth/login {password}` → httpOnly + SameSite=Lax + Secure session cookie `boom_session` (30-day rolling, persisted in `app_data.auth_sessions` so restarts/redeploys don't log you out). Cookies ride every same-origin fetch **and** the SSE stream automatically, so the client needed **zero per-fetch changes** — just one boot gate in `src/App.jsx` that probes `/api/auth/status` and shows `LoginScreen` when required.
- **Machines** (the iOS Shortcut, a future native app) → static `API_TOKEN` via `Authorization: Bearer <token>` or `x-api-token: <token>`.

Passwords are verified with `scrypt` + timing-safe compare; the token is timing-safe compared. Generate both with `node scripts/auth-setup.js [password]`.

### iOS Shortcut

New `POST /api/intake` `{ title|text, notes?, due_date?, high_priority?, tags? }` builds a full task with server-side defaults (`size_inferred=false`, so the background auto-sizer refines it). Step-by-step share-sheet / Siri / Action-button recipe in **`wiki/iOS-Shortcut.md`**.

## Verification

- **Live boot tests** — inert with no env (200 on `/api/data`); with creds: `/api/data` 401 unauthenticated, `/api/intake` 401 on wrong token + creates a task on a valid Bearer token, login rejects wrong password (401) and sets an httpOnly cookie on the right one, cookie then authorizes `/api/data` (200).
- `npm run build`, `eslint`, `npm test` (smoke + date units) all pass.

## Notes / follow-ups

- ⚠️ **Not serverless-friendly.** The session store + persistent notification loops + SSE + in-memory Quokka runner + local SQLite all assume one always-on instance. Host on a small VPS / Fly.io machine / Render service — **not Lambda** (you'd lose the DB and kill the background loops on cold start). Documented across README / Security-Notes / CLAUDE.
- **Secrets at rest** remain plaintext in SQLite (deferred per our discussion — the env-var path for integration keys is the interim workaround). Worth a follow-up before this lives long-term on rented hardware.
- Pre-existing `npm audit` high (`nodemailer` ≤9.0.0, used by the email engine — untouched here; fix is a breaking major bump) flagged, not bundled in.

## Docs

README, `wiki/Security-Notes.md`, `wiki/Architecture.md`, `wiki/Features.md`, `wiki/iOS-Shortcut.md` (new), `CLAUDE.md`, `wiki/Version-History.md`, `.env.example`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CXjPNpD8CLySES5EJMpASB)_