### PR TITLE
feat(tasks): Notes — leave a note without creating a task (+ sync race fix)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,8 @@ Boomerang is a personal ADHD task manager PWA built with React 19, Vite, Express
 - Real-time cross-client sync via SSE
 - Dark mode (single toggle), iOS-style toggle switches throughout settings
 - Header icons: Packages + Quokka (AI adviser) always visible in the top-right; overflow "..." menu contains Settings, Projects, Import, Analytics, Activity Log
-- Quokka — free-form natural-language AI adviser with control over every capability in the app (tasks, routines, GCal, Notion, Trello, Gmail, packages, weather, settings, analytics, knowledge base). 64 server-side tools, staged-execution with user confirmation, LIFO compensation rollback on failure. Named after the perpetually-smiling Australian marsupial. Includes a one-command **integration health check** ("check my integrations") — see Integration Health Check below.
+- Notes — free-floating notes with no task semantics (no due date, no status, no points, no nagging); pinned notes surface as a sticky strip on Today. See Notes section below.
+- Quokka — free-form natural-language AI adviser with control over every capability in the app (tasks, routines, GCal, Notion, Trello, Gmail, packages, weather, settings, analytics, knowledge base, notes). 86 server-side tools, staged-execution with user confirmation, LIFO compensation rollback on failure. Named after the perpetually-smiling Australian marsupial. Includes a one-command **integration health check** ("check my integrations") — see Integration Health Check below.
 - Installable PWA with full-square PNG icons (180, 192, 512) and apple-touch-icon
 
 ### Energy/Capacity Tagging System
@@ -869,6 +870,24 @@ Personal knowledge store Quokka can search. Where things are kept, how-tos, deci
 - Keyword search only (title/tags/summary). Semantic search across full bodies not wired.
 - 5-minute refresh cadence — if the user adds an item in Notion directly and immediately asks Quokka, they need to tap "Sync now" or have Quokka call `refresh_knowledge_index`.
 
