### PR TITLE
release: the alarms row shows a value, not a paragraph

### DIFF
--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -2366,25 +2366,28 @@ function NotificationsPanel({ settings, update, page, setPage }) {
             </div>
           </div>
         )}
+        {/* A row shows its VALUE at rest and folds the explanation behind the ⓘ
+          * (§1.5). The first cut of this printed four lines of prose at every
+          * reader forever, which is the exact pattern the settings redesign
+          * existed to delete. The value here is the count iOS actually holds. */}
         {isNativeShell() && (
-          <div className="v2-settings-row" style={{ alignItems: 'flex-start', flexDirection: 'column', gap: 8 }}>
-            <div className="v2-settings-row-text">
-              <div className="v2-settings-row-label">Reminder alarms (on this device)</div>
-              <div className="v2-settings-row-hint">
+          <SettingRow
+            label="Reminder alarms"
+            value={localMsg || (localPending == null ? '' : `${localPending} scheduled`)}
+            info={
+              <>
                 Tasks with a reminder time, and loops set to remind, are scheduled as local
-                alarms on this phone. They ring with <strong>no network, no VPN and no server</strong> —
+                alarms on this phone — they ring with no network, no VPN and no server, because
                 the phone fires them itself. iOS allows 64 pending at once; a repeating loop
-                costs one of those no matter how far ahead it runs.
-                {localPending != null && ` Currently ${localPending} scheduled.`}
-                {localMsg && ` ${localMsg}`}
-              </div>
-            </div>
-            <div style={{ display: 'flex', gap: 8 }}>
+                costs one of those however far ahead it runs.
+              </>
+            }
+            trailing={
               <button className="v2-settings-btn" onClick={handleLocalEnable} disabled={localBusy}>
                 {localBusy ? 'Working…' : 'Enable + refresh'}
               </button>
-            </div>
-          </div>
+            }
+          />
         )}
 
         {apnsStatus?.configured && apnsStatus?.devices > 0 && (

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -4,6 +4,13 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ---
 
+## 2026-08-02
+
+- style(settings): the alarms row shows a value, not a paragraph [XS]
+  - Caught on device: *"you done forgot that we tuck away description text unless it's asked for."* Correct — the new Reminder-alarms row printed four lines of prose at every reader forever, which is precisely the pattern the settings redesign existed to delete (§1.5: descriptions are optional, subordinate, and folded behind an ⓘ).
+  - Rebuilt as a `SettingRow`: **value at rest** (the pending count iOS actually holds, or the last result), explanation behind the ⓘ, button trailing. Matches the Push / Email / Quiet-hours rows beside it instead of being a prose exception like the APNs block.
+  - Unrelated but confirmed in the same screenshot: the local-notification plugin **compiles and runs** — the row rendered on a real build. `0 repeating, 0 one-off` is correct rather than a failure: `routines.remind` is opt-in and defaults off, and no task had a future reminder time yet.
+
 ## 2026-08-01
 
 - fix(sync): deleting an imported task stops resurrecting it [M]


### PR DESCRIPTION
Promotes `dev` to production.

## What ships

- **`style(settings): the alarms row shows a value, not a paragraph [XS]`** — the Reminder-alarms row in Settings § Notifications was rendering its explanation as always-visible prose, breaking the app's convention that description text stays folded until asked for. Rebuilt as a standard `SettingRow`: the row shows its state (`N scheduled`, or the last status message) at rest, and the explanation now lives behind the ⓘ toggle like every other row.

Also carries the content-neutral relink merge from the local-notifications release (#926), which is already in `main`'s history.

## Verification

- `Build and Publish (Dev)` green on the merged head.
- No behaviour change — copy and layout only; the enable button, status text and pending-count read are the same code paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V45AJzVRjV8j2Sei5Qgr6A

---
_Generated by [Claude Code](https://claude.ai/code/session_01V45AJzVRjV8j2Sei5Qgr6A)_