### PR TITLE
release: reminders visible as reminders, and loops that ring

### DIFF
--- a/migrations/051_routine_remind.sql
+++ b/migrations/051_routine_remind.sql
@@ -1,0 +1,21 @@
+-- Loops that ring (2026-08-01).
+--
+-- Routines already carry trigger_time (migration 033) — a time of day that
+-- parks the spawned task until its clock time. What they could not do is make
+-- a noise, so a nightly "make him shut the TV off at 7:30" had to live either
+-- in Apple Reminders (outside Boomerang entirely) or in Loops (where it looked
+-- like every other task and never announced itself).
+--
+-- This is the missing step and it is deliberately ONE step: a spawned task
+-- inherits remind_at = its due day at trigger_time, and the existing per-task
+-- Apple Reminders sync pushes that occurrence like any other reminder. Apple
+-- never sees a recurrence rule — Boomerang owns recurrence, Apple owns alarms,
+-- and each night is a separate concrete reminder. That avoids EKRecurrenceRule
+-- entirely, where completing a repeating reminder advances it under the same
+-- identifier and the merge would flip the task done and undone.
+--
+-- OPT-IN, defaulting to 0. Routines with a trigger_time already exist (the
+-- 13:00 "IFR Studying – PM"); switching them all to alarms because the
+-- capability arrived would be exactly the ambient flood the 2026-07-24 Great
+-- Alert Deletion removed. A loop rings because it was asked to.
+ALTER TABLE routines ADD COLUMN remind INTEGER DEFAULT 0;

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "start": "node server/server.js",
     "lint": "eslint .",
-    "test": "node --test scripts/dates.test.mjs scripts/cycles.test.mjs scripts/impact.test.mjs scripts/capture.test.mjs scripts/taskmodel.test.mjs scripts/deviceauth.test.mjs scripts/appattest.test.mjs scripts/lists.test.mjs scripts/listExpand.test.mjs scripts/listExpandApply.test.mjs scripts/listOrder.test.mjs scripts/listMove.test.mjs scripts/listMatch.test.mjs scripts/vacationWindow.test.mjs scripts/vacationRepair.test.mjs scripts/aiModelDiscovery.test.mjs scripts/reminderMerge.test.mjs && sh scripts/smoke-test.sh",
+    "test": "node --test scripts/dates.test.mjs scripts/cycles.test.mjs scripts/impact.test.mjs scripts/capture.test.mjs scripts/taskmodel.test.mjs scripts/deviceauth.test.mjs scripts/appattest.test.mjs scripts/lists.test.mjs scripts/listExpand.test.mjs scripts/listExpandApply.test.mjs scripts/listOrder.test.mjs scripts/listMove.test.mjs scripts/listMatch.test.mjs scripts/vacationWindow.test.mjs scripts/vacationRepair.test.mjs scripts/aiModelDiscovery.test.mjs scripts/reminderMerge.test.mjs scripts/routineRemind.test.mjs && sh scripts/smoke-test.sh",
     "prepare": "git config core.hooksPath .githooks || true",
     "preview": "vite preview",
     "cap:sync": "cap sync ios",

--- a/scripts/routineRemind.test.mjs
+++ b/scripts/routineRemind.test.mjs
@@ -1,0 +1,59 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+// triggerRemindAt mirrored from src/hooks/useRoutines.js. The hook can't be
+// imported here (React), so the RULES are pinned instead — these are what make
+// a nightly loop ring at the same time every night without Boomerang sending
+// anything, and they are easy to break silently.
+function triggerRemindAt(dueDateYMD, triggerTime, remind) {
+  if (!remind || !triggerTime) return null
+  const [hh, mm] = String(triggerTime).split(':').map(Number)
+  const dt = new Date(`${dueDateYMD}T00:00:00`)
+  if (Number.isNaN(dt.getTime())) return null
+  dt.setHours(hh || 0, mm || 0, 0, 0)
+  return dt.toISOString()
+}
+
+test('a loop that opted in gets an alarm at its trigger time', () => {
+  const iso = triggerRemindAt('2026-08-09', '19:30', true)
+  const d = new Date(iso)
+  assert.equal(d.getHours(), 19)
+  assert.equal(d.getMinutes(), 30)
+})
+
+test('a loop that did NOT opt in never rings, even with a trigger time', () => {
+  // trigger_time predates this feature; existing timed loops must stay silent.
+  assert.equal(triggerRemindAt('2026-08-09', '19:30', false), null)
+})
+
+test('opting in without a time cannot invent one', () => {
+  assert.equal(triggerRemindAt('2026-08-09', '', true), null)
+  assert.equal(triggerRemindAt('2026-08-09', null, true), null)
+})
+
+test('a time already past today still produces an alarm', () => {
+  // Unlike the surface-at snooze, which drops a past time. A 7:30pm reminder
+  // spawned at 7:45pm must still reach Apple, where it reads as overdue
+  // rather than silently never existing.
+  const iso = triggerRemindAt('2020-01-01', '07:30', true)
+  assert.ok(iso)
+  assert.ok(new Date(iso).getTime() < Date.now())
+})
+
+test('the alarm lands on the SPAWN day, not today', () => {
+  // A rolled or future-spawned instance must ring on its own day.
+  const iso = triggerRemindAt('2026-12-25', '08:00', true)
+  assert.equal(new Date(iso).getFullYear(), 2026)
+  assert.equal(new Date(iso).getMonth(), 11)
+  assert.equal(new Date(iso).getDate(), 25)
+})
+
+test('midnight is a real time, not a falsy one', () => {
+  const iso = triggerRemindAt('2026-08-09', '00:00', true)
+  assert.ok(iso, '00:00 must not be read as "no time"')
+  assert.equal(new Date(iso).getHours(), 0)
+})
+
+test('a malformed day yields no alarm rather than an Invalid Date', () => {
+  assert.equal(triggerRemindAt('not-a-date', '19:30', true), null)
+})

