### PR TITLE
feat(settings): the row/group/nav component family (rebuild PR1)

### DIFF
--- a/src/components/settings/SettingRow.jsx
+++ b/src/components/settings/SettingRow.jsx
@@ -1,0 +1,234 @@
+import { useState } from 'react'
+import { Info, ChevronRight } from 'lucide-react'
+import Toggle from './Toggle'
+import './settings.css'
+
+// The settings row family (wiki/Settings-Design-Language.md §2).
+//
+// ONE rule governs all of it: a row at rest shows its VALUE. Not a
+// description of what lives inside — the value. The surface this replaces
+// spent two lines per row explaining what you'd find if you tapped, and
+// nothing at all on what it was set to, so you had to open everything to
+// learn anything.
+//
+// Consequences encoded below:
+//   - The LABEL is the largest, brightest thing in the row (500 15px
+//     --v2-text). The old surface had it at 600 11px CAPS --v2-text-meta with
+//     a 12px description under it — the description outweighed its own label.
+//   - Descriptions are optional, subordinate, and folded behind an ⓘ. That
+//     honours the standing 2026-07-17 request ("I want to click on each for a
+//     description — otherwise they should be minimized") rather than deleting
+//     them outright.
+//   - The whole row is the touch target wherever the row does one thing.
+//   - Chevrons are lucide, trailing, and mean exactly one thing each:
+//     ChevronRight navigates. Leading ▸ glyphs are banned.
+
+// ---------------------------------------------------------------------------
+// Base row. Every kind below is a thin wrapper over this.
+// ---------------------------------------------------------------------------
+export function SettingRow({
+  label,
+  value,          // trailing text (string or node)
+  info,           // folded description; omit unless it earns its place (§1.5)
+  persistentInfo, // description that must always show — danger/security only
+  onPress,        // makes the whole row a button
+  trailing,       // custom trailing control (toggle, segment, chevron…)
+  disabled,       // dims to 0.45 and blocks interaction (dependent rows)
+  as,             // 'label' for toggle rows so the native control drives it
+  className = '',
+}) {
+  const [showInfo, setShowInfo] = useState(false)
+  const hasInfo = !!info
+
+  const body = (
+    <>
+      <span className="v2-set-row-main">
+        <span className="v2-set-row-label">
+          {label}
+          {hasInfo && (
+            <button
+              type="button"
+              className="v2-set-row-info-btn"
+              aria-label={showInfo ? 'Hide description' : 'Show description'}
+              aria-expanded={showInfo}
+              onClick={(e) => {
+                // Never let the ⓘ trigger the row's own action — on a toggle
+                // row that would flip the setting just for reading about it.
+                e.preventDefault()
+                e.stopPropagation()
+                setShowInfo(s => !s)
+              }}
+            >
+              <Info size={13} strokeWidth={1.75} aria-hidden="true" />
+            </button>
+          )}
+        </span>
+        {persistentInfo && <span className="v2-set-row-desc v2-set-row-desc-always">{persistentInfo}</span>}
+        {hasInfo && showInfo && <span className="v2-set-row-desc">{info}</span>}
+      </span>
+      {value != null && value !== '' && <span className="v2-set-row-value">{value}</span>}
+      {trailing}
+    </>
+  )
+
+  const cls = `v2-set-row${disabled ? ' is-disabled' : ''}${className ? ` ${className}` : ''}`
+
+  if (as === 'label') {
+    return <label className={cls}>{body}</label>
+  }
+  if (onPress && !disabled) {
+    return (
+      <button type="button" className={`${cls} v2-set-row-pressable`} onClick={onPress}>
+        {body}
+      </button>
+    )
+  }
+  return <div className={cls}>{body}</div>
+}
+
+// ---------------------------------------------------------------------------
+// §2.1 Toggle — a boolean that takes effect immediately.
+// The switch IS the value, so no text value. Tapping anywhere flips it, which
+// is why the row renders as a <label> wrapping the real checkbox.
+// ---------------------------------------------------------------------------
+export function ToggleRow({ label, checked, onChange, info, disabled }) {
+  return (
+    <SettingRow
+      as="label"
+      label={label}
+      info={info}
+      disabled={disabled}
+      trailing={<Toggle checked={checked} onChange={onChange} disabled={disabled} />}
+    />
+  )
+}
+
+// ---------------------------------------------------------------------------
+// §2.2 Value — an enum or reference picked from a list.
+// ---------------------------------------------------------------------------
+export function ValueRow({ label, value, onPress, info, disabled, trailing }) {
+  return (
+    <SettingRow
+      label={label}
+      value={value}
+      info={info}
+      onPress={onPress}
+      disabled={disabled}
+      trailing={trailing ?? (onPress ? <ChevronRight size={16} strokeWidth={2} className="v2-set-row-chev" /> : null)}
+    />
+  )
+}
+
+// ---------------------------------------------------------------------------
+// §2.3 Segment — 2–3 short options where seeing all of them at once matters.
+// 4+ options or long labels belong in a ValueRow instead.
+// `stacked` puts the control on its own line: the ONLY sanctioned two-line
+// row at rest, for when the options can't fit beside the label.
+// ---------------------------------------------------------------------------
+export function SegmentRow({ label, value, options, onChange, info, stacked, disabled }) {
+  const segment = (
+    <span className={`v2-settings-segment${options.length >= 4 ? ' v2-settings-segment-4' : ''}`}>
+      {options.map(opt => {
+        const val = typeof opt === 'string' ? opt : opt.value
+        const text = typeof opt === 'string' ? opt : opt.label
+        return (
+          <button
+            key={val}
+            type="button"
+            className={`v2-settings-segment-btn${val === value ? ' v2-settings-segment-btn-active' : ''}`}
+            onClick={() => onChange(val)}
+            disabled={disabled}
+            aria-pressed={val === value}
+          >
+            {text}
+          </button>
+        )
+      })}
+    </span>
+  )
+  return (
+    <SettingRow
+      label={label}
+      info={info}
+      disabled={disabled}
+      className={stacked ? 'v2-set-row-stacked' : ''}
+      trailing={segment}
+    />
+  )
+}
+
+// ---------------------------------------------------------------------------
+// §2.4 Navigation — drills into a sub-page.
+//
+// SUMMARY RULE: the summary must be derivable synchronously from state that
+// is already loaded. If it would need a fetch, pass nothing — an empty
+// trailing area is honest, whereas prose about the destination is the exact
+// failure this whole redesign exists to remove.
+// ---------------------------------------------------------------------------
+export function NavRow({ label, summary, onPress, info, disabled }) {
+  return (
+    <SettingRow
+      label={label}
+      value={summary}
+      info={info}
+      onPress={onPress}
+      disabled={disabled}
+      trailing={<ChevronRight size={16} strokeWidth={2} className="v2-set-row-chev" />}
+    />
+  )
+}
+
+// ---------------------------------------------------------------------------
+// §2.5 Action — a verb. Buttons sit left-aligned in the row body; related
+// actions share one row. An action is never disguised as a toggle or a
+// navigation row.
+// ---------------------------------------------------------------------------
+export function ActionRow({ children, info, label }) {
+  return (
+    <div className="v2-set-row v2-set-row-actions">
+      {label && <span className="v2-set-row-label">{label}</span>}
+      <span className="v2-set-actions">{children}</span>
+      {info && <span className="v2-set-row-desc v2-set-row-desc-always">{info}</span>}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// §2.7 Status — a read-only fact. No chevron: there is nothing to open.
+// `dot` uses the existing integration-status vocabulary.
+// ---------------------------------------------------------------------------
+export function StatusRow({ label, value, mono = true, dot, info }) {
+  return (
+    <SettingRow
+      label={label}
+      info={info}
+      trailing={
+        <span className="v2-set-status">
+          {dot && <span className={`v2-set-dot v2-set-dot-${dot}`} aria-hidden="true" />}
+          <span className={mono ? 'v2-settings-build' : 'v2-set-row-value'}>{value}</span>
+        </span>
+      }
+    />
+  )
+}
+
+// ---------------------------------------------------------------------------
+// §2.8 Credential — never echoes the secret at rest.
+//
+// Deliberately aligned with the Quokka secret blocklist in
+// adviserToolsMisc.js: the settings UI must not display what the adviser is
+// forbidden to read. `lastFour` is opt-in and only for values where showing a
+// tail is genuinely safe.
+// ---------------------------------------------------------------------------
+export function SecretRow({ label, set, lastFour, onPress, info }) {
+  const value = set ? (lastFour ? `•••• ${lastFour}` : 'Set') : 'Not set'
+  return (
+    <SettingRow
+      label={label}
+      value={value}
+      info={info}
+      onPress={onPress}
+      trailing={onPress ? <ChevronRight size={16} strokeWidth={2} className="v2-set-row-chev" /> : null}
+    />
+  )
+}

--- a/src/components/settings/SettingsGroup.jsx
+++ b/src/components/settings/SettingsGroup.jsx
@@ -1,0 +1,21 @@
+import './settings.css'
+
+// A group of rows under an optional caption (§5).
+//
+// GROUPS NEVER COLLAPSE. This replaces `SettingsSection`, which collapsed by
+// default and hid one-word values behind a tap. Pages are kept short by the
+// navigation model instead — a page with ~10 rows in 2–3 groups doesn't need
+// folding, and every redesigned page comes in under that.
+//
+// A caption is earned, not automatic: a page with only one group shows its
+// rows bare, because the page title already names them. The caption is also
+// non-interactive by design — the uppercase treatment used to be the tappable
+// row label, which is precisely how the hierarchy ended up inverted.
+export default function SettingsGroup({ caption, children }) {
+  return (
+    <section className="v2-set-group">
+      {caption && <h3 className="v2-set-group-caption">{caption}</h3>}
+      <div className="v2-set-group-rows">{children}</div>
+    </section>
+  )
+}

--- a/src/components/settings/SettingsNav.jsx
+++ b/src/components/settings/SettingsNav.jsx
@@ -1,0 +1,41 @@
+import { useEffect, useRef, useState } from 'react'
+import './settings.css'
+
+// Stack navigation for the settings surface (§6).
+//
+// This replaces the six-tab strip, which overflowed on a phone — "Notifications"
+// clipped to "Notifica" with nothing indicating the strip scrolled. Scrollable
+// tabs were rejected (off-screen state is undiscoverable, and horizontal scroll
+// inside a sheet fights the iOS dismiss gesture); merging further was rejected
+// too, since the current six ARE already a merge.
+//
+// The index wins on a point the tabs could never match: its rows carry live
+// value summaries, so the root screen answers "what's my setup?" instead of
+// being pure chrome.
+//
+// Depth is capped at two — categories, then the named sub-pages. Anything
+// deeper means the page needs splitting, not another level.
+//
+// Page identity is component state only. It is NEVER persisted: the settings
+// blob is last-writer-wins and UI chrome must not ride it.
+export default function SettingsNav({ page, children }) {
+  const [dir, setDir] = useState('forward')
+  const prev = useRef(page)
+  const depth = (id) => (id === 'index' ? 0 : 1)
+
+  useEffect(() => {
+    if (prev.current !== page) {
+      setDir(depth(page) >= depth(prev.current) ? 'forward' : 'back')
+      prev.current = page
+    }
+  }, [page])
+
+  return (
+    // Keyed on the page so React remounts on navigation — that both restarts
+    // the slide and guarantees a sub-page can't inherit scroll position or
+    // transient state from the page it replaced.
+    <div key={page} className={`v2-set-nav v2-set-nav-${dir}`}>
+      {children}
+    </div>
+  )
+}

--- a/src/components/settings/SettingsPage.jsx
+++ b/src/components/settings/SettingsPage.jsx
@@ -1,0 +1,25 @@
+import { ChevronLeft } from 'lucide-react'
+import './settings.css'
+
+// One page in the settings stack (§6).
+//
+// The root index passes no `onBack` and renders no title block — the modal's
+// own "Settings" header already names it. Sub-pages get a back affordance
+// with a 44px target and their own title in the display face, one step down
+// from the modal title.
+export default function SettingsPage({ title, onBack, backLabel = 'Settings', children }) {
+  return (
+    <div className="v2-set-page">
+      {onBack && (
+        <div className="v2-set-page-head">
+          <button type="button" className="v2-set-back" onClick={onBack}>
+            <ChevronLeft size={18} strokeWidth={2} aria-hidden="true" />
+            <span>{backLabel}</span>
+          </button>
+          {title && <h2 className="v2-set-page-title">{title}</h2>}
+        </div>
+      )}
+      {children}
+    </div>
+  )
+}

--- a/src/components/settings/Toggle.jsx
+++ b/src/components/settings/Toggle.jsx
@@ -1,0 +1,15 @@
+// The settings toggle switch, in its permanent home.
+//
+// An identical copy currently lives inside SettingsModal.jsx — it was itself
+// created to stop ~10 hand-copied duplicates across the panels. This is the
+// canonical one for the new row family; the SettingsModal copy is deleted in
+// the teardown PR once every panel has converted. Markup and class names are
+// unchanged so the existing CSS in SettingsModal.css keeps applying.
+export default function Toggle({ checked, onChange, disabled }) {
+  return (
+    <label className={`v2-settings-toggle${disabled ? ' v2-settings-toggle-disabled' : ''}`}>
+      <input type="checkbox" checked={!!checked} onChange={onChange} disabled={disabled} />
+      <span className="v2-settings-toggle-track"><span className="v2-settings-toggle-thumb" /></span>
+    </label>
+  )
+}

--- a/src/components/settings/index.js
+++ b/src/components/settings/index.js
@@ -1,0 +1,21 @@
+// The settings component family (wiki/Settings-Design-Language.md §7).
+//
+// One component per job — one row family, one group wrapper, one navigation
+// shell. A new settings screen COMPOSES these; it does not define a local
+// SectionHeader. That rule exists because the surface being replaced grew
+// seven parallel collapse implementations, four row-title styles and four
+// row paddings, all by well-meant local invention.
+export { default as SettingsNav } from './SettingsNav'
+export { default as SettingsPage } from './SettingsPage'
+export { default as SettingsGroup } from './SettingsGroup'
+export { default as Toggle } from './Toggle'
+export {
+  SettingRow,
+  ToggleRow,
+  ValueRow,
+  SegmentRow,
+  NavRow,
+  ActionRow,
+  StatusRow,
+  SecretRow,
+} from './SettingRow'

--- a/src/components/settings/settings.css
+++ b/src/components/settings/settings.css
@@ -1,0 +1,210 @@
+/* Settings design language — wiki/Settings-Design-Language.md
+ *
+ * Every colour resolves through an existing --v2-* / --bm-* token; the sizes
+ * and spacings here are component constants, not new global tokens, matching
+ * current practice in this codebase.
+ *
+ * Rows are full-bleed inside the modal body's existing 24px padding. Kept is
+ * "plain hairline rows", not iOS inset cards, so there is no per-row
+ * horizontal padding and no card chrome. The one framed element in the whole
+ * surface is the danger card — that exception is the point. */
+
+/* ── navigation ─────────────────────────────────────────────────────── */
+
+.v2-set-nav {
+  animation: v2-set-slide-fwd var(--v2-dur-emphasis) var(--v2-ease-emphasis);
+}
+.v2-set-nav-back {
+  animation-name: v2-set-slide-back;
+}
+@keyframes v2-set-slide-fwd {
+  from { opacity: 0; transform: translateX(12px); }
+  to   { opacity: 1; transform: none; }
+}
+@keyframes v2-set-slide-back {
+  from { opacity: 0; transform: translateX(-12px); }
+  to   { opacity: 1; transform: none; }
+}
+
+.v2-set-page-head {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 20px;
+}
+.v2-set-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  align-self: flex-start;
+  /* 44px target without 44px of visible chrome: the padding is pulled back
+   * out with a negative margin so the control still optically aligns with
+   * the rows below it. */
+  min-height: 44px;
+  padding: 0 8px 0 4px;
+  margin: -10px 0 0 -6px;
+  border: 0;
+  background: transparent;
+  color: var(--v2-text-meta);
+  font: 400 14px/1.3 var(--v2-font-body);
+  cursor: pointer;
+}
+.v2-set-back:hover { color: var(--v2-text); }
+.v2-set-page-title {
+  margin: 0;
+  font: 700 22px/1.15 var(--v2-font-display);
+  color: var(--v2-text);
+  letter-spacing: -0.01em;
+}
+
+/* ── groups ─────────────────────────────────────────────────────────── */
+
+.v2-set-group + .v2-set-group { margin-top: 28px; }
+
+/* The demoted caption. This treatment used to BE the row label — 600 11px
+ * caps, and brighter than it should have been. It is now non-interactive
+ * chrome and the faintest text on the page. */
+.v2-set-group-caption {
+  margin: 0 0 7px;
+  font: 600 11px/1 var(--v2-font-body);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--v2-text-faint);
+}
+
+/* ── the row ────────────────────────────────────────────────────────── */
+
+.v2-set-row {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  width: 100%;
+  min-height: 52px;
+  padding: 8px 0;
+  border: 0;
+  border-bottom: 1px solid var(--v2-hairline);
+  background: transparent;
+  color: var(--v2-text);
+  text-align: left;
+  font-family: var(--v2-font-body);
+}
+/* No divider after a group's last row, and never two hairlines adjacent —
+ * the old section+row stacking produced exactly that doubling. */
+.v2-set-group-rows > .v2-set-row:last-child { border-bottom: none; }
+
+.v2-set-row-pressable { cursor: pointer; }
+.v2-set-row-pressable:hover .v2-set-row-label { color: var(--v2-text); }
+.v2-set-row-pressable:focus-visible,
+.v2-set-row:focus-within {
+  outline: 2px solid var(--v2-ember, var(--bm-ember, currentColor));
+  outline-offset: -2px;
+  border-radius: 4px;
+}
+
+/* Dependent rows dim rather than disappear, so the relationship between a
+ * parent toggle and its child stays visible instead of being a mystery. */
+.v2-set-row.is-disabled {
+  opacity: 0.45;
+  pointer-events: none;
+}
+
+.v2-set-row-main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+}
+
+/* The loudest thing in the row. */
+.v2-set-row-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  font: 500 15px/1.3 var(--v2-font-body);
+  color: var(--v2-text);
+}
+
+.v2-set-row-info-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--v2-text-faint);
+  cursor: pointer;
+}
+.v2-set-row-info-btn:hover { color: var(--v2-text-meta); }
+
+/* Subordinate to the label in size, weight and colour — all three. The old
+ * surface had descriptions LARGER than the labels they belonged to. */
+.v2-set-row-desc {
+  font: 400 12px/1.5 var(--v2-font-body);
+  color: var(--v2-text-meta);
+  max-width: 52ch;
+}
+.v2-set-row-desc-always { line-height: 1.45; }
+
+.v2-set-row-value {
+  flex: 0 1 auto;
+  text-align: right;
+  font: 400 15px/1.3 var(--v2-font-body);
+  color: var(--v2-text-meta);
+  font-variant-numeric: tabular-nums;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.v2-set-row-chev {
+  flex: 0 0 auto;
+  color: var(--v2-text-faint);
+}
+
+/* The only sanctioned two-line row at rest: a segment that cannot fit
+ * beside its label. */
+.v2-set-row-stacked {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 10px;
+}
+.v2-set-row-stacked .v2-settings-segment { align-self: stretch; }
+
+/* ── actions ────────────────────────────────────────────────────────── */
+
+.v2-set-row-actions {
+  flex-wrap: wrap;
+  gap: 10px;
+}
+.v2-set-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+/* ── status ─────────────────────────────────────────────────────────── */
+
+.v2-set-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  flex: 0 1 auto;
+  min-width: 0;
+}
+.v2-set-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex: 0 0 auto;
+  background: var(--v2-text-faint);
+}
+.v2-set-dot-ok { background: var(--bm-f-eucalypt, #62B98B); }
+.v2-set-dot-warn { background: var(--bm-gold, #E8B04B); }
+.v2-set-dot-off { background: var(--v2-text-faint); }
+
+@media (prefers-reduced-motion: reduce) {
+  .v2-set-nav { animation: none; }
+}

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,16 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-07-27
 
+- feat(settings): the row/group/nav component family (rebuild PR1) [M]
+  - First of the seven PRs in `wiki/Settings-Design-Language.md` §9. **Nothing imports these yet** — zero behaviour change, zero risk, so the shape can be reviewed before any screen depends on it.
+  - `src/components/settings/`: `SettingsNav` (stack navigation replacing the six-tab strip), `SettingsPage`, `SettingsGroup`, `SettingRow` + the seven kind wrappers (`ToggleRow`, `ValueRow`, `SegmentRow`, `NavRow`, `ActionRow`, `StatusRow`, `SecretRow`), a canonical `Toggle`, and one `settings.css`.
+  - **The rule the whole family encodes: a row at rest shows its VALUE.** `NavRow`'s summary contract is explicit about it — the summary must be derivable synchronously from already-loaded state, and if it would need a fetch you pass nothing, because an empty trailing area is honest whereas prose about the destination is the exact failure being removed.
+  - **Hierarchy corrected in the CSS, not just in prose:** label `500 15px --v2-text`, description `400 12px --v2-text-meta` folded behind a per-row `ⓘ`, group caption demoted to `600 11px --v2-text-faint` and made non-interactive. The surface being replaced had the label at `600 11px` CAPS in `--v2-text-meta` with a `12px` description beneath it — the description literally outweighed its own label, and the caps treatment WAS the tappable control.
+  - Descriptions fold rather than vanish, honouring the standing 2026-07-17 request ("I want to click on each for a description — otherwise they should be minimized") instead of overruling it. The `ⓘ` stops propagation so reading about a toggle can never flip it.
+  - Dependent rows dim to 0.45 and go non-interactive rather than hiding, so the parent/child relationship stays legible. Groups never collapse. Chevrons are lucide and trailing only; leading `▸` glyphs are out.
+  - Zero new global tokens — every colour resolves through existing `--v2-*`/`--bm-*`; sizes are component constants, matching current practice. Page identity in `SettingsNav` is component state and is never persisted: the settings blob is last-writer-wins and UI chrome must not ride it.
+  - `Toggle` is copied rather than imported from `SettingsModal.jsx` so this PR touches nothing existing; the old copy is deleted in the teardown PR once every panel has converted. Verified by compiling each file directly with esbuild — ESLint alone would not have caught a break, since no bundle reaches this code yet.
+
 - docs(settings): a design language for the settings surface [M]
   - Per user: "we tried to condense and collapse settings and it made it fucking hard to read and use and it's inconsistent anyway." Design only — `wiki/Settings-Design-Language.md`, no JSX or CSS touched, so the direction can be vetoed before any code exists.
   - **The audit found worse than inconsistency: seven parallel collapse implementations** inside this one surface — `SettingsSection` (`SettingsModal.jsx:25`), a hand-rolled duplicate `SectionHeader` (:2005), `FormDisclosure`, `InfoHintRow`, the notification-history toggle, the integrations expander, and raw `<details>` in Labels — plus four row-title styles and four row paddings.


### PR DESCRIPTION
First of the seven PRs in `wiki/Settings-Design-Language.md` §9.

**Nothing imports these yet.** Zero behaviour change, zero risk — the surface is byte-identical after this merges. The point is to review the shape before any screen depends on it.

## What's here

`src/components/settings/`:

| | |
|---|---|
| `SettingsNav` | Stack navigation — what replaces the six-tab strip |
| `SettingsPage` | Page chrome + back affordance (44px target) |
| `SettingsGroup` | Non-collapsing group with an optional caption |
| `SettingRow` | Base row + seven kind wrappers |
| `Toggle` | Canonical copy of the existing switch |
| `settings.css` | One stylesheet, zero new global tokens |

Kind wrappers: `ToggleRow`, `ValueRow`, `SegmentRow`, `NavRow`, `ActionRow`, `StatusRow`, `SecretRow`.

## The rule the family encodes

**A row at rest shows its value.** `NavRow`'s summary contract states it outright: the summary must be derivable *synchronously* from already-loaded state, and if it would need a fetch you pass **nothing**. An empty trailing area is honest; prose about the destination is precisely the failure being removed.

## The hierarchy fix, in CSS rather than prose

| | Today | Here |
|---|---|---|
| Row label | `600 11px` CAPS `--v2-text-meta` | `500 15px` `--v2-text` |
| Description | `400 12px` `--v2-text-meta` | same, folded behind `ⓘ` |
| Group caption | *(was the tappable label)* | `600 11px` `--v2-text-faint`, non-interactive |

The description was *larger than its own label*, and the uppercase treatment **was** the control you tapped. Both are fixed at the stylesheet level so no future screen can reintroduce them by accident.

## Details worth a look

- **Descriptions fold, they don't vanish** — honouring the standing 2026-07-17 request ("I want to click on each for a description — otherwise they should be minimized") rather than overruling it. The `ⓘ` calls `stopPropagation`, so reading about a toggle can never flip it.
- **Dependent rows dim to 0.45 and go non-interactive** instead of hiding, so the parent/child relationship stays visible.
- **Groups never collapse.** Pages stay short via navigation instead.
- **Chevrons are lucide and trailing only.** The leading `▸` glyph is gone.
- **Page identity is component state and never persisted** — the settings blob is last-writer-wins and UI chrome must not ride it.
- `Toggle` is *copied* rather than imported from `SettingsModal.jsx`, so this PR touches nothing existing. The old copy dies in the teardown PR once every panel has converted.

## Verification

ESLint clean, `npm test` 80/80, smoke test passed, `npm audit` 0 vulnerabilities.

Also **compiled each file directly with esbuild** — worth noting because ESLint alone wouldn't have caught a breakage here: no bundle reaches this code yet, so Vite would never have parsed it.

## Next

PR2 is the navigation shell, and it ships **alone** — it's the riskiest change (tabs → index) and should be judged in isolation on `boomerang-dev`. One open question before I build it: whether the Integrations and Data index rows carry value summaries. I argue yes — `Notion · Trello · GCal` and `53 tasks` are both derivable from state already in memory, no fetch — which is the correction I made to the spec in the renderings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V45AJzVRjV8j2Sei5Qgr6A

---
_Generated by [Claude Code](https://claude.ai/code/session_01V45AJzVRjV8j2Sei5Qgr6A)_