### PR TITLE
fix(ui): swipe-down-to-dismiss on Kept's bottom sheets

### DIFF
--- a/src/hooks/useSheetSwipeDown.js
+++ b/src/hooks/useSheetSwipeDown.js
@@ -1,0 +1,64 @@
+import { useRef, useCallback } from 'react'
+
+// Swipe-down-to-dismiss for a bottom sheet (Kept's `.bm-sheet` family —
+// ThrowSheet, the Tasks action sheet). The grabber bar has always LOOKED
+// draggable but had no touch handling behind it — this wires the gesture up.
+// Attach `sheetRef` to the sheet's root element and spread `handleProps` onto
+// the draggable region (the grabber/handle, not the whole sheet, so the
+// title/input/buttons stay normal tap targets).
+//
+// `extraOffsetRef` is optional: a ref holding another live transform offset
+// (in px) the caller is animating independently — e.g. ThrowSheet's keyboard-
+// occlusion translateY — so the two don't stomp each other's `style.transform`.
+// Call the returned `applyExtraOffset(0)` whenever that other offset changes.
+export default function useSheetSwipeDown(sheetRef, onDismiss, extraOffsetRef) {
+  const dragRef = useRef(null)
+
+  const applyTransform = useCallback((dy) => {
+    const sheet = sheetRef.current
+    if (!sheet) return
+    const total = (extraOffsetRef?.current || 0) + dy
+    sheet.style.transform = total === 0 ? '' : `translateY(${total}px)`
+  }, [sheetRef, extraOffsetRef])
+
+  const onPointerDown = useCallback((e) => {
+    dragRef.current = { y: e.clientY, t: performance.now() }
+    e.currentTarget.setPointerCapture?.(e.pointerId)
+  }, [])
+
+  const onPointerMove = useCallback((e) => {
+    const s = dragRef.current
+    if (!s) return
+    applyTransform(Math.max(0, e.clientY - s.y))
+  }, [applyTransform])
+
+  const endDrag = useCallback((e) => {
+    const s = dragRef.current
+    if (!s) return
+    dragRef.current = null
+    const dy = Math.max(0, e.clientY - s.y)
+    const velocity = dy / Math.max(1, performance.now() - s.t)
+    const sheet = sheetRef.current
+    // Dismiss past ~1/4 of a typical sheet drag or on a quick flick;
+    // otherwise snap back with a short eased transition.
+    if (dy > 90 || velocity > 0.6) {
+      onDismiss?.()
+      return
+    }
+    if (sheet) {
+      sheet.style.transition = 'transform 180ms ease'
+      applyTransform(0)
+      setTimeout(() => { if (sheet) sheet.style.transition = '' }, 200)
+    }
+  }, [sheetRef, onDismiss, applyTransform])
+
+  return {
+    applyExtraOffset: applyTransform,
+    handleProps: {
+      onPointerDown,
+      onPointerMove,
+      onPointerUp: endDrag,
+      onPointerCancel: endDrag,
+    },
+  }
+}

--- a/src/kept/TasksViewKept.jsx
+++ b/src/kept/TasksViewKept.jsx
@@ -1,7 +1,8 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { Check, Search, Pencil, Trash2, X, Undo2, ArrowUpDown } from 'lucide-react'
 import { localYMD, parseLocalDate, addDays } from '../dates'
 import { isSnoozed, formatSnoozeLabel } from '../store'
+import useSheetSwipeDown from '../hooks/useSheetSwipeDown'
 import RowSwipe from './RowSwipe'
 import Section, { useCollapsedSections } from './Section'
 import BoardView from './BoardView'
