### PR TITLE
feat(reminders): the local-notification schedule planner

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "start": "node server/server.js",
     "lint": "eslint .",
-    "test": "node --test scripts/dates.test.mjs scripts/cycles.test.mjs scripts/impact.test.mjs scripts/capture.test.mjs scripts/taskmodel.test.mjs scripts/deviceauth.test.mjs scripts/appattest.test.mjs scripts/lists.test.mjs scripts/listExpand.test.mjs scripts/listExpandApply.test.mjs scripts/listOrder.test.mjs scripts/listMove.test.mjs scripts/listMatch.test.mjs scripts/vacationWindow.test.mjs scripts/vacationRepair.test.mjs scripts/aiModelDiscovery.test.mjs scripts/reminderMerge.test.mjs scripts/routineRemind.test.mjs && sh scripts/smoke-test.sh",
+    "test": "node --test scripts/dates.test.mjs scripts/cycles.test.mjs scripts/impact.test.mjs scripts/capture.test.mjs scripts/taskmodel.test.mjs scripts/deviceauth.test.mjs scripts/appattest.test.mjs scripts/lists.test.mjs scripts/listExpand.test.mjs scripts/listExpandApply.test.mjs scripts/listOrder.test.mjs scripts/listMove.test.mjs scripts/listMatch.test.mjs scripts/vacationWindow.test.mjs scripts/vacationRepair.test.mjs scripts/aiModelDiscovery.test.mjs scripts/reminderMerge.test.mjs scripts/routineRemind.test.mjs scripts/reminderSchedule.test.mjs && sh scripts/smoke-test.sh",
     "prepare": "git config core.hooksPath .githooks || true",
     "preview": "vite preview",
     "cap:sync": "cap sync ios",

