### PR TITLE
fix(ui): APNs already-enabled detection + locked-toggle explainers [S]

### DIFF
--- a/apnsNotifications.js
+++ b/apnsNotifications.js
@@ -96,8 +96,9 @@ export function unregisterApnsDevice(token) {
   return { ok: true, devices: Object.keys(devices).length }
 }
 
-export function getApnsStatus() {
+export function getApnsStatus(deviceToken = null) {
   const c = config()
+  const devices = loadDevices()
   return {
     configured: isApnsConfigured(),
     missing: [
@@ -107,7 +108,11 @@ export function getApnsStatus() {
     ].filter(Boolean),
     env: c.env,
     topic: c.topic,
-    devices: Object.keys(loadDevices()).length,
+    devices: Object.keys(devices).length,
+    // When the caller identifies itself (?token=), say whether THAT device
+    // is in the registry — lets the Settings UI show "already enabled"
+    // instead of a stateless Enable button.
+    ...(deviceToken ? { this_device: !!devices[String(deviceToken).trim().toLowerCase()] } : {}),
   }
 }
 

--- a/server.js
+++ b/server.js
@@ -2788,7 +2788,7 @@ app.get('/api/pushover/link-mode', (req, res) => {
 
 // --- Native iOS push (APNs) — Phase 4 of the native app ---
 app.get('/api/apns/status', (req, res) => {
-  res.json(getApnsStatus())
+  res.json(getApnsStatus(req.query.token || null))
 })
 
 app.post('/api/apns/register', (req, res) => {

--- a/src/AppV2.jsx
+++ b/src/AppV2.jsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { ListChecks } from 'lucide-react'
 import { App as CapacitorApp } from '@capacitor/app'
 import { isNativeShell } from './apiConfig'
-import { wireNativePushTapHandler } from './nativePush'
+import { wireNativePushTapHandler, refreshNativePushRegistration } from './nativePush'
 import Header from './components/Header'
 import ModalShell from './components/ModalShell'
 import BottomTabs from './components/BottomTabs'
@@ -391,6 +391,9 @@ export default function AppV2() {
     }).then((l) => { listener = l }).catch(() => {})
     // Native APNs banner taps route through the same deep-link applier.
     const unwirePush = wireNativePushTapHandler((search) => applyDeepLinkRef.current(search))
+    // Keep the device's APNs registration fresh (tokens can rotate) — only
+    // acts when permission is already granted, so it never prompts.
+    refreshNativePushRegistration()
     return () => { listener?.remove?.(); unwirePush() }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -1576,7 +1576,14 @@ function NotificationsPanel({ settings, update }) {
   const [apnsBusy, setApnsBusy] = useState(false)
   const [apnsMsg, setApnsMsg] = useState('')
   const refreshApnsStatus = useCallback(() => {
-    fetch('/api/apns/status')
+    // Identify this device (stored at register time) so the server can say
+    // whether it's already registered — drives the ✓ button state below.
+    let tokenQs = ''
+    try {
+      const t = localStorage.getItem('boom_apns_token')
+      if (t) tokenQs = `?token=${encodeURIComponent(t)}`
+    } catch { /* state check degrades to the stateless button */ }
+    fetch(`/api/apns/status${tokenQs}`)
       .then(r => r.ok ? r.json() : null)
       .then(d => { if (d) setApnsStatus(d) })
       .catch(() => {})
@@ -1866,12 +1873,24 @@ function NotificationsPanel({ settings, update }) {
                 {apnsStatus?.configured && ` Server ready (${apnsStatus.env}) · ${apnsStatus.devices} device(s) registered.`}
                 {apnsMsg && ` ${apnsMsg}`}
               </div>
+              {apnsStatus?.configured && apnsStatus?.devices > 0 && settings.push_notifications_enabled !== true && (
+                <div className="v2-settings-row-hint" style={{ color: 'var(--v2-danger, #c83a3a)', marginTop: 4 }}>
+                  ⚠ The Push master above is OFF — native banners won't send for real notifications
+                  until it's on. (Send test bypasses it.)
+                </div>
+              )}
             </div>
             <div style={{ display: 'flex', gap: 8 }}>
               {isNativeShell() && (
-                <button className="v2-settings-btn" onClick={handleEnableNativePush} disabled={apnsBusy}>
-                  {apnsBusy ? 'Working…' : 'Enable on this device'}
-                </button>
+                apnsStatus?.this_device ? (
+                  <button className="v2-settings-btn" disabled title="This device is registered — re-registration happens automatically on every launch">
+                    ✓ Enabled on this device
+                  </button>
+                ) : (
+                  <button className="v2-settings-btn" onClick={handleEnableNativePush} disabled={apnsBusy}>
+                    {apnsBusy ? 'Working…' : 'Enable on this device'}
+                  </button>
+                )
               )}
               <button className="v2-settings-btn" onClick={handleApnsTest} disabled={apnsBusy || !apnsStatus?.configured}>
                 Send test
@@ -1945,6 +1964,16 @@ function NotificationsPanel({ settings, update }) {
       {/* Per-type × per-channel — card-per-type layout works at any width */}
       <div className="v2-settings-block">
         <SectionHeader k="types" label="Notification types" hint="Each card toggles a notification type per channel. Frequency is the cooldown between repeats." />
+        {!isCollapsed('types') && (() => {
+          const offMasters = masters.filter(m => settings[m.key] !== true).map(m => m.label)
+          return offMasters.length === 0 ? null : (
+            <div className="v2-settings-row-hint" style={{ marginBottom: 10 }}>
+              {offMasters.join(' + ')} column{offMasters.length > 1 ? 's are' : ' is'} locked because
+              {offMasters.length > 1 ? ' those channels are' : ' that channel is'} off — flip the master
+              in Channels above to edit {offMasters.length > 1 ? 'them' : 'it'}.
+            </div>
+          )
+        })()}
         {!isCollapsed('types') && (
         <div className="v2-notif-cards">
           {NOTIF_TYPES.map(t => (

--- a/src/nativePush.js
+++ b/src/nativePush.js
@@ -36,10 +36,33 @@ export async function enableNativePush() {
     })
     const data = await res.json().catch(() => ({}))
     if (!res.ok || !data.ok) return { ok: false, error: data.error || `Server rejected the token (${res.status}).` }
+    // Remember this device's token so the Settings UI can ask the server
+    // "is THIS device registered?" instead of showing a stateless button.
+    try { localStorage.setItem('boom_apns_token', token) } catch { /* quota — state check degrades */ }
     return { ok: true, devices: data.devices }
   } catch (err) {
     return { ok: false, error: err?.message || 'Native push setup failed.' }
   }
+}
+
+// The APNs token this device registered with, if any. Used by Settings to
+// query per-device registration state.
+export function getStoredApnsToken() {
+  try { return localStorage.getItem('boom_apns_token') || null } catch { return null }
+}
+
+// Silent keep-fresh: APNs tokens can rotate (restore from backup, OS
+// reinstall), and Apple's guidance is to re-register on every launch. Called
+// from AppV2's mount effect — only acts when permission is ALREADY granted,
+// so it can never trigger the iOS permission prompt; if the user has never
+// enabled (or denied), it does nothing.
+export async function refreshNativePushRegistration() {
+  if (!isNativeShell()) return
+  try {
+    const perm = await PushNotifications.checkPermissions()
+    if (perm.receive !== 'granted') return
+    await enableNativePush()
+  } catch { /* background freshness only — Settings has the loud path */ }
 }
 
 export function wireNativePushTapHandler(onDeepLink) {

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,12 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-07-15
 
+- fix(ui): APNs "already enabled" detection + locked-toggle explainers [S]
+  - Prod annoyance report: the APNs "Enable on this device" button rendered stateless — identical before and after registration ("Do you have a clean way to detect that notifications are already enabled?"). Three-part fix:
+  - **Per-device state:** `enableNativePush()` stores the device token (`boom_apns_token`, quota-safe); `GET /api/apns/status?token=…` now answers `this_device: true|false` (`getApnsStatus(deviceToken)` in `apnsNotifications.js`); the Settings button becomes a disabled "✓ Enabled on this device" when registered. Live-verified (registered token → `this_device:true`, unknown → `false`).
+  - **Launch keep-fresh:** `refreshNativePushRegistration()` in `nativePush.js`, called from AppV2's mount effect — re-registers on every launch per Apple guidance (tokens rotate on restore/reinstall). Guarded on permission already granted, so it can never trigger the iOS permission prompt.
+  - **Locked-toggle explainers** (companion report: "why don't I have the ability to enable these?"): the Notification-types section now says which channel columns are locked because their masters are off, and the APNs row shows a red warning when devices are registered but the Push master is OFF — the state where Send test works (direct endpoint) but no real nag would ever send natively.
+
 - fix(store): quota-safe localStorage — the native shell's "Boomerang hit a snag" crash [M]
   - Native-app crash report (ErrorBoundary screen): `setItem` threw "The quota has been exceeded" during hydrate on the `capacitor://localhost` origin, and `save()` had no error handling, so the QuotaExceededError killed the whole render. Unrecoverable by design flaw: "Clear local state & reload" re-hydrated from the server straight back into the same overflow.
   - **Biggest payload found:** `logActivity()` stored a FULL task snapshot per entry — base64 `attachments` included — 500 entries deep. Snapshots now go through `slimSnapshot()`: attachments reduced to a count (`attachments_count`), notes capped at 2000 chars. Snapshots exist for metadata recovery; attachment bodies never belonged there.


### PR DESCRIPTION
## What

Two prod annoyance reports:
1. The APNs "Enable on this device" button is stateless — identical before and after registration.
2. The per-type notification toggles are locked with no explanation when channel masters are off ("why don't I have the ability to enable these?").

## Fix

**Per-device enabled state**
- `enableNativePush()` stores the device token (`boom_apns_token`, quota-safe write).
- `GET /api/apns/status?token=…` answers `this_device: true|false` (`getApnsStatus(deviceToken)`).
- Settings renders a disabled **"✓ Enabled on this device"** when registered.

**Launch keep-fresh**
- `refreshNativePushRegistration()` re-registers on every app launch (Apple guidance — tokens rotate on restore/reinstall). Guarded on permission already being granted, so it can never trigger the iOS permission prompt. Wired in AppV2's mount effect.

**Locked-toggle explainers**
- The Notification-types section now states which channel columns are locked because their masters are off, and how to unlock them.
- The APNs row shows a red warning when devices are registered but the **Push master is OFF** — the trap state where Send test works (direct endpoint) but no real nag would ever send natively.

## Validation

- Live-verified: registered token → `this_device: true`, unknown token → `false`
- lint 0 errors, full build, unit tests + smoke green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V45AJzVRjV8j2Sei5Qgr6A

---
_Generated by [Claude Code](https://claude.ai/code/session_01V45AJzVRjV8j2Sei5Qgr6A)_