### PR TITLE
style(settings): the alarms row shows a value, not a paragraph

### DIFF
--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -2366,25 +2366,28 @@ function NotificationsPanel({ settings, update, page, setPage }) {
             </div>
           </div>
         )}
+        {/* A row shows its VALUE at rest and folds the explanation behind the ⓘ
+          * (§1.5). The first cut of this printed four lines of prose at every
+          * reader forever, which is the exact pattern the settings redesign
+          * existed to delete. The value here is the count iOS actually holds. */}
         {isNativeShell() && (
-          <div className="v2-settings-row" style={{ alignItems: 'flex-start', flexDirection: 'column', gap: 8 }}>
-            <div className="v2-settings-row-text">
-              <div className="v2-settings-row-label">Reminder alarms (on this device)</div>
-              <div className="v2-settings-row-hint">
+          <SettingRow
+            label="Reminder alarms"
+            value={localMsg || (localPending == null ? '' : `${localPending} scheduled`)}
+            info={
+              <>
                 Tasks with a reminder time, and loops set to remind, are scheduled as local
-                alarms on this phone. They ring with <strong>no network, no VPN and no server</strong> —
+                alarms on this phone — they ring with no network, no VPN and no server, because
                 the phone fires them itself. iOS allows 64 pending at once; a repeating loop
-                costs one of those no matter how far ahead it runs.
-                {localPending != null && ` Currently ${localPending} scheduled.`}
-                {localMsg && ` ${localMsg}`}
-              </div>
-            </div>
-            <div style={{ display: 'flex', gap: 8 }}>
+                costs one of those however far ahead it runs.
+              </>
+            }
+            trailing={
               <button className="v2-settings-btn" onClick={handleLocalEnable} disabled={localBusy}>
                 {localBusy ? 'Working…' : 'Enable + refresh'}
               </button>
-            </div>
-          </div>
+            }
+          />
         )}
 
         {apnsStatus?.configured && apnsStatus?.devices > 0 && (

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -4,6 +4,13 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ---
 
+## 2026-08-02
+
+- style(settings): the alarms row shows a value, not a paragraph [XS]
+  - Caught on device: *"you done forgot that we tuck away description text unless it's asked for."* Correct — the new Reminder-alarms row printed four lines of prose at every reader forever, which is precisely the pattern the settings redesign existed to delete (§1.5: descriptions are optional, subordinate, and folded behind an ⓘ).
+  - Rebuilt as a `SettingRow`: **value at rest** (the pending count iOS actually holds, or the last result), explanation behind the ⓘ, button trailing. Matches the Push / Email / Quiet-hours rows beside it instead of being a prose exception like the APNs block.
+  - Unrelated but confirmed in the same screenshot: the local-notification plugin **compiles and runs** — the row rendered on a real build. `0 repeating, 0 one-off` is correct rather than a failure: `routines.remind` is opt-in and defaults off, and no task had a future reminder time yet.
+
 ## 2026-08-01
 
 - fix(sync): deleting an imported task stops resurrecting it [M]


### PR DESCRIPTION
Caught on device: *"you done forgot that we tuck away description text unless it's asked for."*

Correct. The Reminder-alarms row printed four lines of prose at every reader forever — precisely the pattern the settings redesign existed to delete. §1.5: descriptions are optional, subordinate, and folded behind an ⓘ.

Rebuilt as a `SettingRow`:
- **Value at rest** — the pending count iOS actually holds, or the last result.
- **Explanation behind the ⓘ.**
- Button trailing.

It now matches the Push / Email / Quiet-hours rows beside it, instead of being a prose exception like the APNs block.

`npm test` 274/274 + smoke, eslint 0 errors. **No rebuild** — web bundle only.

---

Also confirmed by the same screenshot: **the local-notification plugin compiles and runs.** The row rendered on a real build, which retires the "uncompiled Swift" caveat on `BoomerangLocalNotifs.swift`.

And `0 repeating, 0 one-off` is correct rather than a failure — `routines.remind` is opt-in and defaults off, and no task had a future reminder time yet.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V45AJzVRjV8j2Sei5Qgr6A)_