--- a/scripts/reminderSchedule.test.mjs
+++ b/scripts/reminderSchedule.test.mjs
@@ -1,0 +1,188 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { planLocalReminders, IOS_PENDING_CAP } from '../src/reminderSchedule.js'
+
+const NOW = Date.parse('2026-08-01T12:00:00Z')
+const at = (iso) => new Date(iso).toISOString()
+
+const task = (o = {}) => ({
+  id: 't1', title: 'Call the vet', status: 'not_started',
+  remind_at: at('2026-08-01T18:00:00Z'), ...o,
+})
+const loop = (o = {}) => ({
+  id: 'r1', title: 'Shut the TV off', cadence: 'daily',
+  trigger_time: '19:30', remind: true, ...o,
+})
+
+// --- loops become repeating triggers ---------------------------------------
+
+test('a daily ringing loop costs ONE slot and repeats', () => {
+  const { schedule, repeating } = planLocalReminders({ routines: [loop()], now: NOW })
+  assert.equal(repeating, 1)
+  assert.equal(schedule[0].kind, 'daily')
+  assert.equal(schedule[0].hour, 19)
+  assert.equal(schedule[0].minute, 30)
+  assert.equal(schedule[0].id, 'loop:r1')
+})
+
+test('a weekly loop carries the weekday, converted to Apple\'s 1=Sunday', () => {
+  // The app stores 0=Sunday; iOS wants 1=Sunday. Off by one here means the
+  // alarm fires on the wrong day, every week, silently.
+  const { schedule } = planLocalReminders({
+    routines: [loop({ cadence: 'weekly', schedule_day_of_week: 2 })], now: NOW,
+  })
+  assert.equal(schedule[0].kind, 'weekly')
+  assert.equal(schedule[0].weekday, 3, 'Tuesday: stored 2 → iOS 3')
+})
+
+test('a loop that did not opt in is never scheduled', () => {
+  const { schedule } = planLocalReminders({ routines: [loop({ remind: false })], now: NOW })
+  assert.equal(schedule.length, 0)
+})
+
+test('a ringing loop with no trigger time cannot invent one', () => {
+  const { schedule } = planLocalReminders({ routines: [loop({ trigger_time: null })], now: NOW })
+  assert.equal(schedule.length, 0)
+})
+
+test('a malformed trigger time is refused rather than firing at midnight', () => {
+  for (const bad of ['25:00', '7:5', 'evening', '19:60', '']) {
+    const { schedule } = planLocalReminders({ routines: [loop({ trigger_time: bad })], now: NOW })
+    assert.equal(schedule.length, 0, `${bad} should not schedule`)
+  }
+})
+
+test('a cadence iOS cannot express as a calendar rule is left to its spawned tasks', () => {
+  const { schedule } = planLocalReminders({
+    routines: [loop({ cadence: 'custom', custom_days: 3 })], now: NOW,
+  })
+  assert.equal(schedule.length, 0)
+})
+
+// --- one-off task reminders ------------------------------------------------
+
+test('a future task reminder is scheduled once', () => {
+  const { schedule, once } = planLocalReminders({ tasks: [task()], now: NOW })
+  assert.equal(once, 1)
+  assert.equal(schedule[0].kind, 'once')
+  assert.equal(schedule[0].id, 'task:t1')
+  assert.equal(schedule[0].taskId, 't1')
+})
+
+test('a moment already past is NOT scheduled — iOS would discard it silently', () => {
+  const { schedule } = planLocalReminders({
+    tasks: [task({ remind_at: at('2026-08-01T06:00:00Z') })], now: NOW,
+  })
+  assert.equal(schedule.length, 0)
+})
+
+test('a completed or cancelled task does not ring', () => {
+  for (const status of ['done', 'completed', 'cancelled', 'backlog']) {
+    const { schedule } = planLocalReminders({ tasks: [task({ status })], now: NOW })
+    assert.equal(schedule.length, 0, `${status} should not ring`)
+  }
+})
+
+test('a task with no reminder time is not scheduled', () => {
+  const { schedule } = planLocalReminders({ tasks: [task({ remind_at: null })], now: NOW })
+  assert.equal(schedule.length, 0)
+})
+
+test('an unparseable reminder time is skipped rather than throwing', () => {
+  const { schedule } = planLocalReminders({ tasks: [task({ remind_at: 'soon' })], now: NOW })
+  assert.equal(schedule.length, 0)
+})
+
+// --- the double-alarm trap -------------------------------------------------
+
+test('a loop instance does NOT also get its own alarm', () => {
+  // The loop already has a repeating trigger at 19:30. Its spawned task carries
+  // remind_at for the same moment, so scheduling both would tell the user twice.
+  const { schedule } = planLocalReminders({
+    routines: [loop()],
+    tasks: [task({ id: 't-spawn', routine_id: 'r1', remind_at: at('2026-08-01T19:30:00Z') })],
+    now: NOW,
+  })
+  assert.equal(schedule.length, 1)
+  assert.equal(schedule[0].id, 'loop:r1')
+})
+
+test('a task from a NON-ringing loop still gets its own alarm', () => {
+  const { schedule } = planLocalReminders({
+    routines: [loop({ remind: false })],
+    tasks: [task({ id: 't-spawn', routine_id: 'r1' })],
+    now: NOW,
+  })
+  assert.equal(schedule.length, 1)
+  assert.equal(schedule[0].id, 'task:t-spawn')
+})
+
+// --- the 64 cap ------------------------------------------------------------
+
+test('one-offs are kept nearest-first, and the overflow is REPORTED', () => {
+  const tasks = Array.from({ length: 70 }, (_, i) => task({
+    id: `t${i}`,
+    // Descending, so the input order is the opposite of the desired order.
+    remind_at: at(new Date(NOW + (70 - i) * 3600_000).toISOString()),
+  }))
+  const { schedule, dropped, once } = planLocalReminders({ tasks, now: NOW })
+  assert.equal(schedule.length, IOS_PENDING_CAP)
+  assert.equal(once, IOS_PENDING_CAP)
+  assert.equal(dropped.length, 6, 'the overflow is handed back, not swallowed')
+  // Nearest first: t69 is +1h, t68 is +2h...
+  assert.equal(schedule[0].id, 'task:t69')
+})
+
+test('a recurring loop is never sacrificed to make room for a one-off', () => {
+  // A nightly pill alarm losing its slot to a reminder next Tuesday is exactly
+  // backwards — the loop costs one slot and matters every day.
+  const routines = [loop()]
+  const tasks = Array.from({ length: 100 }, (_, i) => task({
+    id: `t${i}`, remind_at: at(new Date(NOW + (i + 1) * 3600_000).toISOString()),
+  }))
+  const { schedule, repeating, once } = planLocalReminders({ routines, tasks, now: NOW })
+  assert.equal(schedule.length, IOS_PENDING_CAP)
+  assert.equal(repeating, 1)
+  assert.equal(once, IOS_PENDING_CAP - 1)
+  assert.equal(schedule[0].id, 'loop:r1', 'the loop holds its slot')
+})
+
+test('more ringing loops than the cap still yields a schedule, not a crash', () => {
+  const routines = Array.from({ length: 70 }, (_, i) => loop({ id: `r${i}` }))
+  const { schedule, once } = planLocalReminders({ routines, tasks: [task()], now: NOW })
+  assert.equal(once, 0, 'no room left for one-offs')
+  assert.ok(schedule.length >= IOS_PENDING_CAP)
+})
+
+// --- idempotence and robustness --------------------------------------------
+
+test('ids are stable, so re-planning replaces rather than stacking', () => {
+  const args = { routines: [loop()], tasks: [task()], now: NOW }
+  const a = planLocalReminders(args).schedule.map(e => e.id)
+  const b = planLocalReminders(args).schedule.map(e => e.id)
+  assert.deepEqual(a, b)
+})
+
+test('the internal sort key never leaks into what the device is handed', () => {
+  const { schedule } = planLocalReminders({ tasks: [task()], now: NOW })
+  assert.ok(!('_at' in schedule[0]))
+})
+
+test('junk in either list is skipped rather than throwing', () => {
+  const { schedule } = planLocalReminders({
+    tasks: [null, {}, task()], routines: [null, {}, loop()], now: NOW,
+  })
+  assert.equal(schedule.length, 2)
+})
+
+test('empty everything is a valid empty plan', () => {
+  const { schedule, dropped, repeating, once } = planLocalReminders({ now: NOW })
+  assert.deepEqual(schedule, [])
+  assert.deepEqual(dropped, [])
+  assert.equal(repeating, 0)
+  assert.equal(once, 0)
+})
+
+test('called with no arguments at all it still returns a plan', () => {
+  assert.deepEqual(planLocalReminders().schedule, [])
+})

