### PR TITLE
release: physical-only device picker

### DIFF
--- a/scripts/ios-deploy.sh
+++ b/scripts/ios-deploy.sh
@@ -37,26 +37,30 @@ if [ -z "$UDID" ]; then
   # as 'available'); devicectl can reach those too.
   DEVJSON=$(mktemp)
   xcrun devicectl list devices --json-output "$DEVJSON" >/dev/null 2>&1 || true
-  UDID=$(python3 - "$DEVJSON" <<'PYEOF'
-import json, sys
+  UDID=$(python3 - "$DEVJSON" <<'PYINNER'
+import json, re, sys
 try:
     devices = json.load(open(sys.argv[1])).get('result', {}).get('devices', [])
 except Exception:
     devices = []
+# PHYSICAL devices only: hardware UDIDs look like 00008120-XXXXXXXXXXXXXXXX.
+# Simulators carry standard UUIDs — an earlier fallback to d['identifier']
+# happily picked one and devicectl staged the install into CoreSimulator
+# (EBADARCH: device build, simulator target). Never fall back past this.
+HW = re.compile(r'^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{16}$')
+phys = [d for d in devices if HW.match(d.get('hardwareProperties', {}).get('udid') or '')]
 def key(d):
     tunnel = (d.get('connectionProperties', {}).get('tunnelState') or '').lower()
     return 0 if tunnel == 'connected' else 1
-devices.sort(key=key)
-for d in devices:
-    udid = d.get('hardwareProperties', {}).get('udid') or d.get('identifier')
-    if udid:
-        print(udid)
-        break
-PYEOF
+phys.sort(key=key)
+if phys:
+    print(phys[0]['hardwareProperties']['udid'])
+PYINNER
 )
   rm -f "$DEVJSON"
   if [ -z "$UDID" ]; then
-    echo "No iPhone found. Plug it in (unlocked + trusted), or pass a UDID:"
+    echo "No physical iPhone found (simulators are deliberately excluded)."
+    echo "Plug the phone in (unlocked + trusted), or pass a UDID:"
     echo "  sh scripts/ios-deploy.sh \"$SCHEME\" <udid>"
     xcrun devicectl list devices 2>/dev/null || true
     exit 1

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,9 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-07-16
 
+- fix(ios): ios-deploy.sh picked a SIMULATOR — physical devices only now [S]
+  - Second real-run failure mode: the build succeeded (and the bundle-id guard proudly reported the right app), but `devicectl` staged the install into **CoreSimulator** (`EBADARCH`: device-arm64 binary, simulator target). Cause: the JSON picker's fallback to `d['identifier']` — when the phone's tunnel wasn't up, it took "any device," and devicectl's list includes simulators, whose identifiers are standard UUIDs. The picker now accepts ONLY physical hardware (UDID shape `^[0-9A-F]{8}-[0-9A-F]{16}$`), prefers a connected one, and never falls back past that; the no-device error message says simulators are deliberately excluded. Unit-tested: a connected simulator loses to a disconnected physical phone.
+
 - feat(brand): new logo — icon set regenerated from the real art [M]
   - The user's generated brand art landed via the `brand-drop` branch (chat image uploads arrive view-only — no file bytes — so GitHub web upload became the pipeline). **`brand/`** (new top-level dir, dev-only, not in the Docker image) holds the 10 source PNGs: dark/light square marks (1254²), dark/light DEV concepts, dark/light wordmarks, 4 transparent wordmarks.
   - **Generated from the source pixels** (sharp, no re-drawing): `AppIcon.appiconset` 1024 (straight resize of `boomerang_dark.png`), `AppIcon-Dev.appiconset` 1024 (from `boomerang_dev_dark.png`, its baked-in white rounded corners filled with the art's background via an even-odd rounded-rect overlay — the fill seam sits entirely inside the zone iOS's ~22% corner mask removes; the art's own radius is ~16%), PWA `icon-512`/`icon-192`/`apple-touch-icon` PNGs, and `favicon.svg` + legacy `icon-*.svg` as embedded-PNG SVGs of the same art.


### PR DESCRIPTION
Promotes dev → main:

- **fix(ios): ios-deploy.sh picks physical iPhones only** — the identifier fallback could select a simulator (EBADARCH install failure); the picker now requires the physical hardware UDID shape. Script only, no server impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V45AJzVRjV8j2Sei5Qgr6A

---
_Generated by [Claude Code](https://claude.ai/code/session_01V45AJzVRjV8j2Sei5Qgr6A)_