### PR TITLE
docs: revise Escalation Ladder + Growth Areas specs after design review

### DIFF
--- a/wiki/Escalation-Ladder.md
+++ b/wiki/Escalation-Ladder.md
@@ -4,54 +4,70 @@ A task-level feature for the "I need a response from someone and I'm not getting
 
 The originating example (windows quote/repair): email the contractor, no response. After a couple of follow-up emails, switch to calling. After a few unanswered calls, call the company's main line instead of the individual. Still nothing — ask for a salesperson and get someone out in person. Each rung is a **different tactic**, not a repeat of the last one; the ladder's job is to notice "you've hit the ceiling on this approach" and tell you what to try next.
 
+**Revision note (2026-07-04):** this spec was rewritten after a deliberate adversarial design pass (see below) that pushed back hard on the first draft. The core critique: the first draft modeled the *data* thoroughly and the *lifecycle moments* thinly — attempt-logging lived only behind an app-open, advancement was silent/automatic (the user asked for "prompt to move past it," not automate), there was no success path, and attempts earned no points despite being real effort. This revision keeps the one genuinely novel idea (the nudge carries the next tactic, not a generic nag) and fixes the lifecycle gaps.
+
 ---
 
 ## Why not Sequences
 
-Sequences fire the next step when the current one is marked **done** — they model a chain of work you're doing yourself. An escalation ladder fires the next rung when the current one is exhausted by **repeated non-response** — there is no "done" signal from the other party, only a count of attempts and elapsed time. The two are structurally different triggers (completion vs. attempt-threshold) and reusing `follow_ups` would force an awkward fit. This is its own primitive, scoped to a single task.
+Sequences fire the next step when the current one is marked **done** — they model a chain of work you're doing yourself. An escalation ladder fires the next rung when the current one is exhausted by **repeated non-response** — there is no "done" signal from the other party, only a count of attempts. The two are structurally different triggers (completion vs. attempt-threshold) and reusing `follow_ups` would force an awkward fit. This is its own primitive, scoped to a single task.
 
 ---
 
 ## Data model
 
-New columns on `tasks` (new migration `038_add_escalation_ladder.sql`):
+New columns on `tasks` (migration `039_add_escalation_ladder.sql`):
 
 | Column | Type | Notes |
 |---|---|---|
 | `escalation_rungs` | JSON | Ordered array, see shape below. `NULL`/`[]` = feature off for this task. |
 | `escalation_current_rung` | INTEGER | Index into `escalation_rungs`. Defaults to `0`. |
