### PR TITLE
release: task merge + Notion connections link fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -951,7 +951,7 @@ Free-form natural-language control surface — user says "I've rescheduled my FA
 
 **Server modules:**
 - `adviserTools.js` — registry, session/plan storage (10-min TTL, 1-min sweep), `handleToolCall()`, `commitPlan()` with rollback
-- `adviserToolsTasks.js` — 22 task + routine tools (incl. 4 Sequences chain editors: `add_follow_up`, `edit_follow_up`, `remove_follow_up`, `reorder_follow_ups`; + `reconcile_loops`)
+- `adviserToolsTasks.js` — 23 task + routine tools (incl. 4 Sequences chain editors: `add_follow_up`, `edit_follow_up`, `remove_follow_up`, `reorder_follow_ups`; + `reconcile_loops`, `merge_tasks`)
 - `adviserToolsIntegrations.js` — 12 GCal + Notion + Trello tools
 - `adviserToolsMisc.js` — Gmail + packages + weather + settings + analytics + growth-area + notes tools (incl. `check_integrations`, the live cross-integration health probe)
 - `adviserToolsKnowledge.js` — 9 knowledge-base tools (search, get, refresh, list, create, update, delete, link/unlink to tasks)
@@ -966,7 +966,7 @@ Free-form natural-language control surface — user says "I've rescheduled my FA
 | `GET /api/adviser/tools` | Returns the full tool inventory (name + description) for debugging. |
 
 **Tool categories & counts:**
-- Tasks (12): search, get, create (with optional `checklist_items` for multi-part tasks), update, delete, complete, reopen, snooze, move_to_projects, move_to_backlog, activate, research_task (append AI-researched notes with web search)
+- Tasks (13): search, get, create (with optional `checklist_items` for multi-part tasks), update, delete, complete, reopen, snooze, move_to_projects, move_to_backlog, activate, research_task (append AI-researched notes with web search), merge_tasks (fold a duplicate into a survivor — content combined, earliest due date, external links adopted, duplicate deleted; server primitive `mergeTasks()` in db.js, also behind `POST /api/tasks/:id/merge` + the EditTaskModal "Merge duplicate" picker)
 - Routines (7): list, get, create, update, delete, spawn_now, reconcile_loops (stamp completed_history for stuck-open cadence loops whose tasks are done — staged + LIFO-compensated; idempotent; skips stacks + habit loops)
 - Anthropic server-side `web_search` available in the main chat loop — Quokka can look up current info (prices, news, current best-practices) live during a reply, not just from training data
 - Google Calendar (5): list calendars, list events, create/update/delete events

--- a/server/adviserToolsTasks.js
+++ b/server/adviserToolsTasks.js
@@ -5,7 +5,7 @@
 
 import crypto from 'crypto'
 import {
-  upsertTask, getTask, deleteTask, queryTasks, updateTaskPartial,
+  upsertTask, getTask, deleteTask, queryTasks, updateTaskPartial, mergeTasks,
   upsertRoutine, getRoutine, getAllRoutines, deleteRoutine, updateRoutinePartial,
   reconcileRoutineHistory,
   getChildTasks, computeProjectBudget, computeSessionPoints, logProjectSession,
@@ -557,6 +557,32 @@ export function registerTaskTools() {
       return {
         result: { id, deleted: true },
         compensation: async () => { upsertTask(before) },
+      }
+    },
+  })
+
+  registerTool({
+    name: 'merge_tasks',
+    description: 'Merge a duplicate task into a survivor. Folds the duplicate\'s notes (under a provenance divider), tags, checklists, attachments and comments into the survivor, keeps the earliest due date, ORs high-priority/nag opt-ins, adopts external links (Notion/Trello/GCal/Gmail) and enrichment the survivor lacks, then DELETES the duplicate. Use when the user says two tasks are duplicates or the same thing. The survivor keeps its own title. Destructive — always goes through plan confirmation.',
+    schema: {
+      type: 'object',
+      properties: {
+        survivor_id: { type: 'string', description: 'The task that remains after the merge' },
+        duplicate_id: { type: 'string', description: 'The task folded into the survivor and then deleted' },
+      },
+      required: ['survivor_id', 'duplicate_id'],
+    },
+    preview: (args) => `Merge "${taskLabel(args.duplicate_id)}" into "${taskLabel(args.survivor_id)}" (duplicate is deleted)`,
+    execute: async ({ survivor_id, duplicate_id }) => {
+      const beforeSurvivor = getTask(survivor_id)
+      const beforeDupe = getTask(duplicate_id)
+      if (!beforeSurvivor) throw new Error(`Task not found: ${survivor_id}`)
+      if (!beforeDupe) throw new Error(`Task not found: ${duplicate_id}`)
+      const { survivor } = mergeTasks(survivor_id, duplicate_id)
+      return {
+        result: { survivor: summarizeTask(survivor), merged_from: duplicate_id },
+        // LIFO restore: survivor back to its pre-merge state, duplicate re-inserted whole.
+        compensation: async () => { upsertTask(beforeSurvivor); upsertTask(beforeDupe) },
       }
     },
   })