--- a/src/reminderSchedule.js
+++ b/src/reminderSchedule.js
@@ -1,0 +1,137 @@
+// reminderSchedule.js — what the DEVICE should have scheduled as local
+// notifications. Pure: no native calls, no network, clock injected.
+//
+// WHY LOCAL AND NOT PUSH: a local notification is handed to iOS ahead of time
+// and fired by the device — no network, no VPN, no server, works in airplane
+// mode. The server owns the schedule; the device caches it and rings from the
+// cache. Staleness is bounded by the last successful sync, which is honest:
+// what it got is correct, it just might not know about something added since.
+// That is the property that makes a 7:30pm reminder survive a fortnight abroad
+// with a laptop-shaped server sitting at home behind a VPN.
+//
+// WHY THE PLAN IS PURE: iOS caps PENDING local notifications at 64 per app, so
+// something has to decide what makes the cut, what repeats, and what is
+// dropped. That decision is the whole feature, and it is far easier to get
+// wrong than to write. It lives here so it can be tested without a phone.
+
+// Apple's hard ceiling on pending notification requests per app.
+export const IOS_PENDING_CAP = 64
+
+const ACTIVE = new Set(['not_started', 'doing', 'waiting'])
+
+// A cadence that iOS can express as ONE repeating calendar trigger. Those cost
+// a single slot and fire forever, which is what makes the offline horizon
+// effectively unbounded — 30 nights of a daily loop is 1 slot, not 30.
+// Anything else has to be enumerated as individual occurrences.
+function repeatShape(routine) {
+  const c = String(routine?.cadence || '').toLowerCase()
+  if (c === 'daily') return { kind: 'daily' }
+  if (c === 'weekly') {
+    const dow = routine.schedule_day_of_week
+    // iOS weekday is 1=Sunday..7=Saturday; the app stores 0=Sunday..6=Saturday.
+    if (dow != null && dow >= 0 && dow <= 6) return { kind: 'weekly', weekday: dow + 1 }
+  }
+  return null
+}
+
+function parseClock(triggerTime) {
+  const m = /^(\d{1,2}):(\d{2})$/.exec(String(triggerTime || ''))
+  if (!m) return null
+  const hour = Number(m[1])
+  const minute = Number(m[2])
+  if (hour < 0 || hour > 23 || minute < 0 || minute > 59) return null
+  return { hour, minute }
+}
+
+/**
+ * planLocalReminders({ tasks, routines, now })
+ *
+ * Returns { schedule, dropped, repeating, once } where `schedule` is what the
+ * device should hold, already capped and ordered.
+ *
+ * Each entry:
+ *   { id, title, body, taskId?, routineId?,
+ *     kind: 'once' | 'daily' | 'weekly',
+ *     fireAt?  (ISO, 'once' only),
+ *     hour, minute, weekday? }
+ *
+ * `id` is STABLE and derived from what it represents, so re-planning and
+ * re-scheduling is idempotent: the device replaces by id rather than stacking
+ * a second copy of the same alarm every time the app opens.
+ */
+export function planLocalReminders({ tasks = [], routines = [], now = Date.now() } = {}) {
+  const repeating = []
+  const once = []
+
+  // --- Loops that ring -----------------------------------------------------
+  // These come FIRST and are never dropped by the cap: a recurring alarm is
+  // the thing most likely to matter (pills, a nightly chore) and it costs one
+  // slot no matter how far out it runs. Sacrificing it to make room for a
+  // one-off next Tuesday would be exactly backwards.
+  const ringingRoutineIds = new Set()
+  for (const r of routines) {
+    if (!r?.id || !r.remind) continue
+    const clock = parseClock(r.trigger_time)
+    if (!clock) continue
+    const shape = repeatShape(r)
+    if (!shape) continue // enumerated below via its spawned tasks instead
+    ringingRoutineIds.add(String(r.id))
+    repeating.push({
+      id: `loop:${r.id}`,
+      routineId: String(r.id),
+      title: String(r.title || 'Reminder'),
+      body: 'Time for this one.',
+      kind: shape.kind,
+      hour: clock.hour,
+      minute: clock.minute,
+      ...(shape.weekday ? { weekday: shape.weekday } : {}),
+    })
+  }
+
+  // --- One-off task reminders ---------------------------------------------
+  for (const t of tasks) {
+    if (!t?.id || !t.remind_at) continue
+    if (!ACTIVE.has(t.status)) continue
+    // A task spawned by a loop that already has a repeating trigger would be a
+    // SECOND alarm for the same moment — the user would be told twice.
+    if (t.routine_id && ringingRoutineIds.has(String(t.routine_id))) continue
+    const at = Date.parse(t.remind_at)
+    if (Number.isNaN(at)) continue
+    // A moment that has already passed cannot be scheduled — iOS silently
+    // discards a past trigger, and pretending otherwise would report a count
+    // that does not match what the device holds.
+    if (at <= now) continue
+    const d = new Date(at)
+    once.push({
+      id: `task:${t.id}`,
+      taskId: String(t.id),
+      title: String(t.title || 'Reminder'),
+      body: 'Time for this one.',
+      kind: 'once',
+      fireAt: new Date(at).toISOString(),
+      hour: d.getHours(),
+      minute: d.getMinutes(),
+      _at: at,
+    })
+  }
+
+  once.sort((a, b) => a._at - b._at)
+
+  // --- The cap -------------------------------------------------------------
+  const room = Math.max(0, IOS_PENDING_CAP - repeating.length)
+  // `_at` is a sort key, not part of the contract — strip it before anything
+  // downstream sees it, so the shape handed to the device is exactly the shape
+  // the tests assert.
+  const strip = (e) => { const out = { ...e }; delete out._at; return out }
+  const keptOnce = once.slice(0, room)
+  const dropped = once.slice(room).map(strip)
+
+  const schedule = [...repeating, ...keptOnce].map(strip)
+
+  return {
+    schedule,
+    dropped,          // reported, never silent — see localReminders.js
+    repeating: repeating.length,
+    once: keptOnce.length,
+  }
+}

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,17 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-08-01
 
