### PR TITLE
fix(packages): Track-package button no longer fails silently or hangs on 17track

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -444,6 +444,7 @@ Track packages with auto carrier detection, adaptive server-side polling, and de
 - Test connection via `getquota` endpoint (free, no tracking query consumed)
 
 **Polling Strategy:**
+- All 17track fetches (`register`/`changecarrier`/`gettrackinfo`) carry `AbortSignal.timeout(15s)`, and the add-package route races its inline register+poll against an 8s cap (2026-07-20: un-timed awaits let a slow 17track hang `POST /api/packages` for minutes — reported as "Track button does nothing"; the client add form also now surfaces errors inline instead of swallowing them, incl. a friendly 409-duplicate message)
 - Server-side polling loop every 5 minutes, batched API calls (up to 40 per request)
 - Adaptive intervals: 15min (out_for_delivery), 30min (pending), 1-4hr (in_transit), 1hr (exception)
 - API quota tracking with automatic pause/resume at midnight UTC

--- a/server/server.js
+++ b/server/server.js
@@ -2212,6 +2212,9 @@ async function register17track(items, apiKey) {
         '17token': apiKey,
       },
       body: JSON.stringify(deduped),
+      // Bounded: an unreachable/slow 17track must never hang a caller — the
+      // add-package route awaits this inline before responding.
+      signal: AbortSignal.timeout(15_000),
     })
     const data = await res.json()
     console.log('[Packages] 17track register:', res.status, 'accepted:', data.data?.accepted?.length || 0, 'rejected:', data.data?.rejected?.length || 0)
@@ -2244,6 +2247,7 @@ async function changeCarrier17track(trackingNumber, carrierCode, apiKey) {
         '17token': apiKey,
       },
       body: JSON.stringify([{ number: normalize17trackNumber(trackingNumber), carrier: carrierCode }]),
+      signal: AbortSignal.timeout(15_000),
     })
     const data = await res.json()
     console.log('[Packages] 17track changecarrier:', normalize17trackNumber(trackingNumber), '→', carrierCode, 'status:', res.status, 'accepted:', data.data?.accepted?.length || 0)
