### PR TITLE
chore(deps): clear all five audit advisories [XS]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4030,9 +4030,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5024,9 +5024,9 @@
       "dev": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -5530,9 +5530,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.31",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
-      "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.1.tgz",
+      "integrity": "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -5651,9 +5651,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -6781,9 +6781,9 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/wiki/Version-History.md
+++ b/wiki/Version-History.md
@@ -16,6 +16,13 @@ Commit-level changelog for Boomerang, grouped by date. Sizes: `[XS]` trivial, `[
   - The expiry banner says "moves to the archive" now. A warning about losing something you aren't losing is how a user learns to ignore banners.
   - Rules live in `server/chatArchive.js` — pure, no db, clock injected — with 16 tests in `scripts/chatArchive.test.mjs` pinning the one that matters: an expired chat comes back **archived with its messages intact**, never absent. New endpoints `POST /api/adviser/chats/:id/archive` and `/unarchive`; `GET /api/adviser/chats` now returns `{ chats, archived, activeId }`.
   - Verified end to end against a live server with a 31-day-old chat: sweep archived it, log line fired, contents readable, active id cleared, activate restored it on a fresh 30-day clock, and star/unstar on an archived chat left it filed with no phantom countdown. `npm test` 332/332 + smoke, eslint 0 errors. Web only — **no iOS rebuild** (OTA).
+- chore(deps): clear all five audit advisories [XS]
+  - `npm audit` → **0 vulnerabilities**, down from 5 (4 high, 1 moderate). All five were transitive with non-breaking fixes, so this is `npm audit fix` — lockfile only, no `package.json` change, no `--force`.
+  - `brace-expansion` 5.0.8 → 5.0.9 (DoS bypassing the CVE-2026-14257 mitigation), `fast-uri` 3.1.4 → 3.1.5 (host confusion via backslash authority introducer), `hono` 4.12.31 → 4.13.1 (four: CORS ReDoS, `memo()` cross-request SSR retention, Proxy Helper `Connection` header leak, Language Middleware complexity DoS), `ip-address` 10.2.0 → 10.4.0 (three SSRF / trust-boundary bypasses), `nanoid` 3.3.16 → 3.3.18 (infinite loop on zero size).
+  - `hono` and `ip-address` both sit under `@modelcontextprotocol/sdk` (the Notion MCP client), so the SDK's client + streamableHTTP entrypoints were imported directly to confirm the bumps didn't break the transport.
+  - **The TypeScript-<6 pin held** — verified by actually loading `capacitor.config.ts` through `npx cap ls` rather than by reading the version number (TS 5.9.3, Capacitor CLI 8.4.2, 3 iOS plugins listed).
+  - Also reconciled a stale `node_modules`: eslint was installed at 9.39.5 against a `^10.8.0` range in `package.json` and now matches.
+  - `npm test` 316/316 + smoke, eslint 0 errors, build clean.
 
 ## 2026-08-04
 


### PR DESCRIPTION
`npm audit` goes **5 → 0** (4 high, 1 moderate).

All five were transitive with non-breaking fixes available, so this is plain `npm audit fix` — **lockfile only**, no `package.json` change, no `--force`. 15 lines changed.

| Package | | Advisory |
|---|---|---|
| `brace-expansion` | 5.0.8 → 5.0.9 | DoS via unbounded intermediate arrays, bypassing the CVE-2026-14257 mitigation |
| `fast-uri` | 3.1.4 → 3.1.5 | Host confusion via backslash authority introducer |
| `hono` | 4.12.31 → 4.13.1 | CORS ReDoS · `memo()` retaining SSR output across requests · Proxy Helper leaking `Connection`-listed headers · Language Middleware complexity DoS |
| `ip-address` | 10.2.0 → 10.4.0 | Three SSRF / trust-boundary bypasses (octal leading-zero octets, CIDR suffix suppressing special-use classification, IPv4-mapped/NAT64 misclassification) |
| `nanoid` | 3.3.16 → 3.3.18 | Custom generators loop indefinitely when size is zero |

## Checks that aren't just "the version number went up"

- **`hono` and `ip-address` both sit under `@modelcontextprotocol/sdk`** (the Notion MCP client), so the SDK's `client/index.js` and `client/streamableHttp.js` entrypoints were imported directly to confirm the transport still loads.
- **The TypeScript-`<6` pin held** — verified by actually loading `capacitor.config.ts` through `npx cap ls` (TS 5.9.3, Capacitor CLI 8.4.2, 3 iOS plugins listed), not by reading a version.
- Also reconciled a stale `node_modules`: eslint was installed at 9.39.5 against a `^10.8.0` range in `package.json` and now matches.

`npm test` 316/316 + smoke · `eslint` 0 errors · build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V45AJzVRjV8j2Sei5Qgr6A

---
_Generated by [Claude Code](https://claude.ai/code/session_01V45AJzVRjV8j2Sei5Qgr6A)_