-| `escalation_attempt_log` | JSON | Array of `{ at: ISO timestamp, rung_index, note? }` — one entry per logged attempt, all rungs, never trimmed (it's the audit trail + the "how long has this been going on" source). |
+| `escalation_attempt_log` | JSON | Array of `{ id, at: ISO timestamp, rung_index, points: 1 }` — one entry per logged attempt, all rungs, never trimmed (audit trail + "how long has this been going on" + the points source — same shape family as a project's `session_log`). |
+| `escalation_awaiting_advance` | INTEGER (bool) | `1` when the current rung's threshold is met and the app is *offering* to move on but hasn't yet — see Interaction model. Distinct from actually advancing. |
+| `escalation_stuck` | INTEGER (bool) | `1` when the last rung's threshold is met and there's nowhere further to go — triggers the Brainstorm path. |
 
-Rung shape:
+Rung shape — deliberately **one number, not two** (the first draft's `attempts_before_next` + `min_days_before_next` combo was overbuilt: the user's mental model is fuzzy, "a couple more emails, then switch," and with *prompted* advance the threshold only controls when the app starts *asking*, so precision buys nothing):
 
 ```json
 {
   "id": "uuid",
   "label": "Email",
   "suggestion": "Send a polite follow-up email referencing the quote request.",
-  "attempts_before_next": 3,
-  "min_days_before_next": 2
+  "script": "Hi — following up on the windows quote for 123 Main St. Could we get a date on the calendar?",
+  "attempts_before_ready": 3,
+  "nudge_every_days": 2
 }
 ```
 
 - `label` — short tactic name shown on the card ("Email", "Call", "Call main line", "Ask for a manager").
-- `suggestion` — the text surfaced in the nudge/notification for this rung. AI-authored at ladder-creation time (see Quokka tool below) or user-edited.
-- `attempts_before_next` — how many logged attempts at this rung before the ladder auto-advances. `null` = this is the **last rung** — logging attempts here never auto-advances (see "Running out of rungs" below).
-- `min_days_before_next` — floor on elapsed time since the rung's first attempt, even if the attempt count is hit early (stops "call 3 times in one afternoon" from immediately unlocking the next rung — most real escalation only makes sense to move on after giving the current tactic a fair window).
+- `suggestion` — the text surfaced in the nudge/notification for this rung.
+- `script` *(optional but strongly encouraged, AI-authored)* — a literal one-to-two-line opener the user can read or paste, not just a description of the tactic. For confrontation-flavored rungs (calling a stranger, asking to speak to a manager) the barrier is rarely "remember to do it" — it's "know what to say when a human answers." Converting a rung from "make an awkward call" to "read this aloud" is worth more than the entire threshold system; Quokka always tries to write one.
+- `attempts_before_ready` — how many logged attempts at this rung before the app starts *offering* to advance (see Prompted advance below). `null` = this is the **last rung** — reaching it never offers to advance; it flips `escalation_stuck` instead.
+- `nudge_every_days` — how often the nudge fires *while on this rung*, e.g. "call every day" vs. "email, then wait a few days." This is cadence, not just a threshold — the user's own phrasing ("calling them every day or something") is a tempo, and rung 1 ("wait politely") and rung 3 ("call daily until a human answers") need different tempos. This is a per-rung override of the normal stale/nudge frequency, not an additional independent timer.
+
+No reorder UI, no multi-field advance math. Rungs are almost always AI-drafted (see Quokka integration); user edits are inline text tweaks, add-one-at-the-end, or delete — never drag-reordering a state machine by hand.
 
 ---
 
 ## Interaction model
 
-**Logging an attempt.** A "Log attempt" button on the expanded task card (same UX precedent as the existing Project "Log session" button — a single tap, no form). Appends to `escalation_attempt_log`, stamped with the current `escalation_current_rung`.
+The design test for every interaction below: **does the intent reach the user at the moment it's actionable, in one tap or zero?** The first draft failed this test by putting every action behind an app-open.
 
-**Auto-advance.** After each logged attempt, check: has this rung's `attempts_before_next` been reached AND has `min_days_before_next` elapsed since the first attempt logged at this rung? If both, `escalation_current_rung += 1` and the next nudge announces the new rung ("You've emailed 3 times over 4 days with no response — time to call.").
+**Logging an attempt — must be reachable from the nudge itself, not just the card.** In-app: a "Log attempt" button on the expanded task card (same one-tap precedent as the Project "Log session" button). On web push notifications for an active-ladder task: an inline action button (mirrors the existing Snooze 1h / Done pattern already in the service worker) so a call made from the car, ended, can be logged without opening the app. Each logged attempt appends `{id, at: now, rung_index: current, points: 1}` to `escalation_attempt_log`.
 
-**Manual advance.** A "Move to next step" action lets the user jump the queue without waiting on the thresholds (mirrors the existing Loop `skipCycle` pattern) — sometimes you already know email is dead the moment you send it.
+**Attempts earn points.** Per the app's own "waiting = progress" principle — sent the email, made the call is real effort even without resolution — each logged attempt is worth 1 point, summed into the daily total exactly like project session-log points (`computeEscalationStatsToday()` alongside the existing `computeSessionStatsToday()`, both rolled into `computeDailyStats`). This isn't decoration: if logging doesn't feel like scoring, it won't happen, the log goes stale, and the ladder starts nagging on wrong information.
 
-**Nudge integration.** While a task has an active ladder (`escalation_rungs` non-empty and `escalation_current_rung` within range), its notification text is overridden: instead of the generic stale/nudge copy, the message uses the current rung's `suggestion` plus the attempt count so far ("Rung 2/4 · Call — you've called twice, no answer"). This rides the existing per-type notification templates in `pushNotifications.js`/`emailNotifications.js`/`pushoverNotifications.js` — no new transport, just a text-source override keyed on `escalation_rungs` presence.
+**Prompted advance, not automatic.** After a logged attempt, if `attempts_before_ready` is met for the current rung, the *next* nudge changes shape: instead of continuing to ask for another attempt at the same tactic, it asks **"Email's had 3 tries with no response. Ready to switch to calling? [Move on] [One more try]"** — both are one-tap actions (in-app buttons always; web push inline actions where the transport supports it). `escalation_awaiting_advance` is set the moment the threshold is met so the UI can show the prompt state even before the next nudge fires. The app never silently changes what it's asking for — every transition is a decision the user makes, matching the same propose-then-confirm shape as Quokka's staged plans and the loop-reconcile review surface (both already-established "the app surfaces, the user decides" precedents in this codebase).
+- **[Move on]** → `escalation_current_rung += 1`, `escalation_awaiting_advance = 0`, next nudge announces the new rung + its `script`.
+- **[One more try]** → `escalation_awaiting_advance = 0`, stays on the current rung (the counter effectively gets a little slack — the user gets to decide their own threshold was too eager).
 
-**Running out of rungs.** Reaching the last rung's attempt threshold doesn't advance further (there's nowhere to go) — it flips a `stuck` state that changes the ask: instead of "try X again," the card surfaces a **"Brainstorm next moves"** button. This is the "creative way to get people to help" part of the ask — tapping it sends the task's title/notes + the full rung history to Claude and asks for genuinely new angles (public reviews for an alternate contact, a regional office, a different department, a mutual connection, a consumer-complaint channel) rather than another scripted rung, since by definition the user's own script has run out. Results append to the task's notes (same pattern as `research_task`), not a new rung — a brainstorm isn't a repeatable tactic.
+**Manual advance.** A "Move on" action is also available at any time from the expanded card, independent of whether the threshold has been hit yet — sometimes you already know email is dead the moment you send it and don't want to wait for the app to ask.
+
+**Success path — modeled, not an afterthought.** A "Got a response" action, as prominent as Log attempt, available in-app and (where supported) inline on the nudge. Tapping it: clears the active ladder (`escalation_rungs` stays as a record but `escalation_current_rung`/`escalation_awaiting_advance`/`escalation_stuck` reset to closed), fires a genuine celebration toast ("Four rungs and you got them. What's next?" — this is the payoff of days of dreaded persistence and deserves to read like one), and offers a one-tap "Add a follow-up" prompt that hands off to a normal task (or, if there's obvious multi-step follow-on work like "they're coming Tuesday → prep questions → be home," a Sequence) — the natural next primitive once contact is actually established.
+
+**Nudge integration.** While a task has an active ladder, its notification text is overridden across every transport: instead of generic stale/nudge copy, the message uses the current rung's `suggestion` (and `script` where the transport can show enough text) plus the attempt count — or, when `escalation_awaiting_advance` is set, the prompted-advance copy above. Cadence for these nudges is `nudge_every_days` on the current rung, not the task's normal stale/nudge frequency (waiting-status tasks are otherwise nagged calmly; an active-rung task needs to own its own tempo). This is a text-source + cadence override keyed on `escalation_rungs` presence — no new transport, reuses the existing per-type templates in `pushNotifications.js` / `emailNotifications.js` / `pushoverNotifications.js`.
+
+**Running out of rungs.** Reaching the last rung's `attempts_before_ready` (or having no threshold and just... continuing to fail) flips `escalation_stuck` — there's nowhere scripted left to go. The card surfaces a **"Brainstorm next moves"** button. Tapping it runs a Quokka turn with the task's title/notes/full rung history, asking for genuinely new angles (public reviews for an alternate contact, a regional office, a different department, a consumer-complaint channel) — and **stages the results as new rungs** via `set_escalation_ladder` (append), landing as a normal staged-plan Apply, not a wall of prose dumped into notes. The peak-demoralization moment (every planned move has failed) is exactly the wrong time to ask the user to re-author freeform brainstorm text into structured rungs themselves.
 
 ---
 
@@ -60,27 +76,27 @@ Rung shape:
 `EditTaskModal` gets an **Escalation** section (same visual language as the Project/Sequences sections):
 
 - Toggle: "Track contact attempts for this task"
-- Rung list editor — same list/reorder/add/remove interaction as the Sequences `FollowUpStepRow` list, one row per rung (label, suggestion, attempts-before-next, min-days-before-next)
+- Rung list — simple stacked list (label, suggestion, script, tempo), add-one-at-the-end + delete per row. No reorder.
 - Read-only summary once attempts exist: "Rung 2 of 4 · 3 attempts logged · last: 2 days ago"
 
-Task card (collapsed): a small rung indicator next to the energy chip when a ladder is active (e.g. "☎ 2/4"). Expanded card: "Log attempt" + "Move to next step" buttons, attempt history as a compact list.
+Task card (collapsed): a small rung indicator next to the energy chip when a ladder is active (e.g. "☎ 2/4"), with a distinct visual state when `escalation_awaiting_advance` (e.g. an amber pulse) or `escalation_stuck` (e.g. the Brainstorm affordance surfaces directly on the collapsed card, since it's the highest-priority action once stuck). Expanded card: **Log attempt**, **Move on**, **Got a response** buttons (all always visible when a ladder is active — no submenu), attempt history as a compact list, script text shown prominently for the current rung.
 
 ---
 
 ## Quokka integration
 
-One generative tool plus the standard CRUD, all in `adviserToolsTasks.js`:
-
-- **`generate_escalation_ladder({ task_id, situation })`** — the primary entry point. `situation` is free text describing who/what/channels available/urgency (what the user would otherwise type into chat: "trying to get a windows quote from Acme, they went quiet after the initial email, I have their email and a general phone number"). The model drafts an ordered rung list — channel-appropriate, situation-aware thresholds (a time-sensitive ask gets tighter `min_days_before_next` than a someday-maybe task) — and stages it as a `set_escalation_ladder` update for user approval, same staged-plan-confirm flow as every other mutation.
-- **`set_escalation_ladder({ task_id, rungs })`** — direct set/replace, for manual edits or Quokka adjustments after the fact.
+- **`generate_escalation_ladder({ task_id, situation })`** — the primary entry point. `situation` is free text describing who/what/channels available/urgency. The model drafts an ordered rung list (label + suggestion + script + tempo, situation-aware — a time-sensitive ask gets a tighter `nudge_every_days` than a someday-maybe task) and stages it as a `set_escalation_ladder` update for approval.
+- **`set_escalation_ladder({ task_id, rungs })`** — direct set/replace (also used by the Brainstorm-stages-rungs flow above, appending rather than replacing when called in that context).
 - **`log_escalation_attempt({ task_id, note? })`** — lets Quokka log an attempt on the user's behalf mid-conversation ("I called again just now, still nothing — log that").
-- `summarizeTask()` gains the escalation fields so `get_task`/`search_tasks` expose ladder state without a separate fetch.
+- **`advance_escalation_rung({ task_id })`** / **`resolve_escalation({ task_id })`** — Quokka-driven equivalents of Move on / Got a response, for "move this to calling" or "they finally got back to me, close it out" said in chat.
+- `summarizeTask()` gains the escalation fields (current rung, awaiting-advance/stuck flags, attempt count) so `get_task`/`search_tasks` expose ladder state without a separate fetch.
 
 ---
 
 ## Known limitations / parked
 
-- No auto-detection of "attempt" from Gmail/Trello/Notion activity — attempts are user-logged only. Auto-detecting "I emailed them" from the Gmail sync is a plausible future enhancement but adds a lot of surface area (matching sent mail to a task) for v1.
-- No per-rung channel enum/validation — `label`/`suggestion` are free text. A structured channel type (email/call/text/in-person/other) could drive channel-specific UI (a tel: link for a "call" rung) later.
-- The "stuck" brainstorm doesn't currently create tasks/reminders from its output automatically — it's a notes append the user reads and acts on manually. Auto-staging a new rung from the brainstorm is a natural v2 extension once the pattern is validated.
+- **No auto-detection of outbound attempts** (Gmail/Trello/Notion) — attempts are user- or Quokka-logged only. Matching sent mail to a task is real scope, deferred.
+- **Inbound success detection is parked, not built in v1** — the idea (surface "looks like they replied — close the ladder?" when a Gmail message arrives from a matched sender) is cheap in principle since the Gmail scanner already polls, but wiring sender-matching against a specific task is nontrivial and depends on Gmail being connected. "Got a response" stays a manual/Quokka action for now.
+- **Inline notification actions are web-push only in v1.** Email and Pushover show the rung's `suggestion`/`script` as text (a real improvement over generic nag copy) but don't get tappable Log attempt / Move on / Got a response buttons — those platforms' action-button support is either absent (Pushover) or would require building tokenized one-tap action links from scratch (email). Web push already has the actions-array + service-worker-click precedent from Snooze 1h/Done, so it's the only transport this ships with true inline actions on.
+- **Reactive creation (the app noticing a stuck avoidance-prone task and offering to draft a ladder) is parked**, not built in v1. The natural hook exists (the avoidance-boost logic already flags `confrontation`/`errand` tasks sitting in `waiting` too long) but wiring a new proactive-suggestion surface is separate scope from the ladder mechanism itself. v1 creation paths are: the EditTaskModal toggle, or asking Quokka directly ("help me build an escalation plan for the windows quote").
 - Not wired into Routines — a recurring "keep trying to reach the HOA" case would need per-cycle ladder resets, which isn't scoped here.

--- a/wiki/Growth-Areas.md
+++ b/wiki/Growth-Areas.md
@@ -1,78 +1,108 @@
 # Growth Areas (personal-coaching reminders)
 
-An optional, deliberately tiny feature: the user defines a short list of things they want to work on about *themselves* — not tasks, not habits with completion tracking, just standing reminders ("be more observant," "be more patient on calls," "stay focused during deep work"). Boomerang resurfaces them on a cadence the user picks per item. This is the "life organizer, not just task manager" edge of the product — adjacent to Routines/Projects but explicitly **not** a task: nothing to check off, no streak, no points.
+An optional, deliberately tiny feature: the user defines a short list of things they want to work on about *themselves* — not tasks, not habits with completion tracking, just standing reminders ("be more observant," "be more patient on calls," "stay focused during deep work"). Boomerang resurfaces them. This is the "life organizer, not just task manager" edge of the product — adjacent to Routines/Projects but explicitly **not** a task: nothing to check off, no streak, no points.
+
+**Revision note (2026-07-04):** rewritten after an adversarial design pass. The first draft's data model and CRUD were fine; its *delivery mechanism* — a static banner and a static always-visible chip strip, same 2-3 phrases every day — was the actual weak point: static, unchanging text in a fixed slot is textbook habituation bait, and a "coaching" feature that's dismissed on autopilot by day 4 isn't coaching, it's decoration. This revision keeps every locked scope decision (no tracking, per-area surfacing choice) and rebuilds *only* the delivery: rotation instead of a full list, fresh AI-rephrased wording instead of static text, and contextual delivery instead of a permanent chip.
 
 ---
 
-## Scope decisions (locked, per user)
+## Scope decisions (locked, per user — unchanged)
 
-- **No tracking.** Pure reminder text, resurfaced. No progress bar, no streak, no daily check-in prompt. If that changes later it's a deliberate v2, not an oversight.
-- **Surfacing mode is per-area**, not a single global toggle:
-  - `morning` — shown once, first thing in the day, then gets out of the way.
-  - `persistent` — always visible somewhere, ambient.
-  - `both` — shown as the morning nudge AND lives in the persistent strip.
+- **No tracking.** Pure reminder text, resurfaced. No progress bar, no streak, no daily check-in prompt. A streak on "be more patient" would just manufacture guilt — patience isn't completable, so any check-in is either meaningless ritual or a daily self-report of failure. This is locked; if it's revisited, it's a deliberate v2 decision made in the open, not scope creep.
+- **Surfacing choice is per-area** (unchanged as a config concept — the *mechanism* behind each choice is what changed, see below): `morning`, `persistent`, or `both`.
 
 ---
 
 ## Data model
 
-No new table — this is config-shaped data, same category as `labels` (CLAUDE.md: "Settings and labels remain in app_data as JSON blobs (intentional)"). New key: `app_data.growth_areas`, array of:
+`growth_areas` — its **own** `app_data` collection, deliberately kept **out of** the bulk `/api/data` PUT/POST sync blob (the whole-blob last-writer-wins path). CLAUDE.md's durability rules are explicit that cross-device-merged keys need a server-side guard and the streak-anchor incident happened *twice* via exactly this blob; the clean fix here is to never let growth areas ride that path at all rather than patch around it. Real per-record server endpoints instead (see below) — same protective shape as `tasks`/`routines`/`packages`, which are already carved out of `setAllData()` for the identical reason.
 
 ```json
 {
   "id": "uuid",
   "title": "Be more observant",
   "mode": "both",
+  "energy_affinity": "confrontation",
   "active": true,
   "created_at": "iso timestamp"
 }
 ```
 
-`active: false` keeps the item around (edit history / easy re-enable) without surfacing it — same soft-disable pattern used elsewhere in the app rather than deleting.
+- `energy_affinity` *(optional, new)* — one of the existing energy types (`desk`/`people`/`errand`/`confrontation`/`creative`/`physical`), inferred by Quokka at creation time when a title implies one ("more patient on calls" → `confrontation` or `people`). Powers contextual delivery (below). Omit if there's no clean match — not every area maps to a task flavor.
+- `active: false` keeps the item around (edit history / easy re-enable) without surfacing it.
 
 ---
 
-## Surfacing
+## Surfacing (the part that was rebuilt)
 
-**Morning (`morning` | `both`).**
-1. Digest line — `digestBuilder.js` gains a new section (after the existing lead-in, before Today) listing active morning-mode areas: *"Today, work on: being more observant, staying patient on calls."* Rides whichever transports the digest already uses (push/email/Pushover) — no new transport.
-2. Today-view banner — a small dismissible card at the top of the Kept Today view (above the Day Arc hero), same once-per-local-day dismissal model as everything else that's daily-scoped in this app (e.g., loop cycle windows bucket in `settings.user_timezone`). Dismissing hides it until the next local morning; it does **not** mark anything done because there's nothing to complete.
+The locked per-area `mode` choice still exists, but what each mode *does* changed. The first draft's `persistent` was a static always-visible chip strip; that's exactly the habituation trap, so it's gone as a UI element. Instead:
 
-**Persistent (`persistent` | `both`).** A slim always-visible strip — a single line of chips, e.g. under the header or above the section list — listing active persistent-mode areas. No interaction beyond tapping to open the management sheet; this is ambient, not actionable.
+- **`morning`** — eligible for the once-daily rotation (below). Not injected into other surfaces.
+- **`persistent`** — *not* shown as static chrome anywhere. Instead, always eligible for **contextual injection** (What Now + Quokka, below) — "persistent" now means "present wherever it's contextually relevant," not "permanently on screen." This is a closer match to what a coach actually does: speaks at the moment of relevance, not on a fixed schedule.
+- **`both`** — eligible for the morning rotation AND contextual injection.
 
-**Both.** Simply satisfies both rules above — the item shows in the morning banner/digest AND sits in the persistent strip. Not a third rendering path.
+**1. Morning rotation — one area, not a list, and never the same wording twice.**
+
+Each local morning, pick exactly **one** active area from the `morning ∪ both` pool via a stable rotation (day-of-year index mod pool size — deterministic, so re-opening the app the same day always shows the same pick, but tomorrow moves on). Never surface the whole list at once; a list is skimmed, one line lands. With a recommended 2-3 active areas, each gets meaningful attention a couple of mornings a week instead of a daily blur — and it quietly caps the "I optimistically added nine areas one evening" problem, since the surface never grows just because the list does.
+
+The picked area's stored `title` is a stable intent ("be more observant"); what's actually shown is a **fresh AI rendering of it**, generated fresh each day — reusing the same shape as the existing toast-message pipeline (`generateToastMessages()` in `src/api.js`: a short prompt, a 3-second timeout, a static fallback if the AI doesn't answer in time). Example: stored "be more observant" → surfaced "Notice one thing on your commute you'd normally walk past." Novelty is what defeats banner blindness; this is the single highest-leverage piece of the whole feature and needs zero new user-facing config — the user still only ever types a title.
+
+Computed **once per day, server-side, and cached** (`app_data.growth_area_today = { date, area_id, text }`) so the digest and the client banner show the *same* pick and text without two independent AI calls or a chance of disagreeing. Static fallback (AI unavailable/slow) is just the area's own stored title, unmodified — never a blank surface.
+
+Surfaced in two places, both reading the same cached pick:
+1. **Digest line** — `digestBuilder.js` gains a section (after the lead-in, before Today): "☀️ Today: {surfaced text}". Rides whichever transports the digest already uses.
+2. **Today-view banner** — a small dismissible card at the top of the Kept Today view (above the Day Arc hero). Dismiss hides it until the next local morning (bucketed in `settings.user_timezone`, same pattern as everything else daily-scoped in this app). No completion semantics — dismissing isn't "doing" anything, it's just "seen."
+
+**2. Contextual injection — the actual "coaching," not the morning notice.**
+
+A morning banner about staying patient on calls has evaporated by the 2pm call it was actually relevant to. The app already knows task energy types, so:
+- **What Now** (`getWhatNow()`): the active `persistent`/`both` areas (with `energy_affinity` set) are passed alongside the existing weather-summary context. When the model picks a task whose energy matches an area's affinity, it may add one line — "…and this one's a rep for staying patient" — **only when genuinely relevant**, mirroring the existing rule that weather is only mentioned in the reason when it actually affects the pick. Never forced onto every response.
+- **Quokka**: active growth areas (title + affinity, compact) are folded into the system prompt context, so "help me plan this call" or "I'm dreading this one" naturally gets a coaching-flavored response when it's actually relevant, without the user having to bring it up first.
+
+Both reuse the *same* underlying small helper — a "does this task/context match an active area, and if so what's the one-line nudge" function — rather than two independent implementations, since the model input is the same question (task energy + active areas) asked from two call sites.
 
 ---
 
 ## Management UI
 
-A "Growth areas" entry in the System menu (alongside Settings/Analytics/Done/Suggestions/Activity log — matches the existing low-frequency-surface grouping). Simple list CRUD:
+A "Growth areas" entry in the System menu (alongside Settings/Analytics/Done/Suggestions/Activity log). Simple list CRUD:
 
-- Add: title + mode picker (morning / persistent / both)
-- Edit: title, mode, active toggle
-- Delete: removes entirely (no soft-delete needed beyond the existing `active` flag, which already covers "pause without losing the wording")
+- Add: title + mode picker (morning / persistent / both). Copy hint: "Works best with 2-3 active areas — a longer list just means each one is seen less often."
+- Edit: title, mode, active toggle. `energy_affinity` is Quokka-inferred, not a manual field — keeps the add-form to two inputs.
+- Delete: removes entirely (the `active` flag already covers "pause without losing the wording," so no separate soft-delete is needed).
 
-No detail modal, no checklist, no tier system — this is intentionally the simplest possible CRUD surface in the app, on par with Labels.
+No detail modal, no checklist, no tier system — intentionally the simplest CRUD surface in the app, on par with Labels.
+
+---
+
+## Server endpoints
+
+Dedicated per-record endpoints (NOT part of the bulk `/api/data` blob — see Data model above):
+
+| Endpoint | Purpose |
+|---|---|
+| `GET /api/growth-areas` | List all (including inactive, for the management UI) |
+| `POST /api/growth-areas` | Create `{title, mode}`; server infers `energy_affinity` via a cheap Claude call, same conservative-by-default posture as tag inference |
+| `PATCH /api/growth-areas/:id` | Update any subset of fields |
+| `DELETE /api/growth-areas/:id` | Remove |
+| `GET /api/growth-areas/today` | The cached daily rotation pick `{area, text}` (or `null` if no active morning/both areas) — computes + caches on first call of the day, served from cache after |
 
 ---
 
 ## Quokka integration
 
-Standard CRUD, mirroring the Knowledge Base tools' shape (search/create/update/delete) but far smaller surface:
-
 - `list_growth_areas()` — read-only
-- `create_growth_area({ title, mode })`
+- `create_growth_area({ title, mode })` — `energy_affinity` inferred server-side, same as the REST path
 - `update_growth_area({ id, title?, mode?, active? })`
 - `delete_growth_area({ id })`
 
-All staged through the normal mutation/compensation flow (capture the pre-mutation array, restore on rollback) — same shape as every other simple-array mutation tool, no external side effects to worry about.
-
-Natural-language entry points: "I want to work on being more patient, remind me every morning" → `create_growth_area({title: "Be more patient", mode: "morning"})`. "Stop showing the observant one" → `update_growth_area({..., active: false})`.
+All staged through the normal mutation/compensation flow (capture pre-mutation state, restore on rollback). Natural-language entry points: "I want to work on being more patient, remind me every morning" → `create_growth_area({title: "Be more patient", mode: "morning"})`. "Stop showing the observant one" → `update_growth_area({..., active: false})`.
 
 ---
 
 ## Known limitations / parked
 
-- No tracking is a deliberate v1 choice (see Scope decisions), but if it's revisited later, the natural shape is a lightweight end-of-day check-in (thumbs up/down or 1-5) stored per area per day — explicitly NOT built now.
-- No AI-suggested growth areas (unlike tag suggestions / routine suggestions) — the user authors these directly. Could eventually source suggestions from patterns Quokka notices in conversation, but that's speculative and not requested.
-- No integration with notifications' quiet-hours or per-type toggles beyond riding the existing digest transports — a persistent-mode area showing in the UI strip has no notification component at all by design (ambient, not a push).
+- No tracking is a **deliberate, locked** v1 choice — not a placeholder for a future check-in. If that's ever revisited it should be argued for fresh, not slipped in as an obvious next step.
+- No AI-suggested growth areas (unlike tag/routine suggestions) — the user authors these directly. Sourcing suggestions from patterns Quokka notices in conversation is speculative and not requested.
+- `energy_affinity` inference is best-effort and single-valued — an area like "be more patient" that could plausibly apply to several energy types just gets the model's best single guess. Not worth a multi-select for a two-input add form.
+- Contextual injection depends on the model actually judging relevance well; if it over-triggers (mentioning the same area every time a matching-energy task shows up) that's a prompt-tuning problem to watch for after real use, not something mitigated further at ship time.


### PR DESCRIPTION
## Summary

Both specs went through an adversarial design pass (via a fresh model perspective) focused on real-use lifecycle gaps rather than data-model coherence, before implementation started.

**Escalation Ladder:**
- Inline notification action for logging attempts (web push), not just an in-app button behind an app-open
- Prompted advance ("ready to switch tactics?") instead of silent auto-advance — matches the user's actual ask ("prompt to move past it") and the app's existing propose-then-confirm pattern
- A modeled success path ("Got a response") with a real payoff moment
- Attempts earn points, consistent with the existing "waiting = progress" principle
- Optional scripts per rung (literal words to say), not just tactic labels
- Simplified rung shape (one threshold + a cadence field, not two) and dropped the drag-reorder editor
- Brainstorm-when-stuck stages new rungs via Quokka instead of dumping prose into notes

**Growth Areas:**
- Morning surfacing rotates ONE area per day (not the full list) with a fresh AI-rephrased rendering each time, reusing the toast-message pipeline — the fix for the habituation problem the static-banner version had no defense against
- The static always-visible chip strip is cut; "persistent" mode now means contextual injection into What Now / Quokka instead of permanent screen furniture
- `growth_areas` gets its own per-record endpoints, kept out of the bulk `/api/data` sync blob entirely, avoiding the last-writer-wins hazard that caused the streak-anchor incident twice

No code changes in this commit — docs only, ahead of implementation (which follows in subsequent PRs).

## Test plan
N/A — documentation only, no runtime surface to test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017hCKXbBMT3bFSo3ddSNaGp

---
_Generated by [Claude Code](https://claude.ai/code/session_017hCKXbBMT3bFSo3ddSNaGp)_