### PR TITLE
fix(sync): deleting an imported task stops resurrecting it

### DIFF
--- a/migrations/052_remote_tombstones.sql
+++ b/migrations/052_remote_tombstones.sql
@@ -1,0 +1,35 @@
+-- Remote tombstones (2026-08-01).
+--
+-- Reported as "why do these keep coming back??" — three Notion-linked tasks
+-- that reappeared in Anytime after every delete.
+--
+-- Cause: every sync-in path creates a task for any remote item with no
+-- matching local task, and none of them recorded that a task had been deleted
+-- on purpose. Notion is the sharpest case because the database-row pull has no
+-- guard at all (useNotionSync.js) — the page-based pull at least skips a page
+-- whose last_edited is unchanged, but the row pull re-imports unconditionally.
+-- And unlike Trello, deleting a Notion-linked task does not archive anything
+-- upstream, so the row survives and the task is guaranteed to return.
+--
+-- This is the same trap already pinned in CLAUDE.md for LIST items ("a hard
+-- delete is indistinguishable from an item Trello hasn't sent yet, so the next
+-- poll resurrects it"). It was never applied to tasks.
+--
+-- A tombstone is a durable statement of intent: "I deleted this on purpose,
+-- stop bringing it back." It lives on the SERVER rather than in localStorage
+-- because that intent has to survive a reinstall, a cache clear and a second
+-- device — a per-device dismissal would resurrect everything the first time
+-- you open Boomerang somewhere new.
+CREATE TABLE IF NOT EXISTS remote_tombstones (
+  -- 'notion' | 'trello' | 'gcal'. Kept generic rather than one table per
+  -- integration: all three have the identical hole, and a new integration
+  -- should inherit the protection instead of rediscovering the bug.
+  source TEXT NOT NULL,
+  remote_id TEXT NOT NULL,
+  -- What it was, so a human reading the table can tell what they killed.
+  title TEXT,
+  deleted_at TEXT NOT NULL,
+  PRIMARY KEY (source, remote_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_remote_tombstones_source ON remote_tombstones(source);

--- a/server/db.js
+++ b/server/db.js
@@ -2824,3 +2824,39 @@ export function clearReminderLink(taskId) {
   db.run('DELETE FROM reminder_shadows WHERE task_id = ?', [taskId])
   db.run('UPDATE tasks SET reminders_id = NULL WHERE id = ?', [taskId])
 }
+
+// --- Remote tombstones (2026-08-01) ----------------------------------------
+// "I deleted this on purpose, stop re-importing it." See migration 052.
+// Every sync-in path must consult these BEFORE creating a task, or a deleted
+// item returns on the next poll forever.
+
+export function getRemoteTombstones(source = null) {
+  const sql = source
+    ? 'SELECT source, remote_id, title, deleted_at FROM remote_tombstones WHERE source = ?'
+    : 'SELECT source, remote_id, title, deleted_at FROM remote_tombstones'
+  const res = source ? db.exec(sql, [source]) : db.exec(sql)
+  return res[0]?.values.map(v => ({
+    source: v[0], remote_id: v[1], title: v[2], deleted_at: v[3],
+  })) || []
+}
+
+export function addRemoteTombstone({ source, remote_id, title = null }) {
+  if (!source || !remote_id) return false
+  db.run(
+    `INSERT INTO remote_tombstones (source, remote_id, title, deleted_at)
+     VALUES (?, ?, ?, ?)
+     ON CONFLICT(source, remote_id) DO UPDATE SET deleted_at=excluded.deleted_at`,
+    [String(source), String(remote_id), title, new Date().toISOString()],
+  )
+  return true
+}
+
+// Deliberate un-delete: re-linking a remote item you actually do want back.
+// Without this a tombstone would be permanent and the only escape would be
+// editing the database by hand.
+export function removeRemoteTombstone({ source, remote_id }) {
+  if (!source || !remote_id) return false
+  db.run('DELETE FROM remote_tombstones WHERE source = ? AND remote_id = ?',
+    [String(source), String(remote_id)])
+  return true
+}

--- a/server/server.js
+++ b/server/server.js
@@ -18,7 +18,8 @@ import { initDb, getAllData, setAllData, setData, getVersion, bumpVersion, flush
   setEscalationLadder, logEscalationAttempt, advanceEscalationRung,
   dismissEscalationAdvancePrompt, resolveEscalation,
   getVacationWindow, setVacationWindow, isCrisisTask,
-  getReminderShadows, setReminderShadow, clearReminderLink } from './db.js'
+  getReminderShadows, setReminderShadow, clearReminderLink,
+  getRemoteTombstones, addRemoteTombstone, removeRemoteTombstone } from './db.js'
 import { seedDatabase } from './seed.js'
 import { startEmailNotifications, sendTestEmail, getEmailStatus, resetTransporter, sendPackageEmail, verifyEmail, sendSecurityAlertEmail } from './emailNotifications.js'
 import { startPushNotifications, sendTestPush, getPushStatus, getVapidPublicKey, sendPackagePush, sendQuokkaPlanReadyPush, sendSecurityAlertPush } from './pushNotifications.js'
@@ -3509,6 +3510,30 @@ app.post('/api/apns/unregister', (req, res) => {
 
 app.post('/api/apns/test', async (req, res) => {
   res.json(await sendApnsTest())
+})
+
+// --- Remote tombstones (2026-08-01) ---
+// "I deleted this on purpose." Every sync-in path reads these before creating
+// a task; without them a deleted Notion row / Trello card / GCal event comes
+// straight back on the next poll, forever. See migration 052.
+app.get('/api/tombstones', (req, res) => {
+  res.json({ tombstones: getRemoteTombstones(req.query.source || null) })
+})
+
+app.post('/api/tombstones', (req, res) => {
+  const items = Array.isArray(req.body?.items) ? req.body.items : [req.body || {}]
+  let added = 0
+  for (const it of items) {
+    if (addRemoteTombstone({ source: it.source, remote_id: it.remote_id, title: it.title })) added += 1
+  }
+  res.json({ added })
+})
+
+app.delete('/api/tombstones', (req, res) => {
+  const { source, remote_id } = req.query
+  if (!source || !remote_id) return res.status(400).json({ error: 'source and remote_id are required' })
+  removeRemoteTombstone({ source, remote_id })
+  res.json({ ok: true })
 })
 
 // --- Apple Reminders two-way sync (2026-08-01) ---

--- a/src/AppV2.jsx
+++ b/src/AppV2.jsx
@@ -62,7 +62,7 @@ import { useTrelloSync } from './hooks/useTrelloSync'
 import { useNotionSync } from './hooks/useNotionSync'
 import { useGCalSync } from './hooks/useGCalSync'
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts'
-import { inferSize, trelloUpdateCard, serverSkipAdvanceTask, gmailApprove, gmailDismiss, mergeTasks as apiMergeTasks } from './api'
+import { inferSize, trelloUpdateCard, serverSkipAdvanceTask, gmailApprove, gmailDismiss, mergeTasks as apiMergeTasks, addTombstones, remoteLinksOf } from './api'
 import { loadLabels, loadSettings, saveSettings, saveLabels, sortTasks, computeDailyStats, computeStreak, logActivity, localYMD, uuid, LABEL_COLORS, isCrisisTask } from './store'
 import { computeRecords, calculateTaskPoints } from './scoring'
 import { applyTheme, watchSystemTheme } from './theme'
@@ -1009,7 +1009,18 @@ export default function AppV2() {
   const handleDelete = useCallback((id) => {
     const task = tasks.find(t => t.id === id)
     const proceed = () => {
+      // Tombstone EVERY remote link before deleting. Without this the next
+      // sync sees a remote item with no matching task and re-creates it —
+      // which is why three Notion-linked tasks kept reappearing in Anytime.
+      // Fire-and-forget is fine: the tombstone is server-side and idempotent,
+      // and a failure here means the task returns once and gets tombstoned on
+      // the next delete rather than anything being lost.
+      const links = remoteLinksOf(task)
+      if (links.length) addTombstones(links).catch(() => {})
       if (task?.trello_card_id) {
+        // Archiving the card is still worth doing (it keeps Trello tidy), but
+        // it is no longer what PREVENTS re-import — the tombstone is. That
+        // swallowed rejection used to be the whole bug.
         trelloUpdateCard(task.trello_card_id, { closed: true }).catch(() => {})
       }
       deleteTask(id)

--- a/src/api.js
+++ b/src/api.js
@@ -1,4 +1,5 @@
 import { loadSettings, localYMD } from './store'
+import { readJson } from './apiConfig'
 import { SONNET_MODEL, claudeText, NO_THINKING } from '../server/aiModels.js'
 
 const PROXY_URL = '/api/messages'
@@ -2091,4 +2092,40 @@ export async function mergeTasks(survivorId, duplicateId) {
     throw new Error(data.error || `Merge failed (${res.status})`)
   }
   return res.json()
+}
+
+// --- Remote tombstones -----------------------------------------------------
+// "I deleted this on purpose, stop re-importing it." Every sync-in path reads
+// these before creating a task. Server-side rather than localStorage because
+// the intent has to survive a reinstall and a second device — a per-device
+// dismissal resurrects everything the first time you open Boomerang elsewhere.
+
+export async function fetchTombstones(source = null) {
+  const q = source ? `?source=${encodeURIComponent(source)}` : ''
+  const res = await fetch(`/api/tombstones${q}`)
+  const data = await readJson(res, 'The server')
+  return data?.tombstones || []
+}
+
+export async function addTombstones(items) {
+  const list = (Array.isArray(items) ? items : [items]).filter(i => i?.source && i?.remote_id)
+  if (!list.length) return { added: 0 }
+  const res = await fetch('/api/tombstones', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ items: list }),
+  })
+  return readJson(res, 'The server')
+}
+
+// Every remote link a task can carry. Deleting the task tombstones ALL of
+// them — a task imported from Notion and later pushed to Trello would
+// otherwise come back through whichever side wasn't recorded.
+export function remoteLinksOf(task) {
+  if (!task) return []
+  const out = []
+  if (task.notion_page_id) out.push({ source: 'notion', remote_id: task.notion_page_id, title: task.title })
+  if (task.trello_card_id) out.push({ source: 'trello', remote_id: task.trello_card_id, title: task.title })
+  if (task.gcal_event_id) out.push({ source: 'gcal', remote_id: task.gcal_event_id, title: task.title })
+  return out
 }

--- a/src/hooks/useGCalSync.js
+++ b/src/hooks/useGCalSync.js
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { loadSettings, saveSettings, createTask } from '../store'
+import { fetchTombstones } from '../api'
 import { gcalListEvents, aiDedupGCalEvents } from '../api'
 import { deduplicateImports, remoteLog } from '../syncDedup'
 
@@ -106,8 +107,13 @@ export function useGCalSync(tasks, setTasks) {
 
     remoteLog(`[GCalSync] ${eventsToImport.length} new events to create as tasks (${seenRecurring.size} recurring series collapsed)`)
 
+    // Events whose task was deleted on purpose — same hole as Notion and
+    // Trello: without this the next pull re-creates them, forever.
+    const buriedEvents = new Set((await fetchTombstones('gcal').catch(() => [])).map(t => t.remote_id))
+
     const newTasks = []
     for (const event of eventsToImport) {
+      if (buriedEvents.has(event.id)) continue
       // Extract date from event start
       const dueDate = event.start?.date || (event.start?.dateTime ? event.start.dateTime.split('T')[0] : null)
 

--- a/src/hooks/useNotionSync.js
+++ b/src/hooks/useNotionSync.js
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { loadSettings, saveSettings, createTask, safeSetItem } from '../store'
+import { fetchTombstones } from '../api'
 import { notionGetChildPages, notionQueryDatabase, notionGetBlocks, analyzeNotionPage, aiDedupNotionPages } from '../api'
 import { deduplicateImports, remoteLog } from '../syncDedup'
 
@@ -106,8 +107,12 @@ export function useNotionSync(tasks, setTasks) {
     }
 
     // Create tasks for truly new rows (using title directly, no AI analysis needed)
-    const newPages = unlinkedPages.filter(p => !matchMap.has(p.id))
-    remoteLog(`[NotionDbSync] ${newPages.length} new rows to import`)
+    // Rows the user deleted on purpose. This pull has no last_edited guard, so
+    // without the tombstone check a deleted task is re-created on EVERY sync —
+    // the "why do these keep coming back" bug.
+    const buried = new Set((await fetchTombstones('notion').catch(() => [])).map(t => t.remote_id))
+    const newPages = unlinkedPages.filter(p => !matchMap.has(p.id) && !buried.has(p.id))
+    remoteLog(`[NotionDbSync] ${newPages.length} new rows to import (${buried.size} tombstoned)`)
 
     const newTasks = []
     for (const page of newPages) {
@@ -139,6 +144,7 @@ export function useNotionSync(tasks, setTasks) {
     const currentTasks = tasksRef.current
     const linkedPageIds = new Set(currentTasks.filter(t => t.notion_page_id).map(t => t.notion_page_id))
     const pageCache = loadPageCache()
+    const buriedPages = new Set((await fetchTombstones('notion').catch(() => [])).map(t => t.remote_id))
 
     // 2. Separate linked vs unlinked pages
     const unlinkedPages = pages.filter(p => !linkedPageIds.has(p.id))
@@ -185,6 +191,9 @@ export function useNotionSync(tasks, setTasks) {
     const newRoutineSuggestions = []
     for (const page of newPages) {
       // Skip if page hasn't changed since last analysis
+      // A page the user deleted on purpose. Checked BEFORE the last_edited
+      // guard, because editing the page in Notion would otherwise resurrect it.
+      if (buriedPages.has(page.id)) continue
       if (pageCache[page.id] && pageCache[page.id] === page.last_edited) {
         remoteLog(`[NotionSync] skipping unchanged page: "${page.title}"`)
         continue

--- a/src/hooks/useTrelloSync.js
+++ b/src/hooks/useTrelloSync.js
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { loadSettings, saveSettings, createTask } from '../store'
+import { fetchTombstones } from '../api'
 import { trelloSyncAllLists, trelloUpdateCard, trelloBoardLists, inferTrelloListMapping, aiDedupTrelloCards } from '../api'
 import { deduplicateImports, remoteLog } from '../syncDedup'
 
@@ -177,7 +178,12 @@ export function useTrelloSync(tasks, setTasks, changeStatus) {
     const tasksToAdd = []
     const tasksToUpdate = []
 
+    // Cards whose task was deleted on purpose. Archiving the card on delete is
+    // best-effort and its rejection was swallowed, so it could never be the
+    // thing that prevented re-import — this is.
+    const buriedCards = new Set((await fetchTombstones('trello').catch(() => [])).map(t => t.remote_id))
     for (const { card, status } of newCards) {
+      if (buriedCards.has(card.id)) continue
       const matchedTaskId = matchMap.get(card.id)
       if (matchedTaskId) {
         // Auto-link existing task

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,17 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-08-01
 
+- fix(sync): deleting an imported task stops resurrecting it [M]
+  - Reported as *"why are these continuing to come back??"* — three Notion-linked tasks that reappeared in Anytime after every delete.
+  - **Every sync-in path created a task for any remote item with no matching local task, and none recorded a deliberate delete.** Notion is the sharpest case: the database-row pull (`useNotionSync.js`) had no guard whatsoever, so a deleted task came back on EVERY sync, and unlike Trello a Notion delete archives nothing upstream — the row survives, so return was guaranteed. The page-based pull at least skipped an unchanged `last_edited`, which is why only the DB-row items kept reappearing.
+  - The Trello path *looked* protected — `handleDelete` archives the card so "the next inbound sync doesn't re-import the task" — but the call ends in `.catch(() => {})`. One failed request (VPN down, token expired, rate limit) and the delete proceeded, the card stayed open, and the task returned silently. Best-effort cleanup was doing load-bearing work.
+  - This is the same trap already pinned in CLAUDE.md for LIST items ("a hard delete is indistinguishable from an item Trello hasn't sent yet, so the next poll resurrects it"). It was never applied to tasks.
+  - New `remote_tombstones` table (migration 052), generic over `notion` / `trello` / `gcal` rather than one table per integration — all three had the identical hole and a fourth should inherit the protection instead of rediscovering the bug. `GET/POST/DELETE /api/tombstones`; deleting a task now buries **every** remote link it carries, since a task imported from Notion and later pushed to Trello would otherwise return through whichever side went unrecorded.
+  - **Server-side, not localStorage.** "I deleted this" has to survive a reinstall and a second device; a per-device dismissal would resurrect everything the first time the app is opened somewhere new. Un-burying is supported (`DELETE`), so a tombstone is not a life sentence.
+  - Card archiving on Trello delete is kept — it keeps Trello tidy — but it is explicitly no longer what *prevents* re-import.
+  - Verified against a live server: burial, filtering by source, idempotent re-add (no duplicate rows), and un-bury. `npm test` 274/274 + smoke, eslint 0 errors. Web + server only — **no rebuild**.
+
+
 - feat(reminders): the local-notification schedule planner [S]
   - First half of moving reminders off Apple's alarms and into Boomerang's own, **local** notifications — handed to iOS ahead of time and fired by the device, so they ring with no network, no VPN, no server, in airplane mode. The server owns the schedule; the device caches it and rings from the cache. Staleness is bounded by the last successful sync, which is honest: what it got is correct, it just may not know about something added since.
   - `src/reminderSchedule.js` is PURE and clock-injected, because the interesting part is not the scheduling call — it is deciding **what makes the cut**. iOS caps PENDING local notifications at **64 per app**, and that budget has to be spent well. 21 tests.


### PR DESCRIPTION
"Why are these continuing to come back??" — three Notion-linked tasks reappearing in Anytime after every delete.

## Cause

**Every sync-in path created a task for any remote item with no matching local task, and none recorded a deliberate delete.**

Notion is the sharpest case. The database-row pull (`useNotionSync.js:109`) had **no guard at all**:

```js
const newPages = unlinkedPages.filter(p => !matchMap.has(p.id))
```

And unlike Trello, deleting a Notion-linked task archives *nothing* upstream — the row survives, so the task's return was guaranteed. The page-based pull at least skips an unchanged `last_edited`, which is exactly why only the DB-row items kept coming back.

The Trello path *looked* protected. `AppV2.jsx:1018` even says so — *"Archive the Trello card on delete so the next inbound sync doesn't re-import the task"* — but:

```js
trelloUpdateCard(task.trello_card_id, { closed: true }).catch(() => {})
```

One failed request (VPN down, expired token, rate limit) and the delete proceeded anyway, the card stayed open, and the task returned silently. **Best-effort cleanup was doing load-bearing work.**

This is the same trap already pinned in CLAUDE.md for *list items* — "a hard delete is indistinguishable from an item Trello hasn't sent yet, so the next poll resurrects it". It was never applied to tasks.

## Fix

New `remote_tombstones` table (migration 052), **generic over `notion` / `trello` / `gcal`** rather than one table per integration — all three had the identical hole, and a fourth integration should inherit the protection instead of rediscovering the bug.

- `GET` / `POST` / `DELETE /api/tombstones`
- Deleting a task buries **every** remote link it carries — a task imported from Notion and later pushed to Trello would otherwise return through whichever side went unrecorded.
- All three pulls consult tombstones before creating. The Notion page path checks **before** the `last_edited` guard, or editing the page in Notion would resurrect it.
- **Server-side, not localStorage.** "I deleted this" must survive a reinstall and a second device; a per-device dismissal resurrects everything the first time you open Boomerang somewhere new.
- Un-burying is supported, so a tombstone isn't a life sentence.
- Card archiving is kept (it keeps Trello tidy) but is explicitly no longer what *prevents* re-import.

## Verification

Against a live server: burial, filtering by source, **idempotent re-add** (3 rows stayed 3), and un-bury. `npm test` 274/274 + smoke, eslint 0 errors.

**Web + server only — no rebuild.**

## Note on your three

This stops *future* deletes from returning. The three currently in Anytime were created before any tombstone existed, so delete them once more after this deploys and they'll stay gone — or archive the rows in Notion, which also works.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V45AJzVRjV8j2Sei5Qgr6A)_