@@ -2266,6 +2270,7 @@ async function poll17track(trackingNumbers, apiKey) {
       body: JSON.stringify(
         trackingNumbers.map(tn => ({ number: normalize17trackNumber(tn) }))
       ),
+      signal: AbortSignal.timeout(15_000),
     })
 
     if (res.status === 429) {
@@ -2538,10 +2543,16 @@ app.post('/api/packages', async (req, res) => {
 
   upsertPackage(pkg)
 
-  // Register + immediate poll so the card shows real data right away
+  // Register + immediate poll so the card shows real data right away — but
+  // BOUNDED: the row is already saved, so a slow/unreachable 17track must
+  // never hang this response (the prod "Track package does nothing" report:
+  // the un-timed awaits here held the request open for minutes). Past the
+  // race window we respond with the pending package and let the work finish
+  // in the background — its updatePackagePartial still lands for the next
+  // fetch, and the polling loop covers it regardless.
   const apiKey = getTrackingApiKey(req)
   if (apiKey) {
-    try {
+    const initialPoll = (async () => {
       await register17track([pkg], apiKey)
       await new Promise(r => setTimeout(r, 1500))
       const results = await poll17track([pkg.tracking_number], apiKey)
@@ -2565,9 +2576,9 @@ app.post('/api/packages', async (req, res) => {
         updatePackagePartial(pkg.id, updates)
         Object.assign(pkg, updates)
       }
-    } catch (err) {
-      console.error('[Packages] Initial poll failed:', err.message)
-    }
+    })()
+    initialPoll.catch(err => console.error('[Packages] Initial poll failed:', err.message))
+    await Promise.race([initialPoll.catch(() => {}), new Promise(r => setTimeout(r, 8000))])
   }
 
   const newVersion = bumpVersion()

--- a/src/api.js
+++ b/src/api.js
@@ -1257,7 +1257,15 @@ export async function createPackage(trackingNumber, label, carrier) {
     headers,
     body: JSON.stringify({ tracking_number: trackingNumber, label, carrier }),
   })
-  if (!res.ok) throw new Error(`create package failed: ${res.status}`)
+  if (!res.ok) {
+    // Surface the server's reason (e.g. 409 "Tracking number already exists")
+    // — the add form displays this message verbatim.
+    const body = await res.json().catch(() => null)
+    const err = new Error(body?.error || `create package failed: ${res.status}`)
+    err.status = res.status
+    err.existingLabel = body?.label
+    throw err
+  }
   return res.json()
 }
 

--- a/src/components/PackagesModal.css
+++ b/src/components/PackagesModal.css
@@ -278,3 +278,14 @@
 .v2-package-spin {
   animation: v2-spin 0.8s linear infinite;
 }
+
+/* Add-form failure message (2026-07-20) — a failed add must never be silent. */
+.v2-package-add-error {
+  padding: 8px 12px;
+  border-radius: 8px;
+  background: color-mix(in srgb, #d9534f 12%, transparent);
+  color: #c0392b;
+  font: 400 12.5px/1.45 var(--v2-font-body);
+}
+[data-theme="dark"] .v2-package-add-error,
+[data-theme="kept-dark"] .v2-package-add-error { color: #e07b74; }

--- a/src/components/PackagesModal.jsx
+++ b/src/components/PackagesModal.jsx
@@ -166,6 +166,7 @@ export default function PackagesModal({
   const [trackingInput, setTrackingInput] = useState('')
   const [labelInput, setLabelInput] = useState('')
   const [adding, setAdding] = useState(false)
+  const [addError, setAddError] = useState(null)
   const [showAddForm, setShowAddForm] = useState(false)
   const [refreshingAll, setRefreshingAll] = useState(false)
   const [expandedId, setExpandedId] = useState(null)
@@ -191,12 +192,22 @@ export default function PackagesModal({
     const tracking = trackingInput.trim().replace(/\s/g, '')
     if (!tracking) return
     setAdding(true)
+    setAddError(null)
     try {
       // addPackage takes positional args (trackingNumber, label, carrier) — same as v1.
       await onAdd(tracking, labelInput.trim() || null, detectedCarrier?.code || 'other')
       setTrackingInput('')
       setLabelInput('')
       setShowAddForm(false)
+    } catch (err) {
+      // Silent failure destroys trust in the button — say what went wrong.
+      // 409 = already tracked server-side (possibly a pending Gmail import
+      // this device hasn't fetched yet).
+      if (err?.status === 409) {
+        setAddError(`Already tracking this number${err.existingLabel ? ` as "${err.existingLabel}"` : ''}. Pull to refresh if you don't see it.`)
+      } else {
+        setAddError(err?.message || 'Could not add package — check the server connection.')
+      }
     } finally {
       setAdding(false)
     }
@@ -248,6 +259,7 @@ export default function PackagesModal({
               <span>Detected: <strong>{detectedCarrier.name}</strong></span>
             </div>
           )}
+          {addError && <div className="v2-package-add-error">{addError}</div>}
           <button
             className="v2-form-submit"
             onClick={handleAdd}

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -4,6 +4,14 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ---
 
+## 2026-07-20
+
+- fix(packages): Track-package button no longer fails silently or hangs on 17track [M]
+  - Prod report (with screenshot): "Pushing the track button does nothing" — number + label filled, USPS detected, tap, nothing. Two compounding bugs, both reproduced headless:
+  - **Silent client failure:** `handleAdd` in `PackagesModal.jsx` had `try/finally` with no catch — ANY failed `POST /api/packages` (409 duplicate, 401, 500, network) was an unhandled rejection and the form just sat there. Now caught and rendered inline (`.v2-package-add-error`); `createPackage` in `api.js` parses the server's error body so the message is the real reason, with a friendly 409 case ("Already tracking this number as \"X\" — pull to refresh if you don't see it", since the twin may be a pending Gmail import this device hasn't fetched).
+  - **Unbounded 17track awaits:** the add route awaited `register17track` + `poll17track` inline with NO timeout — a slow/unreachable api.17track.net held the response open for minutes, making the button look dead. All three 17track fetches (`register`, `changecarrier`, `gettrackinfo`) now carry `AbortSignal.timeout(15s)` (protects the background polling loop too), and the add route additionally races its inline register+poll against an 8s cap — past it, the response returns the pending package immediately and the poll finishes in the background (its write lands for the next fetch/poll cycle).
+  - Verified headless: happy path renders the row; duplicate attempt shows the inline message instead of nothing.
+
 ## 2026-07-19
 
 - refactor(ui): Kept More/sidebar consolidation — 9 rows down to 4, Notebook merges Notes + Growth areas [M]


### PR DESCRIPTION
## What

Prod report (with screenshot): "Pushing the track button does nothing" — tracking number + label filled, USPS detected, tap, nothing happens. Two compounding bugs, both reproduced headless against a scratch server:

## Bugs + fixes

1. **Silent client failure.** `handleAdd` in `PackagesModal.jsx` was `try/finally` with **no catch** — any failed `POST /api/packages` (409 duplicate, auth, 500, network) became an unhandled rejection with zero UI feedback: spinner flashes, form sits there, package never appears. Errors now render inline in the add form; `createPackage` in `api.js` parses the server's error body so the message is the real reason, with a friendly 409 case: *"Already tracking this number as "X". Pull to refresh if you don't see it."* (the twin may be a pending Gmail import this device hasn't fetched yet).

2. **Unbounded 17track awaits.** The add route awaited `register17track` + `poll17track` inline with **no timeout** — a slow or unreachable `api.17track.net` held the HTTP response open for minutes, making the button look dead even though the row was already saved. All three 17track fetches (`register`, `changecarrier`, `gettrackinfo`) now carry `AbortSignal.timeout(15s)` — which also protects the 5-minute background polling loop from wedging — and the add route additionally races its inline register+poll against an **8s cap**: past it, the response returns the pending package immediately and the poll finishes in the background (its write lands on the next fetch/poll cycle).

## Verification

Headless Chromium against a scratch server, driving the real Kept mobile UI:
- Happy path: `POST /api/packages` 200, package row renders in the list
- Duplicate attempt: 409 → inline message shown in the form (previously: unhandled `create package failed: 409` page error, nothing visible)

Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WRagsiwVpUkSoxNdf8ahNi

---
_Generated by [Claude Code](https://claude.ai/code/session_01WRagsiwVpUkSoxNdf8ahNi)_