@@ -25,6 +26,8 @@ export default function TasksViewKept({ tasks = [], labels = [], routines = [], 
   const [query, setQuery] = useState('')
   const [searchOpen, setSearchOpen] = useState(false)
   const [sheetTask, setSheetTask] = useState(null)
+  const sheetRef = useRef(null)
+  const { handleProps: sheetHandleProps } = useSheetSwipeDown(sheetRef, () => setSheetTask(null))
   // Escape closes the task action sheet — same convention as every other
   // modal/sheet primitive in the app (ModalShell, ConfirmDialog, ThrowSheet).
   useEffect(() => {
@@ -204,8 +207,10 @@ export default function TasksViewKept({ tasks = [], labels = [], routines = [], 
 
       {sheetTask && (
         <div className="bm-sheet-backdrop" onClick={() => setSheetTask(null)}>
-          <div className="bm-sheet" onClick={e => e.stopPropagation()}>
-            <div className="bm-grabber" />
+          <div className="bm-sheet" ref={sheetRef} onClick={e => e.stopPropagation()}>
+            <div className="bm-sheet-handle" {...sheetHandleProps}>
+              <div className="bm-grabber" />
+            </div>
             <h3 className="bm-sheet-title">{sheetTask.title}</h3>
             <div className="bm-chip-row">
               {[

--- a/src/kept/ThrowSheet.jsx
+++ b/src/kept/ThrowSheet.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { SlidersHorizontal } from 'lucide-react'
 import { localYMD, addDays } from '../dates'
+import useSheetSwipeDown from '../hooks/useSheetSwipeDown'
 import './shell.css'
 
 const DATES = [
@@ -28,6 +29,22 @@ export default function ThrowSheet({ open, onClose, onThrow, onMoreOptions }) {
   const [dateId, setDateId] = useState('none')
   const inputRef = useRef(null)
   const sheetRef = useRef(null)
+  // The keyboard-occlusion offset below (px, <= 0) — kept in a ref rather
+  // than composed ad-hoc so the swipe-down handler can add its own live drag
+  // offset on top of it without the two effects fighting over
+  // sheet.style.transform.
+  const kbOffsetRef = useRef(0)
+
+  // Blur before closing — otherwise the focused input unmounts while the
+  // keyboard is still up, and its dismiss animation unwinds mid-re-render of
+  // whatever's now visible underneath (prod report: new tasks landing behind
+  // the collapsing keyboard).
+  const closeAndBlur = () => {
+    inputRef.current?.blur()
+    onClose?.()
+  }
+
+  const { applyExtraOffset, handleProps } = useSheetSwipeDown(sheetRef, closeAndBlur, kbOffsetRef)
 
   // Keyboard-occlusion handling — same visualViewport pattern BottomTabs.jsx
   // and FloatingCapture.jsx already use. Without this, an input this close to
@@ -37,21 +54,22 @@ export default function ThrowSheet({ open, onClose, onThrow, onMoreOptions }) {
   useEffect(() => {
     if (!open) return
     const vv = window.visualViewport
-    const sheet = sheetRef.current
-    if (!vv || !sheet) return
+    if (!vv) return
     const update = () => {
       const occluded = Math.max(0, window.innerHeight - vv.height - vv.offsetTop)
-      sheet.style.transform = occluded > 0 ? `translateY(${-occluded}px)` : ''
+      kbOffsetRef.current = occluded > 0 ? -occluded : 0
+      applyExtraOffset(0)
     }
     update()
     vv.addEventListener('resize', update)
     vv.addEventListener('scroll', update)
     return () => {
-      sheet.style.transform = ''
+      kbOffsetRef.current = 0
+      applyExtraOffset(0)
       vv.removeEventListener('resize', update)
       vv.removeEventListener('scroll', update)
     }
-  }, [open])
+  }, [open, applyExtraOffset])
 
   // Escape closes, same as every other modal/sheet primitive (ModalShell,
   // ConfirmDialog) — this sheet previously only dismissed via backdrop tap.
@@ -63,15 +81,6 @@ export default function ThrowSheet({ open, onClose, onThrow, onMoreOptions }) {
   }, [open, onClose])
 
   if (!open) return null
-
-  // Blur before closing — otherwise the focused input unmounts while the
-  // keyboard is still up, and its dismiss animation unwinds mid-re-render of
-  // whatever's now visible underneath (prod report: new tasks landing behind
-  // the collapsing keyboard).
-  const closeAndBlur = () => {
-    inputRef.current?.blur()
-    onClose?.()
-  }
 
   const send = () => {
     const t = title.trim()
@@ -89,7 +98,9 @@ export default function ThrowSheet({ open, onClose, onThrow, onMoreOptions }) {
   return (
     <div className="bm-sheet-backdrop" onClick={closeAndBlur}>
       <div className="bm-sheet" ref={sheetRef} onClick={e => e.stopPropagation()}>
-        <div className="bm-grabber" />
+        <div className="bm-sheet-handle" {...handleProps}>
+          <div className="bm-grabber" />
+        </div>
         <h3 className="bm-sheet-title">Throw a task</h3>
         <input
           ref={inputRef}

--- a/src/kept/shell.css
+++ b/src/kept/shell.css
@@ -264,6 +264,14 @@
   box-shadow: var(--bm-shadow-pop);
   animation: bm-rise 240ms cubic-bezier(0.3, 1.2, 0.4, 1);
 }
+.bm-sheet-handle {
+  display: flex; justify-content: center;
+  padding: 10px 0 6px;
+  margin: -10px 0 -6px;
+  touch-action: none;
+  cursor: grab;
+}
+.bm-sheet-handle:active { cursor: grabbing; }
 .bm-grabber { width: 36px; height: 4px; border-radius: 4px; background: var(--bm-hairline-strong); margin: 0 auto 12px; }
 .bm-sheet-title {
   font-family: var(--v2-font-display);

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,12 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-07-04
 
+- fix(ui): swipe-down-to-dismiss on Kept's bottom sheets [S]
+  - **User report:** "Throw task modal swipe down doesn't work" — the sheet's grabber bar has always looked draggable (it's the standard bottom-sheet affordance) but no touch handling was ever wired behind it on either `.bm-sheet` (ThrowSheet, and the Tasks action sheet in `TasksViewKept.jsx` shares the identical grabber pattern and the identical gap).
+  - New `src/hooks/useSheetSwipeDown.js`: a small reusable pointer-events hook — drag follows the finger via a live `translateY`, release past ~90px or a quick flick calls the dismiss callback, otherwise the sheet snaps back with a short eased transition. Attaches to a dedicated `.bm-sheet-handle` wrapper around the grabber (not the whole sheet), so the input/chips/buttons below stay normal tap targets and don't fight the drag gesture.
+  - `ThrowSheet.jsx` composes the swipe offset with its existing keyboard-occlusion `translateY` (both now write through the same ref-tracked offset instead of two effects stomping `sheet.style.transform`) so swiping down still works correctly while the keyboard is up.
+  - `TasksViewKept.jsx`'s task action sheet gets the same fix for consistency — it had the exact same grabber-implies-swipe gap.
+
 - fix(ui): wire up the "What now?" row on Kept mobile's More tab [XS]
   - **User report:** "What now is still a dead link" — reported again after the design-audit pass (which added the row to `MoreView.jsx`) had already shipped to `dev`.
   - Root cause: that earlier fix added the `onWhatNow` prop declaration and the row to `MoreView.jsx`, but never updated `KeptShell.jsx`'s `<MoreView>` render call to actually pass `onWhatNow` down — it was only wired to `<TodayView>`. So the prop was `undefined` on the More tab specifically, and tapping the row did nothing. `KeptDesktop.jsx` and `AppV2.jsx`'s own wiring were both already correct (confirmed by re-tracing the whole chain), which is why the bug looked like a phantom the first time.


### PR DESCRIPTION
## Summary
- **User report:** "Throw task modal swipe down doesn't work."
- Root cause: the `.bm-grabber` bar on `ThrowSheet` (and the identical grabber on the Tasks action sheet in `TasksViewKept.jsx`) has always looked like a drag handle — that's the standard bottom-sheet affordance — but no touch/pointer handling was ever wired behind it. Only backdrop-tap and Escape closed the sheet.
- New `src/hooks/useSheetSwipeDown.js`: a small reusable pointer-events hook. Drag follows the finger via a live `translateY`; releasing past ~90px of drag or on a quick flick (velocity threshold) dismisses the sheet; otherwise it snaps back with a short eased transition. Attached to a new `.bm-sheet-handle` wrapper around the grabber only (not the whole sheet), so the input/date chips/buttons below keep working as normal taps and don't fight the drag gesture.
- `ThrowSheet.jsx` already had a keyboard-occlusion effect that also writes `sheet.style.transform` — refactored both to compose through a shared ref-tracked offset instead of two effects overwriting each other, so swiping down still works correctly while the keyboard is up.
- Applied the same fix to `TasksViewKept.jsx`'s task action sheet for consistency — it shares the exact same grabber component and had the identical gap.

## Test plan
- [x] `npx eslint` on the touched files — clean.
- [x] `npm run build` — succeeds.
- [x] `npm test` — full smoke test suite passes.
- [ ] Manual swipe-down verification on a touch device once deployed to `boomerang-dev:3002` (this environment's sandbox can't drive Playwright against any host, including localhost, so this couldn't be visually/interactively verified here — flagging that explicitly).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_017hCKXbBMT3bFSo3ddSNaGp)_