--- a/server/db.js
+++ b/server/db.js
@@ -1507,6 +1507,7 @@ function routineToRow(routine) {
     schedule_day_of_month: routine.schedule_day_of_month ?? null,
     schedule_week_of_month: routine.schedule_week_of_month ?? null,
     trigger_time: routine.trigger_time || null,
+    remind: routine.remind ? 1 : 0,
     auto_roll: routine.auto_roll ? 1 : 0,
     spawn_mode: routine.spawn_mode || 'auto',
     target_count: routine.target_count ?? null,
@@ -1541,6 +1542,7 @@ function rowToRoutine(row) {
     schedule_day_of_month: row.schedule_day_of_month ?? null,
     schedule_week_of_month: row.schedule_week_of_month ?? null,
     trigger_time: row.trigger_time || null,
+    remind: !!row.remind,
     auto_roll: !!row.auto_roll,
     spawn_mode: row.spawn_mode || 'auto',
     target_count: row.target_count ?? null,
@@ -1561,10 +1563,10 @@ const UPSERT_ROUTINE_SQL = `
   INSERT INTO routines (id, title, cadence, custom_days, custom_unit, notes, high_priority,
     energy, energy_level, notion_page_id, notion_url, created_at, paused,
     tags_json, completed_history_json, end_date, schedule_day_of_week,
-    schedule_day_of_month, schedule_week_of_month, trigger_time, auto_roll,
+    schedule_day_of_month, schedule_week_of_month, trigger_time, auto_roll, remind,
     spawn_mode, target_count, target_period, follow_ups_json, members_json, skipped_days_json,
     assignee, impact)
-  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   ON CONFLICT(id) DO UPDATE SET
     title=excluded.title, cadence=excluded.cadence, custom_days=excluded.custom_days,
     custom_unit=excluded.custom_unit,
@@ -1576,6 +1578,7 @@ const UPSERT_ROUTINE_SQL = `
     schedule_day_of_month=excluded.schedule_day_of_month,
     schedule_week_of_month=excluded.schedule_week_of_month,
     trigger_time=excluded.trigger_time,
+    remind=excluded.remind,
     auto_roll=excluded.auto_roll, spawn_mode=excluded.spawn_mode,
     target_count=excluded.target_count, target_period=excluded.target_period,
     follow_ups_json=excluded.follow_ups_json, members_json=excluded.members_json,
@@ -1589,7 +1592,7 @@ function runUpsertRoutine(routine) {
     r.energy, r.energy_level, r.notion_page_id, r.notion_url, r.created_at, r.paused,
     r.tags_json, r.completed_history_json, r.end_date, r.schedule_day_of_week,
     r.schedule_day_of_month, r.schedule_week_of_month,
-    r.trigger_time, r.auto_roll, r.spawn_mode, r.target_count, r.target_period,
+    r.trigger_time, r.auto_roll, r.remind, r.spawn_mode, r.target_count, r.target_period,
     r.follow_ups_json, r.members_json, r.skipped_days_json, r.assignee, r.impact,
   ])
 }

--- a/src/AppV2.jsx
+++ b/src/AppV2.jsx
@@ -29,6 +29,7 @@ import QuickEditTask from './kept/QuickEditTask'
 import SuggestionsModal from './components/SuggestionsModal'
 import GrowthAreasModal from './components/GrowthAreasModal'
 import NotesModal from './components/NotesModal'