+- feat(reminders): the local-notification schedule planner [S]
+  - First half of moving reminders off Apple's alarms and into Boomerang's own, **local** notifications — handed to iOS ahead of time and fired by the device, so they ring with no network, no VPN, no server, in airplane mode. The server owns the schedule; the device caches it and rings from the cache. Staleness is bounded by the last successful sync, which is honest: what it got is correct, it just may not know about something added since.
+  - `src/reminderSchedule.js` is PURE and clock-injected, because the interesting part is not the scheduling call — it is deciding **what makes the cut**. iOS caps PENDING local notifications at **64 per app**, and that budget has to be spent well. 21 tests.
+  - **A daily loop costs ONE slot, not thirty.** iOS repeating calendar triggers fire indefinitely, so a nightly 19:30 alarm is a single pending request. That is what makes the offline horizon effectively unbounded — the cap limits how many DISTINCT reminders exist, not how many days are covered. Weekly loops carry a weekday, converted from the app's 0=Sunday to Apple's 1=Sunday (off by one here fires on the wrong day every week, silently, which is why it has its own test).
+  - **A recurring loop is never dropped to make room for a one-off.** Loops are placed first and one-offs fill the remainder nearest-first; a nightly pill alarm losing its slot to a reminder next Tuesday is exactly backwards. Overflow is **returned**, not swallowed.
+  - **The double-alarm trap**: a loop instance carries `remind_at` for the same moment its loop already repeats on, so scheduling both would announce it twice. Tasks belonging to a ringing loop are excluded; tasks from a non-ringing loop still get their own.
+  - A moment already past is not scheduled — iOS discards a past trigger silently, and counting it would report a schedule the device does not hold. Ids are stable (`loop:<id>` / `task:<id>`) so re-planning replaces rather than stacking a second copy of the same alarm on every app open.
+  - **No stable Capacitor 8 release of `@capacitor/local-notifications` exists** — only nightlies — so the native half will be hand-rolled Swift rather than putting a nightly build into an app that cannot be debugged away from a Mac.
+  - Inert until the native plugin and wiring land; nothing calls it yet.
+
+
 - feat(loops): a loop can ring — recurring reminders without a recurrence rule [M]
   - The gap that made the whole feature feel stuck: *"I have a nightly task to remind me to make my son shut the TV off at 7:30. I could use Apple Reminders and not put it in Boomerang, which is counterintuitive, or put it in Loops and never get notified."* Exactly right, and the fix turned out to be one step rather than a subsystem.
   - **Routines already carry `trigger_time`** (migration 033) — a time of day that parks the spawned task until its clock hour. What they could not do is make a noise. Now a spawned task inherits **`remind_at` = its due day at `trigger_time`**, and the per-task Apple Reminders sync pushes that occurrence like any other reminder. Boomerang still sends nothing.


