### PR TITLE
fix(ui): give Due more room than Priority in the shared date+priority row

### DIFF
--- a/src/components/AddTaskModal.css
+++ b/src/components/AddTaskModal.css
@@ -76,10 +76,13 @@
   margin-top: 8px;
 }
 
-/* Two-column row used for date+priority etc. CSS Grid (over flex) so each
- * column gets exactly half the available width regardless of intrinsic
- * content widths — Safari/iOS renders empty <input type="date"> at a
- * collapsed intrinsic width which broke the flex layout.
+/* Two-column row used for date+priority, frequency+on, every-N+unit, etc.
+ * (also reused as-is by RoutinesModal for several genuinely equal-weight
+ * pairs — that's why the default stays 1:1; see the -due-priority modifier
+ * below for the one pairing that isn't equal-weight). CSS Grid (over flex)
+ * so each column gets a fixed share of the available width regardless of
+ * intrinsic content widths — Safari/iOS renders empty <input type="date">
+ * at a collapsed intrinsic width which broke the flex layout.
  *
  * minmax(0, 1fr) (not the shorthand `1fr` which is minmax(auto, 1fr)) so
  * filled date inputs don't expand the column past its half-share —
@@ -91,6 +94,16 @@
   grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
   gap: 12px;
   margin-top: 18px;
+}
+
+/* Due packs a "YYYY-MM-DD" text field PLUS a calendar-icon button into its
+ * column (DateField.jsx), while Priority is a single button whose longest
+ * label ("! High") is under 10 chars — an even split was cramping the date
+ * text against the fixed-width calendar button (prod report: dates
+ * truncating) while Priority sat on unused space. Same minmax(0, Nfr)
+ * reasoning as the default, just an asymmetric ratio. */
+.v2-form-row-due-priority {
+  grid-template-columns: minmax(0, 3fr) minmax(0, 2fr);
 }
 
 .v2-form-field {

--- a/src/components/AddTaskModal.jsx
+++ b/src/components/AddTaskModal.jsx
@@ -106,7 +106,7 @@ export default function AddTaskModal({ open, onAdd, onClose, parentProject = nul
         )}
       </div>
 
-      <div className="v2-form-row">
+      <div className="v2-form-row v2-form-row-due-priority">
         <div className="v2-form-field">
           <label className="v2-form-label">Due</label>
           <DateField value={form.dueDate} onChange={form.setDueDate} min={today} />

--- a/src/components/EditTaskModal.jsx
+++ b/src/components/EditTaskModal.jsx
@@ -696,7 +696,7 @@ export default function EditTaskModal({
         )
       })()}
 
-      <div className="v2-form-row">
+      <div className="v2-form-row v2-form-row-due-priority">
         <div className="v2-form-field">
           <label className="v2-form-label">Due</label>
           <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>


### PR DESCRIPTION
## Summary

User-reported (with screenshot): the Due date field was truncating ("2026-06-24" cut off) while the adjacent Priority field sat on unused space.

`.v2-form-row`'s even 1:1 grid split was sized to dodge a Safari empty-`<input type="date">` bug, not because the two columns are equal-weight — but Due packs a `YYYY-MM-DD` text field plus a calendar-icon button into its half (`DateField.jsx`) while Priority is a single short button (longest label "! High", under 10 chars), so the date text was cramped against a fixed-width calendar button while Priority had room to spare.

Added a `.v2-form-row-due-priority` modifier (3:2 split) rather than changing the shared class's default — `RoutinesModal` reuses `.v2-form-row` for several genuinely equal-weight pairs (Frequency/On, Every-N/unit, At-time/clear, etc.) that shouldn't skew.

## Test plan

- [x] `npm run build` / `npm test` — all green
- [x] Applied to both `AddTaskModal.jsx` and `EditTaskModal.jsx` (both use the shared row)
- [ ] Worth a look on `boomerang-dev:3002` alongside the rest of the design-audit pass (#617, already merged to dev) — same "can't render CSS in this sandbox" caveat applies

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_017hCKXbBMT3bFSo3ddSNaGp

---
_Generated by [Claude Code](https://claude.ai/code/session_017hCKXbBMT3bFSo3ddSNaGp)_