### PR TITLE
release: away sends nothing

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -3846,6 +3846,25 @@ async function runDigestPipeline({ force = false, reason = 'scheduled' } = {}) {
   const settings = getData('settings') || {}
   const tz = settings.user_timezone || DEFAULT_TIMEZONE
   const todayYMD = ymdInTz(new Date(), tz)
+
+  // AWAY SENDS NOTHING. The digest send path never had an away check — it
+  // gated on the clock, the once-a-day marker and dev-muzzling — so every
+  // morning of a trip fired a 7am push. Reported 2026-08-04, from the trip:
+  // "you do remember you were notifying me of shit while I was on vacation
+  // mode right?"
+  //
+  // The digest is still BUILT, and still leads with the away statement, so
+  // opening the app says what is being held. That is what the "silence you
+  // cannot see" rule actually asks for — a suppression the user can SEE when
+  // they look. It never asked for a daily push to their holiday. An explicit
+  // test send (force) still goes: the user pressed the button.
+  if (!force && isAway(getVacationWindow(), todayYMD)) {
+    // Mark the day, or the minutely tick reassembles the digest until noon.
+    setData('digest_sent_on', { date: todayYMD, at: new Date().toISOString(), fired: [], held: 'away' })
+    console.log(`[digest] ${reason}: held — away (${digest.sections?.away || 'window active'})`)
+    return { success: false, held: 'away', skipped: ['away'], fired: [] }
+  }
+
   const result = await sendDigestNow(digest)
   if (result.success && !force) {
     setData('digest_sent_on', { date: todayYMD, at: new Date().toISOString(), fired: result.fired })
@@ -3907,9 +3926,16 @@ app.get('/api/digest/today', (req, res) => {
 })
 
 // --- Daily digest test (sends via every enabled channel right now) ---
+// `force` defaults true (the Test button: send it now regardless of schedule,
+// once-a-day marker, or away). Pass `{"force": false}` to run the pipeline
+// EXACTLY as the 7am scheduler does — the only way to observe the scheduled
+// path's gates without waiting for morning. Added 2026-08-04 after shipping an
+// away fix verified against the forced path while the scheduled one, which is
+// the one that actually pushes, kept firing through a holiday.
 app.post('/api/digest/test', async (req, res) => {
   try {
-    const result = await runDigestPipeline({ force: true, reason: 'manual' })
+    const force = req.body?.force !== false
+    const result = await runDigestPipeline({ force, reason: force ? 'manual' : 'manual-as-scheduled' })
     res.json(result)
   } catch (err) {
     console.error('[Digest] Test failed:', err.message)

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -4,6 +4,16 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
 
 ---
 
+## 2026-08-04
+
+- fix(digest): away sends nothing [S]
+  - *"You do remember you were notifying me of shit while I was on vacation mode right?"* Yes — and the fix earlier the same day made the away digest **say the right thing** instead of asking whether it should fire at all. Same failure as the rest of this incident, one layer up.
+  - **The digest send path never had an away check.** `digestTick` gates on the clock, the once-a-day marker and dev-muzzling; `runDigestPipeline` gated on nothing. So every morning of a trip fired a 7am push. The away statement work went into the digest's *copy*, which made the push politer and no less of a push.
+  - Scheduled digests are now held while the window is active. The digest is still **built**, and still leads with the away line, so opening the app says what is being held — that is what "silence you cannot see" actually asks for: a suppression the user can SEE **when they look**. It never asked for a daily notification during their holiday. Crisis keeps its own path and is unaffected.
+  - The day is marked when held, or the minutely tick reassembles the digest until noon.
+  - **`POST /api/digest/test` accepts `{"force": false}`** to run the pipeline exactly as the scheduler does. Added because the recurring failure in this whole incident is verifying a path that isn't the one that fires: the Test button forces past every gate, so it can never show you what the 7am run will do. Now it can.
+  - Verified both ways with the window active: scheduled → `held: "away"`, fired nothing; forced → past the gate to the channels. `npm test` 316/316 + smoke, eslint 0 errors. Server only — **no rebuild**.
+
 ## 2026-08-03
 
 - fix(away): the alarms that were still firing mid-trip are device alarms [M]


### PR DESCRIPTION
Promotes `dev` to production.

## What ships

**`fix(digest): away sends nothing [S]`**

The digest send path never had an away check. `digestTick` gates on the clock, the once-a-day marker and dev-muzzling; `runDigestPipeline` gated on nothing — so every morning of a trip fired a 7am push. The earlier away work all went into the digest's *copy*, which made the push politer and no less of a push.

Scheduled digests are now held while the window is active. The digest is still **built** and still leads with the away line, so opening the app says what's being held — a suppression you can see *when you look*, rather than a daily notification during a holiday. Crisis keeps its own path. The day is marked when held, or the minutely tick reassembles until noon.

**`POST /api/digest/test` accepts `{"force": false}`** — runs the pipeline exactly as the scheduler does. The Test button forces past every gate by design, so it could never show what the 7am run would do; there was no way to observe the real path short of waiting for morning.

## Verification

Window active, both paths driven:

```
scheduled   (force:false) → { success: false, held: "away", skipped: ["away"], fired: [] }
Test button (force:true)  → past the away gate, reaches the channels
```

`npm test` 316/316 + smoke. `eslint` 0 errors. Dev build green on `c105bf9`.

Server only — **no Xcode rebuild**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V45AJzVRjV8j2Sei5Qgr6A

---
_Generated by [Claude Code](https://claude.ai/code/session_01V45AJzVRjV8j2Sei5Qgr6A)_