### PR TITLE
feat(packages): rename a package after creation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -464,6 +464,7 @@ Track packages with auto carrier detection, adaptive server-side polling, and de
 
 **UI Features:**
 - Sort by status (default), delivery date, or carrier
+- Rename after creation (2026-07-24): expanded card → Rename → inline label edit (empty label falls back to the tracking number); rides the existing `PATCH /api/packages/:id` + `usePackages.editPackage`, which existed but had no UI affordance
 - Duplicate tracking number detection (client + server)
 - Animated swipe-to-reveal actions (matching TaskCard pattern)
 - Pull-to-refresh triggers batch refresh-all

--- a/package-lock.json
+++ b/package-lock.json
@@ -6899,9 +6899,9 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -7276,9 +7276,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -7296,7 +7296,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -8428,9 +8428,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.20",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.20.tgz",
-      "integrity": "sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {

--- a/src/AppV2.jsx
+++ b/src/AppV2.jsx
@@ -284,7 +284,7 @@ export default function AppV2() {
     }
     return s
   }, [tasks])
-  const { packages, addPackage, removePackage, refresh: refreshPackage, refreshAll: refreshAllPackages } = usePackages()
+  const { packages, addPackage, editPackage, removePackage, refresh: refreshPackage, refreshAll: refreshAllPackages } = usePackages()
   // Notes — free-floating, no task semantics. Server-backed via dedicated
   // endpoints; reload() rides hydrateFromServer so cross-device edits land.
   const { notes, loading: notesLoading, reload: reloadNotes, addNote, editNote, removeNote } = useNotes()
@@ -1814,6 +1814,7 @@ export default function AppV2() {
         onDelete={removePackage}
         onRefresh={refreshPackage}
         onRefreshAll={refreshAllPackages}
+        onEdit={editPackage}
         onClose={() => setShowPackages(false)}
       />
 

--- a/src/components/PackagesModal.css
+++ b/src/components/PackagesModal.css
@@ -308,3 +308,16 @@
   max-width: 170px;
   padding: 8px 10px;
 }
+
+/* Inline rename — the label is editable after creation */
+.v2-package-rename-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 10px 0 4px;
+}
+.v2-package-rename-input {
+  flex: 1 1 auto;
+  min-width: 0;
+  padding: 8px 10px;
+}

--- a/src/components/PackagesModal.jsx
+++ b/src/components/PackagesModal.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo } from 'react'
-import { Plus, Package as PackageIcon, RefreshCw, Trash2, ExternalLink } from 'lucide-react'
+import { Plus, Package as PackageIcon, RefreshCw, Trash2, ExternalLink, Pencil } from 'lucide-react'
 import CarrierLogo from './CarrierLogo'
 import { detectCarrier, getTrackingUrl } from '../utils/carrierDetect'
 import { updatePackage } from '../api'
@@ -37,14 +37,19 @@ function timeAgo(timestamp) {
   return `${days}d ago`
 }
 
-function PackageRow({ pkg, expanded, onToggleExpand, onRefresh, onDelete }) {
+function PackageRow({ pkg, expanded, onToggleExpand, onRefresh, onDelete, onEdit }) {
   const [refreshing, setRefreshing] = useState(false)
   const [confirmDelete, setConfirmDelete] = useState(false)
+  // Rename — the label is editable after creation (prod report: "I don't
+  // have a way to edit existing tracking… I'd like to change the title").
+  const [renaming, setRenaming] = useState(false)
+  const [renameValue, setRenameValue] = useState('')
+  const [savingRename, setSavingRename] = useState(false)
   // Link-only cards get no carrier ETA, so the user can set one by hand
   // (optimistic local copy — the server PATCH lands and syncs on the next
   // hydrate, but the card should reflect the pick instantly).
   const [localEta, setLocalEta] = useState(undefined)
-  useEffect(() => { if (!expanded) setConfirmDelete(false) }, [expanded])
+  useEffect(() => { if (!expanded) { setConfirmDelete(false); setRenaming(false) } }, [expanded])
 
   // Link-out cards — no polling, no refresh, just the carrier-site link.
   // Mirrors the server's UNTRACKABLE_CARRIERS/SHIPPO_CARRIERS gates:
@@ -85,6 +90,22 @@ function PackageRow({ pkg, expanded, onToggleExpand, onRefresh, onDelete }) {
       await onRefresh(pkg.id)
     } finally {
       setRefreshing(false)
+    }
+  }
+
+  const startRename = () => {
+    setRenameValue(pkg.label || '')
+    setRenaming(true)
+  }
+
+  const saveRename = async () => {
+    setSavingRename(true)
+    try {
+      // Empty label is a valid choice — the card falls back to the number.
+      await onEdit(pkg.id, { label: renameValue.trim() })
+      setRenaming(false)
+    } catch { /* row keeps editing state so the input isn't lost */ } finally {
+      setSavingRename(false)
     }
   }
 
@@ -163,7 +184,31 @@ function PackageRow({ pkg, expanded, onToggleExpand, onRefresh, onDelete }) {
           ) : (
             <div className="v2-package-detail-empty">No tracking events yet. Check back soon.</div>
           )}
