### PR TITLE
feat(routines): add assignee for loops/tasks the user supervises but doesn't own

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,6 +145,8 @@ AI-inferred energy tagging on every task — no manual fields to fill in.
 
 **Waiting = Progress:** Moving a task from not_started or doing to waiting awards +1 task and +1 point for the daily count. Reflects real effort (sent the email, made the call) even though the task isn't done. Tracked via `waiting_at` timestamp (migration 032); cleared when leaving waiting status. Counts toward streak and WeekStrip intensity.
 
+**Assignee (2026-07-04, migration 038):** `assignee` TEXT column on both `tasks` and `routines` — free text (e.g. "Jack"), null = the user's own task/loop. For tracking a recurring chore that's for someone the user supervises (e.g. a kid) rather than their own task. No multi-user accounts here — purely informational, since only the user operates this app. `calculateTaskPoints()` in `src/scoring.js` returns a flat `1` point for any task with `assignee` set (instead of `size × energy × speed`) — it's a simple did-it-or-didn't chore, not graded ADHD-effort — but it STILL counts toward the user's own daily points/streak total, since they're the one supervising it. Propagated routine → spawned task at every spawn path (`spawnDueTasks`/`spawnNow`/`logHabit`/stack members), same as `energy_type`/`energy_level` inheritance. UI: `RoutinesModal`'s "For" field; shown as a chip/meta suffix on Kept's `LoopsView`/`LoopDetail`/`TodayView`. Quokka: `create_routine`/`update_routine`/`create_task`/`update_task` all accept it.
+
 **Nagging Boost:** Avoidance-prone types (confrontation, errand) get more frequent notifications.
 - Avoidance type: interval / 1.3 (30% more frequent)
 - High drain (level 3): additional / 1.2

--- a/adviserToolsTasks.js
+++ b/adviserToolsTasks.js
@@ -26,6 +26,9 @@ const TASK_FIELDS = [
   // sibling sub IDs. A sub is "blocked" (hidden from main list) when
   // any blocker is incomplete.
   'blocked_by',
+  // Who this is actually for (migration 038) — e.g. a kid's chore the user
+  // supervises rather than their own task. Free text; null = the user's own.
+  'assignee',
 ]
 
 function summarizeTask(t) {
@@ -53,6 +56,7 @@ function summarizeTask(t) {
     session_count: t.session_count || 0,
     last_session_at: t.last_session_at || null,
     child_visibility: t.child_visibility || 'backstage',
+    assignee: t.assignee || null,
   }
 }
 
@@ -71,6 +75,7 @@ function summarizeRoutine(r) {
     tags: r.tags || [],
     paused: !!r.paused,
     end_date: r.end_date || null,
+    assignee: r.assignee || null,
     last_completed: r.completed_history?.[r.completed_history.length - 1] || null,
     // Sequences: expose the chain template so adviser can address steps
     // by id when calling add/edit/remove/reorder_follow_up tools.
@@ -287,6 +292,10 @@ export function registerTaskTools() {
           items: { type: 'string' },
           description: 'Array of sibling sub task ids that must complete before this sub appears in the main list. Use to model dependency chains (e.g. "Booking day" waits on "Choose destination" + "Research flights"). Hidden from main list until every blocker reaches status=done; shown in the Projects drill-down with a "⏸ waits on X, Y" indicator. Cycles (A blocks B blocks A) are rejected at stage time.',
         },
+        assignee: {
+          type: 'string',
+          description: 'Set when this task is actually for someone else the user supervises (e.g. a kid\'s chore), not the user\'s own task — a name, e.g. "Jack". Leave unset for the user\'s own tasks. Scores a flat 1 point on completion instead of the size x energy formula, but still counts toward the user\'s own daily total.',
+        },
       },
       required: ['title'],
     },