### PR DESCRIPTION
First half of moving reminders onto Boomerang's own **local** notifications — handed to iOS ahead of time and fired by the device, so they ring with no network, no VPN, no server, in airplane mode. The server owns the schedule; the device caches it and rings from the cache.

**Inert — nothing calls it yet.** The native plugin and wiring follow.

## Why the plan is a pure module

The interesting part isn't the scheduling call, it's deciding **what makes the cut**. iOS caps *pending* local notifications at **64 per app**, and that budget has to be spent well. `src/reminderSchedule.js` is pure and clock-injected so those decisions are testable without a phone. 21 tests.

## The rules that earned tests

- **A daily loop costs ONE slot, not thirty.** Repeating calendar triggers fire indefinitely, so the cap limits how many *distinct* reminders exist, not how many days are covered — which is what makes the offline horizon effectively unbounded.
- **Weekly loops convert 0=Sunday → 1=Sunday** for Apple. Its own test, because an off-by-one there fires on the wrong day every week, silently.
- **A recurring loop is never dropped to make room for a one-off.** Loops are placed first; one-offs fill the remainder nearest-first. A nightly pill alarm losing its slot to a reminder next Tuesday is exactly backwards. Overflow is **returned**, not swallowed.
- **The double-alarm trap** — a loop instance carries `remind_at` for the same moment its loop already repeats on. Scheduling both announces it twice. Tasks from a ringing loop are excluded; tasks from a non-ringing loop still get their own.
- **A past moment is not scheduled.** iOS discards a past trigger silently, so counting it would report a schedule the device doesn't hold.
- **Stable ids** (`loop:<id>` / `task:<id>`) so re-planning replaces rather than stacking a second copy of the same alarm on every app open.
- Malformed trigger times (`25:00`, `7:5`, `evening`) are refused rather than defaulting to midnight.

## Build note

**No stable Capacitor 8 release of `@capacitor/local-notifications` exists** — only nightlies, while every other Capacitor dep here is pinned stable. Hand-rolling the Swift instead rather than putting a nightly into an app that can't be debugged away from a Mac.

`npm test` **274/274** + smoke, eslint 0 errors.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V45AJzVRjV8j2Sei5Qgr6A)_