### PR TITLE
fix(ui): show undated tasks in the desktop Today rail

### DIFF
--- a/src/kept/TodayRail.jsx
+++ b/src/kept/TodayRail.jsx
@@ -28,6 +28,21 @@ export default function TodayRail({
     return t.due_date ? String(t.due_date).slice(0, 10) <= todayKey : false
   }).slice(0, 12), [tasks, todayKey, stackIds])
 
+  // Undated active tasks — mirrors TodayView.jsx's "Anytime" section. Without
+  // this, an undated task is fully notifiable (isNotifiable() in db.js has no
+  // due_date requirement) but was invisible anywhere on this rail — the exact
+  // "nagged about something I can't even see" gap reported in prod, since the
+  // rail is what's on screen while browsing Tasks/Loops.
+  const anytimeTasks = useMemo(() => tasks.filter(t => {
+    if (t.parent_id || t.gmail_pending || t.due_date) return false
+    if (t.routine_id && stackIds.has(t.routine_id)) return false
+    if (!ACTIVE.includes(t.status)) return false
+    return !isSnoozed(t)
+  }), [tasks, stackIds])
+  const ANYTIME_CAP = 8
+  const anytimeShown = anytimeTasks.slice(0, ANYTIME_CAP)
+  const anytimeOverflow = anytimeTasks.length - anytimeShown.length
+
   const catches = dailyStats.tasksToday ?? 0
 
   return (
@@ -63,6 +78,29 @@ export default function TodayRail({
             </div>
           ))}
         </div>
+      )}
+
+      {anytimeTasks.length > 0 && (
+        <>
+          <div className="bm-rail-sec">Anytime</div>
+          <div className="bm-rows">
+            {anytimeShown.map(t => (
+              <div key={t.id} className="bm-row bm-rail-row">
+                <button
+                  className={`bm-chk${t.high_priority ? ' is-hi' : ''}`}
+                  onClick={() => onCompleteTask?.(t)}
+                  aria-label="Catch it"
+                ><Check size={12} strokeWidth={3.2} style={{ opacity: 0 }} /></button>
+                <button className="bm-row-body" onClick={() => onOpenTask?.(t)}>
+                  <span className="bm-row-title" style={{ fontSize: 13.5 }}>{t.title}</span>
+                </button>
+              </div>
+            ))}
+          </div>
+          {anytimeOverflow > 0 && (
+            <p className="bm-rail-empty">+{anytimeOverflow} more in Tasks</p>
+          )}
+        </>
       )}
     </aside>
   )

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -4,7 +4,12 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ---
 
-## 2026-07-10
+## 2026-07-11
+
+- fix(ui): desktop Today rail was missing undated ("Anytime") tasks [S]
+  - **User report:** "Getting really frustrated with notifications when the items are in tasks and not in today... if they aren't in today then they should functionally be a backlog task or something should be pushing those tasks forward to today."
+  - Root cause: `isNotifiable()` (`db.js`) makes any `not_started`/`doing`/`waiting` task eligible for stale/nudge nags regardless of `due_date` — no due-date gate at all for ordinary tasks (only `project` status has the due-date-aware `nag_allowed` opt-in). Mobile's `TodayView.jsx` already accounts for this: undated active tasks render in a dedicated "Anytime" section on the Today screen ("the main page must show them"). But `TodayRail.jsx` — the side rail shown on desktop while browsing Tasks/Loops — only ever computed `dueToday` (`due_date <= today`) and had no undated-task section at all. So on desktop, an undated task sat visibly in the main Tasks pane while being completely invisible on the rail that represents "Today" — yet it was still fully nag-eligible. Not a backlog task (backlog is a manual, never-automatic status per `AppV2.jsx`/`adviserToolsTasks.js`) and not shown in Today — exactly the disconnect reported.
+  - Fixed by giving `TodayRail.jsx` the same "Anytime" section `TodayView.jsx` already has (undated, active, unsnoozed, non-stack, non-child tasks), capped at 8 rows with a "+N more in Tasks" note so nothing silently disappears if the list is long. Now every notifiable task surfaces somewhere on the Today surface, on both mobile and desktop.
 
 - fix(store): Quokka's "Could not retrieve response" error on long tool-use turns [S]
   - **User report:** screenshot + transcript of Quokka's "find contractors for my tasks" request — a broad request that legitimately fanned out into 13+ `search_tasks` calls, 2 `get_task` calls, 2 `web_search` calls, and 2 `update_task` calls — ending in "Could not retrieve response" even though the updates had actually been staged.


### PR DESCRIPTION
## Summary
- **User report:** "Getting really frustrated with notifications when the items are in tasks and not in today... if they aren't in today then they should functionally be a backlog task or something should be pushing those tasks forward to today."
- Root cause: `isNotifiable()` (`db.js`) makes any `not_started`/`doing`/`waiting` task eligible for stale/nudge notifications regardless of `due_date` — there's no due-date gate for ordinary tasks (only `status === 'project'` has a due-date-aware `nag_allowed` opt-in). Mobile's `TodayView.jsx` already accounts for this by rendering undated active tasks in a dedicated "Anytime" section. But `TodayRail.jsx` — the side rail shown on desktop while browsing Tasks/Loops — only ever computed `dueToday` (`due_date <= today`), with no undated-task section at all. Result: on desktop, an undated task could sit visibly in the main Tasks pane while being completely invisible on the "Today" rail, yet still be fully nag-eligible. It's not backlog either (backlog is a manual, never-automatic status) — hence the reported disconnect.
- Fix: gave `TodayRail.jsx` the same "Anytime" section `TodayView.jsx` already has (undated, active, unsnoozed, non-stack, non-child tasks), capped at 8 rows with a "+N more in Tasks" note so nothing silently disappears if the list runs long. Every notifiable task now surfaces somewhere on the Today surface, on both mobile and desktop — closing the gap between "what nags you" and "what you can actually see."

## Test plan
- [x] `npx eslint src/kept/TodayRail.jsx` — clean.
- [x] `npm run build` — succeeds.
- [x] `npm test` — full smoke test suite passes.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_017hCKXbBMT3bFSo3ddSNaGp)_