### PR TITLE
release: test digest obeys channel masters

### DIFF
--- a/pushoverNotifications.js
+++ b/pushoverNotifications.js
@@ -794,8 +794,21 @@ export async function sendDigestNow() {
   const fired = []
   const skipped = []
 
+  // The test path must obey the SAME gates as the scheduled path (channel
+  // master AND digest opt-in) — it used to check only the digest flags, so
+  // with all masters off it still fired every opted-in channel: a "test"
+  // that behaves differently from the real thing (2026-07-15 report:
+  // digest toggles all displayed off, test still double-sent).
+  const masterOn = {
+    pushover: settings.pushover_notifications_enabled === true,
+    email: settings.email_notifications_enabled === true,
+    push: settings.push_notifications_enabled === true,
+  }
+
   // Pushover
-  if (settings.pushover_digest_enabled) {
+  if (!masterOn.pushover) {
+    skipped.push({ channel: 'pushover', reason: 'channel master off' })
+  } else if (settings.pushover_digest_enabled) {
     const { userKey, appToken } = getCredentials(settings)
     if (userKey && appToken) {
       const url = buildDeepLink(settings, null)
@@ -821,7 +834,9 @@ export async function sendDigestNow() {
 
   // Email + Web Push delegated to their modules so they reuse the same
   // transporter / VAPID setup. Lazy-imported to avoid circular deps.
-  if (settings.email_digest_enabled) {
+  if (!masterOn.email) {
+    skipped.push({ channel: 'email', reason: 'channel master off' })
+  } else if (settings.email_digest_enabled) {
     try {
       const { sendDigestEmail } = await import('./emailNotifications.js')
       const ok = await sendDigestEmail(digest)
@@ -834,7 +849,9 @@ export async function sendDigestNow() {
     skipped.push({ channel: 'email', reason: 'disabled' })
   }
 
-  if (settings.push_digest_enabled) {
+  if (!masterOn.push) {
+    skipped.push({ channel: 'push', reason: 'channel master off' })
+  } else if (settings.push_digest_enabled) {
     try {
       const { sendDigestPush } = await import('./pushNotifications.js')
       const ok = await sendDigestPush(digest)

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,9 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-07-15
 
+- fix(notifications): Test digest bypassed channel masters [S]
+  - Prod report: test digest double-sent (native iOS + Pushover) while ALL digest toggles displayed off. The scheduled digest paths in all three engines correctly require channel master AND digest opt-in — but `sendDigestNow()` (the Test digest button) checked only the digest opt-in flags. The user's settings carried `push_digest_enabled`/`pushover_digest_enabled: true` from earlier experimenting; masters were off; the honest master-gated display correctly showed "off"… and the test fired both channels anyway under different rules. `sendDigestNow` now applies the same master gates as the scheduled path, with explicit `channel master off` skip reasons in the response. Live-verified: masters off → all three skipped; push master on → push leg attempted, pushover still skipped.
+
 - docs(ios): TestFlight + Xcode Cloud plan [XS]
   - New `wiki/TestFlight-Xcode-Cloud.md`: the "no more Mac builds" plan. Phase 0 = repo prep Claude can do (ci_post_clone.sh web-bundle build, Release-entitlements split for `aps-environment: production`, `ITSAppUsesNonExemptEncryption`, CI build-number wiring); Phases 1–5 = the account-holder's Apple-UI + one-Mac-session path (app record → connect repo → create workflow → `APNS_ENV=production` flip on prod AFTER the TestFlight build is installed and registered — the sandbox/production sequencing trap is called out explicitly → internal tester install). Steady state: merge to `main` → cloud build → TestFlight update, 90-day expiry reset by any push. Boomerang Dev deliberately stays a local sideload.
 


### PR DESCRIPTION
Promotes dev → main:

- **fix(notifications): test digest must obey channel masters** — `sendDigestNow()` checked only the digest opt-in flags while scheduled digests require master + opt-in, so a test could double-send through channels whose toggles displayed off. Same gates now, with explicit skip reasons. Live-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V45AJzVRjV8j2Sei5Qgr6A

---
_Generated by [Claude Code](https://claude.ai/code/session_01V45AJzVRjV8j2Sei5Qgr6A)_