### PR TITLE
release: TestFlight Phase 0 repo prep

### DIFF
--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -439,7 +439,7 @@
 				BOOMERANG_APP_GROUP = group.ryakel.boomerang;
 				BOOMERANG_DISPLAY_NAME = Boomerang;
 				BOOMERANG_URL_SCHEME = boomerang;
-				CODE_SIGN_ENTITLEMENTS = App/App.entitlements;
+				CODE_SIGN_ENTITLEMENTS = App/App.Release.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = L7JZ99D6K5;
@@ -706,7 +706,7 @@
 				BOOMERANG_APP_GROUP = group.ryakel.boomerang.dev;
 				BOOMERANG_DISPLAY_NAME = "Boomerang Dev";
 				BOOMERANG_URL_SCHEME = "boomerang-dev";
-				CODE_SIGN_ENTITLEMENTS = App/App.entitlements;
+				CODE_SIGN_ENTITLEMENTS = App/App.Release.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = L7JZ99D6K5;

--- a/ios/App/App/App.Release.entitlements
+++ b/ios/App/App/App.Release.entitlements
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>aps-environment</key>
+	<string>production</string>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>$(BOOMERANG_APP_GROUP)</string>
+	</array>
+</dict>
+</plist>

--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -35,6 +35,8 @@
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>BoomerangAppGroup</key>
 	<string>$(BOOMERANG_APP_GROUP)</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>

--- a/ios/App/ci_scripts/ci_post_clone.sh
+++ b/ios/App/ci_scripts/ci_post_clone.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+# Xcode Cloud post-clone hook. Xcode Cloud clones the repo and runs xcodebuild
+# — nothing else — so the web bundle (dist/) and the Capacitor sync output
+# (ios/App/App/public + capacitor.config.json) don't exist yet. This script
+# builds them, exactly like the local one-liners do, before the archive step.
+#
+# Lives in ios/App/ci_scripts/ because Xcode Cloud looks for ci_scripts next
+# to the .xcodeproj it's building.
+set -e
+set -x
+
+# Node isn't on the Xcode Cloud runners by default; Homebrew is.
+if ! command -v node >/dev/null 2>&1; then
+  export HOMEBREW_NO_AUTO_UPDATE=1
+  export HOMEBREW_NO_INSTALL_CLEANUP=1
+  brew install node
+fi
+node --version
+npm --version
+
+# Repo root (CI_PRIMARY_REPOSITORY_PATH is set by Xcode Cloud; fall back to
+# walking up from this script for local testing).
+REPO_ROOT="${CI_PRIMARY_REPOSITORY_PATH:-$(cd "$(dirname "$0")/../../.." && pwd)}"
+cd "$REPO_ROOT"
+
+npm ci
+npm run build
+npx cap sync ios
+
+# TestFlight rejects re-used build numbers. Xcode Cloud provides a
+# monotonically increasing CI_BUILD_NUMBER — stamp it into the project so
+# every cloud build uploads cleanly. Local builds keep the static value.
+if [ -n "$CI_BUILD_NUMBER" ]; then
+  cd "$REPO_ROOT/ios/App"
+  xcrun agvtool new-version -all "$CI_BUILD_NUMBER"
+fi
+
+echo "ci_post_clone complete"

--- a/wiki/TestFlight-Xcode-Cloud.md
+++ b/wiki/TestFlight-Xcode-Cloud.md
@@ -10,26 +10,24 @@ times over; cloud-managed signing means no certificates to export or renew.
 
 ---
 
-## Phase 0 — repo prep (Claude, no Mac needed)
+## Phase 0 — repo prep (DONE 2026-07-16)
 
