### PR TITLE
feat(settings): Data converted, danger card re-tokened, SettingsSection deleted (rebuild PR4)

### DIFF
--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -26,26 +26,6 @@ import { MODEL_CATALOG as AI_MODEL_CATALOG, TIER_DEFAULTS as AI_TIER_DEFAULTS } 
 // collapsed (2026-07-17: "Settings should start minimized across the
 // board"). Deliberately NOT persisted: retained open-state is exactly how
 // the pages got long and messy.
-function SettingsSection({ label, hint, children, defaultOpen = false }) {
-  const [open, setOpen] = useState(defaultOpen)
-  return (
-    <div className="v2-settings-section">
-      <button
-        type="button"
-        className={`v2-settings-section-header${open ? '' : ' v2-settings-section-header-collapsed'}`}
-        onClick={() => setOpen(o => !o)}
-        aria-expanded={open}
-      >
-        <span className="v2-settings-section-chev" aria-hidden="true">{open ? '\u25be' : '\u25b8'}</span>
-        <span className="v2-settings-section-header-text">
-          <span className="v2-form-label">{label}</span>
-          {hint && <span className="v2-settings-row-hint">{hint}</span>}
-        </span>
-      </button>
-      {open && children}
-    </div>
-  )
-}
 
 function Toggle({ checked, onChange, disabled }) {
   return (
@@ -264,6 +244,8 @@ const CATEGORIES = ['General', 'Tasks', 'Labels', 'Integrations', 'Notifications
 const PAGE_TITLES = {
   'Tasks/impact': 'Impact dates',
   'Tasks/instructions': 'Custom instructions',
+  'Data/devices': 'Devices',
+  'Data/logs': 'Server logs',
 }
 
 // All Settings tabs now have v2 implementations.
@@ -2986,8 +2968,12 @@ export default function SettingsModal({
       import('../api').then(m => m.trelloStatus()).catch(() => null),
       import('../api').then(m => m.gcalStatus()).catch(() => null),
       import('../api').then(m => m.gmailStatus()).catch(() => null),
-    ]).then(([keys, notion, trello, gcal, gmail]) => {
-      if (!cancelled) setConnStatus({ keys: keys || {}, notion, trello, gcal, gmail })
+      // Device count feeds the Data page's Devices row. Fetched here with the
+      // rest rather than lifted out of AuthDevicesBlock, so that component
+      // stays self-contained and the row still gets a real value.
+      import('../api').then(m => m.getAuthDevices()).catch(() => null),
+    ]).then(([keys, notion, trello, gcal, gmail, devices]) => {
+      if (!cancelled) setConnStatus({ keys: keys || {}, notion, trello, gcal, gmail, devices })
     }).catch(() => { /* summary stays empty; never blocks the surface */ })
     return () => { cancelled = true }
   }, [open])
@@ -3397,27 +3383,46 @@ export default function SettingsModal({
 
         {page === 'Data' && (
           <div className="v2-settings-form">
-            {isNativeShell() && (
-              <SettingsSection label="Server connection" hint="Which server this app talks to.">
-                <div className="v2-settings-block">
-                  <div className="v2-settings-row-hint">
-                    This app talks to <strong>{getApiBase() || 'no server yet'}</strong>. Changing the server or API token reloads the app.
-                  </div>
-                  <button className="v2-settings-btn" onClick={requestConnectionSetup}>
-                    <Server size={13} strokeWidth={1.75} /> Change server…
-                  </button>
-                </div>
-              </SettingsSection>
-            )}
+            <SettingsGroup>
+              {isNativeShell() && (
+                <SettingRow
+                  label="Server"
+                  info="Changing the server or API token reloads the app."
+                  value={getApiBase() || 'not set'}
+                  trailing={
+                    <button className="v2-settings-btn" onClick={requestConnectionSetup}>
+                      <Server size={13} strokeWidth={1.75} /> Change…
+                    </button>
+                  }
+                />
+              )}
+              <NavRow
+                label="Devices"
+                summary={connStatus?.devices
+                  ? `${connStatus.devices.length} device${connStatus.devices.length === 1 ? '' : 's'}`
+                  : ''}
+                onPress={() => setPage('Data/devices')}
+                info="Per-device access tokens. Revoking a device kills its tokens immediately; a superseded refresh token presented again auto-revokes and alerts."
+              />
+              <NavRow
+                label="Server logs"
+                onPress={() => setPage('Data/logs')}
+                info="Live tail of the running server — Google, push, email, DB and SSE lines, plus errors."
+              />
+              <SettingRow
+                label="Activity log"
+                info="Audit trail of edits, completions and deletes. Deleted tasks can be restored from snapshots in the log."
+                onPress={onShowActivityLog ? () => { onClose?.(); onShowActivityLog() } : undefined}
+                disabled={!onShowActivityLog}
+                trailing={<ChevronRight size={16} strokeWidth={2} className="v2-set-row-chev" />}
+              />
+            </SettingsGroup>
 
-            <SettingsSection label="Devices & security" hint="Per-device access tokens (auth Phase A). Revoking a device kills its tokens immediately; a superseded refresh token presented again auto-revokes + alerts.">
-              <AuthDevicesBlock />
-            </SettingsSection>
-
-            <SettingsSection label="Backup" hint="Export / import everything as one JSON file.">
-            <div className="v2-settings-block">
-              <div className="v2-settings-row-hint">Export tasks, routines, settings, and labels as a single JSON file. Importing replaces the current state and reloads.</div>
-              <div className="v2-settings-actions">
+            <SettingsGroup caption="Import & export">
+              <ActionRow
+                label="Backup"
+                info="Tasks, routines, settings and labels as one JSON file. Importing REPLACES the current state and reloads."
+              >
                 <button className="v2-settings-btn" onClick={handleExportData}>
                   <Download size={13} strokeWidth={1.75} /> Export
                 </button>
@@ -3425,61 +3430,45 @@ export default function SettingsModal({
                 <button className="v2-settings-btn" onClick={() => dataImportRef.current?.click()}>
                   <Upload size={13} strokeWidth={1.75} /> Import
                 </button>
-              </div>
-            </div>
-
-            </SettingsSection>
-
-            <SettingsSection label="Activity" hint="Audit trail of edits, completions, and deletes.">
-            <div className="v2-settings-block">
-              <div className="v2-settings-row-hint">Deleted tasks can be restored from snapshots in the log.</div>
-              <button
-                className="v2-settings-btn"
-                onClick={() => { onClose?.(); onShowActivityLog?.() }}
-                disabled={!onShowActivityLog}
-              >
-                <FileText size={13} strokeWidth={1.75} /> Open activity log
-              </button>
-            </div>
-
-            </SettingsSection>
-
-            <SettingsSection label="Server logs" hint="Live tail of the server process.">
-            <div className="v2-settings-block">
-              <div className="v2-settings-row-hint">Google/Push/Email/DB/SSE lines and errors from the running server.</div>
-              <ServerLogsPanel />
-            </div>
-
-            </SettingsSection>
-
-            <SettingsSection label="Markdown import" hint="Parse a pasted markdown list into tasks.">
-            <div className="v2-settings-block">
-              <div className="v2-settings-row-hint">Paste a markdown list or checklist and have it parsed into tasks. Rarely used; lives here so it doesn't crowd the main menu.</div>
-              <button
-                className="v2-settings-btn"
-                onClick={() => { onClose?.(); onShowMarkdownImport?.() }}
-                disabled={!onShowMarkdownImport}
-              >
-                <Upload size={13} strokeWidth={1.75} /> Import from markdown
-              </button>
-            </div>
-
-            </SettingsSection>
+              </ActionRow>
+              {/* No description: the button says what it does. The old copy
+                  ("rarely used; lives here so it doesn't crowd the main menu")
+                  was meta-commentary about the UI's own layout, which is
+                  exactly the kind of prose §1.5 says has to be earned. */}
+              <ActionRow label="Markdown">
+                <button
+                  className="v2-settings-btn"
+                  onClick={() => { onClose?.(); onShowMarkdownImport?.() }}
+                  disabled={!onShowMarkdownImport}
+                >
+                  <Upload size={13} strokeWidth={1.75} /> Import from markdown
+                </button>
+              </ActionRow>
+            </SettingsGroup>
 
             {isDev && (
-              <SettingsSection label="Developer · dev only" hint="Reseed this dev database.">
-              <div className="v2-settings-block">
-                <div className="v2-settings-row-hint">Wipe this dev database and reload fresh seed data (tasks rebased to today, ~250 days of routine history). Only shown on the dev build; the server blocks it everywhere else.</div>
-                <button className="v2-settings-btn" onClick={handleReseed} disabled={reseeding}>
-                  <RefreshCw size={13} strokeWidth={1.75} /> {reseeding ? 'Reseeding…' : 'Reseed dev database'}
-                </button>
-              </div>
-              </SettingsSection>
+              <SettingsGroup caption="Developer · dev only">
+                <ActionRow info="Wipe this dev database and reload fresh seed data. Only shown on the dev build; the server blocks it everywhere else.">
+                  <button className="v2-settings-btn" onClick={handleReseed} disabled={reseeding}>
+                    <RefreshCw size={13} strokeWidth={1.75} /> {reseeding ? 'Reseeding…' : 'Reseed dev database'}
+                  </button>
+                </ActionRow>
+              </SettingsGroup>
             )}
 
-            <SettingsSection label="Danger zone" hint="These wipe data. No undo other than restoring from a backup.">
-            <div className="v2-settings-danger">
-              <div className="v2-settings-danger-actions">
+            {/* The ONE framed element in the whole surface, and last on the
+                page. That exception is the point (§4): everything else is a
+                plain hairline row, so the frame means "this one is different".
+                Never collapsed — hiding a wipe button behind a disclosure is
+                how you tap it by accident. Its description is persistent
+                rather than behind an ⓘ, because "no undo" is not something to
+                make someone go looking for. */}
+            <div className="v2-set-danger">
+              <h3 className="v2-set-danger-caption">Danger zone</h3>
+              <p className="v2-set-danger-note">
+                These wipe data. There is no undo other than restoring from a backup.
+              </p>
+              <div className="v2-set-danger-actions">
                 <button
                   className="v2-settings-btn v2-settings-btn-danger v2-settings-btn-block"
                   onClick={onClearCompleted}
@@ -3498,7 +3487,25 @@ export default function SettingsModal({
                 </button>
               </div>
             </div>
-            </SettingsSection>
+          </div>
+        )}
+
+        {page === 'Data/devices' && (
+          <div className="v2-settings-form">
+            <p className="v2-set-page-intro">
+              Per-device access tokens. Revoking a device kills its tokens immediately;
+              a superseded refresh token presented again auto-revokes and raises a security alert.
+            </p>
+            <AuthDevicesBlock />
+          </div>
+        )}
+
+        {page === 'Data/logs' && (
+          <div className="v2-settings-form">
+            <p className="v2-set-page-intro">
+              Live tail of the running server — Google, push, email, DB and SSE lines, plus errors.
+            </p>
+            <ServerLogsPanel />
           </div>
         )}
 

--- a/src/components/settings/settings.css
+++ b/src/components/settings/settings.css
@@ -275,3 +275,41 @@
   text-transform: uppercase;
   color: var(--v2-text-faint);
 }
+
+/* ── the danger card ────────────────────────────────────────────────── */
+
+/* The ONE framed element in the whole settings surface. Everything else is a
+ * plain hairline row, which is exactly what makes the frame mean something:
+ * "this one is different." It is always last on its page and NEVER collapses —
+ * hiding a wipe button behind a disclosure is how you tap it by accident.
+ *
+ * Re-tokened to --bm-danger, which is already the app-wide destructive colour
+ * (ConnectionSetup, LoginScreen). It previously used a hardcoded rgba(232,68,58)
+ * that matched nothing else and drifted from the palette on its own. */
+.v2-set-danger {
+  margin-top: 28px;
+  padding: 16px;
+  border-radius: 12px;
+  border: 1px solid color-mix(in srgb, var(--bm-danger, #c0392b) 28%, transparent);
+  background: color-mix(in srgb, var(--bm-danger, #c0392b) 5%, transparent);
+}
+.v2-set-danger-caption {
+  margin: 0 0 6px;
+  font: 600 11px/1 var(--v2-font-body);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--bm-danger, #c0392b);
+}
+/* Persistent, not behind an ⓘ — "no undo" is not something to make someone go
+ * looking for (§1.5's one sanctioned exception). */
+.v2-set-danger-note {
+  margin: 0 0 12px;
+  font: 400 12px/1.5 var(--v2-font-body);
+  color: var(--v2-text-meta);
+  max-width: 52ch;
+}
+.v2-set-danger-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,15 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-07-28
 
+- feat(settings): Data converted, danger card re-tokened, SettingsSection deleted (rebuild PR4) [M]
+  - Fourth of the seven PRs in `wiki/Settings-Design-Language.md` §9. Data becomes flat rows plus two sub-pages: **Devices** (`0 devices ›`) and **Server logs** — both previously collapsed sections whose contents are long enough to deserve their own page.
+  - **The danger card is the ONE framed element in the whole surface, and that exception is the point.** Everything else is a plain hairline row, which is exactly what makes a frame mean "this one is different". It sits last, **never collapses** — hiding a wipe button behind a disclosure is how you tap it by accident — and its "no undo" note is **persistent rather than behind an ⓘ**, §1.5's one sanctioned exception.
+  - **Re-tokened to `--bm-danger`**, already the app-wide destructive colour (ConnectionSetup, LoginScreen). It had been a hardcoded `rgba(232, 68, 58, …)` matching nothing else, free to drift from the palette on its own.
+  - **`SettingsSection` deleted** — 20 lines. PR3's conversion left it referenced only by Data; converting Data left it referenced by nothing at all. The plan had this in PR7, but carrying a dead component through two more PRs serves nobody, and the teardown still has plenty to do (the local `SectionHeader`, tab CSS, dead classes). **Zero `SettingsSection` references remain in `src/`.**
+  - The Devices row's summary is a real count, fetched alongside the integration statuses rather than lifted out of `AuthDevicesBlock` — that component stays self-contained and the row still gets a value.
+  - Cut one description as unearned: Markdown import's "rarely used; it lives here so it doesn't crowd the main menu" was meta-commentary about the UI's own layout, and the button already says what it does.
+  - Verified in a browser: Data renders **0 old `SettingsSection`s**, the danger card present and confirmed **last child** with its note visible, `0 devices` on the Devices row, and both sub-pages titling correctly with a "‹ Data" back affordance. No page errors. ESLint 0 errors, build ✓, 134/134 + smoke, audit clean.
+
 - feat(settings): General + Tasks converted to the design language (rebuild PR3) [L]
   - Third of the seven PRs in `wiki/Settings-Design-Language.md` §9, and the one the spec calls the proof artifact — the first pages that actually *look* like the language rather than merely living inside its navigation.
   - **General: 7 rows, 3 groups, nothing collapsed** (Appearance / Home screen / About), exactly as §8 specifies. Every value visible in one glance where before it was three collapsed strips over two-thirds dead space, zero values shown, and 3 taps to see anything. The theme marketing copy ("warm Smoke/Linen canvases, arcs not grids") is **deleted rather than folded** — you can see both themes by tapping them, so prose describing them is pure cost. "Open strip by default" is a dependent row: it dims to 45% while its parent toggle is off instead of vanishing, so the relationship stays visible.


### PR DESCRIPTION
Fourth of the seven PRs in `wiki/Settings-Design-Language.md` §9.

```
‹ Settings
Data

Devices        ⓘ            0 devices ›
Server logs    ⓘ                      ›
Activity log   ⓘ                      ›
IMPORT & EXPORT
Backup           [ Export ] [ Import ]
  Tasks, routines, settings and labels as one JSON file.
  Importing REPLACES the current state and reloads.
Markdown         [ Import from markdown ]

┌─────────────────────────────────────┐
│ DANGER ZONE                         │
│ These wipe data. There is no undo   │
│ other than restoring from a backup. │
│ [ Clear completed tasks ]           │
│ [ Clear all data ]                  │
└─────────────────────────────────────┘
```

**Devices** and **Server logs** become sub-pages — both were collapsed sections whose contents are long enough to deserve their own page rather than a disclosure.

## The danger card is the one framed element, and that's the point

Everything else in settings is a plain hairline row. That's exactly what makes a frame mean *"this one is different."*

- **Last on the page**, always.
- **Never collapses** — hiding a wipe button behind a disclosure is how you tap it by accident.
- **Its "no undo" note is persistent, not behind an ⓘ.** That's §1.5's one sanctioned exception: this is not something to make someone go looking for.

**Re-tokened to `--bm-danger`**, which is already the app-wide destructive colour (ConnectionSetup, LoginScreen). It had been a hardcoded `rgba(232, 68, 58, …)` that matched nothing else and was free to drift from the palette on its own.

## `SettingsSection` is deleted

20 lines. PR3's conversion left it referenced only by Data; converting Data left it referenced by **nothing at all**.

The plan had this in PR7, but carrying a dead component through two more PRs serves nobody — and the teardown still has plenty to do (the local `SectionHeader` inside NotificationsPanel, the tab CSS, the dead classes in §7.3). **Zero `SettingsSection` references remain in `src/`.**

## Details

- The Devices row's summary is a **real count**, fetched alongside the integration statuses rather than lifted out of `AuthDevicesBlock` — that component stays self-contained and the row still gets a value instead of an empty trailing area.
- Cut one description as unearned: Markdown import's *"rarely used; it lives here so it doesn't crowd the main menu"* was meta-commentary about the UI's own layout, and the button already says what it does.

## Verification

Driven in a real browser against a live server:

- Data renders **0 old `SettingsSection`s**
- The danger card is present and confirmed the **last child** of the page, with its note visible
- The Devices row reads **`0 devices`**
- Both sub-pages title correctly with a **"‹ Data"** back affordance, and back returns to Data
- No page errors

ESLint 0 errors, build ✓, `npm test` 134/134 + smoke, `npm audit` clean.

## Next

PR5 — Notifications (flatten the per-type cards into grouped ToggleRows, delete the local `SectionHeader` + `openSections`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V45AJzVRjV8j2Sei5Qgr6A

---
_Generated by [Claude Code](https://claude.ai/code/session_01V45AJzVRjV8j2Sei5Qgr6A)_