### PR TITLE
fix(reminders): the reminder field was in an editor the phone never opens

### DIFF
--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -4,7 +4,7 @@ import { isNativeShell, getApiBase, requestConnectionSetup, readJson } from '../
 import { requestRemindersAccess, syncReminders } from '../remindersSync'
 import {
   loadSettings, saveSettings, loadTasks, saveTasks,
-  loadRoutines, saveRoutines, loadLabels, saveLabels,
+  loadRoutines, saveRoutines, safeSetItem, loadLabels, saveLabels,
   LABEL_COLORS, uuid, localYMD,
 } from '../store'
 import { restoreFromBackup } from '../api'
@@ -266,6 +266,7 @@ const PAGE_TITLES = {
   'Integrations/notion': 'Notion',
   'Integrations/trello': 'Trello',
   'Integrations/gcal': 'Google Calendar',
+  'Integrations/reminders': 'Apple Reminders',
   'Integrations/gmail': 'Gmail',
   'Integrations/tracking': '17track',
   'Integrations/shippo': 'Shippo',
@@ -613,14 +614,24 @@ function IntegrationsPanel({
   // reason it lives somewhere else.
   const [remindersBusy, setRemindersBusy] = useState(false)
   const [remindersMsg, setRemindersMsg] = useState('')
-  const [remindersGranted, setRemindersGranted] = useState(false)
+  // Per-DEVICE, so localStorage rather than the settings blob: Reminders
+  // access is granted on this phone, and syncing that fact to other devices
+  // would be a lie. Component state alone reset on every remount, so a granted
+  // and actively syncing integration reported "Not set".
+  const [remindersGranted, setRemindersGranted] = useState(() => {
+    try { return localStorage.getItem('boom_reminders_ok') === '1' } catch { return false }
+  })
+  const markRemindersOk = () => {
+    setRemindersGranted(true)
+    safeSetItem('boom_reminders_ok', '1')
+  }
   const handleRemindersAccess = async () => {
     setRemindersBusy(true); setRemindersMsg('')
     const res = await requestRemindersAccess()
     // Granting access alone changes nothing visible, so sync immediately —
     // otherwise the button appears to do nothing at all.
     if (res.ok) {
-      setRemindersGranted(true)
+      markRemindersOk()
       const s2 = await syncReminders({ silent: false })
       setRemindersMsg(s2.ok
         ? `Access granted. Synced${s2.imported ? ` — ${s2.imported} brought in` : ''}.`
@@ -633,7 +644,7 @@ function IntegrationsPanel({
   const handleRemindersSync = async () => {
     setRemindersBusy(true); setRemindersMsg('')
     const res = await syncReminders({ silent: false })
-    if (res.ok) setRemindersGranted(true)
+    if (res.ok) markRemindersOk()
     setRemindersMsg(res.ok
       ? `Synced — ${res.imported} brought in, ${res.linked} newly linked${res.unlinked ? `, ${res.unlinked} unlinked` : ''}.${res.held?.length ? ` ${res.held.length} item(s) held; see the console.` : ''}`
       : (res.error || 'Sync failed.'))

--- a/src/kept/QuickEditTask.jsx
+++ b/src/kept/QuickEditTask.jsx
@@ -43,6 +43,8 @@ export default function WallabyEditTask({ task, onSave, onClose, onDelete, onSta
     // energy_level column on read); the snake_case fallback covers raw rows.
     energy: task.energy, energyLevel: task.energyLevel ?? task.energy_level,
     highPriority: task.high_priority, lowPriority: task.low_priority,
+    // ISO in the store, datetime-local in the input.
+    remindAt: task.remind_at ? String(task.remind_at).slice(0, 16) : '',
   })
   const [status, setStatus] = useState(task.status)
   const [checklists, setChecklists] = useState(Array.isArray(task.checklists) ? task.checklists : [])
@@ -80,6 +82,7 @@ export default function WallabyEditTask({ task, onSave, onClose, onDelete, onSta
     notes: form.notes,
     tags: form.selectedTags,
     due_date: form.dueDate || null,
+    remind_at: form.remindAt ? new Date(form.remindAt).toISOString() : null,
     size: form.size,
     energy: form.energy,
     energyLevel: form.energyLevel,
@@ -87,7 +90,7 @@ export default function WallabyEditTask({ task, onSave, onClose, onDelete, onSta
     low_priority: form.lowPriority,
     size_inferred: !!form.size,
     checklists,
-  }), [form.title, form.notes, form.selectedTags, form.dueDate, form.size,
+  }), [form.title, form.notes, form.selectedTags, form.dueDate, form.remindAt, form.size,
     form.energy, form.energyLevel, form.highPriority, form.lowPriority, checklists])
 
   const lastSavedJson = useRef(null)
@@ -150,6 +153,12 @@ export default function WallabyEditTask({ task, onSave, onClose, onDelete, onSta
   // ── chip value labels ───────────────────────────────────────────────────────
   const energyMeta = ENERGY.find(e => e.id === form.energy)
   const priorityLabel = form.highPriority ? 'High' : form.lowPriority ? 'Low' : 'Normal'
+  // Chips show a VALUE at rest, so this reads back the time rather than "Set".
+  const remindLabel = form.remindAt
+    ? new Date(form.remindAt).toLocaleString(undefined, {
+      month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit',
+    })
+    : 'None'
   const tagChips = form.selectedTags.map(id => labelById[id]).filter(Boolean)
 
   const chip = (id, label, value, tone) => (
@@ -248,6 +257,7 @@ export default function WallabyEditTask({ task, onSave, onClose, onDelete, onSta
       <div className="wb-edit-chips">
         {chip('status', 'Status', STATUSES.find(s => s.id === status)?.label || status, status === 'done' ? 'done' : null)}
         {chip('due', 'Due', form.dueDate || 'No date')}
+        {chip('remind', 'Remind', remindLabel)}
         {chip('priority', 'Priority', priorityLabel, form.highPriority ? 'high' : null)}
         {chip('energy', 'Energy', energyMeta ? `${energyMeta.label}${form.energyLevel ? ' ' + '⚡'.repeat(form.energyLevel) : ''}` : 'None')}
         {chip('size', 'Size', form.size || 'Auto')}
@@ -265,6 +275,24 @@ export default function WallabyEditTask({ task, onSave, onClose, onDelete, onSta
       {openChip === 'due' && (
         <div className="wb-edit-picker wb-edit-picker-block">
           <DateField value={form.dueDate} onChange={form.setDueDate} />
+        </div>
+      )}
+      {openChip === 'remind' && (
+        <div className="wb-edit-picker wb-edit-picker-block">
+          {/* A reminder is a MOMENT; the Due chip above is a DAY. Apple
+              Reminders rings it — Boomerang never sends for this. */}
+          <input
+            type="datetime-local"
+            className="wb-edit-date"
+            aria-label="Reminder time"
+            value={form.remindAt || ''}
+            onChange={e => form.setRemindAt(e.target.value)}
+          />
+          {form.remindAt && (
+            <button className="wb-edit-opt" style={{ marginTop: 8 }} onClick={() => form.setRemindAt('')}>
+              Clear reminder
+            </button>
+          )}
         </div>
       )}
       {openChip === 'priority' && (

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,14 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-08-01
 
+- fix(reminders): the reminder field was in an editor the phone never opens [S]
+  - Reported as *"I don't see a place to enter reminders"*, with the integration granted and synced. Correct report: the field existed, in `EditTaskModal`. **Tapping a task in Kept opens `QuickEditTask`**, a different component — the full editor is only reached via "More options", so on the phone the control was effectively unreachable. Shipping a sync with no way to set the thing it syncs.
+  - `QuickEditTask` gains a **Remind** chip beside Due, with a `datetime-local` picker and a Clear action. The chip shows the time at rest (`Aug 9, 6:30 PM`) rather than "Set", per the chip rule that a control displays its VALUE.
+  - **The bug behind the bug:** `QuickEditTask` autosaves off a `useMemo` payload, and its dependency array did not list `form.remindAt`. Setting a reminder never recomputed the payload, so it never saved — the field would have rendered perfectly and silently discarded every value. Caught by driving the real UI and then reading the server, not by looking at the component.
+  - Two smaller defects from the same report's screenshots: the sub-page header read **"Integrations/reminders"** because `PAGE_TITLES` had no entry (the map is deliberately duplicated from the integrations list so a title resolves before that component mounts — a new integration has to be added in both); and the row read **"Not set"** while granted and actively syncing, because the state was component-local and reset on every remount. Access now persists per-DEVICE via `safeSetItem` — syncing that fact to other devices would be a lie, since the grant is on this phone.
+  - Verified by driving the real UI at 402×874: chip renders beside Due, picker opens, label reads back, and the value lands on the server (`remind_at: 2026-08-09T18:30:00.000Z`) and then appears in the sync plan as a CREATE for Apple Reminders.
+
+
 - fix(reminders): Apple Reminders belongs in Integrations, not Notifications [XS]
   - It was first put next to the APNs block, which was the wrong read of what it is. Reminders is a **two-way data sync with an external system** — the same shape as Trello, Notion and Google Calendar, all of which live under Integrations. iOS owning the alarm is a *consequence* of the integration, not a reason to file it as a notification channel; filed there it also implied Boomerang gains a send path, which is exactly what this design avoids.
   - Now a first-class entry in the integrations descriptor list rather than a bespoke block, so it inherits the row treatment, the connected dot, the sub-page routing and the whole-row target every other integration already has. Sits with the other bidirectional syncs.


### PR DESCRIPTION
"I don't see a place to enter reminders" — with the integration granted and synced.

## What happened

The field existed, in `EditTaskModal`. But **tapping a task in Kept opens `QuickEditTask`**, a different component; the full editor is only reachable via "More options". So on the phone the control was effectively unreachable — a sync shipped with no way to set the thing it syncs. My mistake: I added the field without checking which editor the Kept UI actually opens.

`QuickEditTask` now has a **Remind** chip beside Due, with a `datetime-local` picker and a Clear action. The chip shows the time at rest (`Aug 9, 6:30 PM`) rather than "Set", per the rule that a control displays its value.

## The bug behind the bug

`QuickEditTask` autosaves off a `useMemo` payload, and its dependency array **did not list `form.remindAt`**. Setting a reminder never recomputed the payload, so it never saved — the field would have rendered perfectly and silently discarded every value.

Only caught by driving the real UI and then reading the server. Inspecting the component would not have found it.

## Two more from the same screenshots

- The sub-page header read **"Integrations/reminders"** — `PAGE_TITLES` had no entry. That map is deliberately duplicated from the integrations list so a title resolves before the panel mounts, which means a new integration has to be added in both places.
- The row read **"Not set"** while granted and actively syncing, because the state was component-local and reset on every remount. Access now persists **per-device** via `safeSetItem` — syncing that fact to other devices would be a lie, since the grant is on this phone.

## Verification

Driven through the real UI at 402×874, then checked against the server:

- Remind chip renders beside Due; picker opens as `datetime-local`; label reads back `Aug 9, 6:30 PM`.
- Value lands on the server: `remind_at: 2026-08-09T18:30:00.000Z`.
- Appears in the sync plan as a **CREATE** for Apple Reminders.
- `npm test` 246/246 + smoke, eslint 0 errors.

**No Xcode rebuild needed** — this is all web bundle. The native plugin you already built is unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V45AJzVRjV8j2Sei5Qgr6A)_