### PR TITLE
fix(sync): native-app settings never saved — stale-client guard swallowed every push [M]

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -343,9 +343,16 @@ function guardStaleClient(req, res) {
     res.json({ ok: true }) // 200 so old code doesn't retry
     return true
   }
-  // Reject pushes from clients running an old app version
+  // Reject pushes from clients running an old app version. WEB only: this
+  // guard exists for stale cached JS after a deploy (remedy = reload). The
+  // native shell's bundled version is stamped by the Mac/Xcode Cloud build
+  // and can never equal the Docker APP_VERSION — treating that as staleness
+  // silently swallowed every settings toggle made in the native app
+  // (2026-07-16 "push notifications are not staying enabled"). Native
+  // clients skip this check; the data-version check below still applies to
+  // them, which is the guard that actually prevents behind-data clobbers.
   const clientAppVer = req.body._appVersion
-  if (clientAppVer && clientAppVer !== 'dev' && clientAppVer !== appVersion) {
+  if (clientAppVer && req.body._platform !== 'native' && clientAppVer !== 'dev' && clientAppVer !== appVersion) {
     console.log(`[SYNC] REJECTED stale push from app ${clientAppVer} (server is ${appVersion})`)
     res.json({ ok: true, version: getVersion() })
     return true

--- a/src/hooks/useServerSync.js
+++ b/src/hooks/useServerSync.js
@@ -110,6 +110,11 @@ export function useServerSync(tasks, routines, onHydrate, onVersionMismatch) {
     }
     payload._clientId = clientId
     payload._appVersion = typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : 'dev'
+    // The native shell's bundle version is stamped by the Mac build and can
+    // NEVER equal the server's Docker APP_VERSION — the server's stale-client
+    // guard must not treat that mismatch as staleness (same class as the
+    // version-mismatch reload loop, sync edition).
+    payload._platform = isNativeShell() ? 'native' : 'web'
 
     remoteLog('push: PUT /api/data (settings/labels) keys=' + Object.keys(payload).filter(k => !k.startsWith('_')).join(','))
     setSyncStatus('saving')
@@ -492,6 +497,11 @@ export function useServerSync(tasks, routines, onHydrate, onVersionMismatch) {
       if (payload) {
         payload._clientId = clientId
         payload._appVersion = typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : 'dev'
+    // The native shell's bundle version is stamped by the Mac build and can
+    // NEVER equal the server's Docker APP_VERSION — the server's stale-client
+    // guard must not treat that mismatch as staleness (same class as the
+    // version-mismatch reload loop, sync edition).
+    payload._platform = isNativeShell() ? 'native' : 'web'
         navigator.sendBeacon(
           '/api/data',
           new Blob([JSON.stringify(payload)], { type: 'application/json' })

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,12 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-07-16
 
+- fix(sync): native-app settings never saved — stale-client guard swallowed every push [M]
+  - Prod report (round 3 of "toggles won't stay"): the Push master kept reverting when toggled from the native app. Root cause is the sync-side twin of the version-mismatch reload loop: `guardStaleClient` rejects any bulk `/api/data` push whose `_appVersion` ≠ the server's `APP_VERSION` — silently, returning `{ok:true}` — as a stale-cached-JS defense. In the PWA the versions always match (the bundle is built inside the same Docker build). In the NATIVE shell they can never match (bundle stamped by the Mac/Xcode Cloud git checkout vs. the Docker tag), so every settings write from the native app was accepted-and-discarded, then reverted on the next hydrate.
+  - Fix: bulk pushes now carry `_platform` (`native`/`web`, from `isNativeShell()`); the app-version equality check is skipped for native clients — it's a WEB staleness heuristic whose remedy (reload) doesn't exist for a pinned native bundle. The data-version staleness check (`_version < serverVer`) still applies to all clients, which is the guard that actually prevents behind-data clobbers; `preserveAbsentSettings` + the durable-key merges are unaffected.
+  - Live-verified both directions: native client with mismatched app version → settings persist; stale WEB client with mismatched version → still silently rejected, stored settings untouched.
+  - NOTE: needs BOTH sides — the server (container cycle) and a rebuilt app (the client must send `_platform`). Until the next `npm run ios:*`, settings changes should be made from the PWA.
+
 - fix(loops): ended loops left on Today forever + "Resting" archive section [M]
   - Prod report: a loop with end date Jul 14 still surfaced in Today's Loops section on Jul 16, and the user wanted pause/end to behave like an ARCHIVE — stats kept, reactivation possible. Three parts:
   - **The bug:** `isRoutineDue()` in store.js respects `end_date`, but Kept's `TodayView` computes its own due check (`dueKey <= todayKey` from `getNextDueDate`) and never consulted it — an ended loop surfaced daily forever (spawning was already correctly stopped, so only the card lingered). New exported `isRoutineEnded()` in store.js (reused inside `isRoutineDue`); TodayView's loops memo now filters `!paused && !isRoutineEnded`.


### PR DESCRIPTION
## What

Round 3 of "toggles won't stay" — the Push master kept reverting when toggled **from the native app**.

## Root cause

The sync-side twin of the version-mismatch reload loop: `guardStaleClient` silently rejects (returns `{ok:true}`!) any bulk `/api/data` push whose `_appVersion` ≠ the server's `APP_VERSION` — a defense against stale cached web JS. In the PWA the versions always match (bundle built inside the same Docker build). In the **native shell they can never match** (bundle version = Mac/Xcode Cloud git checkout; server version = Docker tag). So every settings write from the native app was accepted-and-discarded, then reverted on the next hydrate.

## Fix

- Bulk pushes carry `_platform` (`native`/`web`, via `isNativeShell()`).
- The app-version equality check is now **web-only** — its remedy (reload the page for fresh JS) doesn't exist for a pinned native bundle.
- The data-version staleness check (`_version < serverVer`) still applies to **all** clients — that's the guard that actually prevents behind-data clobbers. `preserveAbsentSettings` + durable-key merges unaffected.

## Validation (live server)

- Native client with mismatched app version → **settings persist** (verified round-trip)
- Stale WEB client with mismatched version → **still silently rejected**, stored settings untouched
- lint 0 errors, build + tests + smoke green

## Rollout note

Needs both sides: the server (container cycle) **and** a rebuilt app (client must send `_platform`). Until the next `npm run ios:*`, make settings changes from the PWA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V45AJzVRjV8j2Sei5Qgr6A

---
_Generated by [Claude Code](https://claude.ai/code/session_01V45AJzVRjV8j2Sei5Qgr6A)_