-1. **`ios/App/ci_scripts/ci_post_clone.sh`** — Xcode Cloud clones the repo and
-   runs `xcodebuild`, nothing else. This script must install Node (Homebrew is
-   preinstalled on the runners), then `npm ci && npm run build && npx cap sync
-   ios` so `dist/` + the synced native assets exist before the archive step.
-   Without it every cloud build fails on the missing web bundle.
-2. **Entitlements split for APNs environment** — the committed
-   `App.entitlements` says `aps-environment: development` (correct for Xcode
-   sideloads). TestFlight builds need `production`. Add
-   `App.Release.entitlements` (production) and point `CODE_SIGN_ENTITLEMENTS`
-   at it in the Release/Release-Dev configs only — Debug sideloads keep
-   sandbox, archives get production, no manual switching.
-3. **`ITSAppUsesNonExemptEncryption = false`** in Info.plist — otherwise every
-   TestFlight build parks on a manual export-compliance questionnaire in App
-   Store Connect. (Standard HTTPS-only apps qualify for the exemption.)
-4. **Build-number auto-increment** — TestFlight rejects re-used build numbers.
-   Set `CURRENT_PROJECT_VERSION = $(CI_BUILD_NUMBER)`-style wiring (Xcode
-   Cloud exposes the counter; local builds fall back to the static value).
-5. Docs: fold the resulting click-path back into this page.
+All landed:
+
+1. **`ios/App/ci_scripts/ci_post_clone.sh`** — installs Node via Homebrew if
+   missing, then `npm ci && npm run build && npx cap sync ios` from
+   `CI_PRIMARY_REPOSITORY_PATH`, and stamps `CI_BUILD_NUMBER` into the project
+   via `agvtool new-version -all` so every cloud build uploads with a fresh
+   build number. Local builds keep the static value (the agvtool step only
+   runs when `CI_BUILD_NUMBER` is set).
+2. **Entitlements split** — `App.Release.entitlements`
+   (`aps-environment: production`) wired to `CODE_SIGN_ENTITLEMENTS` in the
+   App target's `Release` + `Release-Dev` configs only (verified per-block);
+   Debug sideloads keep sandbox via the original `App.entitlements`.
+3. **`ITSAppUsesNonExemptEncryption = false`** in Info.plist — no manual
+   export-compliance questionnaire per build.
+4. Everything validated: plists parse (dev=development, release=production),
+   pbxproj parses via mod-pbxproj, script `sh -n` clean.
 
 ## Phase 1 — App Store Connect app record (you, ~5 min)
 

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,9 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-07-16
 
+- feat(ios): TestFlight/Xcode Cloud Phase 0 — repo prep [S]
+  - `ios/App/ci_scripts/ci_post_clone.sh` (Xcode Cloud builds the web bundle: brew node if missing → `npm ci` → `npm run build` → `cap sync ios` → `agvtool new-version -all $CI_BUILD_NUMBER` for TestFlight-unique build numbers; local builds unaffected). `App.Release.entitlements` with `aps-environment: production` wired to the App target's Release/Release-Dev configs only (Debug sideloads keep sandbox — no manual env switching, archives are production automatically). `ITSAppUsesNonExemptEncryption = false` in Info.plist (kills the per-build export-compliance questionnaire). Validated: both entitlements plists + Info.plist parse with correct values, pbxproj parses, per-block verification that only Release/Release-Dev reference the new file. Remaining phases (App Store Connect record, repo connect, workflow creation, `APNS_ENV=production` flip AFTER the TestFlight build registers) are the account-holder's — click-path in `wiki/TestFlight-Xcode-Cloud.md`.
+
 - fix(ios): ios-deploy.sh picked a SIMULATOR — physical devices only now [S]
   - Second real-run failure mode: the build succeeded (and the bundle-id guard proudly reported the right app), but `devicectl` staged the install into **CoreSimulator** (`EBADARCH`: device-arm64 binary, simulator target). Cause: the JSON picker's fallback to `d['identifier']` — when the phone's tunnel wasn't up, it took "any device," and devicectl's list includes simulators, whose identifiers are standard UUIDs. The picker now accepts ONLY physical hardware (UDID shape `^[0-9A-F]{8}-[0-9A-F]{16}$`), prefers a connected one, and never falls back past that; the no-device error message says simulators are deliberately excluded. Unit-tested: a connected simulator loses to a disconnected physical phone.
 


### PR DESCRIPTION
Promotes dev → main:

- **feat(ios): TestFlight/Xcode Cloud Phase 0** — `ci_post_clone.sh` (cloud runners build the web bundle + stamp CI build numbers), Release-entitlements split (`aps-environment: production` for archives, sandbox stays for Debug sideloads), export-compliance plist key.

Must be on `main` before the Xcode Cloud workflow is created (the workflow builds from main). iOS project files only; no server impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V45AJzVRjV8j2Sei5Qgr6A

---
_Generated by [Claude Code](https://claude.ai/code/session_01V45AJzVRjV8j2Sei5Qgr6A)_