### PR TITLE
feat(settings): Integrations become per-integration pages; Labels re-cut (rebuild PR6)

### DIFF
--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -79,9 +79,12 @@ function LabelsPanel() {
 
   return (
     <div className="v2-settings-form">
-      <div className="v2-settings-block">
-        <div className="v2-form-label">Existing labels</div>
-        <div className="v2-settings-row-hint">Tap a name to rename. Color swatches show the picker. Use the arrows to reorder.</div>
+      {/* Plain groups, not framed cards — the danger zone stays the ONE framed
+          element in settings. The colour <details> below stay: they are a
+          picker popover, not a hidden section, so they are not part of the
+          collapse family this rebuild is removing. */}
+      <SettingsGroup caption="Existing labels">
+        <p className="v2-set-page-intro">Tap a name to rename. Colour swatches open the picker. Use the arrows to reorder.</p>
         {labels.length === 0 ? (
           <div className="v2-labels-empty">No labels yet. Add one below.</div>
         ) : (
@@ -155,10 +158,9 @@ function LabelsPanel() {
             ))}
           </ul>
         )}
-      </div>
+      </SettingsGroup>
 
-      <div className="v2-settings-block">
-        <div className="v2-form-label">Add a label</div>
+      <SettingsGroup caption="Add a label">
         <div className="v2-labels-add">
           <details className="v2-labels-color">
             <summary className="v2-labels-swatch" style={{ background: newColor }} aria-label="Pick color" />
@@ -189,7 +191,7 @@ function LabelsPanel() {
             <Plus size={13} strokeWidth={2} /> Add
           </button>
         </div>
-      </div>
+      </SettingsGroup>
     </div>
   )
 }
@@ -253,6 +255,20 @@ const PAGE_TITLES = {
   'Notifications/email': 'Email deliverability',
   'Notifications/test': 'Test channels',
   'Notifications/history': 'History',
+  // One per integration. Duplicated from IntegrationsPanel's own list rather
+  // than derived, because the page title has to resolve before that component
+  // mounts — a page whose header says "Integrations/gcal" for a frame is worse
+  // than a small, stable map.
+  'Integrations/anthropic': 'Anthropic',
+  'Integrations/openai': 'OpenAI',
+  'Integrations/notion': 'Notion',
+  'Integrations/trello': 'Trello',
+  'Integrations/gcal': 'Google Calendar',
+  'Integrations/gmail': 'Gmail',
+  'Integrations/tracking': '17track',
+  'Integrations/shippo': 'Shippo',
+  'Integrations/weather': 'Weather',
+  'Integrations/pushover': 'Pushover',
 }
 
 // All Settings tabs now have v2 implementations.
