### PR TITLE
release: native-only push engine fix + digest copy

### DIFF
--- a/apnsNotifications.js
+++ b/apnsNotifications.js
@@ -96,6 +96,12 @@ export function unregisterApnsDevice(token) {
   return { ok: true, devices: Object.keys(devices).length }
 }
 
+// Cheap target check for the push engine's early-bail guards: the Push
+// channel has work to do when EITHER leg has somewhere to deliver.
+export function hasApnsTargets() {
+  return isApnsConfigured() && Object.keys(loadDevices()).length > 0
+}
+
 export function getApnsStatus(deviceToken = null) {
   const c = config()
   const devices = loadDevices()

--- a/pushNotifications.js
+++ b/pushNotifications.js
@@ -13,7 +13,7 @@ import { queryTasks, getAllRoutines, getData, setData, getAllPushSubscriptions, 
 import { getWeatherCache, buildWeatherSummary } from './weatherSync.js'
 import { rewriteNotifBody, canRewriteThisTick } from './notifAi.js'
 import { isInQuietHours, getUserTimeParts } from './userTime.js'
-import { isApnsConfigured, sendApnsToAll } from './apnsNotifications.js'
+import { isApnsConfigured, sendApnsToAll, hasApnsTargets } from './apnsNotifications.js'
 
 // --- Environment (optional overrides) ---
 let vapidPublicKey = process.env.VAPID_PUBLIC_KEY
@@ -318,8 +318,10 @@ async function checkPushDigest() {
 
   if (!checkThrottle('push_digest', 23 * 60 * 60 * 1000)) return
 
+  // Native-only setups (APNs devices, zero web subscriptions) are valid —
+  // sendPush fans out to both legs, so only bail when NEITHER has targets.
   const subscriptions = getAllPushSubscriptions()
-  if (subscriptions.length === 0) return
+  if (subscriptions.length === 0 && !hasApnsTargets()) return
 
   const { buildDigest } = await import('./digestBuilder.js')
   const digest = buildDigest(settings)
@@ -349,8 +351,10 @@ async function runPushCheck() {
     if (!settings.push_notifications_enabled) return
     if (isInQuietHours(settings)) return
 
+    // Same native-aware bail as the digest check: a native-only phone (zero
+    // web subscriptions) must still get the full engine pass.
     const subscriptions = getAllPushSubscriptions()
-    if (subscriptions.length === 0) return
+    if (subscriptions.length === 0 && !hasApnsTargets()) return
 
     const allTasks = queryTasks({})
     const activeTasks = filterNotifiableTasks(allTasks)
@@ -760,5 +764,5 @@ export function startPushNotifications() {
   setupVapid()
   loopTimer = setInterval(runPushCheck, 60 * 1000)
   setTimeout(runPushCheck, 20000) // First check after 20s
-  console.log(`Push notifications: configured (${getAllPushSubscriptions().length} subscription(s))`)
+  console.log(`Push notifications: configured (${getAllPushSubscriptions().length} web subscription(s)${hasApnsTargets() ? ', native APNs active' : ''})`)
 }

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -2290,8 +2290,8 @@ function NotificationsPanel({ settings, update }) {
         {!isCollapsed('digest') && (<>
         <div className="v2-settings-row">
           <div className="v2-settings-row-text">
-            <div className="v2-settings-row-label">Web push digest</div>
-            <div className="v2-settings-row-hint">Requires Web push to be enabled and subscribed on this device.</div>
+            <div className="v2-settings-row-label">Push digest</div>
+            <div className="v2-settings-row-hint">Delivers via the Push channel — native banner on the iOS app, web push on subscribed browsers. Requires the Push master.</div>
           </div>
           <Toggle
             checked={settings.push_notifications_enabled === true && settings.push_digest_enabled === true}

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,9 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-07-15
 
+- fix(notifications): native-only phones got nothing — engine bailed on zero web subscriptions [S]
+  - Prod catch, and a real Phase-4b hole: `runPushCheck()` and `checkPushDigest()` kept their pre-4b `if (subscriptions.length === 0) return` guards, so a native-only setup (APNs device registered, zero web-push subscriptions — exactly the recommended end state) never reached the dual-leg `sendPush()`: no nags, no digest, nothing. Both bails are now native-aware (`subscriptions.length === 0 && !hasApnsTargets()`), with `hasApnsTargets()` (configured + ≥1 device) exported from `apnsNotifications.js`. The send-path functions (`sendPackagePush`/`sendQuokkaPlanReadyPush`/`sendDigestPush`) had no such guards and were already correct. Startup log now reports both legs ("0 web subscription(s), native APNs active" — live-verified).
+
 - fix(ui): APNs "already enabled" detection + locked-toggle explainers [S]
   - Prod annoyance report: the APNs "Enable on this device" button rendered stateless — identical before and after registration ("Do you have a clean way to detect that notifications are already enabled?"). Three-part fix:
   - **Per-device state:** `enableNativePush()` stores the device token (`boom_apns_token`, quota-safe); `GET /api/apns/status?token=…` now answers `this_device: true|false` (`getApnsStatus(deviceToken)` in `apnsNotifications.js`); the Settings button becomes a disabled "✓ Enabled on this device" when registered. Live-verified (registered token → `this_device:true`, unknown → `false`).


### PR DESCRIPTION
Promotes dev → main:

- **fix(notifications): native-only engine bails** — `runPushCheck()`/`checkPushDigest()` kept pre-4b early-returns on zero web subscriptions, so a native-only phone (APNs registered, no web subs) got no nags and no digest. Now native-aware via `hasApnsTargets()`. Also relabels "Web push digest" → "Push digest" (dual-leg description).

Live-verified startup log; lint + tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V45AJzVRjV8j2Sei5Qgr6A

---
_Generated by [Claude Code](https://claude.ai/code/session_01V45AJzVRjV8j2Sei5Qgr6A)_