### PR TITLE
feat(tasks): add Growth Areas — standing personal-coaching reminders

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -806,6 +806,30 @@ Personal knowledge store Quokka can search. Where things are kept, how-tos, deci
 - Keyword search only (title/tags/summary). Semantic search across full bodies not wired.
 - 5-minute refresh cadence — if the user adds an item in Notion directly and immediately asks Quokka, they need to tap "Sync now" or have Quokka call `refresh_knowledge_index`.
 
+### Growth Areas (personal-coaching reminders, 2026-07-04)
+
+Deliberately tiny feature: standing reminders about *yourself* ("be more patient on calls"), not tasks — no tracking, no streak, no check-in. Full spec + design rationale (including the adversarial-review rewrite that killed the original static-banner delivery): `wiki/Growth-Areas.md`.
+
+**Storage.** `growthAreas.js` (root module, in the Dockerfile runtime COPY list). Its own dedicated `app_data` collections — `growth_areas` (the CRUD list) and `growth_area_today` (the cached daily rotation pick) — deliberately kept OUT of the bulk `/api/data` sync blob, same carve-out reasoning as tasks/routines/packages (see Derived-Stat Durability Rules above). The client only ever talks to dedicated `/api/growth-areas*` endpoints, never folding growth-area state into the object `useServerSync.js` pushes, so there's nothing for the whole-blob last-writer-wins path to clobber.
+
+**Data shape:** `{ id, title, mode: 'morning'|'persistent'|'both', energy_affinity, active, created_at }`. `energy_affinity` is inferred server-side via a cheap Claude call at creation time (same `claude-sonnet-4-6` + conservative-single-guess posture as tag inference); omitted when no clean match.
+
+**Surfacing — the part that got rebuilt after the adversarial pass:**
+- **Morning rotation.** One area a day (day-of-year index mod the `morning ∪ both` pool — deterministic per day), rendered as a **fresh AI rephrasing** of the stored title (reuses the toast-message shape: short prompt, timeout, static fallback = the stored title verbatim). Computed once per day, server-side, cached in `growth_area_today` so the digest and the Today-view banner never disagree or double-call the AI. An EMPTY cached pick (no eligible areas yet) is deliberately NOT sticky — `ensureTodayGrowthArea()` only treats a cache hit as final once it holds a real `area_id`, so adding your first area mid-day shows up immediately instead of waiting for tomorrow.
+- **Contextual injection (`persistent`/`both`).** NOT a static chip anymore. Active areas (title + `energy_affinity`) are passed into `getWhatNow()` (`src/api.js`, 6th param) and folded into Quokka's system prompt (`adviserSystemPrompt()` in server.js) — both may mention an area in one line when a task's energy genuinely matches, mirroring the existing "only mention weather when it affects the pick" rule. Never forced.
+- **Digest line.** `digestBuilder.js` reads `getTodayGrowthAreaCached()` (sync, cache-only — the digest builder is fully synchronous and must never block on a live AI call) and renders "☀️ Today: {text}" right after the lead-in, before Today.
+- **Today-view banner.** Small dismissible card above the Day Arc hero in `src/kept/TodayView.jsx` (`getTodayGrowthArea()` client call). Dismiss is "seen," not "done" — persisted in localStorage keyed by the pick's date, reappears next local morning. Same component renders on both KeptShell (mobile) and KeptDesktop (both use `TodayView`).
+
+**Background sync.** `startGrowthAreaSync()` (mirrors `weatherSync.js`'s cadence pattern) ticks every 15 min, calling `ensureTodayGrowthArea()` so the digest always has a warm cache by the time it builds.
+
+**Server endpoints:** `GET/POST /api/growth-areas`, `PATCH/DELETE /api/growth-areas/:id`, `GET /api/growth-areas/today`.
+
+**Management UI:** `GrowthAreasModal` (`src/components/GrowthAreasModal.jsx`) — simplest CRUD surface in the app, on par with Labels. Entry points: System menu (legacy theme), More → Growth areas (Kept mobile), sidebar nav (Kept desktop).
+
+**Quokka tools (4, in `adviserToolsMisc.js`):** `list_growth_areas` (read-only), `create_growth_area`, `update_growth_area`, `delete_growth_area` — staged with capture/restore compensation like every other mutation tool.
+
+**Known limitations:** no tracking is a deliberate locked v1 choice, not a placeholder. No AI-suggested growth areas — the user authors these directly. `energy_affinity` inference is best-effort/single-valued. See the wiki page's "Known limitations / parked" for the rest.
+
 ### Quokka (AI Adviser)
 Free-form natural-language control surface — user says "I've rescheduled my FAA exam to May 12, adjust everything" and Quokka finds related tasks/GCal events/routines and queues the fix. Named after the quokka (a small, perpetually-smiling Australian marsupial). User-facing branding uses "Quokka"; internal code (module names, CSS classes, endpoints under `/api/adviser/`, state vars like `showAdviser`) stays as `adviser`/`Adviser` — renaming plumbing provides no value.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ ENV APP_VERSION=${APP_VERSION}
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY package.json ./
-COPY server.js auth.js db.js seed.js emailNotifications.js pushNotifications.js pushoverNotifications.js digestBuilder.js notifAi.js userTime.js gmailSync.js weatherSync.js notionMCP.js notionMCPProxy.js patternDetection.js tagSuggestions.js knowledgeSync.js ./
+COPY server.js auth.js db.js seed.js emailNotifications.js pushNotifications.js pushoverNotifications.js digestBuilder.js notifAi.js userTime.js gmailSync.js weatherSync.js notionMCP.js notionMCPProxy.js patternDetection.js tagSuggestions.js knowledgeSync.js growthAreas.js ./
 COPY adviserTools.js adviserToolsTasks.js adviserToolsIntegrations.js adviserToolsMisc.js adviserToolsKnowledge.js ./
 COPY migrations ./migrations
 COPY scripts ./scripts

--- a/adviserToolsMisc.js
+++ b/adviserToolsMisc.js
@@ -7,6 +7,7 @@ import {
   listPendingSuggestions, getPatternSuggestion, updateSuggestionStatus, snoozeSuggestion,
 } from './db.js'
 import { registerTool } from './adviserTools.js'
+import { listGrowthAreas, getGrowthArea, createGrowthArea, updateGrowthArea, deleteGrowthArea } from './growthAreas.js'
 
 function ensure(cond, msg) { if (!cond) throw new Error(msg) }
 
@@ -472,6 +473,94 @@ export function registerSuggestionTools() {
 }
 
 // ============================================================
+// Growth areas (personal-coaching reminders — see wiki/Growth-Areas.md)
+// ============================================================
+
+export function registerGrowthAreaTools() {
+  registerTool({
+    name: 'list_growth_areas',
+    description: 'List the user\'s growth areas — standing personal-coaching reminders ("be more patient on calls"), not tasks. Includes inactive ones.',
+    readOnly: true,
+    schema: { type: 'object', properties: {} },
+    execute: async () => ({ result: { areas: listGrowthAreas() } }),
+  })
+
+  registerTool({
+    name: 'create_growth_area',
+    description: 'Create a new growth area. `mode` controls surfacing: "morning" (once-daily rotation), "persistent" (contextual — surfaces in What Now / Quokka when relevant), or "both". energy_affinity is inferred automatically server-side, do not pass it.',
+    schema: {
+      type: 'object',
+      properties: {
+        title: { type: 'string', description: 'e.g. "Be more patient on calls"' },
+        mode: { type: 'string', enum: ['morning', 'persistent', 'both'], default: 'both' },
+      },
+      required: ['title'],
+    },
+    preview: (a) => `Create growth area "${a.title}" (${a.mode || 'both'})`,
+    execute: async (args) => {
+      const area = await createGrowthArea({ title: args.title, mode: args.mode })
+      return {
+        result: { id: area.id, area },
+        compensation: async () => { deleteGrowthArea(area.id) },
+      }
+    },
+  })
+
+  registerTool({
+    name: 'update_growth_area',
+    description: 'Update a growth area\'s title, mode, or active state (active=false pauses it without losing the wording — use for "stop showing X").',
+    schema: {
+      type: 'object',
+      properties: {
+        id: { type: 'string' },
+        title: { type: 'string' },
+        mode: { type: 'string', enum: ['morning', 'persistent', 'both'] },
+        active: { type: 'boolean' },
+      },
+      required: ['id'],
+    },
+    preview: (a) => `Update growth area ${a.id}`,
+    execute: async (args) => {
+      const before = getGrowthArea(args.id)
+      ensure(before, `Growth area not found: ${args.id}`)
+      const updates = {}
+      for (const k of ['title', 'mode', 'active']) if (args[k] !== undefined) updates[k] = args[k]
+      const area = updateGrowthArea(args.id, updates)
+      return {
+        result: { id: args.id, area },
+        compensation: async () => { updateGrowthArea(args.id, before) },
+      }
+    },
+  })
+
+  registerTool({
+    name: 'delete_growth_area',
+    description: 'Permanently remove a growth area.',
+    schema: {
+      type: 'object',
+      properties: { id: { type: 'string' } },
+      required: ['id'],
+    },
+    preview: (a) => `Delete growth area ${a.id}`,
+    execute: async ({ id }) => {
+      const before = getGrowthArea(id)
+      ensure(before, `Growth area not found: ${id}`)
+      deleteGrowthArea(id)
+      return {
+        result: { id, deleted: true },
+        compensation: async () => {
+          const arr = listGrowthAreas()
+          arr.push(before)
+          // deleteGrowthArea/createGrowthArea don't expose a raw re-insert,
+          // so recreate the record directly via the same collection shape.
+          setData('growth_areas', arr)
+        },
+      }
+    },
+  })
+}
+
+// ============================================================
 // Register all misc tools
 // ============================================================
 
@@ -481,4 +570,5 @@ export function registerMiscTools() {
   registerWeatherTools()
   registerSettingsTools()
   registerSuggestionTools()
+  registerGrowthAreaTools()
 }

--- a/digestBuilder.js
+++ b/digestBuilder.js
@@ -10,6 +10,7 @@
  *
  * Sections (in order):
  *   1. Lead-in — friendly opener (rotating static line, AI later via Phase 5)
+ *   1b. Growth area — today's rotating personal-coaching pick (cached, see growthAreas.js)
  *   2. Yesterday recap — completion count + streak (only if there's something positive)
  *   3. Today — tasks due today (overdue rolled in here, gentle phrasing)
  *   4. Coming up — tasks due in next 3 days
@@ -20,6 +21,7 @@
 
 import { queryTasks, getData, getAnalytics, filterNotifiableTasks } from './db.js'
 import { getWeatherCache, buildWeatherSummary } from './weatherSync.js'
+import { getTodayGrowthAreaCached } from './growthAreas.js'
 
 // ACTIVE_STATUSES retained for any legacy refs; new code uses isNotifiable()
 // from db.js so the digest respects nag_allowed / snooze_indefinite / project
@@ -137,10 +139,13 @@ export function buildDigest(settings) {
   }
 
   const weatherSummary = buildWeatherSummary(getWeatherCache())
+  const growthPick = getTodayGrowthAreaCached()
+  const growthText = growthPick?.text || null
 
   // --- Build text version (for SMS gateway, push body, Pushover) ---
   const textParts = []
   textParts.push(pickLeadIn())
+  if (growthText) textParts.push(`☀️ Today: ${growthText}`)
   if (yesterday.length > 0 || streak > 0) {
     const recap = []
     if (yesterday.length > 0) recap.push(`Completed ${yesterday.length} yesterday`)
@@ -184,6 +189,9 @@ export function buildDigest(settings) {
 
   const htmlParts = []
   htmlParts.push(`<p style="font-size:15px;color:#111;margin:0 0 8px 0">${escapeHtml(pickLeadIn())}</p>`)
+  if (growthText) {
+    htmlParts.push(`<p style="font-size:14px;color:#0E6B36;margin:0 0 8px 0;font-weight:500">☀️ Today: ${escapeHtml(growthText)}</p>`)
+  }
   if (yesterday.length > 0 || streak > 0) {
     const bits = []
     if (yesterday.length > 0) bits.push(`<strong>${yesterday.length}</strong> completed yesterday`)

--- a/growthAreas.js
+++ b/growthAreas.js
@@ -1,0 +1,223 @@
+// growthAreas.js — personal "growth areas" (coaching reminders), see
+// wiki/Growth-Areas.md for the full spec.
+//
+// Deliberately its own app_data collection (`growth_areas`), NOT part of the
+// bulk `/api/data` sync blob — the client never folds it into that object,
+// so it can't be clobbered by the whole-blob last-writer-wins path (same
+// carve-out reasoning as tasks/routines/packages, see CLAUDE.md's Derived-
+// Stat Durability Rules). All access goes through dedicated endpoints.
+//
+// Two collections:
+//   growth_areas       — the user's list of areas (CRUD)
+//   growth_area_today  — the cached once-daily rotation pick + AI rendering,
+//                        `{ date, area_id, area_title, text }`
+
+import { getData, setData } from './db.js'
+
+const AREAS_COLLECTION = 'growth_areas'
+const TODAY_COLLECTION = 'growth_area_today'
+const AI_TIMEOUT_MS = 6000
+const VALID_MODES = new Set(['morning', 'persistent', 'both'])
+const ENERGY_TYPES = ['desk', 'people', 'errand', 'confrontation', 'creative', 'physical']
+
+function getAnthropicKey() {
+  return getData('settings')?.anthropic_api_key || process.env.ANTHROPIC_API_KEY || null
+}
+
+function loadAreas() {
+  const arr = getData(AREAS_COLLECTION)
+  return Array.isArray(arr) ? arr : []
+}
+function saveAreas(arr) {
+  setData(AREAS_COLLECTION, arr)
+}
+
+// Buckets "today" in the user's timezone (falls back to server-local),
+// mirroring the pattern in tagSuggestions.js / db.js.
+function todayLocalYMD() {
+  const tz = getData('settings')?.user_timezone
+  try {
+    return new Intl.DateTimeFormat('en-CA', { timeZone: tz || undefined, year: 'numeric', month: '2-digit', day: '2-digit' }).format(new Date())
+  } catch {
+    return new Intl.DateTimeFormat('en-CA', { year: 'numeric', month: '2-digit', day: '2-digit' }).format(new Date())
+  }
+}
+
+function dayOfYear(ymd) {
+  const [y, m, d] = ymd.split('-').map(Number)
+  const start = Date.UTC(y, 0, 0)
+  const cur = Date.UTC(y, m - 1, d)
+  return Math.floor((cur - start) / 86400000)
+}
+
+async function callClaude({ system, user, maxTokens }) {
+  const key = getAnthropicKey()
+  if (!key) return null
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), AI_TIMEOUT_MS)
+  try {
+    const res = await fetch('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'x-api-key': key, 'anthropic-version': '2023-06-01' },
+      body: JSON.stringify({
+        model: 'claude-sonnet-4-6',
+        max_tokens: maxTokens,
+        system,
+        messages: [{ role: 'user', content: user }],
+      }),
+      signal: controller.signal,
+    })
+    if (!res.ok) return null
+    const data = await res.json()
+    return (data?.content?.[0]?.text || '').trim()
+  } catch {
+    return null
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+async function inferEnergyAffinity(title) {
+  const text = await callClaude({
+    system: `Given a personal "growth area" someone wants to work on about themselves, pick the SINGLE best-matching energy type from this list, or "none" if nothing clearly fits: desk (focused computer/paperwork), people (social interaction), errand (going somewhere), confrontation (emotionally difficult interaction), creative (open-ended thinking/making), physical (bodily effort). Reply with just the one word — no punctuation, no explanation.`,
+    user: title,
+    maxTokens: 10,
+  })
+  if (!text) return null
+  const word = text.toLowerCase().replace(/[^a-z]/g, '')
+  return ENERGY_TYPES.includes(word) ? word : null
+}
+
+export function listGrowthAreas() {
+  return loadAreas()
+}
+
+export function getGrowthArea(id) {
+  return loadAreas().find(a => a.id === id) || null
+}
+
+export async function createGrowthArea({ title, mode }) {
+  const t = String(title || '').trim()
+  if (!t) throw new Error('title is required')
+  const m = VALID_MODES.has(mode) ? mode : 'both'
+  const energy_affinity = await inferEnergyAffinity(t)
+  const area = {
+    id: `ga-${Date.now()}-${Math.random().toString(16).slice(2, 8)}`,
+    title: t,
+    mode: m,
+    energy_affinity,
+    active: true,
+    created_at: new Date().toISOString(),
+  }
+  const arr = loadAreas()
+  arr.push(area)
+  saveAreas(arr)
+  return area
+}
+
+export function updateGrowthArea(id, updates = {}) {
+  const arr = loadAreas()
+  const idx = arr.findIndex(a => a.id === id)
+  if (idx === -1) return null
+  const next = { ...arr[idx] }
+  if (updates.title !== undefined) next.title = String(updates.title).trim()
+  if (updates.mode !== undefined && VALID_MODES.has(updates.mode)) next.mode = updates.mode
+  if (updates.active !== undefined) next.active = !!updates.active
+  if (updates.energy_affinity !== undefined) {
+    next.energy_affinity = ENERGY_TYPES.includes(updates.energy_affinity) ? updates.energy_affinity : null
+  }
+  arr[idx] = next
+  saveAreas(arr)
+  return next
+}
+
+export function deleteGrowthArea(id) {
+  const arr = loadAreas()
+  const next = arr.filter(a => a.id !== id)
+  if (next.length === arr.length) return false
+  saveAreas(next)
+  return true
+}
+
+// --- Morning rotation ---
+
+function rotationPool() {
+  return loadAreas().filter(a => a.active && (a.mode === 'morning' || a.mode === 'both'))
+}
+
+function pickRotationArea(pool, ymd) {
+  if (pool.length === 0) return null
+  const idx = dayOfYear(ymd) % pool.length
+  return pool[idx]
+}
+
+async function rephraseArea(area) {
+  const text = await callClaude({
+    system: `You write short, warm, concrete morning nudges for an ADHD-friendly personal coaching app. Given a standing "growth area" the user wants to work on about themselves, write ONE fresh, specific, encouraging sentence (under 16 words) that makes today's version of it concrete and actionable — not a generic restatement. Vary the phrasing every time; never just repeat the input. Reply with just the sentence — no quotes, no preamble.`,
+    user: area.title,
+    maxTokens: 60,
+  })
+  if (!text) return area.title
+  return text.replace(/^["']|["']$/g, '').trim() || area.title
+}
+
+// Computes (if not already cached for today) and returns the daily pick.
+// Safe to call frequently — no-ops once today's pick is cached.
+//
+// A cached EMPTY pick (area_id: null — no eligible areas at the time) is
+// deliberately NOT sticky: it's the common first-run shape (user adds their
+// first morning/both area mid-day, after the background loop's startup tick
+// already cached "nothing to show"). Re-checking the pool costs nothing when
+// it's still empty, and only ever upgrades null → a real pick, so it can't
+// cause the digest/banner disagreement the caching exists to prevent — that
+// risk only applies once a REAL pick (with its AI-rephrased text) has been
+// made and potentially already delivered.
+export async function ensureTodayGrowthArea() {
+  const today = todayLocalYMD()
+  const cached = getData(TODAY_COLLECTION)
+  if (cached?.date === today && cached.area_id) return cached
+
+  const pool = rotationPool()
+  const area = pickRotationArea(pool, today)
+  if (!area) {
+    const empty = { date: today, area_id: null, area_title: null, text: null }
+    setData(TODAY_COLLECTION, empty)
+    return empty
+  }
+  const text = await rephraseArea(area)
+  const result = { date: today, area_id: area.id, area_title: area.title, text }
+  setData(TODAY_COLLECTION, result)
+  return result
+}
+
+// Sync read-only accessor — returns null if today's pick hasn't been
+// computed yet (caller should trigger ensureTodayGrowthArea() separately;
+// digestBuilder.js is synchronous and must never block on a live AI call).
+export function getTodayGrowthAreaCached() {
+  const cached = getData(TODAY_COLLECTION)
+  return cached?.date === todayLocalYMD() ? cached : null
+}
+
+// Active areas eligible for contextual injection (What Now / Quokka).
+export function contextualGrowthAreas() {
+  return loadAreas().filter(a => a.active && (a.mode === 'persistent' || a.mode === 'both'))
+}
+
+// --- Background sync loop, mirrors weatherSync.js's cadence pattern ---
+
+const REFRESH_INTERVAL_MS = 15 * 60 * 1000 // 15 min
+let loopTimer = null
+
+export function startGrowthAreaSync() {
+  const tick = () => {
+    ensureTodayGrowthArea().catch(err => console.error('[GrowthAreas] refresh failed:', err.message))
+  }
+  tick()
+  loopTimer = setInterval(tick, REFRESH_INTERVAL_MS)
+  console.log('[GrowthAreas] Daily rotation sync loop running')
+}
+
+export function stopGrowthAreaSync() {
+  if (loopTimer) clearInterval(loopTimer)
+  loopTimer = null
+}

--- a/server.js
+++ b/server.js
@@ -28,6 +28,7 @@ import { initGmailSync, syncGmail, startGmailPolling, getGmailAccessToken } from
 import { startWeatherSync, refreshWeather, geocodeLocation, getWeatherCache, getWeatherStatus, clearWeatherCache } from './weatherSync.js'
 import { startPatternDetection, runPatternScan } from './patternDetection.js'
 import { startTagSuggestions, runTagScan, listPendingTagSuggestions, dismissTagSuggestion } from './tagSuggestions.js'
+import { startGrowthAreaSync, listGrowthAreas, createGrowthArea, updateGrowthArea, deleteGrowthArea, ensureTodayGrowthArea, contextualGrowthAreas } from './growthAreas.js'
 import { listPendingSuggestions, getPatternSuggestion, updateSuggestionStatus, snoozeSuggestion, countPendingSuggestions } from './db.js'
 import { runBackup } from './scripts/backup-db.js'
 import {
@@ -2841,6 +2842,46 @@ app.post('/api/tag-suggestions/scan', async (req, res) => {
   }
 })
 
+// Growth areas — personal coaching reminders. Dedicated per-record endpoints,
+// deliberately NOT part of the bulk /api/data blob. See wiki/Growth-Areas.md.
+app.get('/api/growth-areas', (req, res) => {
+  res.json({ areas: listGrowthAreas() })
+})
+
+app.post('/api/growth-areas', async (req, res) => {
+  try {
+    const { title, mode } = req.body || {}
+    const area = await createGrowthArea({ title, mode })
+    res.json({ ok: true, area })
+  } catch (err) {
+    res.status(400).json({ error: err.message })
+  }
+})
+
+app.patch('/api/growth-areas/:id', (req, res) => {
+  const area = updateGrowthArea(req.params.id, req.body || {})
+  if (!area) return res.status(404).json({ error: 'Growth area not found' })
+  res.json({ ok: true, area })
+})
+
+app.delete('/api/growth-areas/:id', (req, res) => {
+  const ok = deleteGrowthArea(req.params.id)
+  if (!ok) return res.status(404).json({ error: 'Growth area not found' })
+  res.json({ ok: true })
+})
+
+app.get('/api/growth-areas/today', async (req, res) => {
+  try {
+    // ensureTodayGrowthArea() already returns the cached pick when one exists
+    // (and only ever recomputes a stale/empty cache) — calling it directly
+    // avoids treating a cached "no eligible areas yet" result as permanent.
+    const pick = await ensureTodayGrowthArea()
+    res.json(pick)
+  } catch (err) {
+    res.status(500).json({ error: err.message })
+  }
+})
+
 app.post('/api/notifications/tap', (req, res) => {
   const { taskId, channel } = req.body || {}
   if (!taskId) return res.status(400).json({ error: 'Missing taskId' })
@@ -3171,7 +3212,11 @@ function adviserSystemPrompt() {
   const notionConnected = !!(getData('notion_mcp_tokens')?.access_token || envNotionToken)
   const trelloConnected = !!(envTrelloKey && envTrelloToken)
   const trackingConnected = !!getTrackingApiKey()
-  return `You are Quokka, the cheerful AI adviser for Boomerang — an ADHD task manager PWA. Today is ${today} (${dayOfWeek}). You are named after the quokka (a small, smiley Australian marsupial that looks like it's always having a good day); lean into a warm, upbeat, down-to-earth tone without being cloying. The very occasional Aussie flavor ("no worries", "on ya") is fine but don't overdo it.
+  const growthAreas = contextualGrowthAreas()
+  const growthAreasNote = growthAreas.length > 0
+    ? `\n\nThe user is also working on these personal growth areas (standing self-improvement reminders, not tasks): ${growthAreas.map(a => `"${a.title}"${a.energy_affinity ? ` (${a.energy_affinity})` : ''}`).join(', ')}. When the conversation naturally touches on one of these (e.g. they're dreading a confrontation-flavored task and one of these areas relates to that), you may weave in a brief, warm, coaching-flavored line — but only when it's genuinely relevant to what they said. Never bring these up unprompted or force them into unrelated replies.`
+    : ''
+  return `You are Quokka, the cheerful AI adviser for Boomerang — an ADHD task manager PWA. Today is ${today} (${dayOfWeek}). You are named after the quokka (a small, smiley Australian marsupial that looks like it's always having a good day); lean into a warm, upbeat, down-to-earth tone without being cloying. The very occasional Aussie flavor ("no worries", "on ya") is fine but don't overdo it.${growthAreasNote}
 
 The user will describe something they want done ("I've rescheduled my FAA exam to May 12 — adjust everything", "move all my lawn-care tasks to next weekend since it'll rain", etc.). You have tools that mirror every capability of the app: tasks, routines, Google Calendar, Notion, Trello, Gmail, packages, weather, settings.
 
@@ -3923,6 +3968,7 @@ initDb(dbPath).then(async () => {
     startWeeklyPatternReview()
     startPatternDetection()
     startTagSuggestions()
+    startGrowthAreaSync()
 
     // Background knowledge-base index refresh. Bails silently when not configured.
     startKnowledgeRefreshLoop({ getData, setData })

--- a/src/AppV2.jsx
+++ b/src/AppV2.jsx
@@ -24,6 +24,7 @@ import KeptShell from './kept/KeptShell'
 import KeptDesktop from './kept/KeptDesktop'
 import QuickEditTask from './kept/QuickEditTask'
 import SuggestionsModal from './components/SuggestionsModal'
+import GrowthAreasModal from './components/GrowthAreasModal'
 import PackagesModal from './components/PackagesModal'
 import AdviserModal from './components/AdviserModal'
 import AnalyticsModal from './components/AnalyticsModal'
@@ -111,6 +112,7 @@ export default function AppV2() {
   const [adviserDraftSeed, setAdviserDraftSeed] = useState('')
   const [showAnalytics, setShowAnalytics] = useState(false)
   const [showSuggestions, setShowSuggestions] = useState(false)
+  const [showGrowthAreas, setShowGrowthAreas] = useState(false)
   // 7-day strip visibility — single source of truth. Date tap toggles
   // it in all themes. Two settings can seed the initial state on load:
   //   - week_strip_always_open: explicit "open by default" toggle
@@ -275,10 +277,10 @@ export default function AppV2() {
   // Check app version whenever a view/modal opens — same cadence v1 uses.
   // Catches stale clients without waiting for the next SSE/sync round-trip.
   useEffect(() => {
-    if (showSettings || showDone || showAnalytics || showRoutines || showActivityLog || showPackages || showProjects || showAdviser || showSuggestions || editTarget || showAdd || showWhatNow || showMarkdownImport) {
+    if (showSettings || showDone || showAnalytics || showRoutines || showActivityLog || showPackages || showProjects || showAdviser || showSuggestions || showGrowthAreas || editTarget || showAdd || showWhatNow || showMarkdownImport) {
       checkVersion()
     }
-  }, [showSettings, showDone, showAnalytics, showRoutines, showActivityLog, showPackages, showProjects, showAdviser, showSuggestions, editTarget, showAdd, showWhatNow, showMarkdownImport, checkVersion])
+  }, [showSettings, showDone, showAnalytics, showRoutines, showActivityLog, showPackages, showProjects, showAdviser, showSuggestions, showGrowthAreas, editTarget, showAdd, showWhatNow, showMarkdownImport, checkVersion])
 
   // Deep-link handler. Notifications come in as `/?task=<id>` (task tap),
   // `/?routine=<id>` (habit nudge tap, PR 2 — currently no-op without
@@ -535,6 +537,7 @@ export default function AppV2() {
   if (showAdviser) activeModals.push('adviser')
   if (showAnalytics) activeModals.push('analytics')
   if (showSuggestions) activeModals.push('suggestions')
+  if (showGrowthAreas) activeModals.push('growthAreas')
   if (spacesHubOpen) activeModals.push('spaces')
   if (systemMenuOpen) activeModals.push('systemMenu')
   if (searchOpen) activeModals.push('search')
@@ -556,10 +559,11 @@ export default function AppV2() {
     if (showAdviser) { setShowAdviser(false); return }
     if (showAnalytics) { setShowAnalytics(false); return }
     if (showSuggestions) { setShowSuggestions(false); return }
+    if (showGrowthAreas) { setShowGrowthAreas(false); return }
     if (spacesHubOpen) { setSpacesHubOpen(false); setActiveTab('today'); return }
     if (systemMenuOpen) { setSystemMenuOpen(false); return }
     if (searchOpen) { handleCloseSearch(); return }
-  }, [snoozeTarget, reframeTarget, editTarget, showAdd, showWhatNow, showSettings, showProjects, showDone, showActivityLog, showRoutines, showPackages, showAdviser, showAnalytics, showSuggestions, spacesHubOpen, systemMenuOpen, searchOpen, handleCloseSearch])
+  }, [snoozeTarget, reframeTarget, editTarget, showAdd, showWhatNow, showSettings, showProjects, showDone, showActivityLog, showRoutines, showPackages, showAdviser, showAnalytics, showSuggestions, showGrowthAreas, spacesHubOpen, systemMenuOpen, searchOpen, handleCloseSearch])
 
   const focusSearchInput = useCallback(() => {
     setSearchOpen(true)
@@ -1016,6 +1020,7 @@ export default function AppV2() {
         onOpenDone={() => setShowDone(true)}
         onOpenSuggestions={() => setShowSuggestions(true)}
         onOpenActivityLog={() => setShowActivityLog(true)}
+        onOpenGrowthAreas={() => setShowGrowthAreas(true)}
       />
       <main className={`v2-main${isDesktop ? ' v2-main-kanban' : ''}`}>
         {(tasks.length > 0 || searchOpen) && (
@@ -1344,6 +1349,7 @@ export default function AppV2() {
           onOpenNotifications={() => setShowNotifications(true)}
           onOpenFlightLog={() => setShowFlightLog(true)}
           onOpenSuggestions={() => setShowSuggestions(true)}
+          onOpenGrowthAreas={() => setShowGrowthAreas(true)}
           syncStatus={syncStatus}
           queueLength={queueLength}
         />
@@ -1402,6 +1408,7 @@ export default function AppV2() {
           onOpenFlightLog={() => setShowFlightLog(true)}
           onStatusChange={handleStatusChange}
           onOpenSuggestions={() => setShowSuggestions(true)}
+          onOpenGrowthAreas={() => setShowGrowthAreas(true)}
           syncStatus={syncStatus}
           queueLength={queueLength}
         />
@@ -1635,6 +1642,11 @@ export default function AppV2() {
           // to a manual flush. The user will see the new routine on the
           // Routines screen.
         }}
+      />
+
+      <GrowthAreasModal
+        open={showGrowthAreas}
+        onClose={() => setShowGrowthAreas(false)}
       />
 
       <PackagesModal

--- a/src/api.js
+++ b/src/api.js
@@ -216,7 +216,8 @@ When should this be due? JSON only.`
 // --- What Now ---
 // capacity = optional energy type filter (desk|people|errand|confrontation|creative|physical|null)
 // weather = optional summary string like "Today: sunny, 72° · Tomorrow: rain, 55° · Sat: snow"
-export async function getWhatNow(tasks, time, energy, capacity = null, weather = null) {
+// growthAreas = optional array of active {title, energy_affinity} growth areas (persistent/both mode)
+export async function getWhatNow(tasks, time, energy, capacity = null, weather = null, growthAreas = null) {
   const ACTIVE = ['not_started', 'doing', 'waiting', 'open']
   const ENERGY_LABELS = { desk: 'Desk', people: 'People', errand: 'Errand', confrontation: 'Confrontation', creative: 'Creative', physical: 'Physical' }
   const openTasks = tasks
@@ -236,11 +237,15 @@ export async function getWhatNow(tasks, time, energy, capacity = null, weather =
     ? `\nWEATHER CONTEXT: ${weather}. If outdoor-leaning tasks (errand, physical, or tasks whose titles suggest being outside — mowing, yardwork, grocery, etc.) would benefit from today's weather (nice day, worse weather coming), prefer them. If today is bad weather and later looks better, prefer indoor tasks (desk, creative) and mention that a better day is coming. Only mention weather in the reason when it genuinely affects the pick.`
     : ''
 
+  const growthAreasRule = growthAreas && growthAreas.length > 0
+    ? `\nGROWTH AREAS: The user is also working on these personal growth areas: ${growthAreas.map(a => `"${a.title}"${a.energy_affinity ? ` (relates to ${a.energy_affinity} energy)` : ''}`).join(', ')}. If your pick's energy type matches one of these, you may add ONE short clause to the reason noting it's a rep for that area (e.g. "...and this one's a rep for staying patient") — but ONLY when genuinely relevant. Never force this onto every response; most picks should have no mention of it at all.`
+    : ''
+
   const system = `You are a helpful assistant for someone with ADHD. You help them pick the right task to work on right now. Be warm, direct, and practical. No fluff. Never be preachy or condescending.
 
 Tasks have t-shirt sizes: XS (~5 min), S (~15 min), M (~30-60 min), L (~half day), XL (~full day+).
 Tasks also have energy types (desk, people, errand, confrontation, creative, physical) and drain levels (low, med, high).
-HARD RULE: Never suggest a task bigger than the available time allows. If they have 15 minutes, only suggest XS or S tasks. If they say "fumes" or "low" energy, only suggest XS or S AND prefer low-drain tasks. A medium task requires at least 30 minutes AND moderate energy. Ignore stale/old tasks if they are too big for the window.${capacityRule}${weatherRule}
+HARD RULE: Never suggest a task bigger than the available time allows. If they have 15 minutes, only suggest XS or S tasks. If they say "fumes" or "low" energy, only suggest XS or S AND prefer low-drain tasks. A medium task requires at least 30 minutes AND moderate energy. Ignore stale/old tasks if they are too big for the window.${capacityRule}${weatherRule}${growthAreasRule}
 
 Respond with JSON only — an object with two fields:
 - "picks": array of 1-3 objects with "task" (exact task title from the list) and "reason" (one sentence why this is a good pick right now).
@@ -1420,6 +1425,54 @@ export async function geocodeWeather(query) {
   if (!res.ok) throw new Error(`geocode failed: ${res.status}`)
   const data = await res.json()
   return data.results || []
+}
+
+// --- Growth areas ---
+// Dedicated endpoints, deliberately not part of the bulk /api/data sync blob.
+
+export async function getGrowthAreas() {
+  const res = await fetch('/api/growth-areas')
+  if (!res.ok) throw new Error(`growth areas fetch failed: ${res.status}`)
+  const data = await res.json()
+  return data.areas || []
+}
+
+export async function createGrowthArea({ title, mode }) {
+  const res = await fetch('/api/growth-areas', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ title, mode }),
+  })
+  if (!res.ok) throw new Error(`growth area create failed: ${res.status}`)
+  const data = await res.json()
+  return data.area
+}
+
+export async function updateGrowthArea(id, updates) {
+  const res = await fetch(`/api/growth-areas/${id}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(updates),
+  })
+  if (!res.ok) throw new Error(`growth area update failed: ${res.status}`)
+  const data = await res.json()
+  return data.area
+}
+
+export async function deleteGrowthArea(id) {
+  const res = await fetch(`/api/growth-areas/${id}`, { method: 'DELETE' })
+  if (!res.ok) throw new Error(`growth area delete failed: ${res.status}`)
+  return res.json()
+}
+
+export async function getTodayGrowthArea() {
+  try {
+    const res = await fetch('/api/growth-areas/today')
+    if (!res.ok) return null
+    return res.json()
+  } catch {
+    return null
+  }
 }
 
 // --- AI Adviser ---

--- a/src/components/GrowthAreasModal.css
+++ b/src/components/GrowthAreasModal.css
@@ -1,0 +1,149 @@
+/* Growth areas — simplest CRUD surface in the app, on par with Labels. */
+
+.v2-growth-add {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+.v2-growth-add-input {
+  flex: 1;
+  min-width: 0;
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid var(--v2-hairline);
+  background: var(--v2-bg);
+  color: var(--v2-text);
+  font: 400 14px/1.4 var(--v2-font-body);
+}
+.v2-growth-add-mode {
+  padding: 10px 10px;
+  border-radius: 10px;
+  border: 1px solid var(--v2-hairline);
+  background: var(--v2-bg);
+  color: var(--v2-text);
+  font: 400 13px/1.4 var(--v2-font-body);
+}
+.v2-growth-add-btn {
+  padding: 10px 16px;
+  border-radius: 10px;
+  border: 1px solid var(--v2-accent);
+  background: var(--v2-accent);
+  color: #fff;
+  font: 600 13px/1 var(--v2-font-body);
+  cursor: pointer;
+  white-space: nowrap;
+}
+.v2-growth-add-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.v2-growth-hint {
+  font: 400 12px/1.5 var(--v2-font-body);
+  color: var(--v2-text-meta);
+  margin-bottom: 16px;
+}
+
+.v2-growth-error {
+  font: 400 13px/1.4 var(--v2-font-body);
+  color: var(--v2-alert-high-pri);
+  margin-bottom: 12px;
+}
+
+.v2-growth-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.v2-growth-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 10px 12px;
+  border: 1px solid var(--v2-hairline);
+  border-radius: 12px;
+  background: var(--v2-bg);
+}
+.v2-growth-row-inactive {
+  opacity: 0.55;
+}
+
+.v2-growth-row-main {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+.v2-growth-title {
+  font: 500 14px/1.35 var(--v2-font-body);
+  color: var(--v2-text);
+}
+.v2-growth-chips {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+.v2-growth-chip {
+  display: inline-block;
+  padding: 1px 8px;
+  border-radius: var(--v2-radius-pill);
+  font: 500 11px/1.5 var(--v2-font-body);
+  background: rgba(var(--v2-text-rgb), 0.06);
+  color: var(--v2-text-meta);
+}
+.v2-growth-chip-energy {
+  background: rgba(255, 98, 64, 0.12);
+  color: var(--v2-accent);
+}
+
+.v2-growth-row-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.v2-growth-icon-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border-radius: 8px;
+  border: none;
+  background: transparent;
+  color: var(--v2-text-meta);
+  cursor: pointer;
+}
+.v2-growth-icon-btn:hover:not(:disabled) {
+  background: rgba(var(--v2-text-rgb), 0.06);
+  color: var(--v2-text);
+}
+.v2-growth-icon-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+.v2-growth-icon-btn-danger:hover:not(:disabled) {
+  color: var(--v2-alert-high-pri);
+}
+
+.v2-growth-row-editing {
+  flex-wrap: wrap;
+}
+.v2-growth-edit-input {
+  flex: 1;
+  min-width: 120px;
+  padding: 6px 10px;
+  border-radius: 8px;
+  border: 1px solid var(--v2-hairline);
+  background: var(--v2-bg);
+  color: var(--v2-text);
+  font: 400 13px/1.4 var(--v2-font-body);
+}
+.v2-growth-edit-mode {
+  padding: 6px 8px;
+  border-radius: 8px;
+  border: 1px solid var(--v2-hairline);
+  background: var(--v2-bg);
+  color: var(--v2-text);
+  font: 400 12px/1.4 var(--v2-font-body);
+}

--- a/src/components/GrowthAreasModal.jsx
+++ b/src/components/GrowthAreasModal.jsx
@@ -1,0 +1,195 @@
+import { useState, useEffect, useCallback } from 'react'
+import { Sprout, Trash2, Pencil, X, Check } from 'lucide-react'
+import ModalShell from './ModalShell'
+import EmptyState from './EmptyState'
+import { getGrowthAreas, createGrowthArea, updateGrowthArea, deleteGrowthArea } from '../api'
+import './GrowthAreasModal.css'
+
+const MODE_OPTIONS = [
+  { value: 'morning', label: 'Morning', hint: 'Once-a-day rotation' },
+  { value: 'persistent', label: 'Persistent', hint: 'Surfaces when relevant' },
+  { value: 'both', label: 'Both', hint: 'Morning + relevant moments' },
+]
+
+const MODE_LABEL = { morning: 'Morning', persistent: 'Persistent', both: 'Both' }
+
+const ENERGY_LABEL = { desk: 'Desk', people: 'People', errand: 'Errand', confrontation: 'Confrontation', creative: 'Creative', physical: 'Physical' }
+
+function AreaRow({ area, onUpdate, onDelete, busy }) {
+  const [editing, setEditing] = useState(false)
+  const [title, setTitle] = useState(area.title)
+  const [mode, setMode] = useState(area.mode)
+
+  const save = async () => {
+    const t = title.trim()
+    if (!t) return
+    await onUpdate(area.id, { title: t, mode })
+    setEditing(false)
+  }
+  const cancel = () => { setTitle(area.title); setMode(area.mode); setEditing(false) }
+
+  if (editing) {
+    return (
+      <li className="v2-growth-row v2-growth-row-editing">
+        <input
+          className="v2-growth-edit-input"
+          value={title}
+          onChange={e => setTitle(e.target.value)}
+          autoFocus
+        />
+        <select className="v2-growth-edit-mode" value={mode} onChange={e => setMode(e.target.value)}>
+          {MODE_OPTIONS.map(m => <option key={m.value} value={m.value}>{m.label}</option>)}
+        </select>
+        <button className="v2-growth-icon-btn" onClick={save} disabled={busy} title="Save">
+          <Check size={16} strokeWidth={2} />
+        </button>
+        <button className="v2-growth-icon-btn" onClick={cancel} disabled={busy} title="Cancel">
+          <X size={16} strokeWidth={2} />
+        </button>
+      </li>
+    )
+  }
+
+  return (
+    <li className={`v2-growth-row ${area.active ? '' : 'v2-growth-row-inactive'}`}>
+      <div className="v2-growth-row-main">
+        <span className="v2-growth-title">{area.title}</span>
+        <div className="v2-growth-chips">
+          <span className="v2-growth-chip">{MODE_LABEL[area.mode] || area.mode}</span>
+          {area.energy_affinity && (
+            <span className="v2-growth-chip v2-growth-chip-energy">{ENERGY_LABEL[area.energy_affinity] || area.energy_affinity}</span>
+          )}
+        </div>
+      </div>
+      <div className="v2-growth-row-actions">
+        <label className="v2-settings-toggle" title={area.active ? 'Active' : 'Paused'}>
+          <input
+            type="checkbox"
+            checked={!!area.active}
+            disabled={busy}
+            onChange={e => onUpdate(area.id, { active: e.target.checked })}
+          />
+          <span className="v2-settings-toggle-track"><span className="v2-settings-toggle-thumb" /></span>
+        </label>
+        <button className="v2-growth-icon-btn" onClick={() => setEditing(true)} disabled={busy} title="Edit">
+          <Pencil size={15} strokeWidth={1.75} />
+        </button>
+        <button className="v2-growth-icon-btn v2-growth-icon-btn-danger" onClick={() => onDelete(area.id)} disabled={busy} title="Delete">
+          <Trash2 size={15} strokeWidth={1.75} />
+        </button>
+      </div>
+    </li>
+  )
+}
+
+export default function GrowthAreasModal({ open, onClose }) {
+  const [areas, setAreas] = useState([])
+  const [loading, setLoading] = useState(false)
+  const [newTitle, setNewTitle] = useState('')
+  const [newMode, setNewMode] = useState('both')
+  const [adding, setAdding] = useState(false)
+  const [busyId, setBusyId] = useState(null)
+  const [error, setError] = useState(null)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const list = await getGrowthAreas()
+      setAreas(list)
+    } catch (err) {
+      setError(err.message)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (open) load()
+  }, [open, load])
+
+  const handleAdd = async (e) => {
+    e.preventDefault()
+    const t = newTitle.trim()
+    if (!t) return
+    setAdding(true)
+    setError(null)
+    try {
+      const area = await createGrowthArea({ title: t, mode: newMode })
+      setAreas(prev => [...prev, area])
+      setNewTitle('')
+      setNewMode('both')
+    } catch (err) {
+      setError(err.message)
+    } finally {
+      setAdding(false)
+    }
+  }
+
+  const handleUpdate = async (id, updates) => {
+    setBusyId(id)
+    try {
+      const area = await updateGrowthArea(id, updates)
+      setAreas(prev => prev.map(a => (a.id === id ? area : a)))
+    } catch (err) {
+      setError(err.message)
+    } finally {
+      setBusyId(null)
+    }
+  }
+
+  const handleDelete = async (id) => {
+    setBusyId(id)
+    try {
+      await deleteGrowthArea(id)
+      setAreas(prev => prev.filter(a => a.id !== id))
+    } catch (err) {
+      setError(err.message)
+    } finally {
+      setBusyId(null)
+    }
+  }
+
+  return (
+    <ModalShell
+      open={open}
+      onClose={onClose}
+      title="Growth areas"
+      subtitle="Standing reminders about yourself — not tasks, nothing to check off"
+      width="narrow"
+    >
+      <form className="v2-growth-add" onSubmit={handleAdd}>
+        <input
+          className="v2-growth-add-input"
+          placeholder="e.g. Be more patient on calls"
+          value={newTitle}
+          onChange={e => setNewTitle(e.target.value)}
+          maxLength={80}
+        />
+        <select className="v2-growth-add-mode" value={newMode} onChange={e => setNewMode(e.target.value)}>
+          {MODE_OPTIONS.map(m => <option key={m.value} value={m.value}>{m.label}</option>)}
+        </select>
+        <button className="v2-growth-add-btn" type="submit" disabled={adding || !newTitle.trim()}>
+          {adding ? '...' : 'Add'}
+        </button>
+      </form>
+      <div className="v2-growth-hint">Works best with 2-3 active areas — a longer list just means each one is seen less often.</div>
+
+      {error && <div className="v2-growth-error">{error}</div>}
+
+      {areas.length === 0 ? (
+        <EmptyState
+          icon={Sprout}
+          title={loading ? 'Loading…' : 'No growth areas yet'}
+          body="Add something you want to work on about yourself — Boomerang will resurface it at the right moments, in fresh wording, never as a static banner."
+        />
+      ) : (
+        <ul className="v2-growth-list">
+          {areas.map(a => (
+            <AreaRow key={a.id} area={a} onUpdate={handleUpdate} onDelete={handleDelete} busy={busyId === a.id} />
+          ))}
+        </ul>
+      )}
+    </ModalShell>
+  )
+}

--- a/src/components/SystemMenu.css
+++ b/src/components/SystemMenu.css
@@ -61,6 +61,7 @@
 .v2-system-menu-icon-done { color: #8AB454; }
 .v2-system-menu-icon-suggestions { color: #F2A100; }
 .v2-system-menu-icon-activity { color: #B58EE8; }
+.v2-system-menu-icon-growth { color: #5EAA8C; }
 
 .v2-system-menu-label {
   flex: 1;

--- a/src/components/SystemMenu.jsx
+++ b/src/components/SystemMenu.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react'
-import { Settings as SettingsIcon, BarChart3, History, CheckCircle2, Lightbulb, ChevronRight } from 'lucide-react'
+import { Settings as SettingsIcon, BarChart3, History, CheckCircle2, Lightbulb, Sprout, ChevronRight } from 'lucide-react'
 import './SystemMenu.css'
 
 // Anchored popover off the header ⚙ icon. Hosts the low-frequency
@@ -13,7 +13,7 @@ import './SystemMenu.css'
 // would force the system-menu wiring to pass through Header props.
 export default function SystemMenu({
   open, onClose,
-  onOpenSettings, onOpenAnalytics, onOpenDone, onOpenSuggestions, onOpenActivityLog,
+  onOpenSettings, onOpenAnalytics, onOpenDone, onOpenSuggestions, onOpenActivityLog, onOpenGrowthAreas,
   hasSuggestions = false,
 }) {
   const panelRef = useRef(null)
@@ -83,6 +83,14 @@ export default function SystemMenu({
       terminalCmd: '> log',
       onClick: onOpenActivityLog,
       tint: 'activity',
+    },
+    {
+      key: 'growth',
+      icon: Sprout,
+      label: 'Growth areas',
+      terminalCmd: '> growth',
+      onClick: onOpenGrowthAreas,
+      tint: 'growth',
     },
   ]
 

--- a/src/components/WhatNowModal.jsx
+++ b/src/components/WhatNowModal.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { Target, Monitor, Users, MapPin, Flame, Palette, Dumbbell } from 'lucide-react'
-import { getWhatNow, getWeather } from '../api'
+import { getWhatNow, getWeather, getGrowthAreas } from '../api'
 import { ENERGY_TYPES } from '../store'
 import ModalShell from './ModalShell'
 import './WhatNowModal.css'
@@ -75,7 +75,13 @@ export default function WhatNowModal({ open, tasks, onClose, onComplete }) {
         const weatherData = await getWeather()
         if (weatherData?.enabled) weatherSummary = buildWeatherSummaryFromCache(weatherData)
       } catch { /* weather optional */ }
-      const results = await getWhatNow(tasks, time, energy, capacity, weatherSummary)
+      let growthAreas = null
+      try {
+        const areas = await getGrowthAreas()
+        const contextual = areas.filter(a => a.active && (a.mode === 'persistent' || a.mode === 'both'))
+        if (contextual.length > 0) growthAreas = contextual
+      } catch { /* growth areas optional */ }
+      const results = await getWhatNow(tasks, time, energy, capacity, weatherSummary, growthAreas)
       setSuggestions(results)
     } catch (err) {
       setError(err.message)

--- a/src/kept/KeptDesktop.jsx
+++ b/src/kept/KeptDesktop.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import {
   Home, ListTodo, Repeat2, FolderKanban, BarChart3, Package, Settings,
-  Sparkles, Plus, CheckCircle2, ScrollText, Inbox, Compass, Bell, TrendingUp,
+  Sparkles, Plus, CheckCircle2, ScrollText, Inbox, Compass, Bell, TrendingUp, Sprout,
 } from 'lucide-react'
 import Logo from '../components/Logo'
 import { useSyncBounce } from '../hooks/useSyncBounce'
@@ -23,7 +23,7 @@ export default function KeptDesktop({
   onLogSession, onGmailKeep, onGmailDismiss, onWhatNow, onToggleItem, onUnsnooze,
   onThrow, onOpenFullAdd, onEditLoop, onAddLoop, onSpawnNow, onSkipCycle, onMarkLoopDay, onSkipLoopDay,
   onOpenQuokka, onOpenSettings, onOpenPackages, onOpenAnalytics,
-  onOpenProjects, onOpenDone, onOpenActivity, onOpenSuggestions,
+  onOpenProjects, onOpenDone, onOpenActivity, onOpenSuggestions, onOpenGrowthAreas,
   onOpenNotifications, onOpenFlightLog, onStatusChange,
   syncStatus = 'synced', queueLength = 0,
 }) {
@@ -55,6 +55,7 @@ export default function KeptDesktop({
     { label: 'Analytics', icon: BarChart3, onClick: onOpenAnalytics },
     { label: 'Packages', icon: Package, onClick: onOpenPackages },
     { label: 'Loop suggestions', icon: Inbox, onClick: onOpenSuggestions },
+    { label: 'Growth areas', icon: Sprout, onClick: onOpenGrowthAreas },
     { label: 'Activity log', icon: ScrollText, onClick: onOpenActivity },
   ]
 

--- a/src/kept/KeptShell.jsx
+++ b/src/kept/KeptShell.jsx
@@ -21,6 +21,7 @@ export default function KeptShell({
   onThrow, onOpenFullAdd, onEditLoop, onAddLoop, onSpawnNow, onSkipCycle, onMarkLoopDay, onSkipLoopDay,
   onOpenQuokka, onOpenSettings, onOpenPackages, onOpenAnalytics,
   onOpenProjects, onOpenDone, onOpenActivity, onOpenSuggestions, onOpenNotifications, onOpenFlightLog,
+  onOpenGrowthAreas,
   onRefresh,
   syncStatus = 'synced', queueLength = 0,
 }) {
@@ -46,6 +47,7 @@ export default function KeptShell({
         onOpenPackages={onOpenPackages} onOpenDone={onOpenDone}
         onOpenActivity={onOpenActivity}
         onOpenSettings={onOpenSettings}
+        onOpenGrowthAreas={onOpenGrowthAreas}
       />
     )
   } else {

--- a/src/kept/MoreView.jsx
+++ b/src/kept/MoreView.jsx
@@ -1,16 +1,17 @@
-import { ChevronRight, BarChart3, Package, Settings, FolderKanban, CheckCircle2, ScrollText } from 'lucide-react'
+import { ChevronRight, BarChart3, Package, Settings, FolderKanban, CheckCircle2, ScrollText, Sprout } from 'lucide-react'
 import './shell.css'
 
 // Kept "More" — the low-frequency surfaces. Arcs (projects) routes to the
 // existing ProjectsView; Flight log (profile) arrives with K5's dashboard.
 // Loop suggestions moved to a Sparkles button on the Loops surface
 // (2026-06-11) — suggestions are about loops, they live with loops.
-export default function MoreView({ onOpenProjects, onOpenAnalytics, onOpenPackages, onOpenDone, onOpenActivity, onOpenSettings }) {
+export default function MoreView({ onOpenProjects, onOpenAnalytics, onOpenPackages, onOpenDone, onOpenActivity, onOpenSettings, onOpenGrowthAreas }) {
   const rows = [
     { icon: FolderKanban, label: 'Arcs', sub: 'Long-term projects · sessions + steps', onClick: onOpenProjects },
     { icon: BarChart3, label: 'Analytics', sub: 'Productivity insights', onClick: onOpenAnalytics },
     { icon: CheckCircle2, label: 'Caught', sub: 'Everything you finished', onClick: onOpenDone },
     { icon: Package, label: 'Packages', sub: 'Track deliveries', onClick: onOpenPackages },
+    { icon: Sprout, label: 'Growth areas', sub: 'Standing reminders about yourself', onClick: onOpenGrowthAreas },
     { icon: ScrollText, label: 'Activity log', sub: 'Every change, restorable', onClick: onOpenActivity },
     { icon: Settings, label: 'Settings', sub: 'App configuration', onClick: onOpenSettings },
   ]

--- a/src/kept/TodayView.jsx
+++ b/src/kept/TodayView.jsx
@@ -1,5 +1,6 @@
-import { useMemo, useState } from 'react'
-import { Check, Repeat2, Flame, FolderKanban, Inbox, X, Compass } from 'lucide-react'
+import { useMemo, useState, useEffect } from 'react'
+import { Check, Repeat2, Flame, FolderKanban, Inbox, X, Compass, Sprout } from 'lucide-react'
+import { getTodayGrowthArea } from '../api'
 import DayArc from './DayArc'
 import FlightTrail from './FlightTrail'
 import { localYMD, parseLocalDate } from '../dates'
@@ -32,6 +33,25 @@ export default function TodayView({
   // (prod report: "slider and counts should change with the date selection").
   const [breakdownDay, setBreakdownDay] = useState(null)
   const labelsById = useMemo(() => { const m = {}; for (const l of labels) m[l.id] = l; return m }, [labels])
+
+  // Today's growth-area rotation pick — cached server-side (growthAreas.js),
+  // same one read the digest uses. Dismiss is "seen", not "done" — no
+  // completion semantics — and re-appears the next local morning.
+  const [growthPick, setGrowthPick] = useState(null)
+  const [growthDismissed, setGrowthDismissed] = useState(false)
+  useEffect(() => {
+    let cancelled = false
+    getTodayGrowthArea().then(pick => {
+      if (cancelled || !pick?.text) return
+      setGrowthPick(pick)
+      setGrowthDismissed(localStorage.getItem('bm_growth_banner_dismissed') === pick.date)
+    })
+    return () => { cancelled = true }
+  }, [todayKey])
+  const dismissGrowthBanner = () => {
+    if (growthPick) localStorage.setItem('bm_growth_banner_dismissed', growthPick.date)
+    setGrowthDismissed(true)
+  }
 
   const stackRoutineIds = useMemo(() => new Set(
     routines.filter(r => Array.isArray(r.members) && r.members.length > 0).map(r => r.id),
@@ -177,6 +197,15 @@ export default function TodayView({
 
   return (
     <div className="bm-surface">
+      {growthPick?.text && !growthDismissed && (
+        <div className="bm-growth-banner">
+          <span className="bm-growth-banner-icon"><Sprout size={15} strokeWidth={2} /></span>
+          <span className="bm-growth-banner-text">{growthPick.text}</span>
+          <button className="bm-growth-banner-dismiss" onClick={dismissGrowthBanner} aria-label="Dismiss">
+            <X size={14} strokeWidth={2.2} />
+          </button>
+        </div>
+      )}
       <div className="bm-card bm-card-hero">
         <div className="bm-hero-date">
           <span className="bm-hero-day">{(selStats ? selStats.date : new Date()).toLocaleDateString('en-US', { weekday: 'long' })}</span>

--- a/src/kept/shell.css
+++ b/src/kept/shell.css
@@ -661,3 +661,26 @@
 
 /* Sort toggle active hint (Tasks tab) */
 .bm-back.is-active-sort { color: var(--bm-ember); border-color: var(--bm-ember); }
+
+/* Growth area — today's rotating coaching pick, above the Day Arc hero.
+ * Dismiss is "seen", not "done" — no checkbox, no completion state. */
+.bm-growth-banner {
+  display: flex; align-items: center; gap: 8px;
+  background: var(--bm-card);
+  border: 1px solid var(--bm-hairline);
+  border-radius: 14px;
+  padding: 10px 12px;
+  margin-bottom: 10px;
+}
+.bm-growth-banner-icon { flex: 0 0 auto; color: var(--bm-gold); display: flex; }
+.bm-growth-banner-text {
+  flex: 1 1 auto; min-width: 0;
+  font-size: 13px; line-height: 1.4; color: var(--bm-text);
+}
+.bm-growth-banner-dismiss {
+  flex: 0 0 auto;
+  border: none; background: transparent; color: var(--bm-text-faint);
+  display: flex; align-items: center; justify-content: center;
+  width: 24px; height: 24px; border-radius: 50%; cursor: pointer;
+}
+.bm-growth-banner-dismiss:hover { background: var(--bm-card-2); color: var(--bm-text); }

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,16 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-07-04
 
+- feat(tasks): add Growth Areas — standing personal-coaching reminders [L]
+  - **User request:** two docs-only feature specs (`wiki/Growth-Areas.md`, `wiki/Escalation-Ladder.md`) were sent through an adversarial Fable-model design pass, revised per its critique, then built end-to-end. This commit covers Growth Areas.
+  - Deliberately tiny: standing reminders about *yourself* ("be more patient on calls") — not tasks, no tracking, no streak, no check-in. The rebuilt part vs. the original draft is delivery: rotation instead of a static list, fresh AI-rephrased wording instead of static banner text, and contextual injection instead of a permanent chip (habituation was the design flaw the Fable pass caught).
+  - New `growthAreas.js` root module (Dockerfile runtime COPY list) — its own dedicated `app_data` collections (`growth_areas`, `growth_area_today`), deliberately kept out of the bulk `/api/data` sync blob (same durability reasoning as tasks/routines/packages). Server endpoints: `GET/POST /api/growth-areas`, `PATCH/DELETE /api/growth-areas/:id`, `GET /api/growth-areas/today`.
+  - Morning rotation: one area a day (day-of-year mod pool size), AI-rephrased fresh each day, cached server-side so the digest and Today-view banner agree. Bugfix during testing: an empty cached pick (no eligible areas yet) is no longer sticky — adding your first area now shows up the same day instead of waiting until tomorrow.
+  - Contextual injection: active `persistent`/`both` areas feed into `getWhatNow()` (new 6th param) and Quokka's system prompt — both may mention an area in one line when genuinely relevant, never forced.
+  - Digest gains a "☀️ Today: {text}" line (`digestBuilder.js`, synchronous cache read); Kept's `TodayView` gets a small dismissible banner above the Day Arc hero (dismiss = "seen", reappears next local morning).
+  - Management UI: `GrowthAreasModal` (simplest CRUD in the app, on par with Labels) — entry points in the legacy System menu, Kept mobile More view, and Kept desktop sidebar.
+  - Quokka: 4 new tools (`list_growth_areas`, `create_growth_area`, `update_growth_area`, `delete_growth_area`) in `adviserToolsMisc.js`, staged with capture/restore compensation.
+
 - feat(routines): add `assignee` for loops/tasks the user supervises but doesn't own [M]
   - **User request:** track recurring chores that are for the user's son (something they supervise, not their own task) with simple flat-point scoring rather than the normal ADHD-effort size×energy grading.
   - New `assignee` TEXT column on both `routines` and `tasks` (migration 038). Free text (e.g. "Jack"), null = the user's own task/loop — no multi-user accounts, purely informational/organizational since only the user operates this app.


### PR DESCRIPTION
## Summary

Builds the **Growth Areas** feature (`wiki/Growth-Areas.md`) end-to-end — a deliberately tiny personal-coaching feature: standing reminders about *yourself* ("be more patient on calls"), not tasks. No tracking, no streak, no check-in. This spec was rewritten after an adversarial Fable-model design pass earlier in this session (PR merged as `docs: revise Escalation Ladder + Growth Areas specs after design review`); this PR is the "then build" half.

- **Storage:** new `growthAreas.js` root module (added to the Dockerfile runtime COPY list). Its own dedicated `app_data` collections (`growth_areas`, `growth_area_today`) — deliberately kept **out of** the bulk `/api/data` sync blob, same carve-out reasoning CLAUDE.md documents for tasks/routines/packages (whole-blob last-writer-wins can't touch what it never receives).
- **Endpoints:** `GET/POST /api/growth-areas`, `PATCH/DELETE /api/growth-areas/:id`, `GET /api/growth-areas/today`.
- **Morning rotation:** one area a day (day-of-year mod pool size), rendered as a fresh AI rephrasing (reuses the toast-message shape: short prompt, timeout, static fallback = the stored title). Cached server-side once per day so the digest and Today-view banner never disagree. Caught and fixed during testing: an empty cached pick (no eligible areas yet) is **not** sticky — adding your first area now surfaces same-day instead of waiting until tomorrow.
- **Contextual injection:** active `persistent`/`both` areas feed into `getWhatNow()` (new 6th param) and Quokka's system prompt — a pick may get one relevant line, never forced, mirroring the existing weather-relevance rule.
- **Digest:** new "☀️ Today: {text}" line in `digestBuilder.js` (synchronous cache read — the digest builder never blocks on live AI).
- **Today-view banner:** small dismissible card above the Day Arc hero in Kept's `TodayView` (shared by mobile `KeptShell` and `KeptDesktop`). Dismiss = "seen", not "done" — reappears next local morning.
- **Management UI:** `GrowthAreasModal` — simplest CRUD in the app, on par with Labels. Wired into all three surfaces: legacy System menu, Kept mobile More view, Kept desktop sidebar.
- **Quokka:** 4 new staged tools (`list_growth_areas`, `create_growth_area`, `update_growth_area`, `delete_growth_area`) with capture/restore compensation.

## Test plan

- [x] `npm run build` — clean build
- [x] `npm test` (date/cycle unit tests + smoke test) — all green
- [x] Manual REST round-trip against a fresh SQLite DB: create → list → today (rotation pick + AI-fallback text) → patch (active toggle) → delete, all verified via curl
- [x] Caught + fixed a same-day caching bug where a just-added first area wouldn't surface until the next day
- [x] `npm audit` — no new vulnerabilities introduced (pre-existing high-severity `nodemailer` advisory unrelated to this change)
- [x] Docs updated: `CLAUDE.md` (new Growth Areas section), `wiki/Version-History.md`

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_017hCKXbBMT3bFSo3ddSNaGp

---
_Generated by [Claude Code](https://claude.ai/code/session_017hCKXbBMT3bFSo3ddSNaGp)_