@@ -584,7 +600,7 @@ function OpenAIKeyBlock({ settings, update }) {
 }
 
 function IntegrationsPanel({
-  settings, update, setActiveTab,
+  settings, update, setActiveTab, page, setPage,
   onTrelloSync, trelloSyncing, onNotionSync, notionSyncing, onGCalSync, gcalSyncing,
 }) {
   const [envKeys, setEnvKeys] = useState({ anthropic: false, notion: false, trello: false, tracking: false })
@@ -1132,15 +1148,14 @@ function IntegrationsPanel({
     },
   ]
 
-  // Per-integration collapse state — SESSION-LOCAL, every integration
-  // starts folded on each Settings visit (2026-07-17). The old
-  // persisted-in-settings map meant whatever you once expanded stayed
-  // expanded forever, and the page crept back to a wall of config.
-  const [openIntegrations, setOpenIntegrations] = useState({})
-  const isIntCollapsed = (key) => !openIntegrations[key]
-  const toggleIntCollapsed = (key) => {
-    setOpenIntegrations(s => ({ ...s, [key]: !s[key] }))
-  }
+  // Sub-page routing. Every integration used to be a name-toggle expander in
+  // one long list — a whole parallel collapse implementation of its own, and
+  // the reason this page was a wall of config. Each integration is a page now,
+  // which also finally gives its nested sub-settings a legal home under the
+  // one-level rule (a config block inside an expander inside a page was two
+  // levels of hiding).
+  const sub = page?.startsWith('Integrations/') ? page.slice('Integrations/'.length) : ''
+  const isMain = !sub
 
   const runPushoverTest = async (emergency) => {
     const setter = emergency ? setPushoverEmer : setPushoverTest
@@ -1165,31 +1180,37 @@ function IntegrationsPanel({
 
   return (
     <div className="v2-settings-form">
-      <div className="v2-settings-block">
-        <div className="v2-form-label">Status</div>
-        <div className="v2-settings-row-hint">
-          Connect, configure, and disconnect every integration inline. Tokens persist
-          across reloads — you only connect once.
-        </div>
+      {/* Plain rows, not a framed card — the danger zone stays the ONE framed
+          element in settings. */}
+      <SettingsGroup>
         <ul className="v2-integrations-list">
           {integrations.map(int => (
-            <li key={int.key} className="v2-integrations-row">
-              <span className={`v2-integrations-dot v2-integrations-dot-${int.connected === 'warn' ? 'warn' : int.connected ? 'connected' : 'unconfigured'}`} />
-              <div className="v2-integrations-meta">
-                <button
-                  type="button"
-                  className="v2-integrations-name v2-integrations-name-toggle"
-                  onClick={() => toggleIntCollapsed(int.key)}
-                  aria-expanded={!isIntCollapsed(int.key)}
-                >
-                  <span className="v2-settings-section-chev" aria-hidden="true">
-                    {isIntCollapsed(int.key) ? '▸' : '▾'}
-                  </span>
-                  {int.label}
-                </button>
-                {int.sub && <div className="v2-integrations-sub">{int.sub}</div>}
-                <div className="v2-integrations-hint">{int.hint}</div>
-                {!isIntCollapsed(int.key) && (<>
+            <Fragment key={int.key}>
+              {isMain && (
+                // The WHOLE ROW is the target (§2), not a small trailing
+                // control. The old row made only the integration's NAME
+                // pressable — it was the expander toggle — which is exactly
+                // how the hierarchy ended up inverted, with the label doing
+                // the work and looking like chrome.
+                <SettingRow
+                  label={int.label}
+                  info={int.hint}
+                  onPress={() => setPage(`Integrations/${int.key}`)}
+                  trailing={
+                    <span className="v2-set-status">
+                      <span
+                        className={`v2-set-dot v2-set-dot-${int.connected === 'warn' ? 'warn' : int.connected ? 'ok' : 'off'}`}
+                        aria-hidden="true"
+                      />
+                      <span className="v2-set-row-value">
+                        {int.sub || (int.connected === 'warn' ? 'Needs attention' : int.connected ? 'Connected' : 'Not set')}
+                      </span>
+                      <ChevronRight size={16} strokeWidth={2} className="v2-set-row-chev" />
+                    </span>
+                  }
+                />
+              )}
+              {sub === int.key && (<>
                 {int.inline === 'api-key' && (
                   <div className="v2-integrations-inline">
                     {int.envFlag ? (
@@ -1798,8 +1819,6 @@ function IntegrationsPanel({
                 {int.syncResult && (
                   <div className="v2-integrations-sync-result">{int.syncResult}</div>
                 )}
-                </>)}
-              </div>
               <div className="v2-integrations-row-actions">
                 {int.sync && (
                   <button
@@ -1822,10 +1841,11 @@ function IntegrationsPanel({
                   </button>
                 )}
               </div>
-            </li>
+              </>)}
+            </Fragment>
           ))}
         </ul>
-      </div>
+      </SettingsGroup>
 
       {emergencyConfirm && (
         <div className="v2-settings-confirm-overlay" onClick={() => setEmergencyConfirm(false)}>
@@ -3525,11 +3545,13 @@ export default function SettingsModal({
           <NotificationsPanel settings={settings} update={update} page={page} setPage={setPage} />
         )}
 
-        {page === 'Integrations' && (
+        {page.startsWith('Integrations') && (
           <IntegrationsPanel
             settings={settings}
             update={update}
             setActiveTab={setPage}
+            page={page}
+            setPage={setPage}
             onTrelloSync={onTrelloSync}
             trelloSyncing={trelloSyncing}
             onNotionSync={onNotionSync}

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,14 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-07-28
 
+- feat(settings): Integrations become per-integration pages; Labels re-cut (rebuild PR6) [L]
+  - Sixth of the seven PRs in `wiki/Settings-Design-Language.md` §9. Ten integrations were a single list of **name-toggle expanders** — a whole parallel collapse implementation of its own, and the reason this page was a wall of config. Each is a page now: dot + name + `Connected` / `Not set` / `Needs attention` + chevron.
+  - It also fixes a **one-level-rule violation** nobody had named: a config block inside an expander inside a page was two levels of hiding. Per-integration pages give those nested sub-settings a legal home.
+  - **The whole row is the tap target now, not the name.** The old row made only the integration's NAME pressable — it *was* the expander toggle — which is exactly how the hierarchy ended up inverted, with the label doing the work while looking like chrome. Caught by the browser test: clicking the label found nothing clickable, because only a small trailing control was live.
+  - **Two more framed cards removed** (the integrations list, both Labels blocks), so the danger zone genuinely remains the ONE framed element in the surface. That is now three PRs running where a second frame had quietly crept in — worth noting as the failure mode for this kind of rule: not argued down, just diluted by exceptions nobody flags.
+  - **The colour `<details>` in Labels deliberately stay.** They are a picker popover, not a hidden section, so they are not part of the collapse family this rebuild is removing. Called out rather than silently skipped.
+  - Verified in a browser: **0 name-toggle expanders, 0 `▸` glyphs**, ten rows with live status dots, and six sampled integrations each titling and returning correctly. No page errors. ESLint 0 errors, build ✓, `npm test` 134/134 + smoke, `npm audit` clean.
+
 - feat(settings): Notifications flattened into sub-pages; the last collapse machinery deleted (rebuild PR5) [L]
   - Fifth of the seven PRs in `wiki/Settings-Design-Language.md` §9, and the largest single pocket of the problem: **seven collapsed sections on one screen, every one folded by default**, which is how a settings page ends up telling you nothing.
   - They are **pages now**. Main Notifications is the three channel masters as `ToggleRow`s, quiet hours, and seven `NavRow`s that each say what they are set to: `Morning digest · On`, `Critical mode · Off`, `Deep links · Not set`, `Email deliverability · Not set`, plus Event pings, Test channels and History. Verified in a browser: **0 old section headers, 0 `▸` glyphs**, all seven sub-pages titling and returning correctly, no page errors.


### PR DESCRIPTION
Sixth of the seven PRs in `wiki/Settings-Design-Language.md` §9 — the last big conversion.

```
‹ Settings
Integrations

Anthropic (Claude)  ⓘ    ● Not set      ›
OpenAI              ⓘ    ● Connected    ›
Notion              ⓘ    ● Not set      ›
Trello              ⓘ    ● Not set      ›
Google Calendar     ⓘ    ● Not set      ›
Gmail               ⓘ    ● Not set      ›
17track (packages)  ⓘ    ● Not set      ›
Shippo              ⓘ    ● Not set      ›
Weather             ⓘ    ● Not set      ›
Pushover            ⓘ    ● Not set      ›
```

Ten integrations were a single list of **name-toggle expanders** — a whole parallel collapse implementation of its own, and the reason this page was a wall of config. Each is a page now.

It also fixes a **one-level-rule violation nobody had named**: a config block inside an expander inside a page was *two* levels of hiding. Per-integration pages finally give those nested sub-settings a legal home.

## The whole row is the tap target now — not the name

The old row made only the integration's **name** pressable, because the name *was* the expander toggle. That is exactly how the hierarchy ended up inverted: the label doing the work while looking like chrome.

Caught by the browser test rather than by reading — my first pass moved the navigation onto a small trailing control, and clicking the label found nothing clickable. Fixed to a full-row `SettingRow` with the dot, status and chevron trailing.

## Two more framed cards removed

The integrations list and both Labels blocks. The danger zone genuinely remains the **one** framed element in the surface.

That's now **three PRs running** where a second frame had quietly crept in — worth naming as the failure mode for this kind of rule: it doesn't get argued down, it gets diluted by exceptions nobody flags.

## One thing deliberately kept

The colour `<details>` in Labels stay. They're a **picker popover, not a hidden section**, so they aren't part of the collapse family this rebuild is removing. Calling it out rather than silently skipping it.

## Verification

Driven in a real browser against a live server:

- **0 name-toggle expanders, 0 `▸` glyph chevrons**
- Ten rows with live status dots (`OpenAI · Connected` from env, the rest `Not set`)
- Six sampled integrations — Anthropic, Notion, Trello, Google Calendar, Weather, Pushover — each title correctly with a "‹ Integrations" back affordance and return cleanly
- No page errors

ESLint 0 errors, build ✓, `npm test` 134/134 + smoke, `npm audit` clean.

## Next

PR7 — teardown. Delete the tab CSS and dead classes (§7.3), grep-verify no `v2-settings-section` / `v2-settings-tab` references remain, and update `wiki/Features.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V45AJzVRjV8j2Sei5Qgr6A

---
_Generated by [Claude Code](https://claude.ai/code/session_01V45AJzVRjV8j2Sei5Qgr6A)_