@@ -392,6 +401,7 @@ export function registerTaskTools() {
         // out of the payload when status != 'project' to avoid surprise.
         pinned_to_today: args.status === 'project' ? !!args.pinned_to_today : false,
         nag_allowed: args.status === 'project' ? !!args.nag_allowed : false,
+        assignee: args.assignee || null,
         created_at: now,
         updated_at: now,
         last_touched: now,
@@ -431,6 +441,7 @@ export function registerTaskTools() {
         pinned_to_today: { type: 'boolean', description: 'Project pin toggle (status=project tasks only).' },
         nag_allowed: { type: 'boolean', description: 'Project nag opt-in (status=project tasks only).' },
         blocked_by: { type: 'array', items: { type: 'string' }, description: 'Array of sibling sub task ids that must complete before this sub becomes visible in the main list. Empty array clears all blockers. Cycles are rejected.' },
+        assignee: { type: ['string', 'null'], description: 'Set when this task is actually for someone else the user supervises (e.g. a kid\'s chore) — a name, e.g. "Jack". Pass null to clear (back to the user\'s own task).' },
       },
       required: ['id'],
     },
@@ -792,10 +803,14 @@ export function registerTaskTools() {
             required: ['title'],
           },
         },
+        assignee: {
+          type: 'string',
+          description: 'Set when this loop is actually for someone else the user supervises (e.g. a kid\'s chore), not the user\'s own task — a name, e.g. "Jack". Leave unset for the user\'s own loops. Every spawned task inherits it and scores a flat 1 point on completion instead of the size x energy formula, but still counts toward the user\'s own daily total.',
+        },
       },
       required: ['title', 'cadence'],
     },
-    preview: (args) => `Create routine: "${args.title}" (${args.cadence})${Array.isArray(args.members) && args.members.length ? ` · ${args.members.length}-item stack` : ''}`,
+    preview: (args) => `Create routine: "${args.title}" (${args.cadence})${Array.isArray(args.members) && args.members.length ? ` · ${args.members.length}-item stack` : ''}${args.assignee ? ` · for ${args.assignee}` : ''}`,
     // Pre-stamp the new routine's id at stage time so a chained
     // add_follow_up in the same plan can reference it. Returned to the
     // model as `id` in the staged response. At commit time, execute uses
@@ -839,6 +854,7 @@ export function registerTaskTools() {
         completed_history: [],
         created_at: now,
         updated_at: now,
+        assignee: args.assignee || null,
       }
       upsertRoutine(routine)
       return {
@@ -883,6 +899,7 @@ export function registerTaskTools() {
           },
         },
         last_done: { type: ['string', 'null'], description: 'Set when the routine was last completed, "YYYY-MM-DD" (or null = never done). Drives the next due date — use it to repair a routine that nags as if never done after lost completion history. Sets the most-recent completion entry; does not erase older history.' },
+        assignee: { type: ['string', 'null'], description: 'Set when this loop is actually for someone else the user supervises (e.g. a kid\'s chore) — a name, e.g. "Jack". Pass null to clear (back to the user\'s own loop). Only affects future spawns, not already-spawned tasks.' },
       },
       required: ['id'],
     },

--- a/db.js
+++ b/db.js
@@ -258,6 +258,7 @@ function taskToRow(task) {
     knowledge_page_ids_json: JSON.stringify(task.knowledge_page_ids || []),
     waiting_at: task.waiting_at || null,
     stack_bonus: task.stack_bonus ?? null,
+    assignee: task.assignee || null,
   }
 }
 
@@ -312,6 +313,7 @@ function rowToTask(row) {
     knowledge_page_ids: safeJsonParse(row.knowledge_page_ids_json, []),
     waiting_at: row.waiting_at || null,
     stack_bonus: row.stack_bonus ?? null,
+    assignee: row.assignee || null,
   }
 }
 
@@ -337,8 +339,8 @@ const UPSERT_TASK_SQL = `
     pushover_receipt, follow_ups_json, skipped,
     parent_id, pinned_to_today, nag_allowed, session_count, last_session_at,
     session_log_json, child_visibility, snooze_indefinite, blocked_by_json,
-    knowledge_page_ids_json, stack_bonus)
-  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    knowledge_page_ids_json, stack_bonus, assignee)
+  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   ON CONFLICT(id) DO UPDATE SET
     title=excluded.title, status=excluded.status, notes=excluded.notes,
     due_date=excluded.due_date, snoozed_until=excluded.snoozed_until,
@@ -366,7 +368,8 @@ const UPSERT_TASK_SQL = `
     child_visibility=excluded.child_visibility, snooze_indefinite=excluded.snooze_indefinite,
     blocked_by_json=excluded.blocked_by_json,
     knowledge_page_ids_json=excluded.knowledge_page_ids_json,
