### PR TITLE
fix(ui): move APNs controls into the Channels section [XS]

### DIFF
--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -1771,6 +1771,30 @@ function NotificationsPanel({ settings, update }) {
             Web push isn't supported in this browser. On iOS, add Boomerang to the Home Screen and open from there.
           </div>
         )}
+
+        {/* Native iOS (APNs) — the 4th channel, native shell only. Same
+          * per-device registration shape as the web-push "This device" row. */}
+        {isNativeShell() && (
+          <div className="v2-settings-row" style={{ alignItems: 'flex-start', flexDirection: 'column', gap: 8 }}>
+            <div className="v2-settings-row-text">
+              <div className="v2-settings-row-label">Native iOS (APNs)</div>
+              <div className="v2-settings-row-hint">
+                Boomerang-branded banners — tapping one opens this app.
+                {apnsStatus && !apnsStatus.configured && ` Server not configured yet (missing: ${apnsStatus.missing.join(', ')}).`}
+                {apnsStatus?.configured && ` Server ready (${apnsStatus.env}) · ${apnsStatus.devices} device(s) registered.`}
+                {apnsMsg && ` ${apnsMsg}`}
+              </div>
+            </div>
+            <div style={{ display: 'flex', gap: 8 }}>
+              <button className="v2-settings-btn" onClick={handleEnableNativePush} disabled={apnsBusy}>
+                {apnsBusy ? 'Working…' : 'Enable on this device'}
+              </button>
+              <button className="v2-settings-btn" onClick={handleApnsTest} disabled={apnsBusy || !apnsStatus?.configured}>
+                Send test
+              </button>
+            </div>
+          </div>
+        )}
         </>)}
       </div>
 
@@ -1791,28 +1815,6 @@ function NotificationsPanel({ settings, update }) {
           value={settings.public_app_url || ''}
           onChange={e => update('public_app_url', e.target.value)}
         />
-        {isNativeShell() && (
-          <div className="v2-settings-row">
-            <div className="v2-settings-row-text">
-              <div className="v2-settings-row-label">Native iOS notifications (APNs)</div>
-              <div className="v2-settings-row-hint">
-                Real Boomerang notifications — tapping the banner opens this app.
-                {apnsStatus && !apnsStatus.configured && ` Server not configured yet (missing: ${apnsStatus.missing.join(', ')}).`}
-                {apnsStatus?.configured && ` Server ready (${apnsStatus.env}) · ${apnsStatus.devices} device(s) registered.`}
-                {apnsMsg && ` ${apnsMsg}`}
-              </div>
-              <div className="v2-settings-actions">
-                <button className="v2-settings-btn" onClick={handleEnableNativePush} disabled={apnsBusy}>
-                  {apnsBusy ? 'Working…' : 'Enable on this device'}
-                </button>
-                <button className="v2-settings-btn" onClick={handleApnsTest} disabled={apnsBusy || !apnsStatus?.configured}>
-                  Send test
-                </button>
-              </div>
-            </div>
-          </div>
-        )}
-
         <div className="v2-settings-row">
           <div className="v2-settings-row-text">
             <div className="v2-settings-row-label">Open Pushover links in the iOS app</div>

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,9 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-07-15
 
+- fix(ui): APNs controls belong in the Channels section, not the Public-app-URL card [XS]
+  - Prod report: the native-push block "looks super stupid" as its own one-off section — the Notifications panel already models delivery channels (web push / email / Pushover rows in **Channels**, with web push's "Enable on this device" sub-row as the per-device registration pattern). The APNs block was nested inside the unrelated "Public app URL" card. Moved into Channels as the 4th channel row ("Native iOS (APNs)", native-shell-only), mirroring the web-push device-row layout (column row, same `v2-settings-btn` actions). No behavior change — same status line, Enable, and Send test wiring.
+
 - fix(ios): App Shortcut phrases can't embed a String parameter [XS]
   - Second Mac-compile error in `BoomerangIntents.swift`: "'AppEntity' and 'AppEnum' are the only allowed types for 'taskTitle'". Siri phrases may only embed AppEnum/AppEntity parameters (finite vocabulary); the two parameterized phrases (`"Add \(\.$taskTitle) to …"` / `"Throw \(\.$taskTitle) to …"`) were invalid for a free-form String. Replaced with four non-parameterized phrase variants — Siri collects the title via the parameter's `requestValueDialog` ("What's the task?") instead, which is the standard dictation flow for free-text intents.
 


### PR DESCRIPTION
## What

Prod feedback: the native-push (APNs) controls rendered as a one-off block nested inside the unrelated **Public app URL** card — visually inconsistent with how every other delivery channel is presented.

## Fix

The Notifications panel already has the model for this: the **Channels** section (web push / email / Pushover rows), with web push's "Enable on this device" sub-row as the per-device registration pattern. The APNs block now renders there as the 4th channel row — "Native iOS (APNs)", native-shell-only, same column-row layout and `v2-settings-btn` treatment as the web-push device row.

No behavior change: same status line, same Enable / Send test wiring.

## Validation

- lint 0 errors, tests + smoke green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V45AJzVRjV8j2Sei5Qgr6A

---
_Generated by [Claude Code](https://claude.ai/code/session_01V45AJzVRjV8j2Sei5Qgr6A)_