### PR TITLE
release: Quokka history + search, Integrations tidy

### DIFF
--- a/src/components/AdviserModal.jsx
+++ b/src/components/AdviserModal.jsx
@@ -101,6 +101,37 @@ function ExpiryBanner({ chat, onStar }) {
 }
 
 function ChatList({ chats, activeId, onSwitch, onDelete, onStar, onUnstar, onNew, onBack }) {
+  // Search: titles match instantly; on a 2+ char query the full message
+  // bodies are fetched once (lazily, cached) so content matches too — the
+  // chat count is personal-app small, so fetch-all is fine.
+  const [query, setQuery] = useState('')
+  const [bodies, setBodies] = useState({})
+  const [searchingBodies, setSearchingBodies] = useState(false)
+  useEffect(() => {
+    if (query.trim().length < 2) return
+    const missing = chats.filter(c => bodies[c.id] === undefined)
+    if (missing.length === 0) return
+    let alive = true
+    setSearchingBodies(true)
+    ;(async () => {
+      const api = await import('../api')
+      const fetched = {}
+      await Promise.all(missing.map(async (c) => {
+        try {
+          const full = await api.adviserGetChat(c.id)
+          fetched[c.id] = (full?.messages || []).map(m => typeof m?.content === 'string' ? m.content : '').join('\n').toLowerCase()
+        } catch { fetched[c.id] = '' }
+      }))
+      if (alive) { setBodies(prev => ({ ...prev, ...fetched })); setSearchingBodies(false) }
+    })()
+    return () => { alive = false }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [query, chats])
+  const q = query.trim().toLowerCase()
+  const shown = q.length === 0 ? chats : chats.filter(c =>
+    (c.title || '').toLowerCase().includes(q)
+    || (q.length >= 2 && (bodies[c.id] || '').includes(q)),
+  )
   return (
     <div className="v2-adviser-history">
       <div className="v2-adviser-history-bar">
@@ -109,6 +140,21 @@ function ChatList({ chats, activeId, onSwitch, onDelete, onStar, onUnstar, onNew
           <Plus size={14} strokeWidth={2} /> New
         </button>
       </div>
+      <div style={{ padding: '0 2px 10px' }}>
+        <input
+          type="search"
+          className="v2-form-input"
+          placeholder="Search chats — titles and messages"
+          value={query}
+          onChange={e => setQuery(e.target.value)}
+          aria-label="Search chat history"
+        />
+        {q.length >= 2 && (
+          <div style={{ fontSize: 11.5, color: 'var(--v2-text-meta, #8a8378)', marginTop: 4 }}>
+            {searchingBodies ? 'Searching message contents…' : `${shown.length} match${shown.length !== 1 ? 'es' : ''}`}
+          </div>
+        )}
+      </div>
       {chats.length === 0 ? (
         <EmptyState
           title="No chats yet"
@@ -116,7 +162,7 @@ function ChatList({ chats, activeId, onSwitch, onDelete, onStar, onUnstar, onNew
         />
       ) : (
         <ul className="v2-adviser-chat-list">
-          {chats.map(c => {
+          {shown.map(c => {
             const days = daysUntil(c.expiresAt)
             const expiring = !c.starred && days != null && days <= 7
             const active = c.id === activeId
@@ -285,8 +331,12 @@ export default function AdviserModal({ open, adviser, onClose, onAfterCommit, on
           onClick={() => setShowHistory(v => !v)}
           aria-label="Chats"
         >
+          {/* The mobile chip used to render a SEARCH icon here (Wallaby-era
+            * "search-style chip") for what is actually the chat HISTORY —
+            * reported in prod as "can't get to my chat history without
+            * knowing the search is history". History icon + count, always. */}
           {wallaby
-            ? <Search size={18} strokeWidth={2} />
+            ? <><History size={17} strokeWidth={2} />{chats.length > 0 && <span style={{ fontSize: 11.5, fontWeight: 700, marginLeft: 3 }}>{chats.length}</span>}</>
             : <><History size={14} strokeWidth={1.75} /> {chats.length > 0 ? `${chats.length} chat${chats.length !== 1 ? 's' : ''}` : 'Chats'}</>}
         </button>
         {!showHistory && (

--- a/src/components/SettingsModal.css
+++ b/src/components/SettingsModal.css
@@ -314,6 +314,8 @@
   gap: 6px;
   height: 34px;
   padding: 0 14px;
+  white-space: nowrap;
+  flex-shrink: 0;
   border-radius: var(--v2-radius-pill);
   background: transparent;
   color: var(--v2-text-meta);
@@ -1189,6 +1191,24 @@
   gap: 12px;
   font: 400 13px/1.4 var(--v2-font-body);
   color: var(--v2-text);
+}
+
+.v2-integrations-toggle-row > span:first-child {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+/* Sub-section labels inside an expanded integration (Sync parent /
+   Knowledge base / Database sync / Page template) — one consistent
+   rhythm instead of ad-hoc inline margins. */
+.v2-integrations-inline .v2-form-label {
+  margin-top: 14px;
+  margin-bottom: 2px;
+}
+
+.v2-integrations-inline .v2-form-label:first-child {
+  margin-top: 4px;
 }
 
 .v2-integrations-toggle-btn {

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -897,8 +897,8 @@ function IntegrationsPanel({
       <div className="v2-settings-block">
         <div className="v2-form-label">Status</div>
         <div className="v2-settings-row-hint">
-          Connect, configure, and disconnect every integration inline. Tokens are shared
-          Tokens persist across reloads — you only connect once.
+          Connect, configure, and disconnect every integration inline. Tokens persist
+          across reloads — you only connect once.
         </div>
         <ul className="v2-integrations-list">
           {integrations.map(int => (

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,11 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-07-16
 
+- fix(ui): Quokka history discoverability + chat search; Integrations tidy-up [M]
+  - **Quokka history** (prod: "can't easily get to my chat history without knowing the search is history"): the mobile toolbar chip rendered a SEARCH icon for the chat-history toggle — a Wallaby-era leftover ("search-style chip") that Kept inherited. It's now a History icon + chat count on every theme.
+  - **Chat search** (prod: "Also I have no search"): the history panel gains a search field — titles match instantly; a 2+ character query lazily fetches full message bodies once (cached) so message CONTENT matches too, with a match count / "searching contents…" line.
+  - **Integrations panel** (prod: "looks like shit"): fixed the garbled intro copy ("Tokens are shared Tokens persist across reloads"); `.v2-settings-btn` no longer wraps its label mid-word ("Sync\nnow") or gets crushed in flex rows (`white-space: nowrap` + `flex-shrink: 0`); toggle-row text owns the squeeze (`min-width: 0` + `overflow-wrap`); sub-section labels (Sync parent / Knowledge base / Database sync) get one consistent spacing rhythm instead of ad-hoc inline margins. A full visual redesign of the panel still wants a dedicated design pass with live rendering — this is the make-it-not-broken tier.
+
 - fix(ios): BoomerangNative plugin was never registered — App Group stayed empty, Siri intent dead [S]
   - First real Siri test: the intent RAN (registered in Shortcuts, executed) but replied "Open Boomerang and connect to your server first" on a fully-connected phone. Root cause: Capacitor 6+ does not auto-discover plugins compiled into the app binary — `BoomerangNative` (the localStorage→App Group config bridge from Phase 0) was a well-formed `CAPBridgedPlugin` that nothing ever registered, so every JS `setSharedConfig` call silently failed and the App Group never received `boom_api_base`/`boom_api_token`. The Share Extension reads the same App Group and would have failed identically. Fix: `capacitorDidLoad()` override in `BoomerangViewController` calls `bridge?.registerPluginInstance(BoomerangNative())`. After rebuild + one app launch (the interceptor-install mirror pushes the config), the intent and Share Extension have credentials.
 


### PR DESCRIPTION
Promotes dev → main:

- **fix(ui): Quokka history discoverability + chat search; Integrations tidy-up** — History icon + count replaces the misleading Search icon, real search over chat titles + message contents, garbled Integrations copy fixed, pill/row layout hardening.

Lint + build + tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V45AJzVRjV8j2Sei5Qgr6A

---
_Generated by [Claude Code](https://claude.ai/code/session_01V45AJzVRjV8j2Sei5Qgr6A)_