-    stack_bonus=excluded.stack_bonus`
+    stack_bonus=excluded.stack_bonus,
+    assignee=excluded.assignee`
 
 function runUpsertTask(task) {
   const r = taskToRow(task)
@@ -381,7 +384,7 @@ function runUpsertTask(task) {
     r.pushover_receipt, r.follow_ups_json, r.skipped,
     r.parent_id, r.pinned_to_today, r.nag_allowed, r.session_count, r.last_session_at,
     r.session_log_json, r.child_visibility, r.snooze_indefinite, r.blocked_by_json,
-    r.knowledge_page_ids_json, r.stack_bonus,
+    r.knowledge_page_ids_json, r.stack_bonus, r.assignee,
   ])
 }
 
@@ -1014,6 +1017,7 @@ function routineToRow(routine) {
     follow_ups_json: JSON.stringify(routine.follow_ups || []),
     members_json: JSON.stringify(routine.members || []),
     skipped_days_json: JSON.stringify(routine.skipped_days || []),
+    assignee: routine.assignee || null,
   }
 }
 
@@ -1046,6 +1050,7 @@ function rowToRoutine(row) {
     follow_ups: safeJsonParse(row.follow_ups_json, []),
     members: safeJsonParse(row.members_json, []),
     skipped_days: safeJsonParse(row.skipped_days_json, []),
+    assignee: row.assignee || null,
   }
 }
 
@@ -1058,8 +1063,9 @@ const UPSERT_ROUTINE_SQL = `
     energy, energy_level, notion_page_id, notion_url, created_at, paused,
     tags_json, completed_history_json, end_date, schedule_day_of_week,
     schedule_day_of_month, schedule_week_of_month, trigger_time, auto_roll,
-    spawn_mode, target_count, target_period, follow_ups_json, members_json, skipped_days_json)
-  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    spawn_mode, target_count, target_period, follow_ups_json, members_json, skipped_days_json,
+    assignee)
+  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   ON CONFLICT(id) DO UPDATE SET
     title=excluded.title, cadence=excluded.cadence, custom_days=excluded.custom_days,
     custom_unit=excluded.custom_unit,
@@ -1074,7 +1080,8 @@ const UPSERT_ROUTINE_SQL = `
     auto_roll=excluded.auto_roll, spawn_mode=excluded.spawn_mode,
     target_count=excluded.target_count, target_period=excluded.target_period,
     follow_ups_json=excluded.follow_ups_json, members_json=excluded.members_json,
-    skipped_days_json=excluded.skipped_days_json`
+    skipped_days_json=excluded.skipped_days_json,
+    assignee=excluded.assignee`
 
 function runUpsertRoutine(routine) {
   const r = routineToRow(routine)
@@ -1084,7 +1091,7 @@ function runUpsertRoutine(routine) {
     r.tags_json, r.completed_history_json, r.end_date, r.schedule_day_of_week,
     r.schedule_day_of_month, r.schedule_week_of_month,
     r.trigger_time, r.auto_roll, r.spawn_mode, r.target_count, r.target_period,
-    r.follow_ups_json, r.members_json, r.skipped_days_json,
+    r.follow_ups_json, r.members_json, r.skipped_days_json, r.assignee,
   ])
 }
 