--- a/server/db.js
+++ b/server/db.js
@@ -781,6 +781,85 @@ export function deleteTask(id) {
   schedulePersist()
 }
 
+// Merge a duplicate task into a survivor: fold in the duplicate's content
+// (notes under a provenance divider, tags/attachments/comments unioned,
+// checklists appended unless every item already exists verbatim), keep the
+// earliest due date, OR the opt-in flags, adopt any external links or
+// enrichment the survivor lacks, then delete the duplicate through the
+// normal evidence-preserving path (completion-day provenance + Pushover
+// receipt cancellation). Returns { survivor, duplicate } — duplicate is the
+// full pre-delete record so callers (Quokka rollback, GCal cleanup) can act
+// on it.
+export function mergeTasks(survivorId, duplicateId) {
+  if (survivorId === duplicateId) throw new Error('Cannot merge a task into itself')
+  const survivor = getTask(survivorId)
+  const dupe = getTask(duplicateId)
+  if (!survivor) throw new Error(`Task not found: ${survivorId}`)
+  if (!dupe) throw new Error(`Task not found: ${duplicateId}`)
+
+  const now = new Date().toISOString()
+
+  let notes = (survivor.notes || '').trim()
+  if ((dupe.notes || '').trim()) {
+    notes = [notes, `— merged from "${dupe.title}" (${now.slice(0, 10)}) —`, dupe.notes.trim()]
+      .filter(Boolean).join('\n\n')
+  }
+
+  const survivorItems = new Set(
+    (survivor.checklists || []).flatMap(c => (c.items || []).map(i => (i.text || '').trim().toLowerCase())),
+  )
+  const extraChecklists = (dupe.checklists || []).filter(c =>
+    (c.items || []).some(i => !survivorItems.has((i.text || '').trim().toLowerCase())),
+  )
+
+  const pickEarlier = (a, b) => {
+    if (!a) return b || null
+    if (!b) return a
+    return a <= b ? a : b
+  }
+
+  const updates = {
+    notes,
+    tags: [...new Set([...(survivor.tags || []), ...(dupe.tags || [])])],
+    checklists: [...(survivor.checklists || []), ...extraChecklists],
+    attachments: [...(survivor.attachments || []), ...(dupe.attachments || [])],
+    comments: [...(survivor.comments || []), ...(dupe.comments || [])],
+    due_date: pickEarlier(survivor.due_date, dupe.due_date),
+    high_priority: !!(survivor.high_priority || dupe.high_priority),
+    nag_allowed: !!(survivor.nag_allowed || dupe.nag_allowed),
+    updated_at: now,
+    last_touched: now,
+  }
+
+  // Adopt-if-missing scalars: external links + enrichment the survivor lacks.
+  const ADOPT = ['notion_page_id', 'notion_url', 'trello_card_id', 'trello_card_url',
+    'gcal_event_id', 'gcal_duration', 'gmail_message_id', 'routine_id',
+    'energy', 'energy_level', 'size', 'impact', 'assignee']
+  for (const k of ADOPT) {
+    if ((survivor[k] == null || survivor[k] === '') && dupe[k] != null && dupe[k] !== '') {
+      updates[k] = dupe[k]
+    }
+  }
+
+  // Whole-group adoptions — never interleave two ladders/chains.
+  if (!(survivor.follow_ups || []).length && (dupe.follow_ups || []).length) {
+    updates.follow_ups = dupe.follow_ups
+  }
+  if (!(survivor.escalation_rungs || []).length && (dupe.escalation_rungs || []).length) {
+    updates.escalation_rungs = dupe.escalation_rungs
+    updates.escalation_current_rung = dupe.escalation_current_rung
+    updates.escalation_attempt_log = dupe.escalation_attempt_log
+    updates.escalation_awaiting_advance = dupe.escalation_awaiting_advance
+    updates.escalation_stuck = dupe.escalation_stuck
+  }
+  const kIds = [...new Set([...(survivor.knowledge_page_ids || []), ...(dupe.knowledge_page_ids || [])])]
+  if (kIds.length) updates.knowledge_page_ids = kIds
+
+  updateTaskPartial(survivorId, updates)
+  deleteTask(duplicateId)
+  return { survivor: getTask(survivorId), duplicate: dupe }
+}
+
 export function queryTasks(filters = {}) {
   const clauses = []
   const params = []

--- a/server/server.js
+++ b/server/server.js
@@ -29,7 +29,7 @@ import {
   sendPackagePushover, cancelEmergencyForTask as cancelPushoverEmergencyForTask,
   sendDigestNow,
 } from './pushoverNotifications.js'
-import { upsertPushSubscription, deletePushSubscription, getAllPushSubscriptions, deletePushSubscriptionById, getGmailProcessedCount, clearGmailProcessed, getNotifThrottle, setNotifThrottle, getAllTasks } from './db.js'
+import { upsertPushSubscription, deletePushSubscription, getAllPushSubscriptions, deletePushSubscriptionById, getGmailProcessedCount, clearGmailProcessed, getNotifThrottle, setNotifThrottle, getAllTasks, mergeTasks } from './db.js'
 import { initGmailSync, syncGmail, startGmailPolling, getGmailAccessToken } from './gmailSync.js'
 import { startWeatherSync, refreshWeather, geocodeLocation, getWeatherCache, getWeatherStatus, clearWeatherCache } from './weatherSync.js'
 import { startPatternDetection, runPatternScan } from './patternDetection.js'
@@ -796,6 +796,37 @@ app.post('/api/tasks/:id/escalation/dismiss-prompt', (req, res) => {
     res.json({ task, version: newVersion })
   } catch (err) {
     res.status(400).json({ error: err.message })
+  }
+})
+
+// Merge a duplicate task into a survivor (semantics: mergeTasks in db.js).
+app.post('/api/tasks/:id/merge', async (req, res) => {
+  const dupeId = req.body?.duplicate_id
+  if (!dupeId) return res.status(400).json({ error: 'duplicate_id required' })
+  try {
+    const { survivor, duplicate } = mergeTasks(req.params.id, dupeId)
+    // Best-effort: if the duplicate carried its own calendar event and the
+    // survivor kept a different one, remove the dupe's event so the calendar
+    // doesn't keep a ghost copy. Failure here never fails the merge.
+    if (duplicate.gcal_event_id && duplicate.gcal_event_id !== survivor.gcal_event_id) {
+      try {
+        const accessToken = await getGCalAccessToken()
+        if (accessToken) {
+          const settings = getData('settings') || {}
+          const calId = encodeURIComponent(settings.gcal_calendar_id || 'primary')
+          await fetch(`${GCAL_BASE}/calendars/${calId}/events/${encodeURIComponent(duplicate.gcal_event_id)}`, {
+            method: 'DELETE', headers: { Authorization: `Bearer ${accessToken}` },
+          })
+        }
+      } catch (e) {
+        console.warn(`[Tasks] merge: could not remove duplicate's calendar event: ${e.message}`)
+      }
+    }
+    const newVersion = bumpVersion()
+    broadcast(newVersion, req.body?._clientId || req.headers['x-client-id'])
+    res.json(survivor)
+  } catch (e) {
+    res.status(400).json({ error: e.message })
   }
 })
 

