### PR TITLE
feat(settings): build/version rows minimized — tap the label for the description

### DIFF
--- a/src/components/SettingsModal.css
+++ b/src/components/SettingsModal.css
@@ -1300,3 +1300,26 @@
 .v2-settings-section:last-child {
   border-bottom: none;
 }
+
+/* Tap-for-description rows (build/version). Label + info glyph is the tap
+   target; the hint paragraph only renders while expanded. */
+.v2-settings-info-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+  text-align: left;
+  color: inherit;
+  font: inherit;
+}
+.v2-settings-info-icon {
+  color: var(--v2-text-meta);
+  flex-shrink: 0;
+}
+.v2-settings-info-label[aria-expanded="true"] .v2-settings-info-icon {
+  color: var(--v2-text);
+}

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
-import { Trash2, Download, Upload, RefreshCw, Copy, FileText, ArrowUp, ArrowDown, Plus, ChevronRight, Server } from 'lucide-react'
+import { Trash2, Download, Upload, RefreshCw, Copy, FileText, ArrowUp, ArrowDown, Plus, ChevronRight, Server, Info } from 'lucide-react'
 import { isNativeShell, getApiBase, requestConnectionSetup } from '../apiConfig'
 import {
   loadSettings, saveSettings, loadTasks, saveTasks,
@@ -39,6 +39,31 @@ function SettingsSection({ label, hint, children, defaultOpen = false }) {
         </span>
       </button>
       {open && children}
+    </div>
+  )
+}
+
+// Row whose explanatory hint stays hidden until the label is tapped
+// (2026-07-17: "Build numbers — I want to click on each for a description —
+// otherwise they should be minimized"). The control/value stays visible;
+// only the paragraph folds.
+function InfoHintRow({ label, hint, children }) {
+  const [show, setShow] = useState(false)
+  return (
+    <div className="v2-settings-row">
+      <div className="v2-settings-row-text">
+        <button
+          type="button"
+          className="v2-settings-info-label"
+          onClick={() => setShow(s => !s)}
+          aria-expanded={show}
+        >
+          <span className="v2-settings-row-label">{label}</span>
+          <Info size={13} strokeWidth={1.75} className="v2-settings-info-icon" aria-hidden="true" />
+        </button>
+        {show && <div className="v2-settings-row-hint">{hint}</div>}
+      </div>
+      {children}
     </div>
   )
 }
@@ -3096,26 +3121,24 @@ export default function SettingsModal({
             </SettingsSection>
 
             <SettingsSection label="Build & version" hint="What this client and the server are running.">
-            <div className="v2-settings-row">
-              <div className="v2-settings-row-text">
-                <div className="v2-settings-row-label">App build</div>
-                <div className="v2-settings-row-hint">The bundle this client is running (in the native app: what Xcode installed; on the web: what the server served).</div>
-              </div>
+            <InfoHintRow
+              label="App build"
+              hint="The bundle this client is running (in the native app: what Xcode installed; on the web: what the server served)."
+            >
               <code
                 className="v2-settings-build"
                 onClick={handleBuildTap}
                 role="button"
                 tabIndex={-1}
               >{__APP_VERSION__}</code>
-            </div>
+            </InfoHintRow>
 
-            <div className="v2-settings-row">
-              <div className="v2-settings-row-text">
-                <div className="v2-settings-row-label">Server version</div>
-                <div className="v2-settings-row-hint">Live from the connected server's /api/health — what's actually deployed there right now. These two are DIFFERENT builds in the native app; they only match on the web.</div>
-              </div>
+            <InfoHintRow
+              label="Server version"
+              hint="Live from the connected server's /api/health — what's actually deployed there right now. These two are DIFFERENT builds in the native app; they only match on the web."
+            >
               <code className="v2-settings-build">{serverVersion || '…'}</code>
-            </div>
+            </InfoHintRow>
             </SettingsSection>
           </div>
         )}

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,9 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-07-17
 
+- feat(settings): build/version rows minimized — tap the label for the description [XS]
+  - Follow-up to the start-minimized pass: the App build and Server version rows carried paragraph-length explanations that always rendered. New `InfoHintRow` (label + \u24d8 glyph as the tap target) keeps just the label and the version chip visible; tapping the label reveals/hides the description. The build-tap easter-egg stays on the version code itself.
+
 - feat(settings): every Settings section starts minimized [M]
   - Prod request: "Settings should start minimized across the board. They seem to retain last state, but they get really long and really messy." Root of the mess: Notifications + Integrations persisted their fold state in settings with an all-expanded default — whatever you ever expanded stayed expanded forever — and General/Tasks/Data had no folding at all.
   - New shared `SettingsSection` component (chevron header reusing the existing section-header styling): SESSION-LOCAL state, always starts collapsed, deliberately un-persisted. Notifications + Integrations flipped from the persisted `collapsed_*_sections` maps to the same session-local start-collapsed behavior (the old settings keys become inert, like `v1_disabled`). General wrapped into Appearance / Home screen / Build & version; Tasks into Task behavior / Impact dates / AI tone / AI models & keys; Data into Server connection / Backup / Activity / Server logs / Markdown import / Developer / Danger zone. Labels stays flat (the list IS the content).


### PR DESCRIPTION
Follow-up to the start-minimized Settings pass: the **App build** and **Server version** rows carried always-visible paragraph explanations.

New `InfoHintRow` component: only the label (with a small ⓘ glyph) and the version chip render by default; tapping the label toggles the description. The version-code tap easter egg is untouched. Lint/build/tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V45AJzVRjV8j2Sei5Qgr6A

---
_Generated by [Claude Code](https://claude.ai/code/session_01V45AJzVRjV8j2Sei5Qgr6A)_