+          {renaming && (
+            <div className="v2-package-rename-row">
+              <input
+                className="v2-form-input v2-package-rename-input"
+                placeholder="Label (empty shows the tracking number)"
+                value={renameValue}
+                onChange={e => setRenameValue(e.target.value)}
+                onKeyDown={e => { if (e.key === 'Enter') saveRename() }}
+                maxLength={120}
+                autoFocus
+              />
+              <button className="v2-package-action" onClick={saveRename} disabled={savingRename}>
+                {savingRename ? 'Saving…' : 'Save'}
+              </button>
+              <button className="v2-package-action" onClick={() => setRenaming(false)} disabled={savingRename}>
+                Cancel
+              </button>
+            </div>
+          )}
           <div className="v2-package-actions">
+            {!renaming && (
+              <button className="v2-package-action" onClick={startRename}>
+                <Pencil size={14} strokeWidth={1.75} /> Rename
+              </button>
+            )}
             {!untrackable && (
               <button
                 className="v2-package-action"
@@ -214,7 +259,7 @@ function PackageRow({ pkg, expanded, onToggleExpand, onRefresh, onDelete }) {
 }
 
 export default function PackagesModal({
-  open, packages, onAdd, onDelete, onRefresh, onRefreshAll, onClose,
+  open, packages, onAdd, onDelete, onRefresh, onRefreshAll, onEdit, onClose,
 }) {
   const [trackingInput, setTrackingInput] = useState('')
   const [labelInput, setLabelInput] = useState('')
@@ -339,6 +384,7 @@ export default function PackagesModal({
               onToggleExpand={() => setExpandedId(expandedId === pkg.id ? null : pkg.id)}
               onRefresh={onRefresh}
               onDelete={onDelete}
+              onEdit={onEdit}
             />
           ))}
         </ul>

--- a/wiki/Features.md
+++ b/wiki/Features.md
@@ -405,6 +405,7 @@ Track packages from any carrier with automatic status updates, notifications, an
 - **Status-colored cards** — pending (gray), in transit (blue), out for delivery (teal), delivered (green), exception (red), expired (dim gray). Carrier logos displayed on each card.
 - **Carrier links** — every card has a "Track on [Carrier]" link that opens the carrier's website with the tracking number pre-filled. Works even without an API key.
 - **Detail modal** — tap a card to see the full tracking timeline with events, locations, and timestamps. ETA shown in the status banner.
+- **Rename** — expand a card and hit Rename to change its title any time after creation (clearing the label falls back to showing the tracking number).
 - **Sorting** — sort by status (default, grouped by Issues/Active/Delivered), delivery date (flat by ETA), or carrier (grouped by carrier name).
 - **Batch refresh** — refresh-all button in the header polls all active packages in one batched API call. Pull-to-refresh triggers the same batch refresh.
 - **Auto-refresh on open** — app loads cached data instantly, then silently refreshes all packages from 17track in the background. Cards update automatically via SSE.

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,9 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-07-24
 
+- feat(packages): rename a package after creation [S]
+  - Prod report: "I don't have a way to edit existing tracking. Example I'd like to change the title." The server (`PATCH /api/packages/:id` accepts `label`) and the client hook (`usePackages.editPackage`) both supported it since the feature shipped — there was just no UI affordance anywhere. The expanded package card now has a **Rename** action: inline input (Enter or Save commits, Cancel reverts; empty label deliberately allowed — the card falls back to showing the tracking number), threaded AppV2 → PackagesModal → PackageRow via the previously-unwired `editPackage`. Verified headless: rename through the UI landed in client state and on the server.
+
 - feat(tasks): task model extensions — intentions, first steps, pick-three, punishment-free re-entry, locations [L]
   - Step 1 of the task-model → digest-reshape → watch-app sequence: extends the schema + API so implementation intentions, shrink-it, punishment-free re-entry, location reminders, and the watch app all land on a model that already supports them. No UI changes; existing clients unaffected (all columns nullable/defaulted).
   - **Schema (migration 046):** `intention_when`/`intention_where` (free-text implementation-intention triggers — the value is the commitment phrasing, not machine parsing), `first_step` (shrink-it, ≤140 chars enforced at the API), `location_json` (`{lat, lng, radius_m 50–1000 default 150, label, trigger arrive|leave}` — stored now, geofence delivery later), `committed_on` (pick-three day), `boomerang_count` + `last_boomeranged_at` (came-back-around data, never a shame counter), `released_at` ("let it go" outcome stamp).


### PR DESCRIPTION
Prod report: "I don't have a way to edit existing tracking. Example I'd like to change the title."

The server (`PATCH /api/packages/:id` accepts `label`) and the client hook (`usePackages.editPackage`) have supported this since packages shipped — there was just no UI affordance anywhere. The expanded package card now has a **Rename** action: inline input (Enter/Save commits, Cancel reverts; clearing the label is allowed — the card falls back to showing the tracking number), threaded AppV2 → PackagesModal → PackageRow via the previously-unwired `editPackage`.

Verified headless: renaming through the UI updates both the card and the server record.

Also includes a lockfile-only `npm audit fix` for two advisories published today (postcss, node-tar — both build/transitive); audit clean, tests 42/42 + smoke green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V45AJzVRjV8j2Sei5Qgr6A

---
_Generated by [Claude Code](https://claude.ai/code/session_01V45AJzVRjV8j2Sei5Qgr6A)_