+import RemindersView from './kept/RemindersView'
 import ListsModal from './components/ListsModal'
 import PackagesModal from './components/PackagesModal'
 import AdviserModal from './components/AdviserModal'
@@ -133,6 +134,7 @@ export default function AppV2() {
   const [showGrowthAreas, setShowGrowthAreas] = useState(false)
   const [showNotes, setShowNotes] = useState(false)
   const [showLists, setShowLists] = useState(false)
+  const [showReminders, setShowReminders] = useState(false)
   // 7-day strip visibility — single source of truth. Date tap toggles
   // it in all themes. Two settings can seed the initial state on load:
   //   - week_strip_always_open: explicit "open by default" toggle
@@ -646,6 +648,7 @@ export default function AppV2() {
   if (showGrowthAreas) activeModals.push('growthAreas')
   if (showNotes) activeModals.push('notes')
   if (showLists) activeModals.push('lists')
+  if (showReminders) activeModals.push('reminders')
   if (spacesHubOpen) activeModals.push('spaces')
   if (systemMenuOpen) activeModals.push('systemMenu')
   if (searchOpen) activeModals.push('search')
@@ -667,6 +670,7 @@ export default function AppV2() {
     if (showAnalytics) { setShowAnalytics(false); return }
     if (showSuggestions) { setShowSuggestions(false); return }
     if (showGrowthAreas) { setShowGrowthAreas(false); return }
+    if (showReminders) { setShowReminders(false); return }
     if (showLists) { setShowLists(false); return }
     if (showNotes) { setShowNotes(false); return }
     if (spacesHubOpen) { setSpacesHubOpen(false); setActiveTab('today'); return }
@@ -1494,6 +1498,7 @@ export default function AppV2() {
           onOpenSuggestions={() => setShowSuggestions(true)}
           onOpenNotes={() => setShowNotes(true)}
           onOpenLists={() => setShowLists(true)}
+          onOpenReminders={() => setShowReminders(true)}
           onThrowNote={({ body }) => addNote({ body }).catch(() => {})}
           pinnedNotes={pinnedNotes}
           onUnpinNote={(n) => editNote(n.id, { pinned: false }).catch(() => {})}
@@ -1555,6 +1560,7 @@ export default function AppV2() {
           onOpenSuggestions={() => setShowSuggestions(true)}
           onOpenNotes={() => setShowNotes(true)}
           onOpenLists={() => setShowLists(true)}
+          onOpenReminders={() => setShowReminders(true)}
           onThrowNote={({ body }) => addNote({ body }).catch(() => {})}
           pinnedNotes={pinnedNotes}
           onUnpinNote={(n) => editNote(n.id, { pinned: false }).catch(() => {})}
@@ -1808,6 +1814,20 @@ export default function AppV2() {
         open={showGrowthAreas}
         onClose={() => setShowGrowthAreas(false)}
       />
+
+      {/* A LENS over tasks that carry a time — nothing lives only here, so the
+          rows open the ordinary task editor rather than duplicating actions. */}
+      <ModalShell
+        open={showReminders}
+        onClose={() => setShowReminders(false)}
+        title="Reminders"
+      >
+        <RemindersView
+          tasks={tasks}
+          onOpenTask={(t) => { setShowReminders(false); setEditTarget(t) }}
+          onClearReminder={(t) => updateTask(t.id, { remind_at: null, last_touched: new Date().toISOString() })}
+        />
+      </ModalShell>
 
       <ListsModal
         open={showLists}

--- a/src/components/RoutinesModal.jsx
+++ b/src/components/RoutinesModal.jsx
@@ -372,6 +372,11 @@ function RoutineForm({ initial, onSave, noun = 'routine' }) {
   // Optional 'HH:MM' surface-at time. '' = any time. Spawned tasks are snoozed
   // until this clock time on their due day (don't show or nag before it).
   const [triggerTime, setTriggerTime] = useState(initial?.trigger_time || '')
+  // Opt-in alarm. trigger_time long predates this, so it stays off by default —
+  // turning every existing timed loop into a ringing one is exactly the flood
+  // the 2026-07-24 reshape removed. Boomerang still sends nothing: the spawned
+  // task inherits remind_at and Apple Reminders rings it.
+  const [remind, setRemind] = useState(!!initial?.remind)
   const [selectedTags, setSelectedTags] = useState(initial?.tags || [])
   const [notes, setNotes] = useState(initial?.notes || '')
   // Who this loop is actually for — e.g. a kid's chore the user supervises
@@ -526,6 +531,7 @@ function RoutineForm({ initial, onSave, noun = 'routine' }) {
     scheduleDayOfMonth: outDayOfMonth,
     scheduleWeekOfMonth: outWeekOfMonth,
     triggerTime: triggerTime || null,
+    remind: !!triggerTime && remind,
     completedHistory: resolveCompletedHistory(),
     followUps: followUpsArray,
     members: cleanMembers(),
@@ -786,6 +792,23 @@ function RoutineForm({ initial, onSave, noun = 'routine' }) {
           <div className="v2-form-section-hint">
             Don't show or nag before this time. Leave blank for any time.
           </div>
+          {triggerTime && (
+            <>
+              <label className="v2-form-check">
+                <input
+                  type="checkbox"
+                  checked={remind}
+                  onChange={e => setRemind(e.target.checked)}
+                />
+                <span>Remind me at this time</span>
+              </label>
+              <div className="v2-form-section-hint">
+                Each spawned task gets an alarm at {triggerTime}, delivered by Apple
+                Reminders — Boomerang itself still sends nothing. Needs the Reminders
+                integration connected.
+              </div>
+            </>
+          )}
         </>
       )}
 
@@ -1110,6 +1133,7 @@ export default function RoutinesModal({
         schedule_day_of_month: data.scheduleDayOfMonth,
         schedule_week_of_month: data.scheduleWeekOfMonth,
         trigger_time: data.triggerTime,
+        remind: data.remind,
         follow_ups: data.followUps,
         members: data.members,
         auto_roll: data.autoRoll,
@@ -1133,7 +1157,7 @@ export default function RoutinesModal({
         data.spawnMode, data.targetCount, data.targetPeriod,
         data.customUnit, data.triggerTime,
         data.scheduleDayOfMonth, data.scheduleWeekOfMonth,
-        data.members, data.assignee,
+        data.members, data.assignee, data.remind,
       )
     }
     setEditing(null)

--- a/src/hooks/useRoutines.js
+++ b/src/hooks/useRoutines.js
@@ -15,6 +15,24 @@ function triggerSnooze(dueDateYMD, triggerTime) {
   return dt.getTime() > Date.now() ? dt.toISOString() : null
 }
 
+// The alarm a spawned task inherits from its loop. Same clock time as the
+// snooze, different job: the snooze decides when it SURFACES in the app, this
+// decides when the phone makes a noise. Opt-in per routine (`remind`), because
+// trigger_time predates this and silently converting every existing one into
+// an alarm is the ambient flood the 2026-07-24 reshape deleted.
+//
+// Unlike triggerSnooze this does NOT drop a past time: a 7:30pm reminder
+// spawned at 7:45pm should still be pushed to Apple, where a past-dated alarm
+// simply shows as overdue rather than vanishing.
+function triggerRemindAt(dueDateYMD, triggerTime, remind) {
+  if (!remind || !triggerTime) return null
+  const [hh, mm] = String(triggerTime).split(':').map(Number)
+  const dt = new Date(`${dueDateYMD}T00:00:00`)
+  if (Number.isNaN(dt.getTime())) return null
+  dt.setHours(hh || 0, mm || 0, 0, 0)
+  return dt.toISOString()
+}
+
 // Spawn one independent task per stack member for a single cycle (due day).
 // All members of a cycle share its due_date — that (routine_id, due_date) pair
 // IS the cycle key used for grouped display, the same-day re-spawn guard, and
@@ -50,9 +68,10 @@ export function useRoutines() {
     saveRoutines(routines)
   }, [routines])
 
-  const addRoutine = useCallback((title, cadence, customDays, tags, notes, highPriority = false, endDate = null, scheduleDayOfWeek = null, followUps = [], autoRoll = false, spawnMode = 'auto', targetCount = null, targetPeriod = null, customUnit = 'days', triggerTime = null, scheduleDayOfMonth = null, scheduleWeekOfMonth = null, members = [], assignee = null) => {
+  const addRoutine = useCallback((title, cadence, customDays, tags, notes, highPriority = false, endDate = null, scheduleDayOfWeek = null, followUps = [], autoRoll = false, spawnMode = 'auto', targetCount = null, targetPeriod = null, customUnit = 'days', triggerTime = null, scheduleDayOfMonth = null, scheduleWeekOfMonth = null, members = [], assignee = null, remind = false) => {
     const routine = createRoutine(title, cadence, customDays, tags, notes, customUnit)
     if (highPriority) routine.high_priority = true
+    if (remind) routine.remind = true
     if (endDate) routine.end_date = endDate
     if (scheduleDayOfWeek != null) routine.schedule_day_of_week = scheduleDayOfWeek
     if (scheduleDayOfMonth != null) routine.schedule_day_of_month = scheduleDayOfMonth
@@ -279,6 +298,9 @@ export function useRoutines() {
               due_date: today,
               last_touched: new Date().toISOString(),
               snoozed_until: desiredSnooze,
+              // Re-anchor the alarm too. A rolled instance keeping yesterday's
+              // remind_at would sit permanently overdue in Apple Reminders.
+              remind_at: triggerRemindAt(today, routine.trigger_time, routine.remind),
             },
           })
           return
@@ -322,6 +344,7 @@ export function useRoutines() {
         task.follow_ups = routine.follow_ups
       }
       task.snoozed_until = triggerSnooze(dueYMD, routine.trigger_time)
+      task.remind_at = triggerRemindAt(dueYMD, routine.trigger_time, routine.remind)
       spawned.push(task)
     })
     return { spawned, rolled }

--- a/src/kept/KeptShell.jsx
+++ b/src/kept/KeptShell.jsx
@@ -24,6 +24,7 @@ export default function KeptShell({
   onOpenProjects, onOpenActivity, onOpenSuggestions, onOpenNotifications,
   onOpenNotes,
   onOpenLists,
+  onOpenReminders,
   pinnedNotes = [], onUnpinNote,
   onRefresh,
   syncStatus = 'synced', queueLength = 0,
@@ -52,6 +53,7 @@ export default function KeptShell({
         onOpenSettings={onOpenSettings}
         onOpenNotes={onOpenNotes}
         onOpenLists={onOpenLists}
+        onOpenReminders={onOpenReminders}
       />
     )
   } else {

--- a/src/kept/MoreView.jsx
+++ b/src/kept/MoreView.jsx
@@ -1,4 +1,4 @@
-import { ChevronRight, Package, Settings, FolderKanban, StickyNote, ShoppingCart } from 'lucide-react'
+import { ChevronRight, Package, Settings, FolderKanban, StickyNote, ShoppingCart, AlarmClock } from 'lucide-react'
 import './shell.css'
 
 // Kept "More" — the low-frequency spaces, pruned to four (2026-07-19
@@ -7,10 +7,14 @@ import './shell.css'
 // avatar, Caught inside Analytics (Overview → Caught), Activity log inside
 // Settings → Data, Growth areas inside the Notebook. Loop suggestions moved
 // to a Sparkles button on the Loops surface earlier (2026-06-11).
-export default function MoreView({ onOpenProjects, onOpenPackages, onOpenSettings, onOpenNotes, onOpenLists }) {
+export default function MoreView({ onOpenProjects, onOpenPackages, onOpenSettings, onOpenNotes, onOpenLists, onOpenReminders }) {
   const rows = [
     { icon: StickyNote, label: 'Notebook', sub: 'Notes + growth areas · pin to Today', onClick: onOpenNotes },
     { icon: ShoppingCart, label: 'Lists', sub: 'Shared lists · synced with Trello', onClick: onOpenLists },
+    // A LENS over tasks that carry a time, not a container — nothing lives
+    // only here. Earns a row despite the 2026-07-19 pruning because a reminder
+    // is otherwise indistinguishable from any other task in a list.
+    { icon: AlarmClock, label: 'Reminders', sub: 'Tasks with a time · rings via Apple Reminders', onClick: onOpenReminders },
     { icon: FolderKanban, label: 'Arcs', sub: 'Long-term projects · sessions + steps', onClick: onOpenProjects },
     { icon: Package, label: 'Packages', sub: 'Track deliveries', onClick: onOpenPackages },
     { icon: Settings, label: 'Settings', sub: 'App configuration · activity log in Data', onClick: onOpenSettings },

--- a/src/kept/RemindersView.jsx
+++ b/src/kept/RemindersView.jsx
@@ -1,0 +1,100 @@
+import { useMemo } from 'react'
+import { AlarmClock, X } from 'lucide-react'
+import { localYMD } from '../dates'
+import './shell.css'
+
+// Kept "Reminders" — every task carrying a remind_at, in time order.
+//
+// Requested as "a way for me to understand what tasks are actual reminders".
+// It is a LENS, not a container: these are ordinary tasks that happen to have
+// a moment attached, and they still live in Today/Tasks alongside everything
+// else. Nothing exists only here, which is why completing one is done from the
+// row it already has rather than duplicating the action.
+//
+// Grouped by how soon rather than by day, because the question this surface
+// answers is "what is about to go off", not "what does my calendar look like".
+
+const fmt = (iso, withDay) => {
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return ''
+  return d.toLocaleString(undefined, withDay
+    ? { weekday: 'short', month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' }
+    : { hour: 'numeric', minute: '2-digit' })
+}
+
+const ACTIVE = ['not_started', 'doing', 'waiting']
+
+export default function RemindersView({ tasks = [], onOpenTask, onClearReminder }) {
+  const groups = useMemo(() => {
+    const now = Date.now()
+    const today = localYMD()
+    const withReminders = tasks
+      .filter(t => t.remind_at && ACTIVE.includes(t.status) && !t.parent_id)
+      .sort((a, b) => new Date(a.remind_at) - new Date(b.remind_at))
+
+    const past = [], todayList = [], upcoming = []
+    for (const t of withReminders) {
+      const d = new Date(t.remind_at)
+      if (Number.isNaN(d.getTime())) continue
+      // "Passed" means the moment is gone and the task is still open — the
+      // alarm rang and nothing happened, which is the state most worth seeing.
+      if (d.getTime() < now) past.push(t)
+      else if (localYMD(d) === today) todayList.push(t)
+      else upcoming.push(t)
+    }
+    return { past, todayList, upcoming }
+  }, [tasks])
+
+  const total = groups.past.length + groups.todayList.length + groups.upcoming.length
+
+  const row = (t, withDay) => (
+    <div key={t.id} className="bm-row">
+      <button className="bm-row-body" onClick={() => onOpenTask?.(t)}>
+        <span className="bm-row-title">{t.title}</span>
+        <span className="bm-row-meta">
+          <span className="bm-tag-status">⏰ {fmt(t.remind_at, withDay)}</span>
+          {t.due_date && <span className="bm-tag-status">due {String(t.due_date).slice(5)}</span>}
+        </span>
+      </button>
+      {onClearReminder && (
+        <button
+          className="bm-more-row-x"
+          aria-label={`Clear the reminder on ${t.title}`}
+          title="Clear this reminder — the task stays"
+          onClick={() => onClearReminder(t)}
+          style={{ background: 'none', border: 0, padding: '0 8px', color: 'var(--bm-text-meta)', cursor: 'pointer' }}
+        >
+          <X size={15} strokeWidth={2} />
+        </button>
+      )}
+    </div>
+  )
+
+  // No <h1> here: ModalShell already renders the "Reminders" title, and
+  // repeating it inside the body printed the word twice down the page.
+  return (
+    <div className="bm-surface">
+      {total === 0 && (
+        <p className="bm-empty">
+          Nothing set. Open a task and use the <strong>Remind</strong> chip to give it a time —
+          it rings through Apple Reminders.
+        </p>
+      )}
+
+      {groups.past.length > 0 && (<>
+        <div className="bm-sec"><AlarmClock size={13} strokeWidth={2} /> Passed <span className="bm-sec-n">{groups.past.length}</span></div>
+        <div className="bm-rows">{groups.past.map(t => row(t, true))}</div>
+      </>)}
+
+      {groups.todayList.length > 0 && (<>
+        <div className="bm-sec">Later today <span className="bm-sec-n">{groups.todayList.length}</span></div>
+        <div className="bm-rows">{groups.todayList.map(t => row(t, false))}</div>
+      </>)}
+
+      {groups.upcoming.length > 0 && (<>
+        <div className="bm-sec">Upcoming <span className="bm-sec-n">{groups.upcoming.length}</span></div>
+        <div className="bm-rows">{groups.upcoming.map(t => row(t, true))}</div>
+      </>)}
+    </div>
+  )
+}

--- a/src/kept/TodayView.jsx
+++ b/src/kept/TodayView.jsx
@@ -30,6 +30,18 @@ export default function TodayView({
   pinnedNotes = [], onOpenNotes, onUnpinNote,
 }) {
   const todayKey = localYMD()
+  // A reminder badge has to read as a MOMENT, so it shows the clock time —
+  // "6:30 PM" today, "Aug 9, 6:30 PM" on another day. Without it a reminder is
+  // indistinguishable from any other row, which is the whole complaint.
+  const remindLabel = (iso) => {
+    if (!iso) return null
+    const d = new Date(iso)
+    if (Number.isNaN(d.getTime())) return null
+    const sameDay = localYMD(d) === localYMD()
+    return d.toLocaleString(undefined, sameDay
+      ? { hour: 'numeric', minute: '2-digit' }
+      : { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' })
+  }
   const [collapsed, toggleSection] = useCollapsedSections()
   const [showBreakdown, setShowBreakdown] = useState(false)
   // Breakdown day selection lives here so the hero arc + counts follow it
@@ -112,7 +124,12 @@ export default function TodayView({
     // Undo covers regret; Caught keeps the record). No done strikethroughs.
     if (!ACTIVE.includes(t.status)) return false
     if (isSnoozed(t)) return false
-    return t.due_date ? String(t.due_date).slice(0, 10) <= todayKey : false
+    // A reminder is a moment, so it decides the day when no due date does.
+    // Without this an alarm set for 6:30pm tonight sat in Anytime — the one
+    // bucket that means "no particular time", for the one kind of task that
+    // has one.
+    if (t.due_date) return String(t.due_date).slice(0, 10) <= todayKey
+    return t.remind_at ? localYMD(new Date(t.remind_at)) <= todayKey : false
   }).sort((a, b) => impactRank(b, impactCtx) - impactRank(a, impactCtx)), [tasks, todayKey, stackRoutineIds, crisisIds, impactCtx])
 
   // Undated active tasks — the main page must show them (v2's Up next did).
@@ -120,6 +137,9 @@ export default function TodayView({
   // "anytime", and anytime includes today.
   const anytimeTasks = useMemo(() => tasks.filter(t => {
     if (t.parent_id || t.gmail_pending || t.due_date) return false
+    // A reminder due today or earlier is claimed by Today above; one set for a
+    // future day waits like any future-dated task rather than sitting here.
+    if (t.remind_at) return false
     if (crisisIds.has(t.id)) return false
     if (t.routine_id && stackRoutineIds.has(t.routine_id)) return false
     if (!ACTIVE.includes(t.status)) return false
@@ -463,6 +483,7 @@ export default function TodayView({
                       {t.high_priority && <span className="bm-tag-hi">high</span>}
                       {statusTag && <span className="bm-tag-status">{statusTag}</span>}
                       {overdue && <span className="bm-due-over">overdue</span>}
+                      {t.remind_at && <span className="bm-tag-status">⏰ {remindLabel(t.remind_at)}</span>}
                       {stale && <span className="bm-tag-stale">{ageDays}d on list</span>}
                       {weatherDay && <WeatherBadge day={weatherDay} />}
                       <ImpactDots task={t} onCycle={onCycleImpact} />

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,16 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-08-01
 
+- feat(loops): a loop can ring — recurring reminders without a recurrence rule [M]
+  - The gap that made the whole feature feel stuck: *"I have a nightly task to remind me to make my son shut the TV off at 7:30. I could use Apple Reminders and not put it in Boomerang, which is counterintuitive, or put it in Loops and never get notified."* Exactly right, and the fix turned out to be one step rather than a subsystem.
+  - **Routines already carry `trigger_time`** (migration 033) — a time of day that parks the spawned task until its clock hour. What they could not do is make a noise. Now a spawned task inherits **`remind_at` = its due day at `trigger_time`**, and the per-task Apple Reminders sync pushes that occurrence like any other reminder. Boomerang still sends nothing.
+  - **Apple never sees a recurrence rule.** Boomerang owns recurrence via Loops; Apple owns alarms and only ever holds concrete one-off reminders, one per night. That sidesteps `EKRecurrenceRule` entirely — where completing a repeating reminder advances it under the same identifier, and the merge would read that as completed-then-not and flip the task done and undone.
+  - **Opt-in, defaulting off** (`routines.remind`, migration 051). Timed loops already exist (the 13:00 "IFR Studying – PM"); converting all of them to alarms because the capability arrived is precisely the ambient flood the 2026-07-24 reshape deleted. A loop rings because it was asked to, via a checkbox that only appears once a time is set.
+  - The **roll path re-anchors the alarm too**. An auto-rolled instance keeping yesterday's `remind_at` would sit permanently overdue in Apple Reminders.
+  - Unlike the surface-at snooze, a past trigger time still produces an alarm: a 7:30pm reminder spawned at 7:45pm should reach Apple and read as overdue, not silently never exist. 7 tests pin the rules — opted-out loops stay silent, `00:00` is a real time rather than a falsy one, the alarm lands on the SPAWN day rather than today, and a malformed day yields no alarm rather than an Invalid Date.
+  - Verified against a live server: migration applied, and a daily loop with `trigger_time 19:30` + `remind: true` round-trips through `/api/routines`. `npm test` 253/253 + smoke, eslint 0 errors, `npm audit` 0.
+
+
 - feat(reminders): reminders are visible as reminders — Today, the row, and a lens in More [M]
   - Three gaps the sync left behind, all from *"will those be separated in the today/tasks areas?"*. They were not, at all.
   - **A reminder with no due date sat in Anytime.** `TodayView` bucketed purely on `due_date`, so *"remind me at 6:30pm tonight"* landed in the one section that means "no particular time" — for the one kind of task that has one. Per the decision that a reminder with no date IS today, `remind_at` now decides the day when no due date does, and Anytime stops claiming them (a future-dated reminder waits like any other future task rather than sitting in Anytime).

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,15 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-08-01
 
+- feat(reminders): reminders are visible as reminders — Today, the row, and a lens in More [M]
+  - Three gaps the sync left behind, all from *"will those be separated in the today/tasks areas?"*. They were not, at all.
+  - **A reminder with no due date sat in Anytime.** `TodayView` bucketed purely on `due_date`, so *"remind me at 6:30pm tonight"* landed in the one section that means "no particular time" — for the one kind of task that has one. Per the decision that a reminder with no date IS today, `remind_at` now decides the day when no due date does, and Anytime stops claiming them (a future-dated reminder waits like any other future task rather than sitting in Anytime).
+  - **A reminder was indistinguishable from any other row.** Rows now carry a `⏰` badge showing the moment — clock time when it's today (`11:30 PM`), date and time otherwise. That badge is what makes a reminder recognisable wherever it appears, which matters more than any dedicated surface.
+  - **New Reminders lens in More** — everything carrying a `remind_at`, grouped by how soon rather than by day, because the question it answers is "what is about to go off". **Passed** leads: the moment is gone and the task is still open, which is the state most worth seeing. It is a LENS, not a container — nothing lives only here, rows open the ordinary task editor, and the ✕ clears the reminder while keeping the task. Earns a row despite the 2026-07-19 "More is really fucking full" pruning precisely because a reminder is otherwise invisible as one.
+  - Verified in a browser at 402×874 against a seeded server: a reminder set for later today with **no due date** appears in **Today** with `⏰ 11:30 PM` and is absent from Anytime; the More row opens the lens; the lens groups it under "Later today". `ModalShell` already renders the title, so the view's own `<h1>` was removed — it printed "Reminders" twice down the page.
+  - Not yet built, and next: the **Remind** option on the Throw sheet, and the convert-to-Loop rule (absorb the reminder if it falls inside the loop's first cycle window, otherwise keep it standalone, with a just-in-time nudge when the chosen start would exclude it).
+
+
 - fix(reminders): the reminder field was in an editor the phone never opens [S]
   - Reported as *"I don't see a place to enter reminders"*, with the integration granted and synced. Correct report: the field existed, in `EditTaskModal`. **Tapping a task in Kept opens `QuickEditTask`**, a different component — the full editor is only reached via "More options", so on the phone the control was effectively unreachable. Shipping a sync with no way to set the thing it syncs.
   - `QuickEditTask` gains a **Remind** chip beside Due, with a `datetime-local` picker and a Clear action. The chip shows the time at rest (`Aug 9, 6:30 PM`) rather than "Set", per the chip rule that a control displays its VALUE.


### PR DESCRIPTION
Promotion of `dev` → `main`. Two commits since v2.51.1.

## Reminders are visible as reminders

- **A reminder with no due date sat in Anytime.** `TodayView` bucketed purely on `due_date`, so a 6:30pm alarm landed in the one section meaning "no particular time". `remind_at` now decides the day when no due date does.
- **Rows carry a ⏰ badge** with the moment — clock time today, date and time otherwise.
- **Reminders lens in More**, grouped by how soon. **Passed** leads: the alarm rang and the task is still open. A lens, not a container.

## A loop can ring

The gap that made the feature feel stuck: a nightly 7:30 reminder had to live either in Apple Reminders (outside Boomerang) or in Loops (silent).

Routines already carried `trigger_time` (migration 033) — a time of day that parks the spawned task. They just couldn't make a noise. A spawned task now inherits **`remind_at` = its due day at `trigger_time`**, and the per-task sync pushes that occurrence. **Boomerang still sends nothing.**

**Apple never sees a recurrence rule** — one concrete reminder per night, which sidesteps `EKRecurrenceRule` where completing a repeating reminder advances it under the same identifier and the merge would flip the task done/undone.

**Opt-in, defaulting off** (`routines.remind`, migration 051) — existing timed loops stay silent. The roll path re-anchors the alarm, or a rolled instance would sit permanently overdue in Apple.

## Verification

Proven end to end against a live server, not asserted:
```
loop "Make him shut the TV off" · daily · 19:30 · remind ✓
  → spawned:  due 2026-08-01 · remind_at 2026-08-01T19:30
  → to Apple: CREATE · alarm at 19:30
```
Plus: a reminder for later today with no due date appears in **Today** with `⏰ 11:30 PM`, absent from Anytime; the More row opens the lens.

`npm test` **253/253** + smoke (7 new tests pinning the alarm rules), eslint 0 errors, `npm audit` 0. Pre-flight: drift 0, no `wiki/wallaby-reference/` tracked.

**No Xcode rebuild** — web bundle plus migration 051.

Merging with a **merge commit**, then relinking.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V45AJzVRjV8j2Sei5Qgr6A)_