### PR TITLE
fix(analytics): heatmap shows data on mobile; AI tab findable; Flight log ↔ Analytics de-duped

### DIFF
--- a/src/AppV2.jsx
+++ b/src/AppV2.jsx
@@ -1711,6 +1711,7 @@ export default function AppV2() {
       <FlightLog
         open={showFlightLog}
         onClose={() => setShowFlightLog(false)}
+        onOpenAnalytics={() => { setShowFlightLog(false); setShowAnalytics(true) }}
         tasks={tasks}
         routines={routines}
         records={records}

--- a/src/components/AnalyticsModal.css
+++ b/src/components/AnalyticsModal.css
@@ -42,26 +42,28 @@
   border-color: var(--v2-text);
 }
 
-/* Section tabs (Overview / Tasks / Habits) */
+/* Section tabs — underline navigation (NOT a segmented control; the range +
+   metric pickers below already use that shape, and three identical pill rows
+   made the tabs unreadable as navigation). Mirrors the Settings tab strip. */
 .v2-analytics-tabs {
   display: flex;
-  gap: 4px;
+  gap: 18px;
   margin: 0 0 16px;
+  border-bottom: 1px solid var(--v2-hairline);
 }
 .v2-analytics-tab {
-  flex: 1 1 0;
-  padding: 9px 10px;
-  border-radius: var(--v2-radius-pill);
+  padding: 8px 2px 10px;
   background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
   color: var(--v2-text-meta);
-  border: 1px solid var(--v2-hairline);
-  font: 700 12px/1 var(--v2-font-body);
+  font: 700 13px/1 var(--v2-font-body);
   cursor: pointer;
 }
 .v2-analytics-tab-active {
-  background: var(--v2-text);
-  color: var(--v2-bg);
-  border-color: var(--v2-text);
+  color: var(--v2-text);
+  border-bottom-color: var(--v2-accent, #F26640);
 }
 
 .v2-analytics-summary {
@@ -236,10 +238,18 @@
   text-align: right;
 }
 
-/* 52-week heatmap */
+/* 52-week heatmap. The wrap scrolls; the inner container is the grid's
+   natural width and carries the month labels, so labels and columns stay
+   aligned while scrolling (they used to live outside the scroller and
+   compressed to the viewport width — total label/column mismatch). */
 .v2-analytics-heatmap-wrap {
-  position: relative;
   overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.v2-analytics-heatmap-inner {
+  position: relative;
+  width: max-content;
   padding-top: 18px;
 }
 

--- a/src/components/AnalyticsModal.jsx
+++ b/src/components/AnalyticsModal.jsx
@@ -1,10 +1,8 @@
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect, useMemo, useRef } from 'react'
 import { ENERGY_TYPES, loadLabels } from '../store'
 import ModalShell from './ModalShell'
 import EmptyState from './EmptyState'
 import BalanceRadar from './BalanceRadar'
-import BadgesGrid from './BadgesGrid'
-import { computeBadges } from '../badges'
 import { BarChart3 } from 'lucide-react'
 import './AnalyticsModal.css'
 
@@ -52,7 +50,9 @@ function buildHeatMapGrid(dailyData, metric) {
   return { weeks, months, maxVal }
 }
 
-export default function AnalyticsModal({ open, onClose, tasks = [], routines = [], records = {}, streak = 0 }) {
+// Extra props (tasks/records/streak) were consumed by the badges grid,
+// which moved to the Flight log — callers may still pass them; ignored.
+export default function AnalyticsModal({ open, onClose, routines = [] }) {
   const labels = useMemo(() => loadLabels(), [])
   const labelMap = useMemo(() => Object.fromEntries(labels.map(l => [l.id, l])), [labels])
   const [range, setRange] = useState(30)
@@ -115,11 +115,14 @@ export default function AnalyticsModal({ open, onClose, tasks = [], routines = [
 
   const heatMap = useMemo(() => buildHeatMapGrid(heatMapData, heatMapMetric), [heatMapData, heatMapMetric])
 
-  // Local achievements — derived from data we already have (no new schema).
-  const badges = useMemo(() => computeBadges({
-    lifetimeDone: tasks.filter(t => t.status === 'done').length,
-    routines, records, streak, history: heatMapData || [], tasks,
-  }), [tasks, routines, records, streak, heatMapData])
+  // The grid is wider than a phone; start scrolled to NOW (right edge) —
+  // otherwise mobile shows only the year-old left half, which reads as a
+  // completely empty heatmap (2026-07-17 prod report).
+  const heatmapScrollRef = useRef(null)
+  useEffect(() => {
+    const el = heatmapScrollRef.current
+    if (el) el.scrollLeft = el.scrollWidth
+  }, [open, tab, heatMap])
 
   // Radar spokes derived from history.
   const radarSpokes = useMemo(() => {
@@ -162,6 +165,27 @@ export default function AnalyticsModal({ open, onClose, tasks = [], routines = [
 
   return (
     <ModalShell open={open} onClose={onClose} title="Analytics" width="wide">
+      {/* Section tabs — the modal's primary navigation, so they come FIRST
+          and are styled as underline tabs (2026-07-17: they used to render
+          below two identical-looking segmented controls and read as a third
+          picker — the AI tab was invisible in practice). */}
+      <div className="v2-analytics-tabs" role="tablist" aria-label="Analytics sections">
+        {[
+          { id: 'overview', label: 'Overview' },
+          { id: 'tasks', label: 'Tasks' },
+          { id: 'habits', label: 'Habits' },
+          { id: 'ai', label: 'AI' },
+        ].map(t => (
+          <button
+            key={t.id}
+            role="tab"
+            aria-selected={tab === t.id}
+            className={`v2-analytics-tab${tab === t.id ? ' v2-analytics-tab-active' : ''}`}
+            onClick={() => setTab(t.id)}
+          >{t.label}</button>
+        ))}
+      </div>
+
       {/* Range + metric controls */}
       <div className="v2-analytics-toolbar">
         <div className="v2-analytics-range">
@@ -175,20 +199,22 @@ export default function AnalyticsModal({ open, onClose, tasks = [], routines = [
             </button>
           ))}
         </div>
-        <div className="v2-analytics-metric">
-          <button
-            className={`v2-analytics-metric-btn${metric === 'tasks' ? ' v2-analytics-metric-btn-active' : ''}`}
-            onClick={() => setMetric('tasks')}
-          >
-            Tasks
-          </button>
-          <button
-            className={`v2-analytics-metric-btn${metric === 'points' ? ' v2-analytics-metric-btn-active' : ''}`}
-            onClick={() => setMetric('points')}
-          >
-            Points
-          </button>
-        </div>
+        {(tab === 'overview' || tab === 'tasks') && (
+          <div className="v2-analytics-metric">
+            <button
+              className={`v2-analytics-metric-btn${metric === 'tasks' ? ' v2-analytics-metric-btn-active' : ''}`}
+              onClick={() => setMetric('tasks')}
+            >
+              Tasks
+            </button>
+            <button
+              className={`v2-analytics-metric-btn${metric === 'points' ? ' v2-analytics-metric-btn-active' : ''}`}
+              onClick={() => setMetric('points')}
+            >
+              Points
+            </button>
+          </div>
+        )}
       </div>
 
       {!history ? (
@@ -206,28 +232,12 @@ export default function AnalyticsModal({ open, onClose, tasks = [], routines = [
       ) : (
         <>
           {/* Summary line */}
-          <div className="v2-analytics-summary">
-            <span className="v2-analytics-summary-num">{metric === 'tasks' ? history.totalTasks : history.totalPoints}</span>
-            <span className="v2-analytics-summary-label">{metric === 'tasks' ? 'tasks' : 'points'} · last {range || 'all'} {range ? 'days' : 'time'}</span>
-          </div>
-
-          {/* Section tabs */}
-          <div className="v2-analytics-tabs" role="tablist" aria-label="Analytics sections">
-            {[
-              { id: 'overview', label: 'Overview' },
-              { id: 'tasks', label: 'Tasks' },
-              { id: 'habits', label: 'Habits' },
-              { id: 'ai', label: 'AI' },
-            ].map(t => (
-              <button
-                key={t.id}
-                role="tab"
-                aria-selected={tab === t.id}
-                className={`v2-analytics-tab${tab === t.id ? ' v2-analytics-tab-active' : ''}`}
-                onClick={() => setTab(t.id)}
-              >{t.label}</button>
-            ))}
-          </div>
+          {(tab === 'overview' || tab === 'tasks') && (
+            <div className="v2-analytics-summary">
+              <span className="v2-analytics-summary-num">{metric === 'tasks' ? history.totalTasks : history.totalPoints}</span>
+              <span className="v2-analytics-summary-label">{metric === 'tasks' ? 'tasks' : 'points'} · last {range || 'all'} {range ? 'days' : 'time'}</span>
+            </div>
+          )}
 
           {/* Daily chart */}
           {tab === 'overview' && history.daily?.length > 0 && (
@@ -423,7 +433,8 @@ export default function AnalyticsModal({ open, onClose, tasks = [], routines = [
                   </button>
                 </div>
               </div>
-              <div className="v2-analytics-heatmap-wrap">
+              <div className="v2-analytics-heatmap-wrap" ref={heatmapScrollRef}>
+                <div className="v2-analytics-heatmap-inner">
                 <div className="v2-analytics-heatmap-months">
                   {heatMap.months.map((m, i) => (
                     <span key={i} className="v2-analytics-heatmap-month" style={{ left: `${(m.index / heatMap.weeks.length) * 100}%` }}>
@@ -450,17 +461,9 @@ export default function AnalyticsModal({ open, onClose, tasks = [], routines = [
                     </div>
                   ))}
                 </div>
+                </div>
               </div>
             </section>
-          )}
-
-          {tab === 'overview' && (
-          <section className="v2-analytics-section">
-            <div className="v2-analytics-section-head">
-              <h2 className="v2-analytics-section-title">Achievements</h2>
-            </div>
-            <BadgesGrid badges={badges} />
-          </section>
           )}
 
           {tab === 'habits' && <HabitsAnalytics routines={routines} />}

--- a/src/kept/FlightLog.jsx
+++ b/src/kept/FlightLog.jsx
@@ -12,7 +12,7 @@ import './flightlog.css'
 // and the full achievements wall. Reads the analytics daily series; no
 // new data.
 export default function FlightLog({
-  open, onClose,
+  open, onClose, onOpenAnalytics,
   tasks = [], routines = [], records = {}, streak = 0, dailyStats = {},
 }) {
   const [history, setHistory] = useState([])
@@ -79,6 +79,12 @@ export default function FlightLog({
         <div className="bm-fl-year-title" style={{ marginBottom: 8 }}>Achievements</div>
         <BadgesGrid badges={badges} />
       </div>
+
+      {onOpenAnalytics && (
+        <button type="button" className="bm-fl-analytics-link" onClick={onOpenAnalytics}>
+          Full analytics — charts, patterns, AI usage →
+        </button>
+      )}
     </ModalShell>
   )
 }

--- a/src/kept/analytics.css
+++ b/src/kept/analytics.css
@@ -58,27 +58,10 @@
   box-shadow: var(--wb-shadow-press);
 }
 
-/* Section tabs → contained segmented control. View tabs take the slate
- * (card-3) active fill like every other Wallaby view/range tab — green is
- * reserved for form value-pick segments (see shared.css convention). */
-[data-theme^="kept"] .v2-analytics-tabs {
-  background: var(--wb-card-2);
-  border: 1px solid var(--wb-hairline);
-  border-radius: 10px;
-  padding: 3px;
-  gap: 2px;
-}
-[data-theme^="kept"] .v2-analytics-tab {
-  border: none;
-  background: transparent;
-  border-radius: 10px;
-  color: var(--wb-text-meta);
-}
+/* Section tabs are underline navigation now (2026-07-17) — base styles in
+ * AnalyticsModal.css apply in Kept too; only the accent maps to ember. */
 [data-theme^="kept"] .v2-analytics-tab-active {
-  background: var(--wb-card-3);
-  color: var(--wb-text);
-  box-shadow: var(--wb-shadow-press);
-  border: none;
+  border-bottom-color: var(--bm-ember, #F04E23);
 }
 
 /* Chart fills pick up the Wallaby accent (purple) over the v2 orange */

--- a/src/kept/flightlog.css
+++ b/src/kept/flightlog.css
@@ -59,3 +59,22 @@
   border-color: var(--bm-ember);
   color: var(--bm-on-ember);
 }
+
+/* Handoff to the full Analytics surface (charts / patterns / AI usage) —
+   the Flight log is the profile page (streak + badges); numbers live there. */
+.bm-fl-analytics-link {
+  display: block;
+  width: 100%;
+  margin-top: 18px;
+  padding: 13px 16px;
+  border: 1px solid var(--bm-hairline, rgba(0, 0, 0, 0.08));
+  border-radius: 12px;
+  background: transparent;
+  color: var(--bm-ink, inherit);
+  font: 600 13.5px/1.2 inherit;
+  text-align: left;
+  cursor: pointer;
+}
+.bm-fl-analytics-link:hover {
+  border-color: var(--bm-ember, #F04E23);
+}

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,11 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-07-17
 
+- fix(analytics): heatmap actually shows data on mobile; AI tab findable; Flight log \u2194 Analytics de-duped [M]
+  - **Heatmap ("GitHub style graph is completely broken"):** verified by headless render — the 687px grid sat in a ~308px scroller pinned to the LEFT, so phones showed only the year-old empty half while every active cell was off-screen right; worse, the month labels lived OUTSIDE the scroller and compressed to viewport width, so labels didn't even correspond to columns. Fix: labels moved inside a `heatmap-inner` container at the grid's natural width (labels + columns scroll together), and the scroller auto-positions to NOW on open — recent weeks visible first, swipe back in time. Confirmed post-fix via DOM probe (scrollLeft pinned right, hot cells on-screen) + screenshot.
+  - **AI tab ("where is the AI tab???"):** it rendered, but as the third identical segmented-pill row below the range and metric pickers — invisible as navigation. Tabs (Overview/Tasks/Habits/AI) now sit FIRST in the modal, styled as underline tabs (ember active underline, mirrors Settings); the metric toggle + summary card only render on the tabs they apply to (Overview/Tasks).
+  - **Flight log vs Analytics ("separate surfaces? basically the same data"):** the duplication was the badges grid on both. Achievements now live only on the Flight log (the profile page: streak, arcs, badges); Analytics is the numbers surface (charts, patterns, AI usage). The Flight log gains a "Full analytics — charts, patterns, AI usage \u2192" button that hands off directly, so the trend icon is one tap from everything. Kept's segmented-control tab override retired in `src/kept/analytics.css`.
+
 - fix(ui): Quokka history controls collapsed into one row [XS]
   - Prod screenshot: history view stacked three rows — the (now-redundant) toolbar history chip, a Back-to-chat/New row, then the search bar. The toolbar hides entirely while history is open (ChatList owns the controls), and Back \u00b7 search \u00b7 New share a single row (search flexes, buttons no-shrink). Match-count line renders under the bar only while searching.
 


### PR DESCRIPTION
Three fixes, all **verified by headless Chromium renders** (before/after screenshots + DOM probes against a seeded server):

## 1. "The GitHub style graph is completely broken" — confirmed, root-caused, fixed

The DOM probe found the smoking gun: hot cells rendered perfectly orange at `x=639`… inside a 308px-wide scroller pinned to the **left**. On phones you saw only the year-old empty half of the 687px grid; every active cell was off-screen right. Worse, the month labels lived *outside* the scroller and compressed to viewport width — labels didn't correspond to the columns beneath them at all.

Fix: months + grid now live in a `heatmap-inner` container at the grid's natural width (labels and columns scroll together), and the scroller **auto-positions to NOW** on open — recent weeks visible first, swipe left for history. Post-fix probe: `scrollLeft` pinned right, first hot cell on-screen at x=260; screenshot shows the June/July activity lit up under correctly-aligned labels.

## 2. "Where is the AI tab???" — it rendered, invisibly

The tab strip sat **below** the range picker and metric toggle, styled (especially in Kept) as a third *identical* segmented-pill row — it read as another picker, not navigation. Tabs (Overview / Tasks / Habits / AI) now come first in the modal, styled as underline tabs mirroring Settings (ember underline on active). The metric toggle + summary card only render on the tabs they apply to, so the pickers no longer crowd the navigation. Kept's segmented-control tab override is retired in `src/kept/analytics.css`.

## 3. "Separate surfaces? They basically have the same data" — de-duped and wired together

The overlap was the Achievements/badges grid rendering on **both** the Flight log and Analytics. Now:
- **Flight log** (header trend icon) = the profile page: streak stats, year arcs, badges.
- **Analytics** (More → Analytics) = the numbers surface: charts, patterns, AI usage.
- The Flight log gains a **"Full analytics — charts, patterns, AI usage →"** button that closes it and opens Analytics, so the trend icon is one tap from everything.

Lint 0 errors, build + tests + smoke green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V45AJzVRjV8j2Sei5Qgr6A

---
_Generated by [Claude Code](https://claude.ai/code/session_01V45AJzVRjV8j2Sei5Qgr6A)_