--- a/src/AppV2.jsx
+++ b/src/AppV2.jsx
@@ -59,7 +59,7 @@ import { useTrelloSync } from './hooks/useTrelloSync'
 import { useNotionSync } from './hooks/useNotionSync'
 import { useGCalSync } from './hooks/useGCalSync'
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts'
-import { inferSize, trelloUpdateCard, serverSkipAdvanceTask, gmailApprove, gmailDismiss } from './api'
+import { inferSize, trelloUpdateCard, serverSkipAdvanceTask, gmailApprove, gmailDismiss, mergeTasks as apiMergeTasks } from './api'
 import { loadLabels, loadSettings, saveSettings, saveLabels, sortTasks, computeDailyStats, computeStreak, logActivity, localYMD, uuid, LABEL_COLORS, isCrisisTask } from './store'
 import { computeRecords, calculateTaskPoints } from './scoring'
 import { applyTheme, watchSystemTheme } from './theme'
@@ -1612,6 +1612,13 @@ export default function AppV2() {
             handleAddChildToProject(project)
           }}
           onOpenTask={(otherTask) => setEditTarget(otherTask)}
+          allTasks={tasks}
+          onMerge={async (survivorId, duplicateId) => {
+            const merged = await apiMergeTasks(survivorId, duplicateId)
+            await refetchFromServer()
+            setEditTarget(merged) // stay on the merged result
+            return merged
+          }}
           onSetEscalationRungs={setEscalationRungs}
           onLogEscalationAttempt={logEscalationAttempt}
           onAdvanceEscalationRung={advanceEscalationRung}

