### PR TITLE
docs(ios): Private Relay breaks Siri/Shortcuts DNS on tailnet hostnames

### DIFF
--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,9 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-07-16
 
+- docs(ios): iCloud Private Relay breaks Siri/Shortcuts DNS on tailnet-only hostnames [XS]
+  - On-device debugging after the plugin-registration fix: the Siri intent got past the config gate but failed with "A server with the specified hostname could not be found" — while Safari and the app reached the same hostname on the same phone at the same moment. Root cause (user-confirmed by toggling it off): **iCloud Private Relay** routes DNS for background/system-initiated requests (App Intents from Siri/Shortcuts, Share Extension) through Apple's DNS proxy, bypassing Tailscale's resolver — and the server hostname has no public DNS record. Documented in `wiki/iOS-Native-App.md` (Connectivity section): symptom, confirmed culprit, and the two fixes — Private Relay / Limit IP Address Tracking off, or (durable) a public A record pointing the hostname at the server's Tailscale `100.x` IP so any resolver answers while routing stays tunnel-only. Not fixable from app code; doc-only change.
+
 - fix(ui): Quokka history discoverability + chat search; Integrations tidy-up [M]
   - **Quokka history** (prod: "can't easily get to my chat history without knowing the search is history"): the mobile toolbar chip rendered a SEARCH icon for the chat-history toggle — a Wallaby-era leftover ("search-style chip") that Kept inherited. It's now a History icon + chat count on every theme.
   - **Chat search** (prod: "Also I have no search"): the history panel gains a search field — titles match instantly; a 2+ character query lazily fetches full message bodies once (cached) so message CONTENT matches too, with a match count / "searching contents…" line.

--- a/wiki/iOS-Native-App.md
+++ b/wiki/iOS-Native-App.md
@@ -17,6 +17,27 @@ server on your tailnet and run Tailscale on the iPhone; the app reaches the
 tailnet hostname from anywhere with no public exposure. The `API_TOKEN` gates
 every request.
 
+**⚠️ iCloud Private Relay breaks Siri/Shortcuts/Share (2026-07-16, verified
+on-device).** The hostname only resolves through Tailscale's DNS, and iOS
+routes DNS for *background/system-initiated* requests — the App Intent run
+from Siri/Shortcuts, the Share Extension — through Apple's Private Relay DNS
+proxy, which bypasses the tunnel's resolver entirely. Symptom: the intent
+fails with **"A server with the specified hostname could not be found"** while
+Safari and the app itself reach the same hostname fine on the same phone at
+the same moment (foreground app traffic resolves on-host through the tunnel).
+Confirmed culprit: **Settings → Apple ID → iCloud → Private Relay** (the
+per-network **Limit IP Address Tracking** toggle triggers the same path).
+Fixes, either works:
+- Turn Private Relay off (or Limit IP Address Tracking off for your networks).
+- **Durable:** add a *public* A record for the hostname pointing at the
+  server's Tailscale `100.x` IP. Every resolver (including Apple's proxy) then
+  returns the right answer; routing still requires the tunnel, and `100.x` is
+  unreachable off-tailnet, so nothing is exposed. This survives iOS updates
+  and lets Private Relay stay on.
+
+This is a resolver-selection issue in iOS, not fixable from app code — the
+intent just calls `URLSession` and iOS picks the DNS path per context.
+
 ---
 
 ## The standard rebuild (start here every time)


### PR DESCRIPTION
## What

Documents the iCloud Private Relay DNS gotcha discovered (and user-confirmed on-device) while getting the Siri "Add Boomerang task" intent working.

**The failure:** background/system-initiated requests — App Intents run from Siri/Shortcuts, the Share Extension — resolve DNS through Apple's Private Relay proxy, which bypasses Tailscale's resolver. The server hostname is tailnet-only, so the intent fails with *"A server with the specified hostname could not be found"* while Safari and the app itself reach the same hostname on the same phone at the same moment.

**Confirmed culprit:** Settings → Apple ID → iCloud → **Private Relay** (per-network **Limit IP Address Tracking** triggers the same path).

**Fixes documented:**
- Private Relay / Limit IP Address Tracking off
- Durable: a public A record pointing the hostname at the server's Tailscale `100.x` IP — any resolver then answers, routing stays tunnel-only, nothing is exposed (100.x is unreachable off-tailnet), and Private Relay can stay on

Doc-only: `wiki/iOS-Native-App.md` (Connectivity section) + `wiki/Version-History.md` entry. Not fixable from app code — iOS picks the DNS path per request context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V45AJzVRjV8j2Sei5Qgr6A

---
_Generated by [Claude Code](https://claude.ai/code/session_01V45AJzVRjV8j2Sei5Qgr6A)_