### PR TITLE
fix(ios): App Shortcut phrases can't embed a String parameter [XS]

### DIFF
--- a/ios/App/App/BoomerangIntents.swift
+++ b/ios/App/App/BoomerangIntents.swift
@@ -50,10 +50,14 @@ struct BoomerangShortcuts: AppShortcutsProvider {
     static var appShortcuts: [AppShortcut] {
         AppShortcut(
             intent: AddBoomerangTaskIntent(),
+            // Phrases may only embed AppEnum/AppEntity parameters — a free-form
+            // String can't appear in the spoken trigger, so Siri collects the
+            // title via the parameter's requestValueDialog instead.
             phrases: [
                 "Add a task to \(.applicationName)",
-                "Add \(\.$taskTitle) to \(.applicationName)",
-                "Throw \(\.$taskTitle) to \(.applicationName)"
+                "Add a task in \(.applicationName)",
+                "Throw a task to \(.applicationName)",
+                "New task in \(.applicationName)"
             ],
             shortTitle: "Add task",
             systemImageName: "plus.circle.fill"

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,9 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-07-15
 
+- fix(ios): App Shortcut phrases can't embed a String parameter [XS]
+  - Second Mac-compile error in `BoomerangIntents.swift`: "'AppEntity' and 'AppEnum' are the only allowed types for 'taskTitle'". Siri phrases may only embed AppEnum/AppEntity parameters (finite vocabulary); the two parameterized phrases (`"Add \(\.$taskTitle) to …"` / `"Throw \(\.$taskTitle) to …"`) were invalid for a free-form String. Replaced with four non-parameterized phrase variants — Siri collects the title via the parameter's `requestValueDialog` ("What's the task?") instead, which is the standard dictation flow for free-text intents.
+
 - fix(ios): raise iOS deployment target 15.0 → 16.0 — AppIntents requires it [XS]
   - First real Mac compile of the Mac-session bundle failed: every AppIntents symbol in `BoomerangIntents.swift` errored "only available in iOS 16.0 or newer" because the App target (and project) still carried the Capacitor template's `IPHONEOS_DEPLOYMENT_TARGET = 15.0` (`-target arm64-apple-ios15.0` in the failing swiftc invocation). All 12 remaining `15.0` entries in `project.pbxproj` (project-level + App target, Debug/Release + their `-Dev` clones) bumped to `16.0`, matching the ShareExtension configs which were authored at 16.0 from the start. Chose the target bump over sprinkling `@available(iOS 16, *)` — `AppShortcutsProvider` registration doesn't gate cleanly, and the only device this app targets runs iOS 27. pbxproj re-validated with mod-pbxproj after the edit.
 


### PR DESCRIPTION
## What

Second Mac-compile error in `BoomerangIntents.swift`:

> 'AppEntity' and 'AppEnum' are the only allowed types for 'taskTitle'

## Root cause

App Shortcut **phrases** may only embed parameters whose type is an `AppEnum` or `AppEntity` — Siri needs a finite vocabulary inside a spoken trigger phrase. Two of the phrases embedded the free-form `String` parameter (`"Add \(\.$taskTitle) to …"`, `"Throw \(\.$taskTitle) to …"`), which the AppIntents extractor rejects at compile time.

## Fix

Dropped the parameterized phrases; four non-parameterized variants remain ("Add a task to Boomerang", "Throw a task to Boomerang", …). Siri collects the title via the parameter's `requestValueDialog` ("What's the task?") — the standard dictation flow for free-text intents, same number of exchanges as before.

Swift-only change; no server/bundle impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V45AJzVRjV8j2Sei5Qgr6A

---
_Generated by [Claude Code](https://claude.ai/code/session_01V45AJzVRjV8j2Sei5Qgr6A)_