### PR TITLE
feat(reminders): set a reminder while capturing, not after

### DIFF
--- a/src/AppV2.jsx
+++ b/src/AppV2.jsx
@@ -65,6 +65,7 @@ import { useGCalSync } from './hooks/useGCalSync'
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts'
 import { inferSize, trelloUpdateCard, serverSkipAdvanceTask, gmailApprove, gmailDismiss, mergeTasks as apiMergeTasks, addTombstones, remoteLinksOf } from './api'
 import { loadLabels, loadSettings, saveSettings, saveLabels, sortTasks, computeDailyStats, computeStreak, logActivity, localYMD, uuid, LABEL_COLORS, isCrisisTask } from './store'
+import { localDateTimeValue, nextHalfHour } from './dates'
 import { computeRecords, calculateTaskPoints } from './scoring'
 import { applyTheme, watchSystemTheme } from './theme'
 import './AppV2.css'
@@ -1505,7 +1506,7 @@ export default function AppV2() {
           onToggleHabit={toggleHabitDay}
           onRescheduleTask={(task, ymd) => updateTask(task.id, { due_date: ymd })}
           onDeleteTask={(task) => handleDelete(task.id)}
-          onThrow={({ title, dueDate }) => scrollTaskIntoView(handleAddTask({ title, dueDate }))}
+          onThrow={({ title, dueDate, remindAt }) => scrollTaskIntoView(handleAddTask({ title, dueDate, remindAt }))}
           onOpenFullAdd={(draft) => openAddModal(draft)}
           onEditLoop={(r) => { setEditRoutineId(r.id); setShowRoutines(true) }}
           onAddLoop={() => { setRoutinesOpenToForm(true); setShowRoutines(true) }}
@@ -1567,7 +1568,7 @@ export default function AppV2() {
           onToggleHabit={toggleHabitDay}
           onRescheduleTask={(task, ymd) => updateTask(task.id, { due_date: ymd })}
           onDeleteTask={(task) => handleDelete(task.id)}
-          onThrow={({ title, dueDate }) => scrollTaskIntoView(handleAddTask({ title, dueDate }))}
+          onThrow={({ title, dueDate, remindAt }) => scrollTaskIntoView(handleAddTask({ title, dueDate, remindAt }))}
           onOpenFullAdd={(draft) => openAddModal(draft)}
           onEditLoop={(r) => { setEditRoutineId(r.id); setShowRoutines(true) }}
           onAddLoop={() => { setRoutinesOpenToForm(true); setShowRoutines(true) }}
@@ -1851,6 +1852,10 @@ export default function AppV2() {
           tasks={tasks}
           onOpenTask={(t) => { setShowReminders(false); setEditTarget(t) }}
           onClearReminder={(t) => updateTask(t.id, { remind_at: null, last_touched: new Date().toISOString() })}
+          onNewReminder={() => {
+            setShowReminders(false)
+            openAddModal({ remindAt: localDateTimeValue(nextHalfHour()) })
+          }}
         />
       </ModalShell>
 

--- a/src/components/AddTaskModal.jsx
+++ b/src/components/AddTaskModal.jsx
@@ -19,7 +19,14 @@ export default function AddTaskModal({ open, onAdd, onClose, parentProject = nul
   // opened, so `initial` only ever needs to be read once here — no reset
   // logic required. `initialDraft` seeds a title/date handed off from
   // ThrowSheet's "More options" (previously dropped on the floor).
-  const form = useTaskForm({ title: initialDraft?.title || '', dueDate: initialDraft?.dueDate || getDefaultDueDate() })
+  const form = useTaskForm({
+    title: initialDraft?.title || '',
+    dueDate: initialDraft?.dueDate || getDefaultDueDate(),
+    // A reminder can arrive from the Throw sheet's "More options" handoff, or
+    // from the Reminders lens's "New reminder" button, which opens this modal
+    // pre-armed. Both are datetime-local strings already.
+    remindAt: initialDraft?.remindAt || '',
+  })
   const titleRef = useRef(null)
 
   useEffect(() => {
@@ -120,6 +127,29 @@ export default function AddTaskModal({ open, onAdd, onClose, parentProject = nul
             {priorityLabel}
           </button>
         </div>
+      </div>
+
+      {/* A reminder is a MOMENT ("interrupt me at 3pm"); Due above is a DAY.
+          Optional here — most tasks want a day and nothing more — but a task
+          created with one rings without a second trip through the editor. */}
+      <div className="v2-form-section">
+        <label className="v2-form-label">Remind</label>
+        <input
+          type="datetime-local"
+          className="v2-form-input"
+          aria-label="Reminder time"
+          value={form.remindAt}
+          onChange={e => form.setRemindAt(e.target.value)}
+        />
+        {form.remindAt && (
+          <button
+            className="v2-form-ai-pill v2-form-ai-pill-inline"
+            style={{ marginTop: 6 }}
+            onClick={() => form.setRemindAt('')}
+          >
+            Clear reminder
+          </button>
+        )}
       </div>
 
       <div className="v2-form-section">

--- a/src/dates.js
+++ b/src/dates.js
@@ -33,6 +33,27 @@ export function localYMD(d = new Date()) {
   return `${x.getFullYear()}-${String(x.getMonth() + 1).padStart(2, '0')}-${String(x.getDate()).padStart(2, '0')}`
 }
 
+// → 'YYYY-MM-DDTHH:MM' local, the value shape <input type="datetime-local">
+//   requires. NOT toISOString().slice(0,16) — that is UTC, and it would seed
+//   every picker hours off wherever the user isn't on UTC.
+export function localDateTimeValue(d = new Date()) {
+  const x = d instanceof Date ? d : new Date(d)
+  if (Number.isNaN(x.getTime())) return ''
+  const p = (n) => String(n).padStart(2, '0')
+  return `${x.getFullYear()}-${p(x.getMonth() + 1)}-${p(x.getDate())}T${p(x.getHours())}:${p(x.getMinutes())}`
+}
+
+// A sane default moment for a reminder picker: the next :00 or :30 at least
+// five minutes out. Seeding "now" would hand back a moment that is already
+// gone by the time the sheet is dismissed, and iOS silently discards a local
+// notification scheduled in the past.
+export function nextHalfHour(from = new Date()) {
+  const x = new Date(from.getTime() + 5 * 60 * 1000)
+  x.setSeconds(0, 0)
+  x.setMinutes(x.getMinutes() <= 30 ? 30 : 60)
+  return x
+}
+
 // → new Date offset by n days (local-calendar aware via setDate).
 export function addDays(d, n) {
   const x = parseLocalDate(d)

--- a/src/hooks/useTasks.js
+++ b/src/hooks/useTasks.js
@@ -43,7 +43,7 @@ export function useTasks() {
     return () => clearInterval(interval)
   }, [])
 
-  const addTask = useCallback(({ title, tags = [], dueDate = null, notes = '', notion = null, size = null, size_inferred = false, attachments = [], highPriority = false, lowPriority = false, energy = null, energyLevel = null } = {}) => {
+  const addTask = useCallback(({ title, tags = [], dueDate = null, notes = '', notion = null, size = null, size_inferred = false, attachments = [], highPriority = false, lowPriority = false, energy = null, energyLevel = null, remindAt = null } = {}) => {
     remoteLog('addTask:', title)
     const task = createTask(title, tags, dueDate, notes)
     if (notion) {
@@ -63,6 +63,15 @@ export function useTasks() {
     if (attachments.length > 0) task.attachments = attachments
     if (highPriority) task.high_priority = true
     if (lowPriority) task.low_priority = true
+    // A reminder set at CREATE time. This was the missing half of the feature:
+    // both editors could add one to an existing task, but every creation path
+    // (Throw sheet, full add modal, Quokka) fed through here and this key was
+    // not in the signature above, so the value was destructured away in
+    // silence. A task could be born with a due date but never with a moment.
+    if (remindAt) {
+      const at = new Date(remindAt)
+      if (!Number.isNaN(at.getTime())) task.remind_at = at.toISOString()
+    }
     logActivity('created', task)
     setTasks(prev => [task, ...prev])
     return task.id

--- a/src/kept/RemindersView.jsx
+++ b/src/kept/RemindersView.jsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { AlarmClock, X } from 'lucide-react'
+import { AlarmClock, Plus, X } from 'lucide-react'
 import { localYMD } from '../dates'
 import './shell.css'
 
@@ -24,7 +24,7 @@ const fmt = (iso, withDay) => {
 
 const ACTIVE = ['not_started', 'doing', 'waiting']
 
-export default function RemindersView({ tasks = [], onOpenTask, onClearReminder }) {
+export default function RemindersView({ tasks = [], onOpenTask, onClearReminder, onNewReminder }) {
   const groups = useMemo(() => {
     const now = Date.now()
     const today = localYMD()
@@ -74,10 +74,19 @@ export default function RemindersView({ tasks = [], onOpenTask, onClearReminder 
   // repeating it inside the body printed the word twice down the page.
   return (
     <div className="bm-surface">
+      {onNewReminder && (
+        // A lens over tasks still needs a way to MAKE one. Without this the
+        // surface that exists to answer "what is about to go off" was the one
+        // place in the app you could not set something off.
+        <button className="bm-btn bm-btn-fill bm-reminders-new" onClick={onNewReminder}>
+          <Plus size={15} strokeWidth={2.2} /> New reminder
+        </button>
+      )}
+
       {total === 0 && (
         <p className="bm-empty">
-          Nothing set. Open a task and use the <strong>Remind</strong> chip to give it a time —
-          it rings through Apple Reminders.
+          Nothing set. Throw a task and tap <strong>Remind</strong>, or open any task and use its
+          Remind chip to give it a time.
         </p>
       )}
 

--- a/src/kept/ThrowSheet.jsx
+++ b/src/kept/ThrowSheet.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
-import { SlidersHorizontal } from 'lucide-react'
-import { localYMD, addDays } from '../dates'
+import { AlarmClock, SlidersHorizontal } from 'lucide-react'
+import { localYMD, addDays, localDateTimeValue, nextHalfHour } from '../dates'
 import useSheetSwipeDown from '../hooks/useSheetSwipeDown'
 import './shell.css'
 
@@ -27,10 +27,22 @@ function resolve(id) {
 // mode toggle (2026-07-18) makes jotting a note as fast as adding a task —
 // note mode drops the date chips (notes have no dates) and routes to
 // onThrowNote instead.
+//
+// Remind (2026-08-02) sits on its own row BELOW the date chips because it is a
+// different axis: the chips pick a DAY, a reminder picks a MOMENT. Tapping it
+// reveals the picker inline rather than opening anything, which is the only
+// reason it belongs in quick capture at all — this is where reminders actually
+// get made, and until now the sheet could not make one, so every reminder cost
+// a create-then-reopen round trip through the task editor.
+//
+// A reminder with no date lands on Today: TodayView reads remind_at as the day
+// when there is no due date, so the "No date" chip staying lit is correct and
+// nothing here needs to force a due date to make it show up.
 export default function ThrowSheet({ open, onClose, onThrow, onThrowNote, onMoreOptions }) {
   const [title, setTitle] = useState('')
   const [dateId, setDateId] = useState('none')
   const [mode, setMode] = useState('task')
+  const [remindAt, setRemindAt] = useState('')
   const inputRef = useRef(null)
   const sheetRef = useRef(null)
   // The keyboard-occlusion offset below (px, <= 0) — kept in a ref rather
@@ -92,15 +104,22 @@ export default function ThrowSheet({ open, onClose, onThrow, onThrowNote, onMore
     if (mode === 'note') {
       onThrowNote?.({ body: t })
     } else {
-      onThrow?.({ title: t, dueDate: resolve(dateId) })
+      onThrow?.({ title: t, dueDate: resolve(dateId), remindAt: remindAt || null })
     }
-    setTitle(''); setDateId('none')
+    setTitle(''); setDateId('none'); setRemindAt('')
     closeAndBlur()
   }
 
   const openMoreOptions = () => {
     closeAndBlur()
-    onMoreOptions?.({ title: title.trim(), dueDate: resolve(dateId) })
+    // Hand the reminder over too — a value typed here and then silently
+    // dropped on the way to the full editor is the same class of bug as the
+    // title/date handoff this callback exists to fix.
+    onMoreOptions?.({ title: title.trim(), dueDate: resolve(dateId), remindAt: remindAt || null })
+  }
+
+  const toggleRemind = () => {
+    setRemindAt(prev => (prev ? '' : localDateTimeValue(nextHalfHour())))
   }
 
   return (
@@ -130,6 +149,26 @@ export default function ThrowSheet({ open, onClose, onThrow, onThrowNote, onMore
             {DATES.map(d => (
               <button key={d.id} className={`bm-pick${dateId === d.id ? ' is-on' : ''}`} onClick={() => setDateId(d.id)}>{d.label}</button>
             ))}
+          </div>
+        )}
+        {mode === 'task' && (
+          <div className="bm-throw-remind">
+            <button
+              className={`bm-pick${remindAt ? ' is-on' : ''}`}
+              onClick={toggleRemind}
+              aria-pressed={!!remindAt}
+            >
+              <AlarmClock size={13} strokeWidth={2} /> Remind
+            </button>
+            {remindAt && (
+              <input
+                type="datetime-local"
+                className="bm-throw-remind-input"
+                aria-label="Reminder time"
+                value={remindAt}
+                onChange={e => setRemindAt(e.target.value)}
+              />
+            )}
           </div>
         )}
         <div className="bm-throw-actions">

--- a/src/kept/shell.css
+++ b/src/kept/shell.css
@@ -317,6 +317,30 @@
 .bm-throw-actions { display: flex; gap: 9px; }
 .bm-throw-actions .bm-btn-fill { flex: 1 1 auto; }
 
+/* Remind sits on its own row under the day chips — a different axis (moment,
+   not day), and the picker it reveals needs the full width. */
+.bm-throw-remind { margin-bottom: 12px; }
+.bm-throw-remind .bm-pick { display: inline-flex; align-items: center; gap: 7px; }
+.bm-throw-remind-input {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  margin-top: 8px;
+  border: 1px solid var(--bm-hairline-strong);
+  border-radius: 12px;
+  background: var(--bm-bg);
+  color: var(--bm-text);
+  font: 500 15px/1.4 var(--v2-font-body);
+  padding: 11px 14px;
+}
+.bm-throw-remind-input:focus { outline: none; border-color: var(--bm-ember); }
+
+.bm-reminders-new {
+  display: inline-flex; align-items: center; justify-content: center; gap: 7px;
+  width: 100%;
+  margin-bottom: 14px;
+}
+
 @keyframes bm-fade { from { opacity: 0 } to { opacity: 1 } }
 @keyframes bm-rise { from { transform: translateY(100%) } to { transform: translateY(0) } }
 

--- a/wiki/Features.md
+++ b/wiki/Features.md
@@ -162,6 +162,22 @@ Context-aware preset options that show the exact date and time (e.g., "Tomorrow 
 
 The task schema and API now support implementation intentions (`intention_when`/`intention_where` — "after I pour coffee", "at my desk"), shrink-it first steps (`first_step`, capped at 140 characters so it stays genuinely small), stored locations for future point-of-performance reminders, and a **pick-three commitment model**: commit up to three tasks per day (`POST /api/tasks/:id/commit`), and any commitment the day rolls past simply *comes back around* — returned to the pool overnight with no red badges, no "days late" anywhere. Shelving ("park this, no timer, no guilt") and letting go ("release it" — kept for history, never framed as failure) are first-class actions. `GET /api/today` serves the whole pick-three picture in one round trip, shaped for a small screen. No visible UI yet — this is the foundation step; existing screens are unchanged.
 
+## Reminders
+
+A **due date is a day**; a **reminder is a moment**. Any task can carry one, and a task with a reminder time actually rings — from a local notification on the phone (no server, no VPN, no network needed) and, if the Apple Reminders integration is on, as a mirrored reminder in Apple's app.
+
+**Three ways to set one:**
+
+- **Throw sheet → Remind** — tap *Remind* and a date-and-time picker slides in underneath, pre-filled with the next half hour. This is the fast path: capture and reminder in one gesture, no second trip through an editor.
+- **New task modal → Remind** — the full add form has the same field, so a reminder can be part of a task from the moment it exists.
+- **Any existing task** — open it and use the **Remind** chip (quick editor) or the Remind field (full editor).
+
+**A reminder with no due date is today.** Today reads the reminder time as the day when there's no due date, so a task thrown with just a time shows up where you'd expect without also having to pick "Today".
+
+**Reminders** in the More menu is a **lens**, not a container — it lists every task carrying a time, grouped by *Passed* (the moment came and went and the task is still open), *Later today*, and *Upcoming*. Nothing lives only here; the same tasks sit in Today and Tasks alongside everything else. **New reminder** at the top opens the add form pre-armed, and the ✕ on a row clears the time while keeping the task.
+
+**Loops can ring too.** A recurring loop set to remind (Loop editor → *Remind*) schedules one repeating alarm on the phone rather than one per occurrence — which is what makes an offline stretch survivable: a daily loop costs a single slot no matter how far out it runs.
+
 ## Notes
 
 A place to leave a thought without creating a task. Notes have **no task semantics** — no due date, no status, no points, no nagging, and they never count toward pile-up warnings or analytics.

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -6,6 +6,15 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ## 2026-08-02
 
+- feat(reminders): set a reminder while capturing, not after [M]
+  - Reported bluntly: *"Why in the motherfuck can I not create a fucking reminder…"* — with a screenshot of the Throw sheet offering Task | Note and Today / Tomorrow / Weekend / No date, and nowhere to put a time.
+  - **Every creation path in the app fed through `addTask()` in `useTasks.js`, whose destructured signature had no `remindAt` key.** Both editors could add a reminder to a task that already existed, but a task could never be *born* with one — the value was destructured away in silence on the way in. So the only way to make a reminder was create → find the task → reopen it → Remind chip, four steps for the thing the user described as *"the way I anticipate adding things quickly anyway."*
+  - `addTask()` now takes `remindAt`. The full add modal (`AddTaskModal`) gained the Remind field it never had — `useTaskForm` was already returning `remindAt` from `getFormData()`, so that half was wired to nothing.
+  - **Throw sheet → Remind**, built to the description given: tapping it reveals a date-and-time picker *underneath*, seeded with the next half hour (`nextHalfHour()` — never "now", which iOS silently discards as a past trigger). Its own row below the day chips, because a day and a moment are different axes. "More options" carries the reminder across to the full editor rather than dropping it, the same handoff bug the title/date already had fixed.
+  - The **Reminders** lens gained **New reminder** — a surface that exists to answer "what is about to go off" was the one place in the app you could not set something off.
+  - `localDateTimeValue()` in `dates.js` formats for `<input type="datetime-local">` from LOCAL parts. `toISOString().slice(0,16)` is the obvious-looking version and is UTC — it would seed every picker hours off for anyone not on UTC.
+  - No new rule needed for "a reminder with no date is today": Today already reads `remind_at` as the day when there's no due date, so the "No date" chip staying lit is correct.
+  - Verified end-to-end against a live server with Playwright, not by reading the diff: chip → picker → throw → **`remind_at: 2026-08-09T19:30:00.000Z` on the server**, plus the lens button opening the add modal pre-armed. Web only — **no rebuild** (reaches the phone over OTA).
 - style(settings): the alarms row shows a value, not a paragraph [XS]
   - Caught on device: *"you done forgot that we tuck away description text unless it's asked for."* Correct — the new Reminder-alarms row printed four lines of prose at every reader forever, which is precisely the pattern the settings redesign existed to delete (§1.5: descriptions are optional, subordinate, and folded behind an ⓘ).
   - Rebuilt as a `SettingRow`: **value at rest** (the pending count iOS actually holds, or the last result), explanation behind the ⓘ, button trailing. Matches the Push / Email / Quiet-hours rows beside it instead of being a prose exception like the APNs block.


### PR DESCRIPTION
## The report

> Why in the motherfuck can I not create a fucking reminder…

— with a screenshot of the Throw sheet: Task | Note, Today / Tomorrow / Weekend / No date, and nowhere to put a time.

## Root cause

`addTask()` in `src/hooks/useTasks.js` destructures a fixed whitelist of fields, and **`remindAt` was not in it**. Every creation path in the app funnels through that function, so a task could never be *born* with a reminder — the value was destructured away in silence. Both editors could add one to a task that already existed, which is why the feature looked shipped.

`useTaskForm` was already returning `remindAt` from `getFormData()`. It was wired to nothing.

Net effect: making a reminder cost four steps — throw a task, find it, reopen it, Remind chip — for the thing described as *"the way I anticipate adding things quickly anyway."*

## Changes

- **`addTask()` accepts `remindAt`** and stamps `remind_at` (NaN-guarded).
- **Throw sheet → Remind**, built to the description given: tap it and a date-and-time picker slides in *underneath*, seeded with the next half hour. Its own row below the day chips, because a day and a moment are different axes. "More options" now carries the reminder to the full editor rather than dropping it — the same handoff bug the title/date already had fixed.
- **`AddTaskModal`** gained the Remind field it never had.
- **Reminders lens → New reminder**: the surface that exists to answer "what is about to go off" was the one place in the app you could not set something off. Opens the add modal pre-armed.
- **`localDateTimeValue()` / `nextHalfHour()`** in `dates.js`. Formatting is from LOCAL parts — `toISOString().slice(0,16)` is the obvious-looking version and is UTC, which would seed every picker hours off for anyone not on UTC. The seed is never "now": iOS silently discards a local notification with a past trigger.

"A reminder with no date is today" needed no new rule — Today already reads `remind_at` as the day when there's no due date, so the "No date" chip staying lit is correct.

## Verification

Playwright against a live server, not a read of the diff:

- Remind chip visible → picker appears on tap → seeded `2026-08-02T05:00`
- Set `2026-08-09T19:30`, threw it → server returned `remind_at: "2026-08-09T19:30:00.000Z"`
- Reminders lens → New reminder → add modal opens with the Remind field pre-armed

`npm test` 274/274 + smoke passed. `eslint` 0 errors (4 pre-existing warnings). `npm audit` clean.

Web only — **no Xcode rebuild**; this reaches the phone over the OTA bundle path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V45AJzVRjV8j2Sei5Qgr6A

---
_Generated by [Claude Code](https://claude.ai/code/session_01V45AJzVRjV8j2Sei5Qgr6A)_