--- a/src/api.js
+++ b/src/api.js
@@ -1872,3 +1872,18 @@ export async function aiSearchActivity(query, items) {
   if (!res.ok) throw new Error(`Search failed: ${res.status}`)
   return res.json()
 }
+
+// Merge a duplicate task into a survivor (server-side — combines content,
+// keeps earliest due date, adopts missing external links, deletes the dupe).
+export async function mergeTasks(survivorId, duplicateId) {
+  const res = await fetch(`/api/tasks/${encodeURIComponent(survivorId)}/merge`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ duplicate_id: duplicateId }),
+  })
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({}))
+    throw new Error(data.error || `Merge failed (${res.status})`)
+  }
+  return res.json()
+}

--- a/src/components/EditTaskModal.jsx
+++ b/src/components/EditTaskModal.jsx
@@ -34,6 +34,7 @@ export default function EditTaskModal({
   childTasks = [],
   siblingSubs = [],
   onLogSession, onAddChild, onOpenTask,
+  allTasks = [], onMerge,
   onSetEscalationRungs, onLogEscalationAttempt, onAdvanceEscalationRung,
   onDismissEscalationAdvancePrompt, onResolveEscalation, onBrainstormEscalation,
 }) {
@@ -49,8 +50,31 @@ export default function EditTaskModal({
     lowPriority: task.low_priority || false,
     sizeInferred: !!task.size_inferred,
     attachments: task.attachments || [],
-    notion: task.notion_page_id ? { id: task.notion_page_id, url: task.notion_url } : null,
+    // notion_url is often null (pull-synced / Quokka-linked tasks store only
+    // the page id) — the canonical notion.so/<id-sans-dashes> redirect works
+    // for any page the viewer can access, so derive it rather than render a
+    // dead "Notion ↗" chip with href=undefined.
+    notion: task.notion_page_id
+      ? {
+          id: task.notion_page_id,
+          url: task.notion_url || `https://www.notion.so/${String(task.notion_page_id).replace(/-/g, '')}`,
+        }
+      : null,
   })
+
+  // Merge-duplicate state (search → pick → confirm; the actual merge is
+  // server-side via onMerge → POST /api/tasks/:id/merge).
+  const [mergeQuery, setMergeQuery] = useState('')
+  const [mergePick, setMergePick] = useState(null)
+  const [mergeBusy, setMergeBusy] = useState(false)
+  const [mergeError, setMergeError] = useState(null)
+  const mergeCandidates = useMemo(() => {
+    const q = mergeQuery.trim().toLowerCase()
+    if (q.length < 2) return []
+    return allTasks
+      .filter(t => t.id !== task.id && t.status !== 'done' && (t.title || '').toLowerCase().includes(q))
+      .slice(0, 8)
+  }, [mergeQuery, allTasks, task.id])
 
   // Research state — inline because only EditTaskModal supports it; not worth
   // promoting into useTaskForm since AddTaskModal doesn't use it.
@@ -1144,7 +1168,11 @@ export default function EditTaskModal({
         <div className="v2-edit-connections">
           {form.notionResult ? (
             <div className="v2-edit-connection-pill v2-edit-connection-linked">
-              <a href={form.notionResult.url} target="_blank" rel="noopener noreferrer">Notion ↗</a>
+              <a
+                href={form.notionResult.url || (form.notionResult.id ? `https://www.notion.so/${String(form.notionResult.id).replace(/-/g, '')}` : undefined)}
+                target="_blank"
+                rel="noopener noreferrer"
+              >Notion ↗</a>
               <button
                 type="button"
                 className="v2-edit-connection-unlink"
@@ -1226,6 +1254,68 @@ export default function EditTaskModal({
         )}
       </div>
       </FormDisclosure>
+
+      {onMerge && (
+        <FormDisclosure label="Merge duplicate">
+          <div className="v2-form-section v2-form-section-compact">
+            <div className="v2-edit-notion-reason">
+              Fold another task into this one — its notes, checklist, tags and links move
+              here (earliest due date wins), and the other task is deleted.
+            </div>
+            <input
+              type="text"
+              className="v2-form-input"
+              placeholder="Search tasks to merge in…"
+              value={mergeQuery}
+              onChange={e => { setMergeQuery(e.target.value); setMergePick(null); setMergeError(null) }}
+            />
+            {!mergePick && mergeCandidates.length > 0 && (
+              <ul className="v2-edit-notion-list">
+                {mergeCandidates.map(t => (
+                  <li key={t.id}>
+                    <button type="button" className="v2-edit-notion-page" onClick={() => setMergePick(t)}>
+                      {t.title}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+            {mergePick && (
+              <div className="v2-edit-merge-confirm">
+                <div className="v2-edit-notion-reason">
+                  Merge &ldquo;{mergePick.title}&rdquo; into this task? It will be deleted.
+                </div>
+                <div style={{ display: 'flex', gap: 8 }}>
+                  <button
+                    type="button"
+                    className="v2-settings-btn"
+                    disabled={mergeBusy}
+                    onClick={async () => {
+                      setMergeBusy(true)
+                      setMergeError(null)
+                      try {
+                        await onMerge(task.id, mergePick.id)
+                        setMergePick(null)
+                        setMergeQuery('')
+                      } catch (e) {
+                        setMergeError(e.message || 'Merge failed')
+                      } finally {
+                        setMergeBusy(false)
+                      }
+                    }}
+                  >
+                    {mergeBusy ? 'Merging…' : 'Merge'}
+                  </button>
+                  <button type="button" className="v2-settings-btn" disabled={mergeBusy} onClick={() => setMergePick(null)}>
+                    Cancel
+                  </button>
+                </div>
+              </div>
+            )}
+            {mergeError && <div className="v2-form-error">{mergeError}</div>}
+          </div>
+        </FormDisclosure>
+      )}
 
       {labels.length > 0 && (
         <FormDisclosure

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -4,6 +4,19 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ---
 
+## 2026-07-22
+
+- feat(tasks): merge duplicates — fold one task into another [M]
+  - User request: "say I have duplicates or whatever, I could log related/duplicate and merge tasks." One server-side primitive, three surfaces.
+  - **`mergeTasks(survivorId, duplicateId)` in `server/db.js`:** notes fold in under a provenance divider (`— merged from "title" (date) —`), tags/attachments/comments union, checklists append (skipped when every item already exists verbatim), earliest due date wins, `high_priority`/`nag_allowed` OR, adopt-if-missing scalars (Notion/Trello/GCal/Gmail links, routine_id, energy/size/impact/assignee), whole-group adoption for `follow_ups` and the escalation ladder (never interleaves two chains), knowledge-page ids union. The duplicate then goes through the normal `deleteTask` path (completion-day provenance stamped, Pushover Emergency receipts cancelled). No schema change.
+  - **`POST /api/tasks/:id/merge` `{duplicate_id}`** — returns the merged survivor; best-effort deletes the duplicate's own GCal event when the survivor keeps a different one (no ghost calendar copies); bump+broadcast.
+  - **Quokka `merge_tasks`** (adviserToolsTasks) — staged/destructive, plan-confirmed; LIFO compensation restores the survivor's pre-merge state and re-inserts the duplicate whole. "These two are the same thing, merge them" now works.
+  - **EditTaskModal "Merge duplicate" disclosure** — search picker over active tasks (open task is the survivor), inline confirm ("It will be deleted"), stays on the merged result afterward. Threaded `allTasks`/`onMerge` from AppV2; refetches server truth post-merge.
+  - Verified against a live scratch server: provenance divider, tag union, earliest-due, priority OR, adopted notion_page_id, duplicate 404s, self-merge 400s.
+
+- fix(tasks): "Notion ↗" connections chip no longer a dead link [XS]
+  - Prod report with screenshot: the Connections pill rendered `<a href={undefined}>` for any task whose `notion_url` is null — pull-synced and Quokka-linked tasks store only `notion_page_id`. The modal now derives the canonical `https://www.notion.so/<id-sans-dashes>` redirect when the stored URL is missing (both at form init and defensively at the anchor), which resolves for any page the viewer can access.
+
 ## 2026-07-21
 
 - fix(settings): Shippo shows connected when configured via SHIPPO_API_TOKEN env var [XS]


### PR DESCRIPTION
Promotes `dev` → `main` (2 commits):

- **feat(tasks): merge duplicates — fold one task into another [M]** (#814) — `mergeTasks()` primitive in db.js (provenance divider, unions, earliest due date, adopt-if-missing links, evidence-preserving delete), `POST /api/tasks/:id/merge` with GCal ghost-event cleanup, staged Quokka `merge_tasks` with LIFO rollback, EditTaskModal "Merge duplicate" picker. Rider fix: the Connections "Notion ↗" chip no longer renders `href=undefined` for tasks storing only a page id.
- (relink merge commit #813, already reflected on both branches)

Pre-promotion checklist: wallaby-reference absent ✓ · drift `dev..main` = 0 ✓ · dev CI green on the promoted tip ✓

**Merge method must be `merge`** per repo rules.

First release delivered to the phone purely via OTA (bootstrap rebuild done).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EecpSceYhjUFzBAmgG4Vj4

---
_Generated by [Claude Code](https://claude.ai/code/session_01EecpSceYhjUFzBAmgG4Vj4)_