+### Notes (free-floating notes, 2026-07-18, migration 044)
+
+User request verbatim: *"I need a concept of a note. Something where I can leave a note without creating a task that has a due date."* First-class `notes` concept with deliberately ZERO task semantics — no due date, no status, no points, no nagging; notes can never leak into notification pools, pile-up counts, or analytics because they are not tasks.
+
+**Storage.** Own SQL table `notes` (migration 044: `id`, `body`, `pinned`, `created_at`, `updated_at`) + CRUD in `server/db.js` (`getAllNotes` orders pinned-first then `updated_at` desc — every surface shows that order). Dedicated per-record endpoints (`GET/POST /api/notes`, `PATCH/DELETE /api/notes/:id` in `server.js`), deliberately NOT part of the bulk `/api/data` blob — same carve-out reasoning as growth areas/packages (see Derived-Stat Durability Rules). Writes bump the sync version + broadcast; the client's `useNotes` hook (`src/hooks/useNotes.js`) refetches from `hydrateFromServer` in `AppV2.jsx`, so cross-device edits land on the normal sync cadence.
+
+**Pinned = leave a note on the fridge.** `pinned: true` renders the note as a gold sticky strip (`bm-note-sticky` in `src/kept/shell.css`) at the top of Kept's Today — mobile and desktop — above the Day Arc hero, next to the growth banner. Tap opens the Notes surface; the X **unpins** (never deletes). Unpinned notes live only in the Notes page.
+
+**Capture paths:** (1) the Throw sheet's **Task | Note** toggle (`ThrowSheet.jsx` — note mode hides the date chips + More-options, placeholder "What do you want to remember?", button "Leave it", routes to `onThrowNote`); (2) the Notes surface composer (with pin-on-create checkbox); (3) Quokka (`create_note`).
+
+**Notes surface:** `NotesModal` (`src/components/NotesModal.{jsx,css}`, GrowthAreasModal's CRUD vocabulary) — entry points: More → Notes (Kept mobile), sidebar → Notes (Kept desktop). Rows: body, pinned/edited meta, pin toggle, inline edit, **"Make it a task"** (promote: first line → task title, remainder → task `notes`, then the note is deleted — goes through `handleAddTask`, so auto size/energy/tag inference applies), delete.
+
+**Quokka tools (4, in `adviserToolsMisc.js`):** `list_notes` (read-only), `create_note` (pinned only when the user explicitly wants it on Today), `update_note`, `delete_note` — staged with capture/restore compensation.
+
+**Distinct from the Knowledge Base:** notes are quick local jots (own SQLite table, instant, no external deps); knowledge is durable Notion-backed reference. The `list_notes` tool description spells this out so Quokka routes correctly.
+
+**Known limitations:** no legacy-theme entry point (Kept-only surfaces: More/sidebar/Today/Throw — the standard theme can still reach notes via Quokka); no note search (the list is expected to stay short — search lands if real usage disagrees); no reorder beyond pinned-first/recency.
+
 ### Growth Areas (personal-coaching reminders, 2026-07-04)
 
 Deliberately tiny feature: standing reminders about *yourself* ("be more patient on calls"), not tasks — no tracking, no streak, no check-in. Full spec + design rationale (including the adversarial-review rewrite that killed the original static-banner delivery): `wiki/Growth-Areas.md`.
@@ -931,9 +950,9 @@ Free-form natural-language control surface — user says "I've rescheduled my FA
 - `adviserTools.js` — registry, session/plan storage (10-min TTL, 1-min sweep), `handleToolCall()`, `commitPlan()` with rollback
 - `adviserToolsTasks.js` — 22 task + routine tools (incl. 4 Sequences chain editors: `add_follow_up`, `edit_follow_up`, `remove_follow_up`, `reorder_follow_ups`; + `reconcile_loops`)
 - `adviserToolsIntegrations.js` — 12 GCal + Notion + Trello tools
-- `adviserToolsMisc.js` — 21 Gmail + packages + weather + settings + analytics tools (incl. `check_integrations`, the live cross-integration health probe)
+- `adviserToolsMisc.js` — Gmail + packages + weather + settings + analytics + growth-area + notes tools (incl. `check_integrations`, the live cross-integration health probe)
 - `adviserToolsKnowledge.js` — 9 knowledge-base tools (search, get, refresh, list, create, update, delete, link/unlink to tasks)
-- **Total:** 64 tools; diagnostic list at `GET /api/adviser/tools`
+- **Total:** 86 tools (live count from the registry — this number drifts as features land; trust `GET /api/adviser/tools` over any doc); diagnostic list at `GET /api/adviser/tools`
 
 **Server endpoints:**
 | Endpoint | Purpose |
@@ -955,6 +974,7 @@ Free-form natural-language control surface — user says "I've rescheduled my FA
 - Weather (3): get, refresh, geocode
 - Settings + analytics (5): get/update settings (secrets blocked), get analytics, get analytics history, `check_integrations` (live one-pass health check across every integration — see below)
 - Knowledge base (9): search, get, refresh, list, create, update, delete, link/unlink to tasks (see Knowledge Base section above)
+- Notes (4): list, create, update, delete — free-floating notes, no task semantics (see Notes section above)
 
 **Rollback compensation:**
 - Local DB creates → delete on rollback
@@ -1251,6 +1271,8 @@ Wrapping the existing web app in a Capacitor shell to add native surfaces (Share
 **Recovery diagnostic.** `scripts/recover-from-notification-log.js` (read-only) queries `notification_log` (which survives `setAllData` since it's not in the bulk-PUT collection list) for unique `(task_id, most_recent_title)` pairs and flags which IDs are still present in the live `tasks` table. Up to 500 rows of history.
 
 **Flush-before-hydrate (2026-06-21).** A local mutation (completing a task, an edit) is written to state instantly but its server push is debounced (`DEBOUNCE_MS = 300` in `useServerSync.js`). `fetchAndHydrate` must **flush** that pending push before overwriting local state with the server's copy — NOT cancel it. The original code cancelled the pending push, so any refetch landing inside the 300ms window (`visibilitychange` app-refocus, an `sse-update` from another device, `pull-refresh`) discarded the user's change and the task resurfaced ("I checked it off and it came back"). `pushChanges` is awaitable; `fetchAndHydrate` awaits it, then fetches the merged per-record result (push-then-fetch is order-safe because tasks/routines are per-record). Corollary rule: **any new refetch/hydrate path must flush local mutations first** — never blind-overwrite local state that may hold an unpushed change. The post-hydrate echo-suppression window must also never *drop* a real edit made inside it (reschedule past the window; the per-record diff already neutralizes the echo).
+
+**Flush-before-bulk-push (2026-07-18, same bug class as above).** The manual settings/labels `flush()` used to CANCEL the pending per-record debounce, and `pushBulkState`'s success handler advanced `prevTasks`/`prevRoutines` to current state — so a task added within 300ms of any settings write (prod shape: first-ever task add → streak-anchor effect saves settings → flush) was marked "already pushed" without ever reaching the server. Fixed: `flush()` runs the pending `pushChanges` before the bulk push, and `pushBulkState` only bootstraps the per-record snapshots when they're still null (fresh-empty-server path) — a bulk push carries settings/labels only and must NEVER claim tasks/routines as pushed. Corollary of the corollary rule: any code path that cancels the per-record debounce timer must either push the pending changes itself or leave the snapshots alone.
 
 **Server log timestamps.** Every `console.log/.error/.warn` call gets an ISO-8601 timestamp prefix automatically (wrappers in `server.js` near line 161). Don't add manual timestamps to log lines.
 

--- a/migrations/044_notes.sql
+++ b/migrations/044_notes.sql
@@ -1,0 +1,14 @@
+-- Notes (2026-07-18): free-floating notes — a place to leave a thought
+-- without creating a task. No due date, no status, no points, no nagging;
+-- deliberately NOT columns on the tasks table so notes can never leak into
+-- notification pools, pile-up counts, or analytics. `pinned` notes surface
+-- as a sticky strip at the top of Today (leave-a-note-on-the-fridge model);
+-- unpinned notes live only in the Notes surface.
+CREATE TABLE IF NOT EXISTS notes (
+  id TEXT PRIMARY KEY,
+  body TEXT NOT NULL,
+  pinned INTEGER DEFAULT 0,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_notes_pinned ON notes(pinned);

--- a/server/adviserToolsMisc.js
+++ b/server/adviserToolsMisc.js
@@ -5,6 +5,7 @@ import {
   getPackage, getAllPackages, upsertPackage, deletePackage, updatePackagePartial,
   getData, setData, getAnalytics, getAnalyticsHistory, getGmailProcessedCount,
   listPendingSuggestions, getPatternSuggestion, updateSuggestionStatus, snoozeSuggestion,
+  getAllNotes, getNote, upsertNote, updateNotePartial, deleteNote,
 } from './db.js'
 import { registerTool } from './adviserTools.js'
 import { listGrowthAreas, getGrowthArea, createGrowthArea, updateGrowthArea, deleteGrowthArea } from './growthAreas.js'
@@ -569,6 +570,100 @@ export function registerGrowthAreaTools() {
 }
 
 // ============================================================
+// Notes (free-floating notes — no task semantics, no due date, no nagging)
+// ============================================================
+
+export function registerNoteTools() {
+  registerTool({
+    name: 'list_notes',
+    description: 'List the user\'s notes — free-floating notes with no task semantics (no due date, no status, no nagging). Pinned notes also show as a sticky strip on Today. Distinct from the Notion knowledge base: notes are quick local jots, knowledge is durable reference.',
+    readOnly: true,
+    schema: { type: 'object', properties: {} },
+    execute: async () => ({ result: { notes: getAllNotes() } }),
+  })
+
+  registerTool({
+    name: 'create_note',
+    description: 'Leave a note for the user ("note to self: …"). NOT a task — no due date, no reminders. Set pinned=true only when the user wants it visible on Today ("leave a note on my Today screen", "pin a note").',
+    schema: {
+      type: 'object',
+      properties: {
+        body: { type: 'string', description: 'The note text (multi-line ok)' },
+        pinned: { type: 'boolean', default: false },
+      },
+      required: ['body'],
+    },
+    preview: (a) => `Create ${a.pinned ? 'pinned ' : ''}note "${String(a.body || '').slice(0, 60)}"`,
+    execute: async (args) => {
+      const now = new Date().toISOString()
+      const note = {
+        id: `note-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+        body: String(args.body || '').trim(),
+        pinned: !!args.pinned,
+        created_at: now,
+        updated_at: now,
+      }
+      ensure(note.body, 'Note body cannot be empty')
+      upsertNote(note)
+      return {
+        result: { id: note.id, note },
+        compensation: async () => { deleteNote(note.id) },
+      }
+    },
+  })
+
+  registerTool({
+    name: 'update_note',
+    description: 'Update a note\'s body or pin state (pinned=true shows it on Today; pinned=false tucks it back into the Notes surface).',
+    schema: {
+      type: 'object',
+      properties: {
+        id: { type: 'string' },
+        body: { type: 'string' },
+        pinned: { type: 'boolean' },
+      },
+      required: ['id'],
+    },
+    preview: (a) => `Update note ${a.id}`,
+    execute: async (args) => {
+      const before = getNote(args.id)
+      ensure(before, `Note not found: ${args.id}`)
+      const updates = {}
+      if (args.body !== undefined) {
+        updates.body = String(args.body).trim()
+        ensure(updates.body, 'Note body cannot be empty')
+      }
+      if (args.pinned !== undefined) updates.pinned = !!args.pinned
+      const note = updateNotePartial(args.id, updates)
+      return {
+        result: { id: args.id, note },
+        compensation: async () => { upsertNote(before) },
+      }
+    },
+  })
+
+  registerTool({
+    name: 'delete_note',
+    description: 'Permanently delete a note.',
+    schema: {
+      type: 'object',
+      properties: { id: { type: 'string' } },
+      required: ['id'],
+    },
+    preview: (a) => `Delete note ${a.id}`,
+    execute: async ({ id }) => {
+      const before = getNote(id)
+      ensure(before, `Note not found: ${id}`)
+      deleteNote(id)
+      return {
+        result: { id, deleted: true },
+        compensation: async () => { upsertNote(before) },
+      }
+    },
+  })
+}
+
+// ============================================================
 // Register all misc tools
 // ============================================================
 
@@ -579,4 +674,5 @@ export function registerMiscTools() {
   registerSettingsTools()
   registerSuggestionTools()
   registerGrowthAreaTools()
+  registerNoteTools()
 }

--- a/server/db.js
+++ b/server/db.js
@@ -1674,6 +1674,67 @@ export function deletePackage(id) {
   schedulePersist()
 }
 
+// ============================================================
+// Notes CRUD operations (migration 044) — free-floating notes, no task
+// semantics. Dedicated table + per-record endpoints, never part of the
+// bulk /api/data blob (same carve-out reasoning as packages).
+// ============================================================
+
+function rowToNote(row) {
+  return {
+    id: row.id,
+    body: row.body,
+    pinned: !!row.pinned,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  }
+}
+
+export function upsertNote(note) {
+  db.run(
+    `INSERT INTO notes (id, body, pinned, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?)
+     ON CONFLICT(id) DO UPDATE SET
+       body=excluded.body, pinned=excluded.pinned, updated_at=excluded.updated_at`,
+    [note.id, note.body, note.pinned ? 1 : 0, note.created_at, note.updated_at],
+  )
+  schedulePersist()
+}
+
+export function getNote(id) {
+  const stmt = db.prepare('SELECT * FROM notes WHERE id = ?')
+  stmt.bind([id])
+  if (stmt.step()) {
+    const row = stmt.getAsObject()
+    stmt.free()
+    return rowToNote(row)
+  }
+  stmt.free()
+  return null
+}
+
+export function getAllNotes() {
+  // Pinned first, then most-recently-touched — same order every surface shows.
+  const results = []
+  const stmt = db.prepare('SELECT * FROM notes ORDER BY pinned DESC, updated_at DESC')
+  while (stmt.step()) results.push(rowToNote(stmt.getAsObject()))
+  stmt.free()
+  return results
+}
+
+export function updateNotePartial(id, updates) {
+  const existing = getNote(id)
+  if (!existing) return null
+  const merged = { ...existing, ...updates, updated_at: new Date().toISOString() }
+  upsertNote(merged)
+  return getNote(id)
+}
+
+export function deleteNote(id) {
+  db.run('DELETE FROM notes WHERE id = ?', [id])
+  schedulePersist()
+}
+
 // --- Gmail processed messages ---
 
 export function isGmailProcessed(messageId) {

--- a/server/server.js
+++ b/server/server.js
@@ -14,6 +14,7 @@ import { initDb, getAllData, setAllData, setData, getVersion, bumpVersion, flush
   markNotifEntriesRead, markAllNotifsRead,
   getChildTasks, computeProjectBudget, computeSessionPoints, logProjectSession,
   findActiveSpawnTwin, dedupeSpawnedTasks, logAiUsage, getAiUsageSummary,
+  getAllNotes, getNote, upsertNote, updateNotePartial, deleteNote,
   PROJECT_CONSTANTS,
   setEscalationLadder, logEscalationAttempt, advanceEscalationRung,
   dismissEscalationAdvancePrompt, resolveEscalation } from './db.js'
@@ -3130,6 +3131,54 @@ app.get('/api/growth-areas/today', async (req, res) => {
   } catch (err) {
     res.status(500).json({ error: err.message })
   }
+})
+
+// Notes — free-floating notes, no task semantics (no due date, no status,
+// no nagging, no points). Dedicated per-record endpoints, deliberately NOT
+// part of the bulk /api/data blob. Pinned notes surface on Today.
+app.get('/api/notes', (req, res) => {
+  res.json({ notes: getAllNotes() })
+})
+
+app.post('/api/notes', (req, res) => {
+  const body = (req.body?.body || '').trim()
+  if (!body) return res.status(400).json({ error: 'body required' })
+  const now = new Date().toISOString()
+  const note = {
+    id: `note-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    body,
+    pinned: !!req.body?.pinned,
+    created_at: now,
+    updated_at: now,
+  }
+  upsertNote(note)
+  const newVersion = bumpVersion()
+  broadcast(newVersion, req.body?._clientId || req.headers['x-client-id'])
+  res.json({ ok: true, note: getNote(note.id) || note })
+})
+
+app.patch('/api/notes/:id', (req, res) => {
+  const updates = {}
+  if (typeof req.body?.body === 'string') {
+    const trimmed = req.body.body.trim()
+    if (!trimmed) return res.status(400).json({ error: 'body cannot be empty' })
+    updates.body = trimmed
+  }
+  if (req.body?.pinned !== undefined) updates.pinned = !!req.body.pinned
+  const note = updateNotePartial(req.params.id, updates)
+  if (!note) return res.status(404).json({ error: 'Note not found' })
+  const newVersion = bumpVersion()
+  broadcast(newVersion, req.body?._clientId || req.headers['x-client-id'])
+  res.json({ ok: true, note })
+})
+
+app.delete('/api/notes/:id', (req, res) => {
+  const note = getNote(req.params.id)
+  if (!note) return res.status(404).json({ error: 'Note not found' })
+  deleteNote(req.params.id)
+  const newVersion = bumpVersion()
+  broadcast(newVersion, req.headers['x-client-id'])
+  res.json({ ok: true })
 })
 
 app.post('/api/notifications/tap', (req, res) => {

--- a/src/AppV2.jsx
+++ b/src/AppV2.jsx
@@ -27,6 +27,7 @@ import KeptDesktop from './kept/KeptDesktop'
 import QuickEditTask from './kept/QuickEditTask'
 import SuggestionsModal from './components/SuggestionsModal'
 import GrowthAreasModal from './components/GrowthAreasModal'
+import NotesModal from './components/NotesModal'
 import PackagesModal from './components/PackagesModal'
 import AdviserModal from './components/AdviserModal'
 import AnalyticsModal from './components/AnalyticsModal'
@@ -50,6 +51,7 @@ import { useCrisisTriage } from './hooks/useCrisisTriage'
 import { useRealityCheck } from './hooks/useRealityCheck'
 import { useToastPrefetch } from './hooks/useToastPrefetch'
 import { usePackages } from './hooks/usePackages'
+import { useNotes } from './hooks/useNotes'
 import { useAdviser } from './hooks/useAdviser'
 import { useIsDesktop } from './hooks/useIsDesktop'
 import { useWeather } from './hooks/useWeather'
@@ -127,6 +129,7 @@ export default function AppV2() {
   const [showAnalytics, setShowAnalytics] = useState(false)
   const [showSuggestions, setShowSuggestions] = useState(false)
   const [showGrowthAreas, setShowGrowthAreas] = useState(false)
+  const [showNotes, setShowNotes] = useState(false)
   // 7-day strip visibility — single source of truth. Date tap toggles
   // it in all themes. Two settings can seed the initial state on load:
   //   - week_strip_always_open: explicit "open by default" toggle
@@ -282,6 +285,10 @@ export default function AppV2() {
     return s
   }, [tasks])
   const { packages, addPackage, removePackage, refresh: refreshPackage, refreshAll: refreshAllPackages } = usePackages()
+  // Notes — free-floating, no task semantics. Server-backed via dedicated
+  // endpoints; reload() rides hydrateFromServer so cross-device edits land.
+  const { notes, loading: notesLoading, reload: reloadNotes, addNote, editNote, removeNote } = useNotes()
+  const pinnedNotes = useMemo(() => notes.filter(n => n.pinned), [notes])
   // Trello status push lives at this level so handleComplete / status-change
   // / handleUncomplete can fire it for any task with a linked Trello card.
   const { pushStatusToTrello, syncTrello, syncing: trelloSyncing } = useTrelloSync(tasks, setTasks, changeStatus)
@@ -304,6 +311,9 @@ export default function AppV2() {
     serverHydratedRef.current = true
     if (data.tasks) hydrateTasks(data.tasks)
     if (data.routines) hydrateRoutines(data.routines)
+    // Notes live on their own endpoint (not in the bulk blob) — refresh them
+    // on the same cadence so a note left on another device shows up.
+    reloadNotes()
     if (data.settings) {
       if (data.settings.sort_by) setSortBy(data.settings.sort_by)
     }
@@ -311,7 +321,7 @@ export default function AppV2() {
       saveLabels(data.labels)
       setLabels(data.labels)
     }
-  }, [hydrateTasks, hydrateRoutines])
+  }, [hydrateTasks, hydrateRoutines, reloadNotes])
 
   const { flush: flushSync, checkVersion, syncStatus, queueLength, refetch: refetchFromServer } = useServerSync(tasks, routines, hydrateFromServer, (newVersion) => {
     setUpdateVersion(newVersion)
@@ -326,10 +336,10 @@ export default function AppV2() {
   // Check app version whenever a view/modal opens — same cadence v1 uses.
   // Catches stale clients without waiting for the next SSE/sync round-trip.
   useEffect(() => {
-    if (showSettings || showDone || showAnalytics || showRoutines || showActivityLog || showPackages || showProjects || showAdviser || showSuggestions || showGrowthAreas || editTarget || showAdd || showWhatNow || showMarkdownImport) {
+    if (showSettings || showDone || showAnalytics || showRoutines || showActivityLog || showPackages || showProjects || showAdviser || showSuggestions || showGrowthAreas || showNotes || editTarget || showAdd || showWhatNow || showMarkdownImport) {
       checkVersion()
     }
-  }, [showSettings, showDone, showAnalytics, showRoutines, showActivityLog, showPackages, showProjects, showAdviser, showSuggestions, showGrowthAreas, editTarget, showAdd, showWhatNow, showMarkdownImport, checkVersion])
+  }, [showSettings, showDone, showAnalytics, showRoutines, showActivityLog, showPackages, showProjects, showAdviser, showSuggestions, showGrowthAreas, showNotes, editTarget, showAdd, showWhatNow, showMarkdownImport, checkVersion])
 
   // Deep-link handler. Notifications come in as `/?task=<id>` (task tap),
   // `/?suggestions=1` (routine_suggestion push), or `/?adviser=...` (plan
@@ -617,6 +627,7 @@ export default function AppV2() {
   if (showAnalytics) activeModals.push('analytics')
   if (showSuggestions) activeModals.push('suggestions')
   if (showGrowthAreas) activeModals.push('growthAreas')
+  if (showNotes) activeModals.push('notes')
   if (spacesHubOpen) activeModals.push('spaces')
   if (systemMenuOpen) activeModals.push('systemMenu')
   if (searchOpen) activeModals.push('search')
@@ -638,10 +649,11 @@ export default function AppV2() {
     if (showAnalytics) { setShowAnalytics(false); return }
     if (showSuggestions) { setShowSuggestions(false); return }
     if (showGrowthAreas) { setShowGrowthAreas(false); return }
+    if (showNotes) { setShowNotes(false); return }
     if (spacesHubOpen) { setSpacesHubOpen(false); setActiveTab('today'); return }
     if (systemMenuOpen) { setSystemMenuOpen(false); return }
     if (searchOpen) { handleCloseSearch(); return }
-  }, [snoozeTarget, reframeTarget, editTarget, showAdd, showWhatNow, showSettings, showProjects, showDone, showActivityLog, showRoutines, showPackages, showAdviser, showAnalytics, showSuggestions, showGrowthAreas, spacesHubOpen, systemMenuOpen, searchOpen, handleCloseSearch])
+  }, [snoozeTarget, reframeTarget, editTarget, showAdd, showWhatNow, showSettings, showProjects, showDone, showActivityLog, showRoutines, showPackages, showAdviser, showAnalytics, showSuggestions, showGrowthAreas, showNotes, spacesHubOpen, systemMenuOpen, searchOpen, handleCloseSearch])
 
   const focusSearchInput = useCallback(() => {
     setSearchOpen(true)
@@ -1463,6 +1475,10 @@ export default function AppV2() {
           onOpenNotifications={() => setShowNotifications(true)}
           onOpenSuggestions={() => setShowSuggestions(true)}
           onOpenGrowthAreas={() => setShowGrowthAreas(true)}
+          onOpenNotes={() => setShowNotes(true)}
+          onThrowNote={({ body }) => addNote({ body }).catch(() => {})}
+          pinnedNotes={pinnedNotes}
+          onUnpinNote={(n) => editNote(n.id, { pinned: false }).catch(() => {})}
           syncStatus={syncStatus}
           queueLength={queueLength}
         />
@@ -1522,6 +1538,10 @@ export default function AppV2() {
           onStatusChange={handleStatusChange}
           onOpenSuggestions={() => setShowSuggestions(true)}
           onOpenGrowthAreas={() => setShowGrowthAreas(true)}
+          onOpenNotes={() => setShowNotes(true)}
+          onThrowNote={({ body }) => addNote({ body }).catch(() => {})}
+          pinnedNotes={pinnedNotes}
+          onUnpinNote={(n) => editNote(n.id, { pinned: false }).catch(() => {})}
           syncStatus={syncStatus}
           queueLength={queueLength}
         />
@@ -1764,6 +1784,25 @@ export default function AppV2() {
       <GrowthAreasModal
         open={showGrowthAreas}
         onClose={() => setShowGrowthAreas(false)}
+      />
+
+      <NotesModal
+        open={showNotes}
+        onClose={() => setShowNotes(false)}
+        notes={notes}
+        loading={notesLoading}
+        onAdd={addNote}
+        onUpdate={editNote}
+        onDelete={removeNote}
+        onPromote={async (note) => {
+          // First line → task title, remainder → task notes; the note itself
+          // is removed once the task exists (its content lives on in the task).
+          const lines = String(note.body || '').split('\n')
+          const title = (lines[0] || '').trim().slice(0, 200) || 'Note'
+          const rest = lines.slice(1).join('\n').trim()
+          handleAddTask({ title, ...(rest ? { notes: rest } : {}) })
+          await removeNote(note.id)
+        }}
       />
 
       <PackagesModal

--- a/src/api.js
+++ b/src/api.js
@@ -1625,6 +1625,45 @@ export async function getTodayGrowthArea() {
   }
 }
 
+// --- Notes ---
+// Free-floating notes, no task semantics. Dedicated endpoints, deliberately
+// not part of the bulk /api/data sync blob (same carve-out as growth areas).
+
+export async function fetchNotes() {
+  const res = await fetch('/api/notes')
+  if (!res.ok) throw new Error(`notes fetch failed: ${res.status}`)
+  const data = await res.json()
+  return data.notes || []
+}
+
+export async function createNoteApi({ body, pinned }) {
+  const res = await fetch('/api/notes', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ body, pinned }),
+  })
+  if (!res.ok) throw new Error(`note create failed: ${res.status}`)
+  const data = await res.json()
+  return data.note
+}
+
+export async function updateNoteApi(id, updates) {
+  const res = await fetch(`/api/notes/${id}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(updates),
+  })
+  if (!res.ok) throw new Error(`note update failed: ${res.status}`)
+  const data = await res.json()
+  return data.note
+}
+
+export async function deleteNoteApi(id) {
+  const res = await fetch(`/api/notes/${id}`, { method: 'DELETE' })
+  if (!res.ok) throw new Error(`note delete failed: ${res.status}`)
+  return res.json()
+}
+
 // --- AI Adviser ---
 
 // Opens a streaming SSE connection to the adviser. Calls `onEvent(event, data)` for each

--- a/src/components/NotesModal.css
+++ b/src/components/NotesModal.css
@@ -1,0 +1,151 @@
+/* Notes — free-floating notes, no task semantics. Same calm CRUD vocabulary
+ * as GrowthAreasModal/Labels. */
+
+.v2-notes-add {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+.v2-notes-add-input {
+  width: 100%;
+  min-height: 64px;
+  resize: vertical;
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid var(--v2-hairline);
+  background: var(--v2-bg);
+  color: var(--v2-text);
+  font: 400 14px/1.45 var(--v2-font-body);
+}
+.v2-notes-add-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+.v2-notes-add-pin {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font: 400 12.5px/1.4 var(--v2-font-body);
+  color: var(--v2-text-meta);
+  cursor: pointer;
+}
+.v2-notes-add-pin input {
+  margin: 0;
+  accent-color: var(--v2-accent);
+}
+.v2-notes-add-btn {
+  padding: 10px 16px;
+  border-radius: 10px;
+  border: 1px solid var(--v2-accent);
+  background: var(--v2-accent);
+  color: #fff;
+  font: 600 13px/1 var(--v2-font-body);
+  cursor: pointer;
+  white-space: nowrap;
+}
+.v2-notes-add-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.v2-notes-hint {
+  font: 400 12px/1.5 var(--v2-font-body);
+  color: var(--v2-text-meta);
+  margin-bottom: 16px;
+}
+
+.v2-notes-error {
+  font: 400 13px/1.4 var(--v2-font-body);
+  color: var(--v2-alert-high-pri);
+  margin-bottom: 12px;
+}
+
+.v2-notes-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.v2-notes-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 10px 12px;
+  border: 1px solid var(--v2-hairline);
+  border-radius: 12px;
+  background: var(--v2-bg);
+}
+.v2-notes-row-pinned {
+  border-color: color-mix(in srgb, var(--v2-accent) 45%, var(--v2-hairline));
+}
+
+.v2-notes-row-main {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+.v2-notes-body {
+  font: 400 14px/1.45 var(--v2-font-body);
+  color: var(--v2-text);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+.v2-notes-meta {
+  font: 400 11.5px/1.4 var(--v2-font-body);
+  color: var(--v2-text-meta);
+}
+
+.v2-notes-row-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.v2-notes-icon-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border-radius: 8px;
+  border: none;
+  background: transparent;
+  color: var(--v2-text-meta);
+  cursor: pointer;
+}
+.v2-notes-icon-btn:hover:not(:disabled) {
+  background: rgba(var(--v2-text-rgb), 0.06);
+  color: var(--v2-text);
+}
+.v2-notes-icon-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+.v2-notes-icon-btn-danger:hover:not(:disabled) {
+  color: var(--v2-alert-high-pri);
+}
+.v2-notes-icon-btn.is-pinned { color: var(--v2-accent); }
+
+.v2-notes-row-editing {
+  flex-wrap: wrap;
+}
+.v2-notes-edit-input {
+  flex: 1 1 100%;
+  min-height: 64px;
+  resize: vertical;
+  padding: 8px 10px;
+  border-radius: 8px;
+  border: 1px solid var(--v2-hairline);
+  background: var(--v2-bg);
+  color: var(--v2-text);
+  font: 400 13.5px/1.45 var(--v2-font-body);
+}
+.v2-notes-row-editing-actions {
+  display: flex;
+  gap: 4px;
+  margin-left: auto;
+}

--- a/src/components/NotesModal.jsx
+++ b/src/components/NotesModal.jsx
@@ -1,0 +1,176 @@
+import { useState } from 'react'
+import { StickyNote, Trash2, Pencil, X, Check, Pin, PinOff, ListPlus } from 'lucide-react'
+import ModalShell from './ModalShell'
+import EmptyState from './EmptyState'
+import './NotesModal.css'
+
+function fmtWhen(iso) {
+  if (!iso) return ''
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return ''
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+}
+
+function NoteRow({ note, onUpdate, onDelete, onPromote, busy }) {
+  const [editing, setEditing] = useState(false)
+  const [body, setBody] = useState(note.body)
+
+  const save = async () => {
+    const b = body.trim()
+    if (!b) return
+    await onUpdate(note.id, { body: b })
+    setEditing(false)
+  }
+  const cancel = () => {
+    setBody(note.body)
+    setEditing(false)
+  }
+
+  if (editing) {
+    return (
+      <li className="v2-notes-row v2-notes-row-editing">
+        <textarea
+          className="v2-notes-edit-input"
+          value={body}
+          onChange={e => setBody(e.target.value)}
+          autoFocus
+        />
+        <div className="v2-notes-row-editing-actions">
+          <button className="v2-notes-icon-btn" onClick={save} disabled={busy || !body.trim()} title="Save">
+            <Check size={16} strokeWidth={2} />
+          </button>
+          <button className="v2-notes-icon-btn" onClick={cancel} disabled={busy} title="Cancel">
+            <X size={16} strokeWidth={2} />
+          </button>
+        </div>
+      </li>
+    )
+  }
+
+  return (
+    <li className={`v2-notes-row${note.pinned ? ' v2-notes-row-pinned' : ''}`}>
+      <div className="v2-notes-row-main">
+        <span className="v2-notes-body">{note.body}</span>
+        <span className="v2-notes-meta">
+          {note.pinned ? 'Pinned to Today · ' : ''}{fmtWhen(note.updated_at || note.created_at)}
+        </span>
+      </div>
+      <div className="v2-notes-row-actions">
+        <button
+          className={`v2-notes-icon-btn${note.pinned ? ' is-pinned' : ''}`}
+          onClick={() => onUpdate(note.id, { pinned: !note.pinned })}
+          disabled={busy}
+          title={note.pinned ? 'Unpin from Today' : 'Pin to Today'}
+        >
+          {note.pinned ? <PinOff size={15} strokeWidth={1.75} /> : <Pin size={15} strokeWidth={1.75} />}
+        </button>
+        <button className="v2-notes-icon-btn" onClick={() => setEditing(true)} disabled={busy} title="Edit">
+          <Pencil size={15} strokeWidth={1.75} />
+        </button>
+        <button className="v2-notes-icon-btn" onClick={() => onPromote(note)} disabled={busy} title="Make it a task">
+          <ListPlus size={15} strokeWidth={1.75} />
+        </button>
+        <button className="v2-notes-icon-btn v2-notes-icon-btn-danger" onClick={() => onDelete(note.id)} disabled={busy} title="Delete">
+          <Trash2 size={15} strokeWidth={1.75} />
+        </button>
+      </div>
+    </li>
+  )
+}
+
+// Notes — a place to leave a thought without creating a task. No due date,
+// no status, no points, no nagging. Pinned notes also show as a sticky strip
+// at the top of Today. "Make it a task" promotes a note into a real task
+// (first line → title, rest → task notes) and removes the note.
+export default function NotesModal({ open, onClose, notes = [], loading = false, onAdd, onUpdate, onDelete, onPromote }) {
+  const [newBody, setNewBody] = useState('')
+  const [newPinned, setNewPinned] = useState(false)
+  const [adding, setAdding] = useState(false)
+  const [busyId, setBusyId] = useState(null)
+  const [error, setError] = useState(null)
+
+  const handleAdd = async (e) => {
+    e.preventDefault()
+    const b = newBody.trim()
+    if (!b) return
+    setAdding(true)
+    setError(null)
+    try {
+      await onAdd({ body: b, pinned: newPinned })
+      setNewBody('')
+      setNewPinned(false)
+    } catch (err) {
+      setError(err.message)
+    } finally {
+      setAdding(false)
+    }
+  }
+
+  const wrap = (id, fn) => async (...args) => {
+    setBusyId(id)
+    setError(null)
+    try {
+      await fn(...args)
+    } catch (err) {
+      setError(err.message)
+    } finally {
+      setBusyId(null)
+    }
+  }
+
+  return (
+    <ModalShell
+      open={open}
+      onClose={onClose}
+      title="Notes"
+      subtitle="Leave yourself a note — no due date, no nagging, nothing to check off"
+      width="narrow"
+    >
+      <form className="v2-notes-add" onSubmit={handleAdd}>
+        <textarea
+          className="v2-notes-add-input"
+          placeholder="Jot something down…"
+          value={newBody}
+          onChange={e => setNewBody(e.target.value)}
+          maxLength={4000}
+        />
+        <div className="v2-notes-add-row">
+          <label className="v2-notes-add-pin">
+            <input type="checkbox" checked={newPinned} onChange={e => setNewPinned(e.target.checked)} />
+            Pin to Today
+          </label>
+          <button className="v2-notes-add-btn" type="submit" disabled={adding || !newBody.trim()}>
+            {adding ? '...' : 'Add note'}
+          </button>
+        </div>
+      </form>
+      <div className="v2-notes-hint">
+        Pinned notes stay visible at the top of Today — like a note on the fridge.
+        If a note turns out to be something you need to actually do, promote it with "Make it a task."
+      </div>
+
+      {error && <div className="v2-notes-error">{error}</div>}
+
+      {notes.length === 0 ? (
+        <EmptyState
+          icon={StickyNote}
+          title={loading ? 'Loading…' : 'No notes yet'}
+          body="Notes are for thoughts that aren't tasks — an idea, a reminder-to-self, something to mention to someone. They never nag."
+        />
+      ) : (
+        <ul className="v2-notes-list">
+          {notes.map(n => (
+            <NoteRow
+              key={n.id}
+              note={n}
+              busy={busyId === n.id}
+              onUpdate={wrap(n.id, onUpdate)}
+              onDelete={wrap(n.id, onDelete)}
+              onPromote={wrap(n.id, onPromote)}
+            />
+          ))}
+        </ul>
+      )}
+    </ModalShell>
+  )
+}

--- a/src/hooks/useNotes.js
+++ b/src/hooks/useNotes.js
@@ -1,0 +1,50 @@
+import { useState, useCallback, useEffect } from 'react'
+import { fetchNotes, createNoteApi, updateNoteApi, deleteNoteApi } from '../api'
+
+// Notes — free-floating notes with no task semantics (no due date, no status,
+// no nagging, no points). Server is the source of truth via dedicated
+// /api/notes endpoints; AppV2 calls reload() from hydrateFromServer so a note
+// left on another device shows up on the next sync round-trip, same freshness
+// tier as everything else.
+export function useNotes() {
+  const [notes, setNotes] = useState([])
+  const [loading, setLoading] = useState(true)
+
+  const reload = useCallback(async () => {
+    try {
+      const data = await fetchNotes()
+      setNotes(data)
+    } catch (err) {
+      console.error('[Notes] Load failed:', err)
+      // Keep current state on failure — a flaky fetch shouldn't blank the list.
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => { reload() }, [reload])
+
+  const addNote = useCallback(async ({ body, pinned = false }) => {
+    const note = await createNoteApi({ body, pinned })
+    // Server list order is pinned-first then updated_at desc — mirror it.
+    setNotes(prev => {
+      const next = [note, ...prev.filter(n => n.id !== note.id)]
+      return next.sort((a, b) => (b.pinned - a.pinned) || (a.updated_at < b.updated_at ? 1 : -1))
+    })
+    return note
+  }, [])
+
+  const editNote = useCallback(async (id, updates) => {
+    const note = await updateNoteApi(id, updates)
+    setNotes(prev => prev.map(n => (n.id === id ? note : n))
+      .sort((a, b) => (b.pinned - a.pinned) || (a.updated_at < b.updated_at ? 1 : -1)))
+    return note
+  }, [])
+
+  const removeNote = useCallback(async (id) => {
+    await deleteNoteApi(id)
+    setNotes(prev => prev.filter(n => n.id !== id))
+  }, [])
+
+  return { notes, loading, reload, addNote, editNote, removeNote }
+}

--- a/src/hooks/useServerSync.js
+++ b/src/hooks/useServerSync.js
@@ -136,8 +136,15 @@ export function useServerSync(tasks, routines, onHydrate, onVersionMismatch) {
           setSyncStatus('offline')
         } else return res.json().then(r => {
           serverVersion.current = r.version
-          prevTasks.current = latestState.current.tasks
-          prevRoutines.current = latestState.current.routines
+          // Bulk push carries settings/labels ONLY — it must never claim
+          // tasks/routines as pushed. Overwriting the per-record snapshots
+          // here swallowed any task added in the last ~300ms (the debounced
+          // per-record push diffs against these and would see "no change").
+          // The snapshots are only bootstrapped when they're still null —
+          // the fresh-empty-server path, where local state is the accepted
+          // baseline and there's nothing on the server to lose.
+          if (!prevTasks.current) prevTasks.current = latestState.current.tasks
+          if (!prevRoutines.current) prevRoutines.current = latestState.current.routines
           remoteLog('push: success v' + r.version)
           setSyncStatus('saved')
           if (savedTimer.current) clearTimeout(savedTimer.current)
@@ -533,9 +540,20 @@ export function useServerSync(tasks, routines, onHydrate, onVersionMismatch) {
   // Manual flush for settings/labels changes (still bulk since those live in app_data)
   const flush = useCallback(() => {
     remoteLog('flush: manual (settings/labels changed)')
-    if (debounceTimer.current) clearTimeout(debounceTimer.current)
+    if (debounceTimer.current) {
+      clearTimeout(debounceTimer.current)
+      debounceTimer.current = null
+      // A per-record push was pending — run it now instead of dropping it.
+      // Cancelling without pushing lost any task/routine change made in the
+      // last DEBOUNCE_MS whenever a settings write followed it (prod shape:
+      // first-ever task add → streak-anchor effect saves settings → flush
+      // raced the 300ms task debounce and the task never synced).
+      if (hydrated.current) {
+        pushChanges(latestState.current.tasks, latestState.current.routines)
+      }
+    }
     pushBulkState()
-  }, [pushBulkState])
+  }, [pushBulkState, pushChanges])
 
   // Check app version against server on demand
   const checkVersion = useCallback(() => {

--- a/src/kept/KeptDesktop.jsx
+++ b/src/kept/KeptDesktop.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import {
   Home, ListTodo, Repeat2, FolderKanban, BarChart3, Package, Settings,
-  Sparkles, Plus, CheckCircle2, ScrollText, Inbox, Compass, Bell, TrendingUp, Sprout,
+  Sparkles, Plus, CheckCircle2, ScrollText, Inbox, Compass, Bell, TrendingUp, Sprout, StickyNote,
 } from 'lucide-react'
 import Logo from '../components/Logo'
 import { useSyncBounce } from '../hooks/useSyncBounce'
@@ -22,9 +22,10 @@ export default function KeptDesktop({
   onCompleteTask, onOpenTask, onToggleHabit, onRescheduleTask, onDeleteTask,
   onLogSession, onGmailKeep, onGmailDismiss, onWhatNow, onToggleItem, onUnsnooze,
   onCycleImpact,
-  onThrow, onOpenFullAdd, onEditLoop, onAddLoop, onSpawnNow, onSkipCycle, onMarkLoopDay, onSkipLoopDay,
+  onThrow, onThrowNote, onOpenFullAdd, onEditLoop, onAddLoop, onSpawnNow, onSkipCycle, onMarkLoopDay, onSkipLoopDay,
   onOpenQuokka, onOpenSettings, onOpenPackages, onOpenAnalytics,
   onOpenProjects, onOpenDone, onOpenActivity, onOpenSuggestions, onOpenGrowthAreas,
+  onOpenNotes, pinnedNotes = [], onUnpinNote,
   onOpenNotifications, onStatusChange,
   syncStatus = 'synced', queueLength = 0,
 }) {
@@ -50,6 +51,7 @@ export default function KeptDesktop({
   ]
   const navReview = [
     { label: 'Notifications', icon: Bell, onClick: onOpenNotifications },
+    { label: 'Notes', icon: StickyNote, onClick: onOpenNotes },
     { label: 'Arcs', icon: FolderKanban, onClick: onOpenProjects },
     { label: 'Caught', icon: CheckCircle2, onClick: onOpenDone },
     { label: 'Analytics', icon: BarChart3, onClick: onOpenAnalytics },
@@ -83,6 +85,7 @@ export default function KeptDesktop({
         onLogSession={onLogSession} onGmailKeep={onGmailKeep} onGmailDismiss={onGmailDismiss}
         onWhatNow={onWhatNow}
         onCycleImpact={onCycleImpact}
+        pinnedNotes={pinnedNotes} onOpenNotes={onOpenNotes} onUnpinNote={onUnpinNote}
       />
     )
   }
@@ -142,6 +145,7 @@ export default function KeptDesktop({
         open={throwOpen}
         onClose={() => setThrowOpen(false)}
         onThrow={onThrow}
+        onThrowNote={onThrowNote}
         onMoreOptions={onOpenFullAdd}
       />
     </div>

--- a/src/kept/KeptShell.jsx
+++ b/src/kept/KeptShell.jsx
@@ -19,10 +19,11 @@ export default function KeptShell({
   onCompleteTask, onOpenTask, onToggleHabit, onRescheduleTask, onDeleteTask,
   onLogSession, onGmailKeep, onGmailDismiss, onWhatNow, onToggleItem, onUnsnooze,
   onCycleImpact,
-  onThrow, onOpenFullAdd, onEditLoop, onAddLoop, onSpawnNow, onSkipCycle, onMarkLoopDay, onSkipLoopDay,
+  onThrow, onThrowNote, onOpenFullAdd, onEditLoop, onAddLoop, onSpawnNow, onSkipCycle, onMarkLoopDay, onSkipLoopDay,
   onOpenQuokka, onOpenSettings, onOpenPackages, onOpenAnalytics,
   onOpenProjects, onOpenDone, onOpenActivity, onOpenSuggestions, onOpenNotifications,
-  onOpenGrowthAreas,
+  onOpenGrowthAreas, onOpenNotes,
+  pinnedNotes = [], onUnpinNote,
   onRefresh,
   syncStatus = 'synced', queueLength = 0,
 }) {
@@ -50,6 +51,7 @@ export default function KeptShell({
         onOpenActivity={onOpenActivity}
         onOpenSettings={onOpenSettings}
         onOpenGrowthAreas={onOpenGrowthAreas}
+        onOpenNotes={onOpenNotes}
         onWhatNow={onWhatNow}
       />
     )
@@ -63,6 +65,7 @@ export default function KeptShell({
         onLogSession={onLogSession} onGmailKeep={onGmailKeep} onGmailDismiss={onGmailDismiss}
         onWhatNow={onWhatNow}
         onCycleImpact={onCycleImpact}
+        pinnedNotes={pinnedNotes} onOpenNotes={onOpenNotes} onUnpinNote={onUnpinNote}
       />
     )
   }
@@ -82,6 +85,7 @@ export default function KeptShell({
         open={throwOpen}
         onClose={() => setThrowOpen(false)}
         onThrow={onThrow}
+        onThrowNote={onThrowNote}
         onMoreOptions={onOpenFullAdd}
       />
     </div>

--- a/src/kept/MoreView.jsx
+++ b/src/kept/MoreView.jsx
@@ -1,13 +1,14 @@
-import { ChevronRight, BarChart3, Package, Settings, FolderKanban, CheckCircle2, ScrollText, Sprout, Compass } from 'lucide-react'
+import { ChevronRight, BarChart3, Package, Settings, FolderKanban, CheckCircle2, ScrollText, Sprout, Compass, StickyNote } from 'lucide-react'
 import './shell.css'
 
 // Kept "More" — the low-frequency surfaces. Arcs (projects) routes to the
 // existing ProjectsView; Flight log (profile) arrives with K5's dashboard.
 // Loop suggestions moved to a Sparkles button on the Loops surface
 // (2026-06-11) — suggestions are about loops, they live with loops.
-export default function MoreView({ onOpenProjects, onOpenAnalytics, onOpenPackages, onOpenDone, onOpenActivity, onOpenSettings, onOpenGrowthAreas, onWhatNow }) {
+export default function MoreView({ onOpenProjects, onOpenAnalytics, onOpenPackages, onOpenDone, onOpenActivity, onOpenSettings, onOpenGrowthAreas, onOpenNotes, onWhatNow }) {
   const rows = [
     { icon: Compass, label: 'What now?', sub: 'Get a pick based on time + energy', onClick: onWhatNow },
+    { icon: StickyNote, label: 'Notes', sub: 'Thoughts that aren’t tasks · pin to Today', onClick: onOpenNotes },
     { icon: FolderKanban, label: 'Arcs', sub: 'Long-term projects · sessions + steps', onClick: onOpenProjects },
     { icon: BarChart3, label: 'Analytics', sub: 'Productivity insights', onClick: onOpenAnalytics },
     { icon: CheckCircle2, label: 'Caught', sub: 'Everything you finished', onClick: onOpenDone },

--- a/src/kept/ThrowSheet.jsx
+++ b/src/kept/ThrowSheet.jsx
@@ -23,10 +23,14 @@ function resolve(id) {
 }
 
 // The Throw sheet — quick capture (spec §6). Title + smart date chips; "More
-// options" hands off to the full AddTaskModal with nothing lost.
-export default function ThrowSheet({ open, onClose, onThrow, onMoreOptions }) {
+// options" hands off to the full AddTaskModal with nothing lost. A Task|Note
+// mode toggle (2026-07-18) makes jotting a note as fast as adding a task —
+// note mode drops the date chips (notes have no dates) and routes to
+// onThrowNote instead.
+export default function ThrowSheet({ open, onClose, onThrow, onThrowNote, onMoreOptions }) {
   const [title, setTitle] = useState('')
   const [dateId, setDateId] = useState('none')
+  const [mode, setMode] = useState('task')
   const inputRef = useRef(null)
   const sheetRef = useRef(null)
   // The keyboard-occlusion offset below (px, <= 0) — kept in a ref rather
@@ -85,7 +89,11 @@ export default function ThrowSheet({ open, onClose, onThrow, onMoreOptions }) {
   const send = () => {
     const t = title.trim()
     if (!t) return
-    onThrow?.({ title: t, dueDate: resolve(dateId) })
+    if (mode === 'note') {
+      onThrowNote?.({ body: t })
+    } else {
+      onThrow?.({ title: t, dueDate: resolve(dateId) })
+    }
     setTitle(''); setDateId('none')
     closeAndBlur()
   }
@@ -101,26 +109,38 @@ export default function ThrowSheet({ open, onClose, onThrow, onMoreOptions }) {
         <div className="bm-sheet-handle" {...handleProps}>
           <div className="bm-grabber" />
         </div>
-        <h3 className="bm-sheet-title">Throw a task</h3>
+        <div className="bm-throw-mode-row">
+          <h3 className="bm-sheet-title">{mode === 'note' ? 'Leave a note' : 'Throw a task'}</h3>
+          <div className="bm-throw-mode">
+            <button className={`bm-pick${mode === 'task' ? ' is-on' : ''}`} onClick={() => setMode('task')}>Task</button>
+            <button className={`bm-pick${mode === 'note' ? ' is-on' : ''}`} onClick={() => setMode('note')}>Note</button>
+          </div>
+        </div>
         <input
           ref={inputRef}
           className="bm-throw-input"
-          placeholder="What needs doing?"
+          placeholder={mode === 'note' ? 'What do you want to remember?' : 'What needs doing?'}
           value={title}
           onChange={e => setTitle(e.target.value)}
           onKeyDown={e => { if (e.key === 'Enter') send() }}
           autoFocus
         />
-        <div className="bm-chip-row">
-          {DATES.map(d => (
-            <button key={d.id} className={`bm-pick${dateId === d.id ? ' is-on' : ''}`} onClick={() => setDateId(d.id)}>{d.label}</button>
-          ))}
-        </div>
+        {mode === 'task' && (
+          <div className="bm-chip-row">
+            {DATES.map(d => (
+              <button key={d.id} className={`bm-pick${dateId === d.id ? ' is-on' : ''}`} onClick={() => setDateId(d.id)}>{d.label}</button>
+            ))}
+          </div>
+        )}
         <div className="bm-throw-actions">
-          <button className="bm-btn bm-btn-fill" onClick={send} disabled={!title.trim()}>Throw it</button>
-          <button className="bm-btn bm-btn-ghost" onClick={openMoreOptions} aria-label="More options">
-            <SlidersHorizontal size={15} strokeWidth={2} />
+          <button className="bm-btn bm-btn-fill" onClick={send} disabled={!title.trim()}>
+            {mode === 'note' ? 'Leave it' : 'Throw it'}
           </button>
+          {mode === 'task' && (
+            <button className="bm-btn bm-btn-ghost" onClick={openMoreOptions} aria-label="More options">
+              <SlidersHorizontal size={15} strokeWidth={2} />
+            </button>
+          )}
         </div>
       </div>
     </div>

--- a/src/kept/TodayView.jsx
+++ b/src/kept/TodayView.jsx
@@ -1,5 +1,5 @@
 import { useMemo, useState, useEffect } from 'react'
-import { Check, Repeat2, Flame, FolderKanban, Inbox, X, Compass, Sprout } from 'lucide-react'
+import { Check, Repeat2, Flame, FolderKanban, Inbox, X, Compass, Sprout, StickyNote } from 'lucide-react'
 import { getTodayGrowthArea } from '../api'
 import DayArc from './DayArc'
 import FlightTrail from './FlightTrail'
@@ -27,6 +27,7 @@ export default function TodayView({
   dailyStats = {}, pointsGoal = 15, streak = 0,
   onCompleteTask, onOpenTask, onToggleHabit, onDeleteTask, onEditLoop,
   onLogSession, onGmailKeep, onGmailDismiss, onWhatNow, onCycleImpact,
+  pinnedNotes = [], onOpenNotes, onUnpinNote,
 }) {
   const todayKey = localYMD()
   const [collapsed, toggleSection] = useCollapsedSections()
@@ -269,6 +270,23 @@ export default function TodayView({
           <span className="bm-growth-banner-icon"><Sprout size={15} strokeWidth={2} /></span>
           <span className="bm-growth-banner-text">{growthPick.text}</span>
           <button className="bm-growth-banner-dismiss" onClick={dismissGrowthBanner} aria-label="Dismiss">
+            <X size={14} strokeWidth={2.2} />
+          </button>
+        </div>
+      ))}
+      {/* Pinned notes — the leave-a-note-on-the-fridge strip. Tap opens the
+        * Notes surface; the X unpins (the note itself survives in Notes). */}
+      {pinnedNotes.map(n => (
+        <div key={n.id} className="bm-note-sticky" onClick={() => onOpenNotes?.()} role="button" tabIndex={0}
+          onKeyDown={e => { if (e.key === 'Enter') onOpenNotes?.() }}>
+          <span className="bm-note-sticky-icon"><StickyNote size={15} strokeWidth={2} /></span>
+          <span className="bm-note-sticky-text">{n.body}</span>
+          <button
+            className="bm-note-sticky-unpin"
+            onClick={e => { e.stopPropagation(); onUnpinNote?.(n) }}
+            aria-label="Unpin note"
+            title="Unpin (keeps the note in Notes)"
+          >
             <X size={14} strokeWidth={2.2} />
           </button>
         </div>

--- a/src/kept/shell.css
+++ b/src/kept/shell.css
@@ -709,6 +709,44 @@
 }
 .bm-growth-banner-restore:hover { color: var(--bm-gold); }
 
+/* Pinned notes — the leave-a-note-on-the-fridge strip, above the Day Arc
+ * hero (next to the growth banner). Tap opens the Notes surface; the X
+ * unpins (never deletes — the note stays in Notes). */
+.bm-note-sticky {
+  display: flex; align-items: flex-start; gap: 8px;
+  width: 100%;
+  background: var(--bm-gold-soft);
+  border: 1px solid color-mix(in srgb, var(--bm-gold) 35%, transparent);
+  border-radius: 14px;
+  padding: 10px 12px;
+  margin-bottom: 10px;
+  text-align: left;
+  cursor: pointer;
+}
+.bm-note-sticky-icon { flex: 0 0 auto; color: var(--bm-gold); display: flex; margin-top: 1px; }
+.bm-note-sticky-text {
+  flex: 1 1 auto; min-width: 0;
+  font-size: 13px; line-height: 1.4; color: var(--bm-text);
+  white-space: pre-wrap; overflow-wrap: anywhere;
+  display: -webkit-box; -webkit-line-clamp: 4; -webkit-box-orient: vertical; overflow: hidden;
+}
+.bm-note-sticky-unpin {
+  flex: 0 0 auto;
+  border: none; background: transparent; color: var(--bm-text-faint);
+  display: flex; align-items: center; justify-content: center;
+  width: 24px; height: 24px; border-radius: 50%; cursor: pointer;
+}
+.bm-note-sticky-unpin:hover { background: var(--bm-card-2); color: var(--bm-text); }
+
+/* Throw sheet Task|Note mode toggle */
+.bm-throw-mode-row {
+  display: flex; align-items: center; justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 12px;
+}
+.bm-throw-mode-row .bm-sheet-title { margin: 0; }
+.bm-throw-mode { display: flex; gap: 6px; flex: 0 0 auto; }
+
 /* --- Crisis tag ("prio") — the one deliberately loud surface in Kept.
  * See wiki/Crisis-Tag-And-Impact-Ranking.md. --- */
 .bm-crisis-row {

--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -158,6 +158,17 @@ CREATE TABLE app_data (
   collection TEXT PRIMARY KEY,
   data_json TEXT NOT NULL
 );
+
+-- Notes (migration 044) — free-floating notes, no task semantics. Own table
+-- + dedicated endpoints, never part of the bulk /api/data blob. `pinned`
+-- notes render as a sticky strip at the top of Today.
+CREATE TABLE notes (
+  id TEXT PRIMARY KEY,
+  body TEXT NOT NULL,
+  pinned INTEGER DEFAULT 0,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
 ```
 
 ```sql
@@ -361,10 +372,14 @@ carries a valid `boom_session` cookie (human login) OR a valid `API_TOKEN` in
 | `GET` | `/api/knowledge` | Search/filter/list cached knowledge items (`?q=&type=&limit=`) |
 | `GET` | `/api/knowledge/:id` | Cached metadata + on-demand body fetch |
 | `POST` | `/api/knowledge/refresh` | Force-refresh from Notion |
+| `GET` | `/api/notes` | List notes (pinned first, then most recently touched) |
+| `POST` | `/api/notes` | Create a note (`{ body, pinned? }`) |
+| `PATCH` | `/api/notes/:id` | Update a note's body and/or pin state |
+| `DELETE` | `/api/notes/:id` | Delete a note |
 
 ## AI Adviser
 
-`adviserTools.js` is the engine. `adviserToolsTasks.js`, `adviserToolsIntegrations.js`, `adviserToolsMisc.js`, and `adviserToolsKnowledge.js` register 60+ tools via `registerTool({ name, description, schema, readOnly, preview, execute })`. Includes 5 project tools added 2026-05-17 (`pin_project_to_today`, `log_project_session`, `project_set_nag_policy`, `link_task_to_project`, `list_project_children`) and 9 knowledge-base tools added 2026-05-21 (`search_knowledge`, `get_knowledge`, `refresh_knowledge_index`, `list_knowledge`, `create_knowledge`, `update_knowledge`, `delete_knowledge`, `link_knowledge_to_task`, `unlink_knowledge_from_task`).
+`adviserTools.js` is the engine. `adviserToolsTasks.js`, `adviserToolsIntegrations.js`, `adviserToolsMisc.js`, and `adviserToolsKnowledge.js` register 60+ tools via `registerTool({ name, description, schema, readOnly, preview, execute })`. Includes 5 project tools added 2026-05-17 (`pin_project_to_today`, `log_project_session`, `project_set_nag_policy`, `link_task_to_project`, `list_project_children`) and 9 knowledge-base tools added 2026-05-21 (`search_knowledge`, `get_knowledge`, `refresh_knowledge_index`, `list_knowledge`, `create_knowledge`, `update_knowledge`, `delete_knowledge`, `link_knowledge_to_task`, `unlink_knowledge_from_task`), and 4 notes tools added 2026-07-18 (`list_notes`, `create_note`, `update_note`, `delete_note`).
 
 **Staged execution.** During `/api/adviser/chat`, read-only tools run immediately and return data; mutation tools do nothing except return a `preview` string and push a staged step into the session's plan. When the user confirms, `/api/adviser/commit` runs every staged step in order via `commitPlan()`.
 

--- a/wiki/Features.md
+++ b/wiki/Features.md
@@ -148,6 +148,16 @@ Context-aware preset options that show the exact date and time (e.g., "Tomorrow 
 
 **Later — set aside.** A "Later — set aside (no resurface)" option at the bottom of the snooze list parks a task indefinitely. The task stays in the Snoozed section but never auto-resurfaces, and notifications skip it entirely. Use it for "I don't want to think about this right now and I don't know when I will." Bring it back manually by opening Snooze on the task and tapping "↺ Bring back now" at the top.
 
+## Notes
+
+A place to leave a thought without creating a task. Notes have **no task semantics** — no due date, no status, no points, no nagging, and they never count toward pile-up warnings or analytics.
+
+- **Capture** — the Throw sheet (center Throw button on mobile, ⌘K on desktop) has a **Task | Note** toggle: flip to Note, type, "Leave it." Or open the Notes surface and use its composer. Or tell Quokka ("note to self: the pool key is in the junk drawer").
+- **Pin to Today** — a pinned note shows as a gold sticky strip at the top of Today, like a note on the fridge. Tap it to open Notes; the X unpins (the note itself is kept). Unpinned notes live only in the Notes page.
+- **Notes surface** — More → Notes (mobile) or the sidebar (desktop): edit inline, pin/unpin, delete.
+- **Make it a task** — if a note turns out to be something you actually need to do, promote it: the first line becomes the task title, the rest becomes the task's notes, and the note is removed. The new task gets normal auto size/energy/tag inference.
+- **Quokka** — `list_notes` / `create_note` / `update_note` / `delete_note`; distinct from the Notion-backed Knowledge Base (notes are quick local jots, knowledge is durable reference).
+
 ## Projects
 
 `status: 'project'` tasks. Silent by default — no notifications, no stale pressure. Pin a project to today to surface it on the main list with a dedicated card.

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -4,6 +4,21 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ---
 
+## 2026-07-18
+
+- feat(tasks): Notes — leave a note without creating a task [L]
+  - User request: "I need a concept of a note. Something where I can leave a note without creating a task that has a due date." New first-class `notes` concept — free-floating notes with NO task semantics: no due date, no status, no points, no nagging, never counted in pile-up or analytics. Deliberately its own SQL table (migration 044: id/body/pinned/timestamps) + dedicated per-record endpoints (`GET/POST /api/notes`, `PATCH/DELETE /api/notes/:id`) — never part of the bulk `/api/data` blob (same carve-out as growth areas/packages), so the whole-blob LWW hazard can't touch it.
+  - **Pinned = leave a note on the fridge.** Pinned notes render as a gold sticky strip at the top of Kept's Today (mobile + desktop), above the Day Arc hero next to the growth banner. Tap opens the Notes surface; the X unpins (never deletes). Unpinned notes live only in the Notes page.
+  - **Capture:** the Throw sheet (center Throw button / ⌘K) gains a **Task | Note** toggle — note mode drops the date chips, placeholder flips to "What do you want to remember?", button becomes "Leave it". Plus the Notes surface's composer (with a pin-on-create checkbox) and Quokka.
+  - **Notes surface:** `NotesModal` (More → Notes on mobile, sidebar → Notes on desktop) — composer, pinned-first list, inline edit, pin/unpin, delete, and **"Make it a task"**: first line → task title, remainder → task notes, note removed once the task exists (goes through the normal `handleAddTask` path, so auto-sizing/tagging apply).
+  - **Quokka tools (4, in `adviserToolsMisc.js`):** `list_notes` (read-only), `create_note` ("note to self: …"; `pinned` only when the user asks for it on Today), `update_note`, `delete_note` — staged with capture/restore compensation like every other mutation tool. Live registry now reports 86 tools total (the docs' old "64" count had drifted; corrected).
+  - Cross-device: note writes bump the sync version + broadcast; `useNotes.reload()` rides `hydrateFromServer` so a note left on the phone appears on the desktop on the next sync round-trip.
+  - Verified end-to-end on a scratch server: full CRUD + validation via API; headless renders of the Today sticky, Throw-sheet note mode (created a real note through the UI), Notes list, and the promote flow (task landed server-side with body split into title/notes, note removed).
+
+- fix(sync): manual settings flush no longer swallows a just-added task [M]
+  - Found while live-verifying Notes, but pre-existing on `dev` and reproducible against a clean baseline: `flush()` (the manual settings/labels push) cleared the pending per-record debounce timer, and `pushBulkState`'s success handler then advanced `prevTasks`/`prevRoutines` to current state — marking any task/routine change from the last ~300ms as "already pushed" without ever pushing it. Concrete prod shape: the first-ever task add triggers the streak-anchor effect, which saves settings + flushes within the 300ms window → the task exists locally but never reaches the server (verified: baseline won the race by ~60ms of render timing; the Notes branch shifted timing and lost it deterministically).
+  - Fix, both halves: `flush()` now runs the pending per-record push before the bulk push (same pattern `fetchAndHydrate` already uses), and `pushBulkState` only bootstraps the per-record snapshots when they're still null (the fresh-empty-server path) instead of overwriting them — a bulk push carries settings/labels only and must never claim tasks as pushed. Verified: the previously-lost throw now lands server-side with the settings flush racing it.
+
 ## 2026-07-17
 
 - fix(routines): duplicate-spawn guard v2 — due_date out of the key + automatic cleanup sweep [M]


### PR DESCRIPTION
## Notes — "I need a concept of a note"

A first-class notes concept with **zero task semantics** — no due date, no status, no points, no nagging, never counted in pile-up or analytics.

- **Storage:** own `notes` table (migration 044) + dedicated `/api/notes` CRUD endpoints — deliberately never part of the bulk `/api/data` blob (same carve-out as growth areas/packages).
- **Pin to Today:** pinned notes show as a gold sticky strip at the top of Today (mobile + desktop) — like a note on the fridge. Tap opens Notes; the X unpins (never deletes).
- **Capture:** the Throw sheet (center button / ⌘K) gets a **Task | Note** toggle — note mode drops the date chips, button becomes "Leave it". Plus the Notes surface composer (pin-on-create) and Quokka ("note to self: …").
- **Notes surface:** More → Notes (mobile) / sidebar → Notes (desktop) — inline edit, pin/unpin, delete, and **"Make it a task"** (first line → title, rest → task notes, note removed; normal auto-inference applies).
- **Quokka:** `list_notes` / `create_note` / `update_note` / `delete_note`, staged with capture/restore compensation.

## fix(sync): manual settings flush swallowed a just-added task

Found while live-verifying this feature, **pre-existing on dev** (reproduced against a clean baseline): `flush()` cleared the pending per-record debounce and `pushBulkState`'s success handler advanced `prevTasks`/`prevRoutines` — marking any task added in the last ~300ms as "already pushed" without pushing it (prod shape: first-ever task add → streak-anchor effect saves settings → flush wins the race → task never syncs). Fixed: `flush()` now pushes pending per-record ops first, and `pushBulkState` only bootstraps the snapshots when they're null.

## Verification

- Scratch server: full CRUD + validation via API; migration 044 applies; 4 note tools live in the adviser registry.
- Headless UI: Today sticky renders; Throw note mode creates a real note; Notes list correct; promote lands the task server-side with body split into title/notes.
- Sync fix: baseline reproduced the lost-task race; post-fix the same flow lands the task alongside the racing settings flush.
- Lint, `npm test`, build, smoke, `npm audit` (0 vulnerabilities) all green. Docs updated (Version-History, CLAUDE.md, Features, Architecture).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V45AJzVRjV8j2Sei5Qgr6A

---
_Generated by [Claude Code](https://claude.ai/code/session_01V45AJzVRjV8j2Sei5Qgr6A)_