--- a/migrations/038_add_assignee.sql
+++ b/migrations/038_add_assignee.sql
@@ -1,0 +1,17 @@
+-- Assignee: track loops/tasks that are for someone else the user supervises
+-- (e.g. a kid's chore) rather than the user's own task. Purely informational
+-- (this app has no multi-user accounts) — a free-text name shown as a chip
+-- on the card. NULL/empty = "mine" (unchanged behavior).
+--
+-- routines.assignee  Set on the routine template; propagated onto each
+--                     spawned task at spawn time (spawnDueTasks/spawnNow),
+--                     same pattern as energy_type/energy_level.
+-- tasks.assignee      Also settable directly on a one-off task (no routine
+--                     required) for an ad-hoc chore.
+--
+-- Scoring: an assigned task/routine still counts toward the user's own daily
+-- points/streak (per user decision — they're supervising it), but scores a
+-- flat 1 point per completion instead of the size x energy x speed formula,
+-- since it's a simple did-it-or-didn't chore rather than graded effort.
+ALTER TABLE routines ADD COLUMN assignee TEXT DEFAULT NULL;
+ALTER TABLE tasks ADD COLUMN assignee TEXT DEFAULT NULL;

--- a/src/components/RoutinesModal.jsx
+++ b/src/components/RoutinesModal.jsx
@@ -374,6 +374,11 @@ function RoutineForm({ initial, onSave, noun = 'routine' }) {
   const [triggerTime, setTriggerTime] = useState(initial?.trigger_time || '')
   const [selectedTags, setSelectedTags] = useState(initial?.tags || [])
   const [notes, setNotes] = useState(initial?.notes || '')
+  // Who this loop is actually for — e.g. a kid's chore the user supervises
+  // rather than their own task (migration 038). Free text, blank = mine.
+  // Propagated onto every spawned task; scores a flat point per completion
+  // (see calculateTaskPoints in scoring.js) instead of size x energy.
+  const [assignee, setAssignee] = useState(initial?.assignee || '')
   const [highPriority, setHighPriority] = useState(initial?.high_priority || false)
   const [endDate, setEndDate] = useState(initial?.end_date || '')
   const [autoRoll, setAutoRoll] = useState(initial?.auto_roll || false)
@@ -528,6 +533,7 @@ function RoutineForm({ initial, onSave, noun = 'routine' }) {
     spawnMode,
     targetCount: isHabit ? Math.max(1, Number(targetCount) || 1) : null,
     targetPeriod: isHabit ? targetPeriod : null,
+    assignee: assignee.trim() || null,
   })
 
   const handleSave = () => {
@@ -587,6 +593,7 @@ function RoutineForm({ initial, onSave, noun = 'routine' }) {
   const extrasSummaryBits = []
   if (selectedTags.length) extrasSummaryBits.push(`${selectedTags.length} label${selectedTags.length === 1 ? '' : 's'}`)
   if (notes.trim()) extrasSummaryBits.push('notes')
+  if (assignee.trim()) extrasSummaryBits.push(`for ${assignee.trim()}`)
 
   return (
     <div className="v2-routine-form">
@@ -991,6 +998,19 @@ function RoutineForm({ initial, onSave, noun = 'routine' }) {
           </div>
         )}
         <div className="v2-form-section">
+          <label className="v2-form-label">For</label>
+          <input
+            type="text"
+            className="v2-form-input"
+            placeholder="Leave blank if it's yours — or a name, e.g. Jack"
+            value={assignee}
+            onChange={e => setAssignee(e.target.value)}
+          />
+          <div className="v2-form-section-hint">
+            Marks this as someone else's chore you're supervising. Spawned tasks score a flat 1 point each (instead of size × energy) but still count toward your own daily total.
+          </div>
+        </div>
+        <div className="v2-form-section">
           <label className="v2-form-label">Notes</label>
           <textarea
             className="v2-form-textarea"
@@ -1096,6 +1116,7 @@ export default function RoutinesModal({
         spawn_mode: data.spawnMode,
         target_count: data.targetCount,
         target_period: data.targetPeriod,
+        assignee: data.assignee,
       }
       // Only touch completed_history when the "Last done" date was changed
       // (undefined = leave it alone; never send undefined into the merge).
@@ -1112,7 +1133,7 @@ export default function RoutinesModal({
         data.spawnMode, data.targetCount, data.targetPeriod,
         data.customUnit, data.triggerTime,
         data.scheduleDayOfMonth, data.scheduleWeekOfMonth,
-        data.members,
+        data.members, data.assignee,
       )
     }
     setEditing(null)

--- a/src/hooks/useRoutines.js
+++ b/src/hooks/useRoutines.js
@@ -36,6 +36,7 @@ function spawnStackMembers(routine, dueYMD) {
     const energyLevel = m.energy_level ?? routine.energyLevel
     if (energy) task.energy = energy
     if (energyLevel) task.energyLevel = energyLevel
+    if (routine.assignee) task.assignee = routine.assignee
     task.snoozed_until = snooze
     return task
   })
@@ -48,7 +49,7 @@ export function useRoutines() {
     saveRoutines(routines)
   }, [routines])
 
-  const addRoutine = useCallback((title, cadence, customDays, tags, notes, highPriority = false, endDate = null, scheduleDayOfWeek = null, followUps = [], autoRoll = false, spawnMode = 'auto', targetCount = null, targetPeriod = null, customUnit = 'days', triggerTime = null, scheduleDayOfMonth = null, scheduleWeekOfMonth = null, members = []) => {
+  const addRoutine = useCallback((title, cadence, customDays, tags, notes, highPriority = false, endDate = null, scheduleDayOfWeek = null, followUps = [], autoRoll = false, spawnMode = 'auto', targetCount = null, targetPeriod = null, customUnit = 'days', triggerTime = null, scheduleDayOfMonth = null, scheduleWeekOfMonth = null, members = [], assignee = null) => {
     const routine = createRoutine(title, cadence, customDays, tags, notes, customUnit)
     if (highPriority) routine.high_priority = true
     if (endDate) routine.end_date = endDate
@@ -59,6 +60,7 @@ export function useRoutines() {
     if (Array.isArray(followUps) && followUps.length > 0) routine.follow_ups = followUps
     if (Array.isArray(members) && members.length > 0) routine.members = members
     if (autoRoll) routine.auto_roll = true
+    if (assignee) routine.assignee = assignee
     if (spawnMode === 'habit') {
       routine.spawn_mode = 'habit'
       routine.target_count = targetCount
@@ -161,6 +163,7 @@ export function useRoutines() {
     task.last_touched = now
     if (routine.energy) task.energy = routine.energy
     if (routine.energyLevel) task.energyLevel = routine.energyLevel
+    if (routine.assignee) task.assignee = routine.assignee
     setRoutines(prev => prev.map(r => r.id === routineId
       ? { ...r, completed_history: [...(r.completed_history || []), now] }
       : r))
@@ -210,6 +213,7 @@ export function useRoutines() {
     if (routine.high_priority) task.high_priority = true
     if (routine.energy) task.energy = routine.energy
     if (routine.energyLevel) task.energyLevel = routine.energyLevel
+    if (routine.assignee) task.assignee = routine.assignee
     if (Array.isArray(routine.follow_ups) && routine.follow_ups.length > 0) {
       task.follow_ups = routine.follow_ups
     }
@@ -309,6 +313,7 @@ export function useRoutines() {
       task.notion_page_id = routine.notion_page_id
       task.notion_url = routine.notion_url
       if (routine.high_priority) task.high_priority = true
+      if (routine.assignee) task.assignee = routine.assignee
       if (Array.isArray(routine.follow_ups) && routine.follow_ups.length > 0) {
         task.follow_ups = routine.follow_ups
       }

--- a/src/kept/LoopDetail.jsx
+++ b/src/kept/LoopDetail.jsx
@@ -45,9 +45,10 @@ export default function LoopDetail({ routine, color, spawnBlocked = false, tasks
     : cycleUnitLabel(routine, past.length === 1)
 
   const anchor = formatScheduleAnchor(routine)
-  const meta = isHabit
+  const meta = (isHabit
     ? `habit · ${routine.target_count}× / ${routine.target_period}`
-    : `${formatCadence(routine)}${anchor ? ` · ${anchor}` : ''}${routine.trigger_time ? ` · ${routine.trigger_time}` : ''}`
+    : `${formatCadence(routine)}${anchor ? ` · ${anchor}` : ''}${routine.trigger_time ? ` · ${routine.trigger_time}` : ''}`)
+    + (routine.assignee ? ` · for ${routine.assignee}` : '')
 
   const handleSpawn = () => {
     if (spawnBlocked) return

--- a/src/kept/LoopsView.jsx
+++ b/src/kept/LoopsView.jsx
@@ -104,6 +104,11 @@ export default function LoopsView({ routines = [], tasks = [], onEditLoop, onAdd
               style={{ flex: '1 1 auto', minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', background: 'none', border: 'none', padding: 0, font: 'inherit', color: 'inherit', textAlign: 'left', cursor: 'pointer' }}
               onClick={() => setDetailId(r.id)}
             >{r.title}</button>
+            {r.assignee && (
+              <span style={{ fontSize: 10.5, fontWeight: 600, color: 'var(--bm-text-meta)', border: '1px solid var(--bm-hairline)', borderRadius: 999, padding: '2px 7px', flex: '0 0 auto' }}>
+                {r.assignee}
+              </span>
+            )}
             {gapCount > 0 && (
               <button className="bm-loop-fix-chip" onClick={() => setDetailId(r.id)} aria-label={`${gapCount} day${gapCount === 1 ? '' : 's'} to fix`}>
                 {gapCount} to fix

--- a/src/kept/TodayView.jsx
+++ b/src/kept/TodayView.jsx
@@ -305,13 +305,14 @@ export default function TodayView({
                 >{done && <Check size={13} strokeWidth={3.4} />}</button>
                 <button className="bm-row-body" onClick={() => onOpenTask?.(t)}>
                   <span className={`bm-row-title${done ? ' is-done' : ''}`}>{t.title}</span>
-                  {!done && (overdue || stale || statusTag || t.high_priority || chips.length > 0 || weatherDay) && (
+                  {!done && (overdue || stale || statusTag || t.high_priority || chips.length > 0 || weatherDay || t.assignee) && (
                     <span className="bm-row-meta">
                       {t.high_priority && <span className="bm-tag-hi">high</span>}
                       {statusTag && <span className="bm-tag-status">{statusTag}</span>}
                       {overdue && <span className="bm-due-over">overdue</span>}
                       {stale && <span className="bm-tag-stale">{ageDays}d on list</span>}
                       {weatherDay && <WeatherBadge day={weatherDay} />}
+                      {t.assignee && <span className="bm-tag-status">for {t.assignee}</span>}
                       {chips.slice(0, 3).map(l => (
                         <span key={l.id} className="bm-tagdot" style={{ '--tag': l.color }}><i />{l.name}</span>
                       ))}
@@ -345,8 +346,9 @@ export default function TodayView({
                     <button className="bm-chk" onClick={() => onCompleteTask?.(t)} aria-label="Catch it" />
                     <button className="bm-row-body" onClick={() => onOpenTask?.(t)}>
                       <span className="bm-row-title">{t.title}</span>
-                      {chips.length > 0 && (
+                      {(chips.length > 0 || t.assignee) && (
                         <span className="bm-row-meta">
+                          {t.assignee && <span className="bm-tag-status">for {t.assignee}</span>}
                           {chips.slice(0, 3).map(l => (
                             <span key={l.id} className="bm-tagdot" style={{ '--tag': l.color }}><i />{l.name}</span>
                           ))}

--- a/src/scoring.js
+++ b/src/scoring.js
@@ -14,7 +14,14 @@ const ENERGY_MULTIPLIER = { 1: 1.0, 2: 1.5, 3: 2.0 }
 
 // Calculate points for a single task.
 // Uses completed_at if available, otherwise assumes "now" (for previewing points).
+//
+// Assigned tasks (task.assignee set — e.g. a kid's chore the user supervises
+// rather than their own task, migration 038) score a flat 1 point instead of
+// the size x energy x speed formula: it's a simple did-it-or-didn't chore,
+// not graded ADHD-effort. Still counts toward the user's own daily total —
+// only the per-task amount changes.
 export function calculateTaskPoints(task) {
+  if (task.assignee) return 1
   const base = SIZE_POINTS[task.size] || 1
   const energyMult = ENERGY_MULTIPLIER[task.energyLevel] || 1.0
   const completedAt = task.completed_at ? new Date(task.completed_at) : new Date()

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,15 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-07-04
 
+- feat(routines): add `assignee` for loops/tasks the user supervises but doesn't own [M]
+  - **User request:** track recurring chores that are for the user's son (something they supervise, not their own task) with simple flat-point scoring rather than the normal ADHD-effort size×energy grading.
+  - New `assignee` TEXT column on both `routines` and `tasks` (migration 038). Free text (e.g. "Jack"), null = the user's own task/loop — no multi-user accounts, purely informational/organizational since only the user operates this app.
+  - Propagated from routine → spawned task at every spawn path (`spawnDueTasks`, `spawnNow`, `logHabit`, stack members) — same pattern as `energy_type`/`energy_level` inheritance.
+  - Scoring: `calculateTaskPoints()` in `src/scoring.js` now returns a flat `1` for any task with `assignee` set, instead of the `size × energy × speed` formula — per user decision, still counts toward the user's own daily points/streak total (they're supervising it), it just scores like a simple did-it-or-didn't chore rather than graded effort.
+  - UI: `RoutinesModal`'s "Labels & notes" section gains a "For" text field (blank = mine). Kept's `LoopsView`/`LoopDetail` show a small chip/meta suffix when set; `TodayView`'s task rows show "for {name}" in the meta line.
+  - Quokka: `create_routine`/`update_routine` and `create_task`/`update_task` all accept `assignee` now (routines for recurring chores, tasks for one-off ad-hoc ones); `summarizeTask`/`summarizeRoutine` expose it so the model can read current state.
+  - Verified: a standalone script against a fresh SQLite DB (all 38 migrations) confirms the `assignee` column round-trips correctly on both `routines` and `tasks` (set and unset cases), and a scoring script confirms `calculateTaskPoints` returns flat `1` for an assigned task regardless of size/energy while leaving the user's own tasks' scoring unchanged. `eslint` clean, production build clean, `npm test` passes.
+
 - feat(weather): surface the "Best days" recommendation + hide badges on weather-independent tasks [S]
   - **Prod feedback:** the 7-day forecast widget in `EditTaskModal` just listed the week passively — no actual "do it on X day" suggestion, even though the data made it obvious (e.g. tomorrow was the clearest day of the week). Separately, the on-card weather badge in Kept's Today view was showing on every dated task regardless of whether it was actually weather-relevant — indoor/weather-independent routines like "IFR Studying" and "Weekly Cleaning" (tagged `inside`) displayed the same rain badge as genuinely outdoor tasks.
   - Root cause 1: `pickBestDays()`/`formatBestDaysLine()` in `src/components/WeatherSection.jsx` were fully implemented and exported (and documented in CLAUDE.md as a shipped "Best days" feature) but **never actually called from anywhere in the app** — dead code since the day they were written. The forecast widget only ever highlighted the task's own due date, never the best-scoring day.


### PR DESCRIPTION
## Summary

Ability to track recurring chores that are for someone the user supervises (e.g. their son) rather than their own task, per the scoping decisions:

- **Structure:** a dedicated `assignee` field (free text, e.g. "Jack") — new column on both `routines` and `tasks` (migration 038). Null = the user's own task/loop. No multi-user accounts — this is purely informational since only the user operates this app.
- **Scoring:** `calculateTaskPoints()` in `src/scoring.js` returns a flat **1 point** for any task with `assignee` set, instead of the `size × energy × speed` formula — it's a simple did-it-or-didn't chore, not graded ADHD-effort.
- **Attribution:** still counts toward the user's own daily points/streak/rally — they're the one supervising it and want credit for staying on top of it.
- **Propagation:** routine → spawned task at every spawn path (`spawnDueTasks`, `spawnNow`, `logHabit`, stack members), same pattern as `energy_type`/`energy_level` inheritance.

## What changed
- `migrations/038_add_assignee.sql` — new column on both tables
- `db.js` — task/routine row↔object mapping + upsert SQL
- `src/hooks/useRoutines.js` — `addRoutine` param + propagation at every spawn path
- `src/scoring.js` — flat-point branch in `calculateTaskPoints`
- `src/components/RoutinesModal.jsx` — "For" text field in the Labels & notes section
- `src/kept/LoopsView.jsx` / `LoopDetail.jsx` / `TodayView.jsx` — chip/meta display
- `adviserToolsTasks.js` — `create_routine`/`update_routine`/`create_task`/`update_task` all accept `assignee`; `summarizeTask`/`summarizeRoutine` expose it

## Test plan
- [x] Standalone script against a fresh SQLite DB (all 38 migrations) confirms `assignee` round-trips correctly on both `routines` and `tasks` (set and unset)
- [x] Standalone script confirms `calculateTaskPoints` returns flat `1` for an assigned task regardless of size/energy, while the user's own tasks score unchanged
- [x] `eslint` clean
- [x] Production build clean
- [x] `npm test` (date units + cycles units + smoke test) passes
- [x] Docs updated: `wiki/Version-History.md`, `CLAUDE.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017hCKXbBMT3bFSo3ddSNaGp

---
_Generated by [Claude Code](https://claude.ai/code/session_017hCKXbBMT3bFSo3ddSNaGp)_